### PR TITLE
Interactive firmware version selection during installation

### DIFF
--- a/Firmware/INSTALLATION.md
+++ b/Firmware/INSTALLATION.md
@@ -43,8 +43,8 @@ export MOTHBOX_HOME=/your/custom/path
 
 The installation script automatically:
 - Detects your Raspberry Pi model (Pi 4 or Pi 5)
+- Lets you choose firmware version (4.x or 5.x) based on your hardware
 - Installs all system and Python dependencies
-- Configures appropriate firmware version
 - Sets up directory structure
 
 1. **Clone the repository:**
@@ -61,9 +61,10 @@ The installation script automatically:
 
    The script will:
    - Detect if you have Pi 4 or Pi 5
+   - Prompt you to select firmware version (4.x or 5.x)
    - Install system packages (python3-picamera2, etc.)
    - Install Python dependencies (opencv-python, RPi.GPIO, etc.)
-   - Copy appropriate firmware (4.x or 5.x)
+   - Copy selected firmware files
    - Create directories and set permissions
 
 3. **Configure your Mothbox:**
@@ -250,13 +251,39 @@ The installation script automatically installs all required dependencies:
 
 **Note on GPIO Library:** Mothbox uses `rpi-lgpio` instead of the older `RPi.GPIO` library. This provides full compatibility with both Raspberry Pi 4 and Pi 5, as Pi 5 uses a new GPIO architecture (RP1 chip) that requires the modern `lgpio` backend. The `rpi-lgpio` package provides the exact same API as `RPi.GPIO`, so all existing code works without modification.
 
-### Raspberry Pi Model Detection
+### Raspberry Pi Model Detection and Firmware Selection
 
 The installation script automatically detects your Pi model:
 - Reads `/proc/cpuinfo` to identify Pi 4 or Pi 5
-- Selects appropriate firmware version (4.x or 5.x)
+- Recommends appropriate firmware version (4.x or 5.x)
+- **Allows you to choose firmware version interactively**
 - Copies correct configuration files
 - Optimizes camera settings for your hardware
+
+**Choosing Firmware Version:**
+
+Both firmware versions (4.x and 5.x) work on both Pi 4 and Pi 5. The difference is in GPIO pin mappings for relay control:
+
+- **4.x firmware:** Uses GPIO pins 26/20/21 for relays (legacy hardware)
+- **5.x firmware:** Uses GPIO pins 5/19/9 for relays (current hardware)
+
+During installation, you'll see:
+```
+Detected: Raspberry Pi 5
+Recommended firmware: 5.x
+
+Firmware versions use different GPIO pin mappings:
+  4.x firmware: Relay pins 26/20/21 (legacy)
+  5.x firmware: Relay pins 5/19/9 (current hardware)
+
+Select firmware version:
+  1) 4.x firmware
+  2) 5.x firmware
+
+Choice [2]:
+```
+
+Choose based on your actual hardware configuration, not just your Pi model.
 
 ### Camera Configuration
 

--- a/Firmware/install_mothbox.sh
+++ b/Firmware/install_mothbox.sh
@@ -106,6 +106,50 @@ fi
 echo -e "${GREEN}✓ Detected Raspberry Pi ${PI_VERSION}${NC}"
 echo ""
 
+# Interactive firmware selection
+echo -e "${BLUE}Firmware Selection${NC}"
+echo "Detected: Raspberry Pi ${PI_VERSION}"
+echo "Recommended firmware: ${PI_VERSION}.x"
+echo ""
+echo "Firmware versions use different GPIO pin mappings:"
+echo "  4.x firmware: Relay pins 26/20/21 (legacy)"
+echo "  5.x firmware: Relay pins 5/19/9 (current hardware)"
+echo ""
+echo "Select firmware version:"
+echo "  1) 4.x firmware"
+echo "  2) 5.x firmware"
+echo ""
+
+# Determine default based on detected Pi
+if [ "$PI_VERSION" = "4" ]; then
+    DEFAULT_CHOICE=1
+else
+    DEFAULT_CHOICE=2
+fi
+
+# Read user choice with default
+while true; do
+    read -p "Choice [$DEFAULT_CHOICE]: " FIRMWARE_CHOICE
+    FIRMWARE_CHOICE=${FIRMWARE_CHOICE:-$DEFAULT_CHOICE}
+
+    case $FIRMWARE_CHOICE in
+        1)
+            FIRMWARE_VERSION="4"
+            echo -e "${GREEN}✓ Selected: 4.x firmware${NC}"
+            break
+            ;;
+        2)
+            FIRMWARE_VERSION="5"
+            echo -e "${GREEN}✓ Selected: 5.x firmware${NC}"
+            break
+            ;;
+        *)
+            echo -e "${RED}Invalid choice. Please enter 1 or 2.${NC}"
+            ;;
+    esac
+done
+echo ""
+
 # Ask for confirmation
 read -p "Proceed with installation? (y/N) " -n 1 -r
 echo
@@ -157,8 +201,8 @@ sudo cp -r "$SCRIPT_DIR"/* "$MOTHBOX_HOME/"
 if [ "$INSTALL_TYPE" = "production" ]; then
     echo -e "${BLUE}Setting up production configuration...${NC}"
 
-    # Config files are in the Pi-version-specific directory
-    CONFIG_SOURCE="$SCRIPT_DIR/${PI_VERSION}.x"
+    # Config files are in the firmware-version-specific directory
+    CONFIG_SOURCE="$SCRIPT_DIR/${FIRMWARE_VERSION}.x"
 
     # Copy config files from source
     if [ -f "$CONFIG_SOURCE/controls.txt" ]; then
@@ -191,6 +235,7 @@ echo -e "${GREEN}Installation Complete!${NC}"
 echo -e "${GREEN}================================================================================${NC}"
 echo ""
 echo -e "${BLUE}Raspberry Pi Model:${NC} Pi ${PI_VERSION}"
+echo -e "${BLUE}Firmware Version:${NC} ${FIRMWARE_VERSION}.x"
 echo -e "${BLUE}Mothbox Location:${NC} $MOTHBOX_HOME"
 echo -e "${BLUE}Configuration:${NC} $CONFIG_DIR"
 echo -e "${BLUE}Data Directory:${NC} $DATA_DIR"
@@ -199,7 +244,7 @@ echo -e "${YELLOW}Next Steps:${NC}"
 echo "1. Review and edit configuration files in: $CONFIG_DIR"
 echo "2. Update your crontab to point to: $MOTHBOX_HOME"
 echo "3. Test the installation by running: python3 $MOTHBOX_HOME/mothbox_paths.py"
-echo "4. Test photo capture: python3 $MOTHBOX_HOME/${PI_VERSION}.x/TakePhoto.py"
+echo "4. Test photo capture: python3 $MOTHBOX_HOME/${FIRMWARE_VERSION}.x/TakePhoto.py"
 echo ""
 
 if [ "$INSTALL_TYPE" = "custom" ]; then


### PR DESCRIPTION
Resolves #6

## Summary
Adds interactive firmware version selection to the installation script, allowing users to choose between 4.x and 5.x firmware based on their hardware configuration rather than being forced by Pi model detection.

## Changes

### Installation Script (`install_mothbox.sh`)
- **Interactive prompt** for firmware selection after Pi detection
- **GPIO pin information displayed** to help users make informed choice:
  - 4.x firmware: GPIO pins 26/20/21 (legacy hardware)
  - 5.x firmware: GPIO pins 5/19/9 (current hardware)
- **Smart defaults** based on detected Pi model (Pi 4 → 4.x, Pi 5 → 5.x)
- **Input validation** with retry loop for invalid choices
- **New variable** `FIRMWARE_VERSION` used throughout instead of `PI_VERSION`
- **Enhanced output** shows both Pi model and selected firmware version

### Documentation (`INSTALLATION.md`)
- New section explaining firmware selection process
- Clarified that both firmware versions work on both Pi models
- Added example of interactive prompt
- Updated Quick Start to mention firmware selection

## User Experience

During installation, users now see:
```
Detected: Raspberry Pi 5
Recommended firmware: 5.x

Firmware versions use different GPIO pin mappings:
  4.x firmware: Relay pins 26/20/21 (legacy)
  5.x firmware: Relay pins 5/19/9 (current hardware)

Select firmware version:
  1) 4.x firmware
  2) 5.x firmware

Choice [2]: 
```

## Testing
- ✅ Bash syntax check passed
- ✅ Variable usage verified throughout script
- ✅ Documentation updated and reviewed
- Ready for hardware testing on Pi 4 and Pi 5

## Related Issues
- Parent: #4 - Enhanced installation script with dependency management
- Related: #7 - Interactive GPIO configuration (future enhancement)