### PR TITLE
docs: Update uninstaller GPIO state file documentation

### DIFF
--- a/Firmware/uninstall_mothbox.sh
+++ b/Firmware/uninstall_mothbox.sh
@@ -268,7 +268,8 @@ echo -e "${BLUE}Cleaning up temporary files...${NC}"
 CLEANED_FILES=0
 
 # Remove GPIO state file (legacy /tmp location for backward compatibility)
-# Note: Current GPIO state is in DATA_DIR/gpio_state.json (removed with DATA_DIR cleanup)
+# Note: Current GPIO state is stored in DATA_DIR/gpio_state.json
+#       and is already removed during DATA_DIR cleanup (see lines 248-250 above)
 if [ -f "/tmp/mothbox_gpio_state.json" ]; then
     sudo rm -f "/tmp/mothbox_gpio_state.json"
     echo -e "${GREEN}✓ Removed /tmp/mothbox_gpio_state.json${NC}"


### PR DESCRIPTION
## Summary
Updates the documentation comment in the uninstaller script to clearly document both the legacy and current GPIO state file locations.

## Changes Made
- Updated comment at lines 270-272 in `Firmware/uninstall_mothbox.sh`
- Clarified that `/tmp/mothbox_gpio_state.json` is the legacy location kept for backward compatibility
- Added explicit documentation that the current location `DATA_DIR/gpio_state.json` is already removed during DATA_DIR cleanup (lines 248-250)
- Improved multi-line formatting for better readability

## Context
The GPIO state file was moved from `/tmp/mothbox_gpio_state.json` to `DATA_DIR/gpio_state.json` in previous updates. While the new location is already cleaned up when DATA_DIR is removed, this wasn't explicitly documented in the temporary files cleanup section, leading to potential confusion about whether the file is being properly removed.

## Testing
- No functional changes, documentation only
- Verified comment accurately references the DATA_DIR cleanup code at lines 248-250

Closes #27