### PR TITLE
Fix preset type normalization (resolves #60)

### DIFF
--- a/Firmware/Tests/unit/test_preset_type_normalization.py
+++ b/Firmware/Tests/unit/test_preset_type_normalization.py
@@ -391,6 +391,183 @@ class TestPresetTypeNormalization:
         assert preset_manager._convert_value_type('sharpness', 1.0, 'liveview') == 1.0
         assert preset_manager._convert_value_type('focus_peaking_enabled', False, 'liveview') is False
 
+    def test_malformed_int_values_logged_and_preserved(self, preset_manager, caplog):
+        """Test that malformed int values trigger warning and stay as strings"""
+        import logging
+
+        # Enable logging capture
+        with caplog.at_level(logging.WARNING):
+            # Test 'abc' for integer field
+            result = preset_manager._convert_value_type('ExposureTime', 'abc', 'camera')
+            assert result == 'abc'  # Preserved as string
+            assert 'Failed to convert' in caplog.text
+            assert 'ExposureTime' in caplog.text
+
+            caplog.clear()
+
+            # Test '1.5' for integer field (float string)
+            # AfMode uses _validate_int_enum which should be detected as int type
+            result = preset_manager._convert_value_type('AfMode', '1.5', 'camera')
+            assert result == '1.5'  # Should stay as string since int('1.5') fails
+            assert 'Failed to convert' in caplog.text
+            assert 'AfMode' in caplog.text
+
+    def test_malformed_float_values_logged_and_preserved(self, preset_manager, caplog):
+        """Test that malformed float values trigger warning"""
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            # Test 'xyz' for float field
+            result = preset_manager._convert_value_type('Sharpness', 'xyz', 'camera')
+            assert result == 'xyz'  # Preserved as string
+            assert 'Failed to convert' in caplog.text
+            assert 'Sharpness' in caplog.text
+
+    def test_malformed_bool_values_handled_gracefully(self, preset_manager):
+        """Test that malformed bool values default to False"""
+        # 'maybe' is not in the boolean list, so it will be handled by _infer_type
+        # which will treat it as a string
+        result = preset_manager._convert_value_type('AeEnable', 'maybe', 'camera')
+
+        # Since 'maybe' doesn't match any boolean pattern, it returns False
+        # (not in ['true', '1', 'yes'])
+        assert result is False
+
+    def test_schema_based_type_derivation_camera(self, preset_manager):
+        """Test that camera setting types are derived from ALLOWED_CAMERA_SETTINGS"""
+        # Boolean fields
+        assert preset_manager._convert_value_type('AwbEnable', 'true', 'camera') is True
+        assert preset_manager._convert_value_type('AeEnable', 'false', 'camera') is False
+
+        # Integer fields
+        result_int = preset_manager._convert_value_type('AfMode', '1', 'camera')
+        assert isinstance(result_int, int)
+        assert result_int == 1
+
+        # Float fields
+        result_float = preset_manager._convert_value_type('AnalogueGain', '8.0', 'camera')
+        assert isinstance(result_float, float)
+        assert result_float == 8.0
+
+        # String fields
+        result_str = preset_manager._convert_value_type('FocusPeakingColor', 'GREEN', 'camera')
+        assert isinstance(result_str, str)
+        assert result_str == 'green'  # Lowercased
+
+    def test_schema_based_type_derivation_liveview(self, preset_manager):
+        """Test that liveview setting types are derived from ALLOWED_LIVEVIEW_SETTINGS"""
+        # Boolean fields
+        assert preset_manager._convert_value_type('awb_enable', 'true', 'liveview') is True
+        assert preset_manager._convert_value_type('ae_enable', 'false', 'liveview') is False
+
+        # Integer fields
+        result_int = preset_manager._convert_value_type('noise_reduction_mode', '2', 'liveview')
+        assert isinstance(result_int, int)
+        assert result_int == 2
+
+        # Float fields
+        result_float = preset_manager._convert_value_type('sharpness', '1.5', 'liveview')
+        assert isinstance(result_float, float)
+        assert result_float == 1.5
+
+        # String fields
+        result_str = preset_manager._convert_value_type('focus_peaking_color', 'RED', 'liveview')
+        assert isinstance(result_str, str)
+        assert result_str == 'red'  # Lowercased
+
+    def test_type_derivation_caching(self, preset_manager):
+        """Test that type derivation results are cached for performance"""
+        # First call should populate cache
+        preset_manager._convert_value_type('ExposureTime', '500', 'camera')
+
+        # Check that cache entry exists
+        assert ('camera', 'ExposureTime') in preset_manager._type_cache
+        assert preset_manager._type_cache[('camera', 'ExposureTime')] == int
+
+        # Subsequent calls should use cache
+        preset_manager._convert_value_type('ExposureTime', '600', 'camera')
+        # Cache should still have the same entry
+        assert preset_manager._type_cache[('camera', 'ExposureTime')] == int
+
+    def test_unknown_setting_falls_back_to_inference(self, preset_manager, caplog):
+        """Test that unknown settings use type inference"""
+        import logging
+
+        with caplog.at_level(logging.DEBUG):
+            # Unknown camera setting
+            result = preset_manager._convert_value_type('UnknownSetting', '42', 'camera')
+            assert result == 42  # Inferred as int
+            assert 'not found in validation schema' in caplog.text
+
+    def test_normalize_with_schema_validates_correctly(self, preset_manager):
+        """Test that normalized presets validate correctly"""
+        settings = {
+            'camera': {
+                'ExposureTime': '500',
+                'AnalogueGain': '8.0',
+                'AeEnable': 'true',
+            },
+            'liveview': {
+                'noise_reduction_mode': '1',
+                'sharpness': '1.5',
+                'awb_enable': 'false',
+            }
+        }
+
+        # Save preset (which normalizes)
+        success, message = preset_manager.save_preset(
+            name='test_schema_normalized',
+            settings=settings,
+            description='Test schema-based normalization'
+        )
+
+        assert success is True
+
+        # Load and verify types
+        loaded = preset_manager.get_preset('test_schema_normalized')
+        assert isinstance(loaded['settings']['camera']['ExposureTime'], int)
+        assert isinstance(loaded['settings']['camera']['AnalogueGain'], float)
+        assert isinstance(loaded['settings']['camera']['AeEnable'], bool)
+        assert isinstance(loaded['settings']['liveview']['noise_reduction_mode'], int)
+        assert isinstance(loaded['settings']['liveview']['sharpness'], float)
+        assert isinstance(loaded['settings']['liveview']['awb_enable'], bool)
+
+    def test_derive_type_from_validator_patterns(self, preset_manager):
+        """Test type derivation from various validator patterns"""
+        from routes.camera import ALLOWED_CAMERA_SETTINGS, ALLOWED_LIVEVIEW_SETTINGS
+
+        # Test boolean pattern derivation
+        bool_type = preset_manager._derive_type_from_validator(
+            'AeEnable',
+            ALLOWED_CAMERA_SETTINGS['AeEnable'],
+            'camera'
+        )
+        assert bool_type == bool
+
+        # Test int pattern derivation
+        int_type = preset_manager._derive_type_from_validator(
+            'AfMode',
+            ALLOWED_CAMERA_SETTINGS['AfMode'],
+            'camera'
+        )
+        assert int_type == int
+
+        # Test float pattern derivation
+        float_type = preset_manager._derive_type_from_validator(
+            'Sharpness',
+            ALLOWED_CAMERA_SETTINGS['Sharpness'],
+            'camera'
+        )
+        assert float_type == float
+
+        # Test string pattern derivation
+        str_type = preset_manager._derive_type_from_validator(
+            'FocusPeakingColor',
+            ALLOWED_CAMERA_SETTINGS['FocusPeakingColor'],
+            'camera'
+        )
+        assert str_type == str
+
 
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])

--- a/Firmware/Tests/unit/test_preset_type_normalization.py
+++ b/Firmware/Tests/unit/test_preset_type_normalization.py
@@ -1,0 +1,396 @@
+"""
+Unit tests for preset type normalization
+
+Tests the PresetManager's ability to normalize string values to proper types
+when saving presets from different sources (CSV files, TXT files, frontend JSON).
+"""
+
+import pytest
+import sys
+from pathlib import Path
+import tempfile
+import shutil
+
+# Setup path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "webui" / "backend"))
+
+from preset_manager import PresetManager
+
+
+class TestPresetTypeNormalization:
+    """Test suite for preset type normalization"""
+
+    @pytest.fixture
+    def preset_manager(self):
+        """Create a preset manager with temporary directories"""
+        temp_dir = tempfile.mkdtemp()
+        builtin_dir = Path(temp_dir) / "builtin"
+        user_dir = Path(temp_dir) / "user"
+        builtin_dir.mkdir()
+        user_dir.mkdir()
+
+        manager = PresetManager(builtin_dir, user_dir)
+
+        yield manager
+
+        # Cleanup
+        shutil.rmtree(temp_dir)
+
+    def test_normalize_camera_integer_strings(self, preset_manager):
+        """Test that string integers are converted to int for camera settings"""
+        settings = {
+            'camera': {
+                'ExposureTime': '499',
+                'AfMode': '1',
+                'NoiseReductionMode': '2',
+                'HDR': '3'
+            }
+        }
+
+        normalized = preset_manager._normalize_setting_types(settings)
+
+        assert isinstance(normalized['camera']['ExposureTime'], int)
+        assert normalized['camera']['ExposureTime'] == 499
+        assert isinstance(normalized['camera']['AfMode'], int)
+        assert normalized['camera']['AfMode'] == 1
+        assert isinstance(normalized['camera']['NoiseReductionMode'], int)
+        assert normalized['camera']['NoiseReductionMode'] == 2
+        assert isinstance(normalized['camera']['HDR'], int)
+        assert normalized['camera']['HDR'] == 3
+
+    def test_normalize_camera_float_strings(self, preset_manager):
+        """Test that string floats are converted to float for camera settings"""
+        settings = {
+            'camera': {
+                'AnalogueGain': '8.0',
+                'Sharpness': '1.5',
+                'Brightness': '0.0',
+                'Contrast': '2.5',
+                'Saturation': '1.0'
+            }
+        }
+
+        normalized = preset_manager._normalize_setting_types(settings)
+
+        assert isinstance(normalized['camera']['AnalogueGain'], float)
+        assert normalized['camera']['AnalogueGain'] == 8.0
+        assert isinstance(normalized['camera']['Sharpness'], float)
+        assert normalized['camera']['Sharpness'] == 1.5
+        assert isinstance(normalized['camera']['Brightness'], float)
+        assert normalized['camera']['Brightness'] == 0.0
+
+    def test_normalize_camera_boolean_strings(self, preset_manager):
+        """Test that string booleans are converted to bool for camera settings"""
+        settings = {
+            'camera': {
+                'AeEnable': 'True',
+                'AwbEnable': 'true',
+                'LensShadingEnable': 'False',
+                'DefectCorrectionEnable': 'false',
+                'UseCustomTuning': '1'
+            }
+        }
+
+        normalized = preset_manager._normalize_setting_types(settings)
+
+        assert isinstance(normalized['camera']['AeEnable'], bool)
+        assert normalized['camera']['AeEnable'] is True
+        assert isinstance(normalized['camera']['AwbEnable'], bool)
+        assert normalized['camera']['AwbEnable'] is True
+        assert isinstance(normalized['camera']['LensShadingEnable'], bool)
+        assert normalized['camera']['LensShadingEnable'] is False
+        assert isinstance(normalized['camera']['DefectCorrectionEnable'], bool)
+        assert normalized['camera']['DefectCorrectionEnable'] is False
+        assert isinstance(normalized['camera']['UseCustomTuning'], bool)
+        assert normalized['camera']['UseCustomTuning'] is True
+
+    def test_normalize_liveview_integer_strings(self, preset_manager):
+        """Test that string integers are converted to int for liveview settings"""
+        settings = {
+            'liveview': {
+                'noise_reduction_mode': '1',
+                'awb_mode': '2',
+                'stream_width': '1920',
+                'stream_height': '1080',
+                'stream_quality': '85'
+            }
+        }
+
+        normalized = preset_manager._normalize_setting_types(settings)
+
+        assert isinstance(normalized['liveview']['noise_reduction_mode'], int)
+        assert normalized['liveview']['noise_reduction_mode'] == 1
+        assert isinstance(normalized['liveview']['stream_width'], int)
+        assert normalized['liveview']['stream_width'] == 1920
+        assert isinstance(normalized['liveview']['stream_height'], int)
+        assert normalized['liveview']['stream_height'] == 1080
+
+    def test_normalize_liveview_float_strings(self, preset_manager):
+        """Test that string floats are converted to float for liveview settings"""
+        settings = {
+            'liveview': {
+                'sharpness': '1.0',
+                'brightness': '0.5',
+                'contrast': '1.5',
+                'saturation': '1.0',
+                'focus_peaking_intensity': '100.0'
+            }
+        }
+
+        normalized = preset_manager._normalize_setting_types(settings)
+
+        assert isinstance(normalized['liveview']['sharpness'], float)
+        assert normalized['liveview']['sharpness'] == 1.0
+        assert isinstance(normalized['liveview']['brightness'], float)
+        assert normalized['liveview']['brightness'] == 0.5
+        assert isinstance(normalized['liveview']['contrast'], float)
+        assert normalized['liveview']['contrast'] == 1.5
+
+    def test_normalize_liveview_boolean_strings(self, preset_manager):
+        """Test that string booleans are converted to bool for liveview settings"""
+        settings = {
+            'liveview': {
+                'focus_peaking_enabled': 'True',
+                'awb_enable': 'true',
+                'ae_enable': 'false'
+            }
+        }
+
+        normalized = preset_manager._normalize_setting_types(settings)
+
+        assert isinstance(normalized['liveview']['focus_peaking_enabled'], bool)
+        assert normalized['liveview']['focus_peaking_enabled'] is True
+        assert isinstance(normalized['liveview']['awb_enable'], bool)
+        assert normalized['liveview']['awb_enable'] is True
+        assert isinstance(normalized['liveview']['ae_enable'], bool)
+        assert normalized['liveview']['ae_enable'] is False
+
+    def test_normalize_string_fields_remain_strings(self, preset_manager):
+        """Test that actual string fields remain as strings"""
+        settings = {
+            'camera': {
+                'FocusPeakingColor': 'green',
+                'FocusPeakingAlgorithm': 'laplacian'
+            },
+            'liveview': {
+                'focus_peaking_color': 'RED',
+                'focus_peaking_algorithm': 'SOBEL'
+            }
+        }
+
+        normalized = preset_manager._normalize_setting_types(settings)
+
+        assert isinstance(normalized['camera']['FocusPeakingColor'], str)
+        assert normalized['camera']['FocusPeakingColor'] == 'green'
+        assert isinstance(normalized['liveview']['focus_peaking_color'], str)
+        assert normalized['liveview']['focus_peaking_color'] == 'red'  # Lowercased
+        assert isinstance(normalized['liveview']['focus_peaking_algorithm'], str)
+        assert normalized['liveview']['focus_peaking_algorithm'] == 'sobel'  # Lowercased
+
+    def test_normalize_mixed_types(self, preset_manager):
+        """Test normalization with mixed type settings"""
+        settings = {
+            'camera': {
+                'ExposureTime': '500',          # String int
+                'AnalogueGain': '8.0',          # String float
+                'AeEnable': 'True',             # String bool
+                'Sharpness': 1.5,               # Already float
+                'AfMode': 1,                    # Already int
+                'AwbEnable': True               # Already bool
+            },
+            'liveview': {
+                'noise_reduction_mode': '2',   # String int
+                'sharpness': '1.0',            # String float
+                'focus_peaking_enabled': 'true', # String bool
+                'brightness': 0.5,             # Already float
+                'stream_width': 1920,          # Already int
+                'awb_enable': False            # Already bool
+            }
+        }
+
+        normalized = preset_manager._normalize_setting_types(settings)
+
+        # Camera settings
+        assert isinstance(normalized['camera']['ExposureTime'], int)
+        assert normalized['camera']['ExposureTime'] == 500
+        assert isinstance(normalized['camera']['AnalogueGain'], float)
+        assert normalized['camera']['AnalogueGain'] == 8.0
+        assert isinstance(normalized['camera']['AeEnable'], bool)
+        assert normalized['camera']['AeEnable'] is True
+        assert isinstance(normalized['camera']['Sharpness'], float)
+        assert normalized['camera']['Sharpness'] == 1.5
+        assert isinstance(normalized['camera']['AfMode'], int)
+        assert normalized['camera']['AfMode'] == 1
+        assert isinstance(normalized['camera']['AwbEnable'], bool)
+        assert normalized['camera']['AwbEnable'] is True
+
+        # Liveview settings
+        assert isinstance(normalized['liveview']['noise_reduction_mode'], int)
+        assert normalized['liveview']['noise_reduction_mode'] == 2
+        assert isinstance(normalized['liveview']['sharpness'], float)
+        assert normalized['liveview']['sharpness'] == 1.0
+        assert isinstance(normalized['liveview']['focus_peaking_enabled'], bool)
+        assert normalized['liveview']['focus_peaking_enabled'] is True
+        assert isinstance(normalized['liveview']['brightness'], float)
+        assert normalized['liveview']['brightness'] == 0.5
+        assert isinstance(normalized['liveview']['stream_width'], int)
+        assert normalized['liveview']['stream_width'] == 1920
+        assert isinstance(normalized['liveview']['awb_enable'], bool)
+        assert normalized['liveview']['awb_enable'] is False
+
+    def test_normalize_unknown_fields_infer_type(self, preset_manager):
+        """Test that unknown fields have their type inferred"""
+        settings = {
+            'camera': {
+                'UnknownIntField': '42',
+                'UnknownFloatField': '3.14',
+                'UnknownBoolField': 'true',
+                'UnknownStringField': 'custom_value'
+            }
+        }
+
+        normalized = preset_manager._normalize_setting_types(settings)
+
+        assert isinstance(normalized['camera']['UnknownIntField'], int)
+        assert normalized['camera']['UnknownIntField'] == 42
+        assert isinstance(normalized['camera']['UnknownFloatField'], float)
+        assert normalized['camera']['UnknownFloatField'] == 3.14
+        assert isinstance(normalized['camera']['UnknownBoolField'], bool)
+        assert normalized['camera']['UnknownBoolField'] is True
+        assert isinstance(normalized['camera']['UnknownStringField'], str)
+        assert normalized['camera']['UnknownStringField'] == 'custom_value'
+
+    def test_save_preset_normalizes_types(self, preset_manager):
+        """Test that save_preset applies type normalization"""
+        settings = {
+            'camera': {
+                'ExposureTime': '499',
+                'AnalogueGain': '8.0',
+                'AeEnable': 'True',
+                'Sharpness': '1.5'
+            },
+            'liveview': {
+                'noise_reduction_mode': '1',
+                'sharpness': '1.0',
+                'focus_peaking_enabled': 'true'
+            }
+        }
+
+        success, message = preset_manager.save_preset(
+            name='test_preset',
+            settings=settings,
+            description='Test preset with string types',
+            workflow='both'
+        )
+
+        assert success is True
+
+        # Load the preset and verify types
+        loaded_preset = preset_manager.get_preset('test_preset')
+        assert loaded_preset is not None
+
+        camera_settings = loaded_preset['settings']['camera']
+        assert isinstance(camera_settings['ExposureTime'], int)
+        assert camera_settings['ExposureTime'] == 499
+        assert isinstance(camera_settings['AnalogueGain'], float)
+        assert camera_settings['AnalogueGain'] == 8.0
+        assert isinstance(camera_settings['AeEnable'], bool)
+        assert camera_settings['AeEnable'] is True
+        assert isinstance(camera_settings['Sharpness'], float)
+        assert camera_settings['Sharpness'] == 1.5
+
+        liveview_settings = loaded_preset['settings']['liveview']
+        assert isinstance(liveview_settings['noise_reduction_mode'], int)
+        assert liveview_settings['noise_reduction_mode'] == 1
+        assert isinstance(liveview_settings['sharpness'], float)
+        assert liveview_settings['sharpness'] == 1.0
+        assert isinstance(liveview_settings['focus_peaking_enabled'], bool)
+        assert liveview_settings['focus_peaking_enabled'] is True
+
+    def test_empty_settings_handled_gracefully(self, preset_manager):
+        """Test that empty settings don't cause errors"""
+        settings = {
+            'camera': {},
+            'liveview': {}
+        }
+
+        normalized = preset_manager._normalize_setting_types(settings)
+
+        assert normalized['camera'] == {}
+        assert normalized['liveview'] == {}
+
+    def test_only_camera_settings(self, preset_manager):
+        """Test normalization with only camera settings"""
+        settings = {
+            'camera': {
+                'ExposureTime': '500',
+                'Sharpness': '1.5'
+            }
+        }
+
+        normalized = preset_manager._normalize_setting_types(settings)
+
+        assert 'camera' in normalized
+        assert 'liveview' not in normalized
+        assert isinstance(normalized['camera']['ExposureTime'], int)
+        assert isinstance(normalized['camera']['Sharpness'], float)
+
+    def test_only_liveview_settings(self, preset_manager):
+        """Test normalization with only liveview settings"""
+        settings = {
+            'liveview': {
+                'sharpness': '1.0',
+                'focus_peaking_enabled': 'true'
+            }
+        }
+
+        normalized = preset_manager._normalize_setting_types(settings)
+
+        assert 'liveview' in normalized
+        assert 'camera' not in normalized
+        assert isinstance(normalized['liveview']['sharpness'], float)
+        assert isinstance(normalized['liveview']['focus_peaking_enabled'], bool)
+
+    def test_infer_type_edge_cases(self, preset_manager):
+        """Test edge cases in type inference"""
+        # Test various boolean representations
+        assert preset_manager._infer_type('true') is True
+        assert preset_manager._infer_type('True') is True
+        assert preset_manager._infer_type('TRUE') is True
+        assert preset_manager._infer_type('false') is False
+        assert preset_manager._infer_type('False') is False
+        assert preset_manager._infer_type('FALSE') is False
+        assert preset_manager._infer_type('yes') is True
+        assert preset_manager._infer_type('no') is False
+        assert preset_manager._infer_type('1') is True
+        assert preset_manager._infer_type('0') is False
+
+        # Test numeric edge cases
+        assert isinstance(preset_manager._infer_type('42'), int)
+        assert preset_manager._infer_type('42') == 42
+        assert isinstance(preset_manager._infer_type('3.14'), float)
+        assert preset_manager._infer_type('3.14') == 3.14
+        assert isinstance(preset_manager._infer_type('0'), bool)  # '0' is bool False
+        assert isinstance(preset_manager._infer_type('2'), int)  # '2' is int
+
+        # Test string edge cases
+        assert isinstance(preset_manager._infer_type('hello'), str)
+        assert preset_manager._infer_type('hello') == 'hello'
+        assert isinstance(preset_manager._infer_type(''), str)
+        assert preset_manager._infer_type('') == ''
+
+    def test_convert_value_type_already_correct(self, preset_manager):
+        """Test that values with correct types are not modified"""
+        # Camera settings
+        assert preset_manager._convert_value_type('ExposureTime', 500, 'camera') == 500
+        assert preset_manager._convert_value_type('Sharpness', 1.5, 'camera') == 1.5
+        assert preset_manager._convert_value_type('AeEnable', True, 'camera') is True
+
+        # Liveview settings
+        assert preset_manager._convert_value_type('noise_reduction_mode', 2, 'liveview') == 2
+        assert preset_manager._convert_value_type('sharpness', 1.0, 'liveview') == 1.0
+        assert preset_manager._convert_value_type('focus_peaking_enabled', False, 'liveview') is False
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])

--- a/Firmware/webui/backend/preset_manager.py
+++ b/Firmware/webui/backend/preset_manager.py
@@ -12,13 +12,18 @@ This module provides functionality to:
 import json
 import os
 import sys
+import logging
+import re
 from pathlib import Path
 from datetime import datetime
-from typing import Dict, List, Optional, Tuple, Any, Union
+from typing import Dict, List, Optional, Tuple, Any, Union, Callable
 
-# Import validation schema for type normalization
+# Import validation schemas for type normalization
 sys.path.insert(0, str(Path(__file__).parent))
-from routes.camera import ALLOWED_CAMERA_SETTINGS
+from routes.camera import ALLOWED_CAMERA_SETTINGS, ALLOWED_LIVEVIEW_SETTINGS
+
+# Setup logging
+logger = logging.getLogger(__name__)
 
 
 class PresetManager:
@@ -37,6 +42,96 @@ class PresetManager:
 
         # Create user directory if it doesn't exist
         self.user_dir.mkdir(parents=True, exist_ok=True)
+
+        # Cache for type derivation results to avoid re-analyzing validators
+        self._type_cache: Dict[Tuple[str, str], type] = {}
+
+    def _derive_type_from_validator(self, key: str, validator: Callable, setting_type: str) -> Optional[type]:
+        """
+        Derive the expected type from a validation lambda function.
+
+        Analyzes validation function source code patterns to determine expected type:
+        - float(v) with decimal range → float
+        - int(v) in [...] → int
+        - .lower() in ['true', 'false'] → bool
+        - .lower() in [string list] → str
+
+        Args:
+            key: Setting name
+            validator: Validation lambda function
+            setting_type: 'camera' or 'liveview' (for cache key)
+
+        Returns:
+            Python type (int, float, bool, str) or None if unable to determine
+        """
+        # Check cache first
+        cache_key = (setting_type, key)
+        if cache_key in self._type_cache:
+            return self._type_cache[cache_key]
+
+        try:
+            # Get the source code of the validator (works for lambdas and functions)
+            import inspect
+
+            # Check if it's a lambda or a function
+            validator_name = getattr(validator, '__name__', None)
+
+            # Handle special function names that indicate type
+            if validator_name:
+                if 'int_enum' in validator_name:
+                    derived_type = int
+                    self._type_cache[cache_key] = derived_type
+                    return derived_type
+                elif 'exposure_time' in validator_name:
+                    # ExposureTime validation function returns int
+                    derived_type = int
+                    self._type_cache[cache_key] = derived_type
+                    return derived_type
+
+            source = inspect.getsource(validator).strip()
+
+            # Pattern matching to infer type
+            derived_type = None
+
+            # Check for calls to validation helper functions
+            if '_validate_int_enum' in source or '_validate_exposure_time' in source:
+                derived_type = int
+
+            # Boolean: str(v).lower() in ['true', 'false']
+            elif re.search(r"\.lower\(\)\s+in\s+\[.*['\"]true['\"].*['\"]false['\"]", source):
+                derived_type = bool
+
+            # String enum: str(v).lower() in ['option1', 'option2', ...]
+            # (but NOT the boolean pattern above)
+            elif re.search(r"str\(v\)\.lower\(\)", source) and not re.search(r"['\"]true['\"]", source):
+                derived_type = str
+
+            # Float: float(v) with decimal literals in range checks
+            elif re.search(r"float\(v\)", source) and re.search(r"\d+\.\d+", source):
+                derived_type = float
+
+            # Integer: int(v) in [...] or range checks with integers only
+            elif re.search(r"int\(v\)", source):
+                derived_type = int
+
+            # isinstance checks (complex validators)
+            elif re.search(r"isinstance\(v,\s*int\)", source):
+                derived_type = int
+            elif re.search(r"isinstance\(v,\s*float\)", source):
+                derived_type = float
+            elif re.search(r"isinstance\(v,\s*bool\)", source):
+                derived_type = bool
+
+            # Cache the result
+            if derived_type:
+                self._type_cache[cache_key] = derived_type
+
+            return derived_type
+
+        except (OSError, TypeError) as e:
+            # inspect.getsource() can fail for built-in functions or C code
+            logger.debug(f"Could not derive type for {setting_type} setting '{key}': {e}")
+            return None
 
     def _normalize_setting_types(self, settings: Dict[str, Any]) -> Dict[str, Any]:
         """
@@ -71,7 +166,11 @@ class PresetManager:
 
     def _convert_value_type(self, key: str, value: Any, setting_type: str) -> Union[int, float, bool, str]:
         """
-        Convert a single setting value from string to its proper type.
+        Convert a single setting value from string to its proper type using validation schemas.
+
+        This method derives the expected type from the validation schema (ALLOWED_CAMERA_SETTINGS
+        or ALLOWED_LIVEVIEW_SETTINGS) rather than using hardcoded type lists. This ensures
+        consistency between validation and type normalization.
 
         Args:
             key: Setting name (e.g., 'ExposureTime', 'sharpness')
@@ -79,117 +178,127 @@ class PresetManager:
             setting_type: 'camera' or 'liveview'
 
         Returns:
-            Value with proper type
+            Value with proper type, or original value if conversion fails
         """
-        # If already correct type, return as-is
+        # If already non-string type, return as-is (already correct type)
         if not isinstance(value, str):
             return value
 
-        # For camera settings, use ALLOWED_CAMERA_SETTINGS schema
-        if setting_type == 'camera':
-            # Map camera setting to expected type based on validation
-            if key in ['AeEnable', 'AwbEnable', 'LensShadingEnable',
-                      'DefectCorrectionEnable', 'UseCustomTuning',
-                      'FocusPeakingEnabled']:
-                # Boolean fields
+        # Get the appropriate validation schema
+        schema = ALLOWED_CAMERA_SETTINGS if setting_type == 'camera' else ALLOWED_LIVEVIEW_SETTINGS
+
+        # Check if key exists in schema
+        if key in schema:
+            validator = schema[key]
+
+            # Derive type from validator function
+            expected_type = self._derive_type_from_validator(key, validator, setting_type)
+
+            if expected_type == bool:
+                # Boolean conversion: 'true', '1', 'yes' → True
                 return value.lower() in ['true', '1', 'yes']
 
-            elif key in ['ExposureTime', 'AeMeteringMode', 'AfMode', 'AfSpeed',
-                        'AfRange', 'AfMetering', 'AwbMode', 'NoiseReductionMode',
-                        'HDR', 'HDR_width', 'FocusBracket', 'ImageFileType',
-                        'VerticalFlip', 'AutoCalibration', 'AutoCalibrationPeriod',
-                        'FocusPeakingIntensity', 'FlashDelay_BeforeCapture',
-                        'FlashDelay_AfterCapture', 'FocusBracket_SettleDelay',
-                        'FocusBracket_LockColorGains']:
-                # Integer fields
+            elif expected_type == int:
+                # Integer conversion
                 try:
                     return int(value)
-                except (ValueError, TypeError):
+                except (ValueError, TypeError) as e:
+                    logger.warning(
+                        f"Failed to convert {setting_type} setting '{key}' value '{value}' to int: {e}. "
+                        f"Keeping as string."
+                    )
                     return value
 
-            elif key in ['Sharpness', 'Brightness', 'Contrast', 'Saturation',
-                        'ExposureValue', 'AnalogueGain', 'LensPosition',
-                        'ColourGainRed', 'ColourGainBlue', 'FocusBracket_Start',
-                        'FocusBracket_End', 'FocusBracket_ColorGainRed',
-                        'FocusBracket_ColorGainBlue']:
-                # Float fields
+            elif expected_type == float:
+                # Float conversion
                 try:
                     return float(value)
-                except (ValueError, TypeError):
+                except (ValueError, TypeError) as e:
+                    logger.warning(
+                        f"Failed to convert {setting_type} setting '{key}' value '{value}' to float: {e}. "
+                        f"Keeping as string."
+                    )
                     return value
 
-            elif key in ['FocusPeakingColor', 'FocusPeakingAlgorithm']:
-                # String fields - keep as-is
+            elif expected_type == str:
+                # String enum - lowercase for consistency
                 return value.lower() if value else value
 
             else:
-                # Unknown field - try to infer type
+                # Could not derive type from validator - fall back to inference
+                logger.debug(
+                    f"Could not derive type for {setting_type} setting '{key}' from validator. "
+                    f"Using type inference."
+                )
                 return self._infer_type(value)
-
-        # For liveview settings
-        elif setting_type == 'liveview':
-            # Map liveview settings to expected types
-            if key in ['focus_peaking_enabled', 'awb_enable', 'ae_enable']:
-                # Boolean fields
-                return value.lower() in ['true', '1', 'yes']
-
-            elif key in ['noise_reduction_mode', 'awb_mode', 'stream_width',
-                        'stream_height', 'stream_quality', 'stream_framerate']:
-                # Integer fields
-                try:
-                    return int(value)
-                except (ValueError, TypeError):
-                    return value
-
-            elif key in ['sharpness', 'brightness', 'contrast', 'saturation',
-                        'focus_peaking_intensity', 'exposure_value', 'analogue_gain']:
-                # Float fields
-                try:
-                    return float(value)
-                except (ValueError, TypeError):
-                    return value
-
-            elif key in ['focus_peaking_color', 'focus_peaking_algorithm']:
-                # String fields
-                return value.lower() if value else value
-
-            else:
-                # Unknown field - try to infer type
-                return self._infer_type(value)
+        else:
+            # Unknown setting not in schema - use type inference
+            logger.debug(
+                f"{setting_type.capitalize()} setting '{key}' not found in validation schema. "
+                f"Using type inference."
+            )
+            return self._infer_type(value)
 
         return value
 
     def _infer_type(self, value: str) -> Union[int, float, bool, str]:
         """
-        Infer the proper type for a string value.
+        Infer the proper type for a string value when schema lookup fails.
+
+        This method is ONLY used as a fallback when:
+        1. A setting is not found in ALLOWED_CAMERA_SETTINGS or ALLOWED_LIVEVIEW_SETTINGS
+        2. Type derivation from the validator function fails
+
+        For known settings, type conversion is always schema-based via _convert_value_type().
+
+        Type inference hierarchy:
+        1. Boolean: 'true', 'false', 'yes', 'no', '1', '0' → bool
+           - Note: '0'/'1' are treated as booleans in this fallback
+           - Schema-based conversion distinguishes boolean vs integer fields
+        2. Integer: No decimal point → int (e.g., '42', '100')
+        3. Float: Contains decimal point → float (e.g., '3.14', '1.0')
+        4. String: Everything else → str (e.g., 'green', 'custom')
 
         Args:
             value: String value to convert
 
         Returns:
             Value with inferred type
+
+        Examples:
+            >>> _infer_type('true')
+            True
+            >>> _infer_type('1')
+            True  # Treated as boolean in fallback
+            >>> _infer_type('42')
+            42
+            >>> _infer_type('3.14')
+            3.14
+            >>> _infer_type('hello')
+            'hello'
         """
         if not isinstance(value, str):
             return value
 
-        # Try boolean
+        # Try boolean - includes '1'/'0' for compatibility
+        # (Note: Schema-based conversion handles proper bool vs int distinction)
         if value.lower() in ['true', 'false', 'yes', 'no', '1', '0']:
             return value.lower() in ['true', 'yes', '1']
 
-        # Try integer
+        # Try integer (no decimal point)
         try:
             if '.' not in value:
                 return int(value)
         except (ValueError, TypeError):
             pass
 
-        # Try float
+        # Try float (has decimal point or scientific notation)
         try:
             return float(value)
         except (ValueError, TypeError):
             pass
 
-        # Keep as string
+        # Keep as string (for text values, enums, etc.)
         return value
 
     def list_presets(self) -> List[Dict]:

--- a/Firmware/webui/backend/preset_manager.py
+++ b/Firmware/webui/backend/preset_manager.py
@@ -11,9 +11,14 @@ This module provides functionality to:
 
 import json
 import os
+import sys
 from pathlib import Path
 from datetime import datetime
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Any, Union
+
+# Import validation schema for type normalization
+sys.path.insert(0, str(Path(__file__).parent))
+from routes.camera import ALLOWED_CAMERA_SETTINGS
 
 
 class PresetManager:
@@ -32,6 +37,160 @@ class PresetManager:
 
         # Create user directory if it doesn't exist
         self.user_dir.mkdir(parents=True, exist_ok=True)
+
+    def _normalize_setting_types(self, settings: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Normalize setting value types from strings to their proper types.
+
+        This ensures consistent JSON serialization regardless of data source:
+        - Numbers stored as strings (from CSV/TXT files) → int/float
+        - Booleans stored as strings ("true", "True", "false") → bool
+        - Actual string values remain strings
+
+        Args:
+            settings: Dict with 'camera' and/or 'liveview' settings
+
+        Returns:
+            Settings dict with normalized types
+        """
+        normalized = {}
+
+        # Normalize camera settings
+        if 'camera' in settings:
+            normalized['camera'] = {}
+            for key, value in settings['camera'].items():
+                normalized['camera'][key] = self._convert_value_type(key, value, 'camera')
+
+        # Normalize liveview settings
+        if 'liveview' in settings:
+            normalized['liveview'] = {}
+            for key, value in settings['liveview'].items():
+                normalized['liveview'][key] = self._convert_value_type(key, value, 'liveview')
+
+        return normalized
+
+    def _convert_value_type(self, key: str, value: Any, setting_type: str) -> Union[int, float, bool, str]:
+        """
+        Convert a single setting value from string to its proper type.
+
+        Args:
+            key: Setting name (e.g., 'ExposureTime', 'sharpness')
+            value: Raw value (possibly string)
+            setting_type: 'camera' or 'liveview'
+
+        Returns:
+            Value with proper type
+        """
+        # If already correct type, return as-is
+        if not isinstance(value, str):
+            return value
+
+        # For camera settings, use ALLOWED_CAMERA_SETTINGS schema
+        if setting_type == 'camera':
+            # Map camera setting to expected type based on validation
+            if key in ['AeEnable', 'AwbEnable', 'LensShadingEnable',
+                      'DefectCorrectionEnable', 'UseCustomTuning',
+                      'FocusPeakingEnabled']:
+                # Boolean fields
+                return value.lower() in ['true', '1', 'yes']
+
+            elif key in ['ExposureTime', 'AeMeteringMode', 'AfMode', 'AfSpeed',
+                        'AfRange', 'AfMetering', 'AwbMode', 'NoiseReductionMode',
+                        'HDR', 'HDR_width', 'FocusBracket', 'ImageFileType',
+                        'VerticalFlip', 'AutoCalibration', 'AutoCalibrationPeriod',
+                        'FocusPeakingIntensity', 'FlashDelay_BeforeCapture',
+                        'FlashDelay_AfterCapture', 'FocusBracket_SettleDelay',
+                        'FocusBracket_LockColorGains']:
+                # Integer fields
+                try:
+                    return int(value)
+                except (ValueError, TypeError):
+                    return value
+
+            elif key in ['Sharpness', 'Brightness', 'Contrast', 'Saturation',
+                        'ExposureValue', 'AnalogueGain', 'LensPosition',
+                        'ColourGainRed', 'ColourGainBlue', 'FocusBracket_Start',
+                        'FocusBracket_End', 'FocusBracket_ColorGainRed',
+                        'FocusBracket_ColorGainBlue']:
+                # Float fields
+                try:
+                    return float(value)
+                except (ValueError, TypeError):
+                    return value
+
+            elif key in ['FocusPeakingColor', 'FocusPeakingAlgorithm']:
+                # String fields - keep as-is
+                return value.lower() if value else value
+
+            else:
+                # Unknown field - try to infer type
+                return self._infer_type(value)
+
+        # For liveview settings
+        elif setting_type == 'liveview':
+            # Map liveview settings to expected types
+            if key in ['focus_peaking_enabled', 'awb_enable', 'ae_enable']:
+                # Boolean fields
+                return value.lower() in ['true', '1', 'yes']
+
+            elif key in ['noise_reduction_mode', 'awb_mode', 'stream_width',
+                        'stream_height', 'stream_quality', 'stream_framerate']:
+                # Integer fields
+                try:
+                    return int(value)
+                except (ValueError, TypeError):
+                    return value
+
+            elif key in ['sharpness', 'brightness', 'contrast', 'saturation',
+                        'focus_peaking_intensity', 'exposure_value', 'analogue_gain']:
+                # Float fields
+                try:
+                    return float(value)
+                except (ValueError, TypeError):
+                    return value
+
+            elif key in ['focus_peaking_color', 'focus_peaking_algorithm']:
+                # String fields
+                return value.lower() if value else value
+
+            else:
+                # Unknown field - try to infer type
+                return self._infer_type(value)
+
+        return value
+
+    def _infer_type(self, value: str) -> Union[int, float, bool, str]:
+        """
+        Infer the proper type for a string value.
+
+        Args:
+            value: String value to convert
+
+        Returns:
+            Value with inferred type
+        """
+        if not isinstance(value, str):
+            return value
+
+        # Try boolean
+        if value.lower() in ['true', 'false', 'yes', 'no', '1', '0']:
+            return value.lower() in ['true', 'yes', '1']
+
+        # Try integer
+        try:
+            if '.' not in value:
+                return int(value)
+        except (ValueError, TypeError):
+            pass
+
+        # Try float
+        try:
+            return float(value)
+        except (ValueError, TypeError):
+            pass
+
+        # Keep as string
+        return value
 
     def list_presets(self) -> List[Dict]:
         """
@@ -175,7 +334,10 @@ class PresetManager:
         if workflow not in ['photo', 'liveview', 'both']:
             return False, "Workflow must be 'photo', 'liveview', or 'both'"
 
-        # Build preset data FIRST
+        # Normalize setting types FIRST (convert strings to proper types)
+        normalized_settings = self._normalize_setting_types(settings)
+
+        # Build preset data
         preset_data = {
             'name': name,
             'display_name': name.replace('_', ' ').title(),
@@ -185,7 +347,7 @@ class PresetManager:
             'author': 'user',
             'category': 'user',
             'workflow': workflow,
-            'settings': settings
+            'settings': normalized_settings
         }
 
         # Normalize and validate the complete preset structure

--- a/Firmware/webui/backend/routes/camera.py
+++ b/Firmware/webui/backend/routes/camera.py
@@ -175,6 +175,50 @@ ALLOWED_CAMERA_SETTINGS = {
     'FocusPeakingAlgorithm': lambda v: str(v).lower() in ['laplacian', 'sobel', 'canny'],
 }
 
+# Liveview settings validation schema
+# These settings control the live preview stream and real-time camera controls
+ALLOWED_LIVEVIEW_SETTINGS = {
+    # Boolean controls - Enable/disable features
+    'focus_peaking_enabled': lambda v: str(v).lower() in ['true', 'false'],
+    'awb_enable': lambda v: str(v).lower() in ['true', 'false'],
+    'ae_enable': lambda v: str(v).lower() in ['true', 'false'],
+    'lens_shading_enable': lambda v: str(v).lower() in ['true', 'false'],
+    'defect_correction_enable': lambda v: str(v).lower() in ['true', 'false'],
+    'use_custom_tuning': lambda v: str(v).lower() in ['true', 'false'],
+
+    # Integer controls - Modes and discrete values
+    'noise_reduction_mode': lambda v: int(v) in [0, 1, 2],  # 0=Off, 1=Fast, 2=High Quality
+    'awb_mode': lambda v: 0 <= int(v) <= 7,  # 0=Auto, 1=Incandescent, ..., 7=Custom
+    'af_mode': lambda v: int(v) in [0, 1, 2],  # 0=Manual, 1=Auto Single, 2=Continuous
+    'af_speed': lambda v: int(v) in [0, 1],  # 0=Normal, 1=Fast
+    'af_range': lambda v: int(v) in [0, 1, 2],  # 0=Normal, 1=Macro, 2=Full
+    'ae_metering_mode': lambda v: int(v) in [0, 1, 2],  # 0=Centre, 1=Spot, 2=Matrix
+
+    # Stream configuration (integers)
+    'stream_width': lambda v: 640 <= int(v) <= 1920,
+    'stream_height': lambda v: 480 <= int(v) <= 1080,
+    'stream_quality': lambda v: 1 <= int(v) <= 100,  # JPEG quality
+    'stream_framerate': lambda v: 1 <= int(v) <= 60,
+
+    # Float controls - Continuous adjustments
+    'sharpness': lambda v: 0.0 <= float(v) <= 4.0,
+    'brightness': lambda v: -1.0 <= float(v) <= 1.0,
+    'contrast': lambda v: 0.0 <= float(v) <= 4.0,
+    'saturation': lambda v: 0.0 <= float(v) <= 4.0,
+    'analogue_gain': lambda v: 1.0 <= float(v) <= 16.0,  # ISO gain
+    'exposure_value': lambda v: -8.0 <= float(v) <= 8.0,  # EV compensation
+    'lens_position': lambda v: 0.0 <= float(v) <= 10.0,  # Diopters (manual focus)
+
+    # Color gains (floats) - for manual white balance
+    'colour_gains_red': lambda v: 1.0 <= float(v) <= 4.0,
+    'colour_gains_blue': lambda v: 1.0 <= float(v) <= 4.0,
+
+    # Focus peaking configuration
+    'focus_peaking_intensity': lambda v: 0.0 <= float(v) <= 200.0,
+    'focus_peaking_color': lambda v: str(v).lower() in ['green', 'red', 'yellow', 'cyan', 'magenta'],
+    'focus_peaking_algorithm': lambda v: str(v).lower() in ['laplacian', 'sobel', 'canny'],
+}
+
 camera_bp = Blueprint('camera', __name__)
 
 


### PR DESCRIPTION
## Summary
Fixes inconsistent type handling in preset files by normalizing all setting values to their proper JSON types (int, float, bool) instead of strings.

## Problem
When presets were created from current settings (`from_current=true`), values were read from CSV and TXT files as strings and saved to JSON as strings:
```json
{
  "liveview": {
    "noise_reduction_mode": "1",
    "awb_enable": "True",
    "sharpness": "1.0"
  }
}
```

When created from frontend data, proper JSON types were preserved:
```json
{
  "liveview": {
    "noise_reduction_mode": 1,
    "awb_enable": true,
    "sharpness": 1.0
  }
}
```

This inconsistency caused:
- Type conversion issues during validation
- Harder debugging ("1" vs 1 confusion)
- Potential validation inconsistencies
- Less readable JSON files

## Solution
Added automatic type normalization in `PresetManager.save_preset()`:

1. **New method `_normalize_setting_types()`**: Converts string values to proper types based on comprehensive schema mapping
2. **New method `_convert_value_type()`**: Handles individual setting conversions for camera and liveview settings
3. **New method `_infer_type()`**: Intelligently infers types for unknown fields
4. **Integration**: Type normalization runs automatically before validation in save flow

## Changes
- `webui/backend/preset_manager.py` - Added 158 lines of type normalization logic
- `Tests/unit/test_preset_type_normalization.py` - New file with 15 comprehensive unit tests

## Testing
All 15 unit tests pass ✓

Test coverage includes:
- String → int/float/bool conversions for camera settings
- String → int/float/bool conversions for liveview settings  
- Mixed type handling (some strings, some already correct types)
- Edge cases (empty settings, unknown fields)
- Integration with `save_preset()` method

## Impact
✅ All saved presets now use native JSON types regardless of source  
✅ Consistent serialization from CSV/TXT files and frontend JSON  
✅ Improved validation reliability  
✅ Enhanced debugging experience  
✅ Backward compatible with existing presets  

## Test Plan
- [x] Unit tests pass (15/15)
- [ ] Manual testing: Create preset using "Save As" button
- [ ] Manual testing: Create preset using "Update" button
- [ ] Manual testing: Verify JSON files contain proper types
- [ ] Manual testing: Apply presets and verify settings work correctly

Closes #60