### PR TITLE
feat: Add HDR/Focus Bracket series detection (Issue #110)

### DIFF
--- a/Firmware/CLAUDE.md
+++ b/Firmware/CLAUDE.md
@@ -170,6 +170,58 @@ sudo systemctl status gps-exif-tagger.service
 - Service auto-restarts on failure with exponential backoff
 - Compatible with all Mothbox photo formats (.jpg, .jpeg, case-insensitive)
 
+### Series Detection System (Issue #110)
+
+**Overview**: Automatic detection and grouping of HDR and Focus Bracket photo series based on TakePhoto.py naming patterns.
+
+**Naming Patterns** (from TakePhoto.py):
+- **HDR**: `{name}_{YYYY_MM_DD__HH_MM_SS}_HDR{index}.jpg` (e.g., `moth_2024_01_15__10_30_00_HDR0.jpg`)
+- **Focus Bracket**: `ManFocus_{name}_{YYYY_MM_DD__HH_MM_SS}_FB{index}.jpg` (e.g., `ManFocus_moth_2024_01_15__10_30_00_FB0.jpg`)
+
+**Architecture**:
+- **Library**: `webui/backend/lib/series_detection.py` - Core pattern matching (97.89% coverage)
+  - `detect_series_type()`: Parse filename to get series type and index
+  - `get_series_id()`: Generate unique grouping key for series
+  - `group_photos_into_series()`: Group photos by series ID
+
+- **Service**: `webui/backend/services/series_service.py` - Cached service layer (91.94% coverage)
+  - `SeriesService`: Thread-safe service with configurable cache TTL
+  - Methods: `get_series_for_directory()`, `get_series_by_id()`, `invalidate_cache()`, `get_statistics()`
+
+- **API**: `webui/backend/routes/gallery.py` - REST endpoints
+  - `GET /api/gallery/series`: List all series (paginated, filterable)
+  - `GET /api/gallery/series/<series_id>`: Get specific series details
+  - `GET /api/gallery/series/stats`: Get cache statistics
+  - `POST /api/gallery/series/cache/invalidate`: Invalidate cache
+
+**Performance Targets**:
+- Single filename parsing: <10ms
+- 1000 photos grouping: <100ms
+- Cache hit ratio: >80%
+
+**Usage**:
+```python
+from webui.backend.lib.series_detection import detect_series_type, get_series_id
+from webui.backend.services.series_service import SeriesService
+
+# Detect series type from filename
+info = detect_series_type(Path("moth_2024_01_15__10_30_00_HDR0.jpg"))
+# Returns: SeriesInfo(series_type="hdr", base_name="moth_2024_01_15__10_30_00", index=0)
+
+# Use service with caching
+service = SeriesService(cache_ttl=300)  # 5 minute cache
+series_list = service.get_series_for_directory("/var/lib/mothbox/photos")
+```
+
+**Testing**:
+- Unit tests: `Tests/unit/test_series_detection_lib.py` (48 tests)
+- Unit tests: `Tests/unit/test_series_service.py` (31 tests)
+- API tests: `Tests/unit/test_series_api.py` (17 tests)
+- Performance tests: `Tests/performance/test_series_detection_performance.py` (16 tests)
+
+**Documentation**:
+- `webui/docs/dev/api/gallery.md`: API documentation with Series Endpoints section
+
 ### Camera System
 
 Two camera workflows:
@@ -476,12 +528,15 @@ const lonDisplay = formatCoordinateDisplay(-122.4194, false);
 - `install_mothbox.sh`: Installation script with Pi detection and firmware selection
 - `webui/cli/gps_exif_tagger.py`: Main GPS EXIF embedding tool (CLI and watch mode)
 - `webui/backend/lib/gps_exif_lib.py`: GPS EXIF library (coordinate conversion, EXIF embedding, verification)
+- `webui/backend/lib/series_detection.py`: **Series detection library** (HDR/FB pattern matching, 97.89% coverage)
+- `webui/backend/services/series_service.py`: **Series service** (cached series queries, 91.94% coverage)
 - `webui/shared/gps_coordinates.py`: **GPS coordinate utilities** (decimal ↔ DMS conversion, validation, formatting) - webui-shared library
 - `webui/frontend/src/utils/gpsCoordinates.ts`: **GPS coordinate utilities (TypeScript)** (identical behavior to Python)
 - `webui/backend/app.py`: Flask app initialization, CSRF, CORS, SocketIO setup
 - `webui/backend/constants.py`: **Centralized constants** (camera timeouts, HDR/focus bracket settings, MJPEG encoder params, AF modes)
 - `webui/backend/liveview_stream.py`: Camera streaming engine (2500+ lines)
 - `webui/backend/routes/camera.py`: Camera control API (1270+ lines)
+- `webui/backend/routes/gallery.py`: Gallery API (photos, thumbnails, series endpoints)
 - `pyproject.toml`: pytest, coverage, bandit, and ruff configuration
 - `Tests/README.md`: Comprehensive testing documentation
 - `Tests/manual/gps_exif_service/`: GPS EXIF service manual testing procedures
@@ -489,6 +544,7 @@ const lonDisplay = formatCoordinateDisplay(-122.4194, false);
 - `webui/docs/GPS_COORDINATE_UTILITIES.md`: GPS coordinate conversion utilities documentation
 - `webui/docs/CAMERA_SETTINGS.md`: Camera settings and configuration guide
 - `webui/docs/LIVEVIEW_STREAMING.md`: LiveView streaming architecture and usage
+- `webui/docs/dev/api/gallery.md`: **Gallery API documentation** (photo, thumbnail, series endpoints)
 
 ## Development Workflow
 

--- a/Firmware/Tests/performance/test_series_detection_performance.py
+++ b/Firmware/Tests/performance/test_series_detection_performance.py
@@ -1,0 +1,419 @@
+"""
+Performance tests for Series Detection Algorithm (Issue #110)
+
+Validates performance targets:
+- Single filename parsing: <10ms
+- 1000 photos grouping: <100ms (with warm cache)
+- Cache hit ratio: >80%
+"""
+
+import pytest
+import time
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+
+# Import will fail until implementation exists
+try:
+    from webui.backend.lib.series_detection import (
+        detect_series_type,
+        get_series_id,
+        group_photos_into_series,
+    )
+    from webui.backend.services.series_service import SeriesService, PhotoSeries
+    IMPLEMENTATION_EXISTS = True
+except ImportError:
+    IMPLEMENTATION_EXISTS = False
+
+
+pytestmark = pytest.mark.skipif(
+    not IMPLEMENTATION_EXISTS,
+    reason="Implementation not yet created"
+)
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+@pytest.fixture
+def temp_photos_dir(tmp_path):
+    """Create a temporary photos directory."""
+    photos_dir = tmp_path / "photos"
+    photos_dir.mkdir()
+    return photos_dir
+
+
+@pytest.fixture
+def large_photo_set(temp_photos_dir):
+    """Create 1000 photos for performance testing (mix of series and singles)."""
+    photos = []
+
+    # Create 100 HDR series (3 photos each = 300 photos)
+    for series_num in range(100):
+        base = f"moth_2024_01_{series_num:02d}__10_00_00"
+        for i in range(3):
+            p = temp_photos_dir / f"{base}_HDR{i}.jpg"
+            p.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+            photos.append(p)
+
+    # Create 100 Focus Bracket series (5 photos each = 500 photos)
+    for series_num in range(100):
+        base = f"ManFocus_moth_2024_02_{series_num:02d}__11_00_00"
+        for i in range(5):
+            p = temp_photos_dir / f"{base}_FB{i}.jpg"
+            p.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+            photos.append(p)
+
+    # Create 200 single photos (non-series)
+    for i in range(200):
+        p = temp_photos_dir / f"single_2024_03_{i:03d}__12_00_00.jpg"
+        p.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+        photos.append(p)
+
+    return photos  # Total: 1000 photos
+
+
+@pytest.fixture
+def series_service():
+    """Create a fresh SeriesService instance."""
+    return SeriesService(cache_ttl=60)
+
+
+# ============================================================================
+# Single Filename Parsing Performance (<10ms)
+# ============================================================================
+
+class TestSingleFilenameParsing:
+    """Test single filename parsing performance."""
+
+    def test_hdr_filename_parsing_under_10ms(self):
+        """Parsing HDR filename should complete in <10ms."""
+        filename = Path("moth_2024_01_15__10_30_00_HDR0.jpg")
+
+        start = time.perf_counter()
+        for _ in range(100):  # Run 100 times for stable measurement
+            result = detect_series_type(filename)
+        elapsed = (time.perf_counter() - start) / 100  # Average
+
+        assert result is not None
+        assert result.series_type == "hdr"
+        assert elapsed < 0.010, f"Parsing took {elapsed*1000:.2f}ms, expected <10ms"
+
+    def test_focus_bracket_filename_parsing_under_10ms(self):
+        """Parsing Focus Bracket filename should complete in <10ms."""
+        filename = Path("ManFocus_moth_2024_01_15__10_30_00_000000_FB0.jpg")
+
+        start = time.perf_counter()
+        for _ in range(100):
+            result = detect_series_type(filename)
+        elapsed = (time.perf_counter() - start) / 100
+
+        assert result is not None
+        assert result.series_type == "focus_bracket"
+        assert elapsed < 0.010, f"Parsing took {elapsed*1000:.2f}ms, expected <10ms"
+
+    def test_non_series_filename_parsing_under_10ms(self):
+        """Parsing non-series filename should complete in <10ms."""
+        filename = Path("regular_photo_2024_01_15__10_30_00.jpg")
+
+        start = time.perf_counter()
+        for _ in range(100):
+            result = detect_series_type(filename)
+        elapsed = (time.perf_counter() - start) / 100
+
+        assert result is None  # Not a series
+        assert elapsed < 0.010, f"Parsing took {elapsed*1000:.2f}ms, expected <10ms"
+
+    def test_get_series_id_under_10ms(self):
+        """get_series_id() should complete in <10ms."""
+        filenames = [
+            Path("moth_2024_01_15__10_30_00_HDR0.jpg"),
+            Path("ManFocus_moth_2024_01_15__10_30_00_FB0.jpg"),
+            Path("regular_photo.jpg"),
+        ]
+
+        for filename in filenames:
+            start = time.perf_counter()
+            for _ in range(100):
+                get_series_id(filename)
+            elapsed = (time.perf_counter() - start) / 100
+
+            assert elapsed < 0.010, f"get_series_id took {elapsed*1000:.2f}ms for {filename}"
+
+
+# ============================================================================
+# Batch Grouping Performance (<100ms for 1000 photos)
+# ============================================================================
+
+class TestBatchGroupingPerformance:
+    """Test grouping performance for large photo sets."""
+
+    def test_group_1000_photos_under_100ms(self, large_photo_set):
+        """Grouping 1000 photos should complete in <100ms."""
+        start = time.perf_counter()
+        result = group_photos_into_series(large_photo_set)
+        elapsed = time.perf_counter() - start
+
+        # Verify correct grouping (200 series: 100 HDR + 100 FB)
+        assert len(result) == 200, f"Expected 200 series, got {len(result)}"
+
+        # Verify performance
+        assert elapsed < 0.100, f"Grouping took {elapsed*1000:.1f}ms, expected <100ms"
+
+    def test_service_scan_1000_photos_under_500ms(self, series_service, large_photo_set, temp_photos_dir):
+        """SeriesService should scan 1000 photos in <500ms (first scan, cold cache)."""
+        start = time.perf_counter()
+        result = series_service.get_series_for_directory(temp_photos_dir)
+        elapsed = time.perf_counter() - start
+
+        # Should find 200 series
+        assert len(result) == 200
+
+        # First scan can be slower due to I/O, but should still be reasonable
+        assert elapsed < 0.500, f"Service scan took {elapsed*1000:.1f}ms, expected <500ms"
+
+    def test_service_cached_lookup_under_10ms(self, series_service, large_photo_set, temp_photos_dir):
+        """Cached lookups should complete in <10ms."""
+        # Warm the cache
+        series_service.get_series_for_directory(temp_photos_dir)
+
+        # Measure cached lookup
+        start = time.perf_counter()
+        for _ in range(10):
+            result = series_service.get_series_for_directory(temp_photos_dir)
+        elapsed = (time.perf_counter() - start) / 10
+
+        assert len(result) == 200
+        assert elapsed < 0.010, f"Cached lookup took {elapsed*1000:.2f}ms, expected <10ms"
+
+
+# ============================================================================
+# Cache Hit Ratio (>80%)
+# ============================================================================
+
+class TestCacheEfficiency:
+    """Test cache hit ratio targets."""
+
+    def test_cache_hit_ratio_above_80_percent(self, series_service, large_photo_set, temp_photos_dir):
+        """Cache hit ratio should exceed 80% for typical usage patterns."""
+        # Initial scan (cache miss)
+        series_service.get_series_for_directory(temp_photos_dir)
+
+        # Simulate typical usage: 10 repeated queries
+        for _ in range(10):
+            series_service.get_series_for_directory(temp_photos_dir)
+
+        stats = series_service.get_statistics()
+
+        total = stats['cache_hits'] + stats['cache_misses']
+        hit_ratio = stats['cache_hits'] / total if total > 0 else 0
+
+        # Should have 10 hits and 1 miss = 90.9% hit rate
+        assert hit_ratio >= 0.80, f"Cache hit ratio {hit_ratio*100:.1f}%, expected >80%"
+
+    def test_cache_statistics_tracking(self, series_service, large_photo_set, temp_photos_dir):
+        """Cache statistics should be accurately tracked."""
+        initial_stats = series_service.get_statistics()
+        assert initial_stats['cache_hits'] == 0
+        assert initial_stats['cache_misses'] == 0
+
+        # First call - cache miss
+        series_service.get_series_for_directory(temp_photos_dir)
+        stats_after_first = series_service.get_statistics()
+        assert stats_after_first['cache_misses'] == 1
+
+        # Second call - cache hit
+        series_service.get_series_for_directory(temp_photos_dir)
+        stats_after_second = series_service.get_statistics()
+        assert stats_after_second['cache_hits'] == 1
+
+    def test_cache_invalidation_forces_rescan(self, series_service, large_photo_set, temp_photos_dir):
+        """Cache invalidation should force a rescan."""
+        # Warm cache
+        series_service.get_series_for_directory(temp_photos_dir)
+
+        # Invalidate
+        series_service.invalidate_cache()
+
+        # Next call should be a cache miss
+        series_service.get_series_for_directory(temp_photos_dir)
+
+        stats = series_service.get_statistics()
+        assert stats['cache_misses'] == 2  # Initial + after invalidation
+
+
+# ============================================================================
+# Concurrent Access Performance
+# ============================================================================
+
+class TestConcurrentAccessPerformance:
+    """Test performance under concurrent access."""
+
+    def test_concurrent_reads_no_contention(self, series_service, large_photo_set, temp_photos_dir):
+        """Concurrent reads should not cause significant contention."""
+        # Warm cache
+        series_service.get_series_for_directory(temp_photos_dir)
+
+        results = []
+        errors = []
+
+        def reader():
+            try:
+                start = time.perf_counter()
+                result = series_service.get_series_for_directory(temp_photos_dir)
+                elapsed = time.perf_counter() - start
+                results.append((len(result), elapsed))
+            except Exception as e:
+                errors.append(str(e))
+
+        # Start 10 concurrent readers
+        threads = [threading.Thread(target=reader) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # No errors
+        assert len(errors) == 0, f"Errors: {errors}"
+
+        # All readers got correct results
+        for count, elapsed in results:
+            assert count == 200
+            assert elapsed < 0.100, f"Concurrent read took {elapsed*1000:.1f}ms"
+
+    def test_mixed_read_write_operations(self, series_service, large_photo_set, temp_photos_dir):
+        """Mixed read/write operations should not deadlock."""
+        # Warm cache
+        series_service.get_series_for_directory(temp_photos_dir)
+
+        results = []
+        errors = []
+
+        def reader():
+            try:
+                for _ in range(5):
+                    series_service.get_series_for_directory(temp_photos_dir)
+                results.append("read_ok")
+            except Exception as e:
+                errors.append(f"read: {e}")
+
+        def writer():
+            try:
+                for _ in range(3):
+                    series_service.invalidate_cache()
+                    time.sleep(0.001)
+                results.append("write_ok")
+            except Exception as e:
+                errors.append(f"write: {e}")
+
+        # Start mixed operations
+        threads = []
+        for _ in range(5):
+            threads.append(threading.Thread(target=reader))
+        for _ in range(2):
+            threads.append(threading.Thread(target=writer))
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5.0)  # 5 second timeout to detect deadlocks
+
+        # Check for timeouts (deadlock indicator)
+        alive = [t for t in threads if t.is_alive()]
+        assert len(alive) == 0, "Potential deadlock detected"
+
+        # No errors
+        assert len(errors) == 0, f"Errors: {errors}"
+
+
+# ============================================================================
+# Memory Efficiency
+# ============================================================================
+
+class TestMemoryEfficiency:
+    """Test memory usage patterns."""
+
+    def test_photoSeries_dataclass_memory_footprint(self, temp_photos_dir):
+        """PhotoSeries dataclass should have reasonable memory footprint."""
+        import sys
+
+        # Create a PhotoSeries with 5 photos
+        photos = [temp_photos_dir / f"photo_{i}.jpg" for i in range(5)]
+        for p in photos:
+            p.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+
+        series = PhotoSeries(
+            series_id="test_series",
+            series_type="hdr",
+            base_name="test_2024_01_15__10_00_00",
+            photos=photos,
+            count=5,
+            cover_photo=photos[0]
+        )
+
+        # Check basic size (rough estimate)
+        size = sys.getsizeof(series)
+        # Dataclass overhead should be minimal (<500 bytes excluding paths)
+        assert size < 500, f"PhotoSeries overhead {size} bytes, expected <500"
+
+    def test_service_cache_does_not_grow_unbounded(self, series_service, tmp_path):
+        """Cache should not grow unbounded when scanning multiple directories."""
+        # Create and scan 10 different directories
+        for i in range(10):
+            dir_path = tmp_path / f"photos_{i}"
+            dir_path.mkdir()
+
+            # Create some photos in each
+            for j in range(10):
+                p = dir_path / f"moth_2024_01_{i:02d}__10_00_0{j}_HDR0.jpg"
+                p.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+
+            series_service.get_series_for_directory(dir_path)
+
+        stats = series_service.get_statistics()
+
+        # Cache should contain all 10 directories
+        assert stats['cache_entries'] == 10
+
+        # Total series should be 10 (one per directory, since we only made HDR0 files)
+        # Actually 0 because single photos don't form series (count < 2)
+        assert stats['total_series'] == 0
+
+
+# ============================================================================
+# Regression Tests for Known Performance Issues
+# ============================================================================
+
+class TestPerformanceRegressions:
+    """Prevent known performance regressions."""
+
+    def test_regex_compilation_is_cached(self):
+        """Regex patterns should be pre-compiled (not compiled on each call)."""
+        # This is a code quality check - patterns should be module-level constants
+        from webui.backend.lib import series_detection
+
+        # Check that patterns exist as module-level attributes
+        assert hasattr(series_detection, 'HDR_PATTERN')
+        assert hasattr(series_detection, 'FB_PATTERN')
+
+    def test_no_excessive_file_io_on_repeated_calls(self, series_service, large_photo_set, temp_photos_dir):
+        """Repeated calls should use cache, not re-scan filesystem."""
+        # First call
+        series_service.get_series_for_directory(temp_photos_dir)
+
+        # Track glob calls
+        glob_calls = []
+        original_glob = Path.glob
+
+        def tracking_glob(self, pattern):
+            glob_calls.append(pattern)
+            return original_glob(self, pattern)
+
+        # Second call (should hit cache)
+        with patch.object(Path, 'glob', tracking_glob):
+            series_service.get_series_for_directory(temp_photos_dir)
+
+        # No glob calls should have been made (cache hit)
+        assert len(glob_calls) == 0, f"Unexpected glob calls: {glob_calls}"

--- a/Firmware/Tests/unit/test_metadata_service.py
+++ b/Firmware/Tests/unit/test_metadata_service.py
@@ -142,12 +142,13 @@ def sample_hdr_series(temp_photos_dir):
     Create a series of HDR photos with sequential numbering (module-scoped)
 
     Simulates Mothbox HDR capture workflow.
+    Uses correct naming pattern from TakePhoto.py: {name}_{timestamp}_HDR{index}.jpg
     """
     photos = []
     base_name = "mothbox_2024_10_15__14_30_00"
 
-    for i in range(1, 4):
-        photo_path = temp_photos_dir / f"{base_name}_{i}.jpg"
+    for i in range(3):  # HDR0, HDR1, HDR2 (0-indexed)
+        photo_path = temp_photos_dir / f"{base_name}_HDR{i}.jpg"
 
         # Skip if already exists
         if not photo_path.exists():
@@ -166,12 +167,13 @@ def sample_focus_bracket_series(temp_photos_dir):
     Create a series of focus bracket photos (module-scoped)
 
     Simulates Mothbox focus stacking workflow.
+    Uses correct naming pattern from capture_focus_bracket.py: ManFocus_{name}_{timestamp}_FB{index}.jpg
     """
     photos = []
-    base_name = "mothbox_2024_10_15__15_00_00"
+    base_name = "ManFocus_mothbox_2024_10_15__15_00_00"
 
-    for i in range(1, 6):
-        photo_path = temp_photos_dir / f"{base_name}_focus_{i}.jpg"
+    for i in range(5):  # FB0, FB1, FB2, FB3, FB4 (0-indexed)
+        photo_path = temp_photos_dir / f"{base_name}_FB{i}.jpg"
 
         # Skip if already exists
         if not photo_path.exists():
@@ -506,23 +508,23 @@ class TestHDRFocusBracketDetection:
 
     def test_detect_hdr_series(self, metadata_service, sample_hdr_series):
         """Test detection of HDR photo series"""
-        # Test middle photo of series
+        # Test middle photo of series (HDR1)
         metadata = metadata_service.get_photo_metadata(sample_hdr_series[1])
 
         deployment = metadata['deployment']
         assert deployment['series_type'] == 'hdr'
         assert deployment['series_count'] == 3
-        assert deployment['series_index'] == 2  # Middle photo (1-indexed)
+        assert deployment['series_index'] == 1  # Middle photo (0-indexed: HDR1)
 
     def test_detect_focus_bracket_series(self, metadata_service, sample_focus_bracket_series):
         """Test detection of focus bracket photo series"""
-        # Test first photo of series
+        # Test first photo of series (FB0)
         metadata = metadata_service.get_photo_metadata(sample_focus_bracket_series[0])
 
         deployment = metadata['deployment']
         assert deployment['series_type'] == 'focus_bracket'
         assert deployment['series_count'] == 5
-        assert deployment['series_index'] == 1
+        assert deployment['series_index'] == 0  # First photo (0-indexed: FB0)
 
     def test_single_photo_has_no_series(self, metadata_service, sample_photo_with_exif):
         """Test single photo not part of series"""
@@ -755,42 +757,42 @@ class TestSeriesDetectionEdgeCases:
     """Test _detect_series_info() method with various edge cases"""
 
     def test_hdr_series_detection_pattern(self, metadata_service, temp_photos_dir):
-        """Test HDR series detection with standard pattern (e.g., photo_HDR_1of3.jpg)"""
-        # Create HDR series with explicit pattern
+        """Test HDR series detection with standard pattern (e.g., photo_2024_01_15__10_00_00_HDR0.jpg)"""
+        # Create HDR series with correct TakePhoto.py pattern
         base_name = "mothbox_2024_11_01__10_00_00"
         photos = []
-        for i in range(1, 4):
-            photo_path = temp_photos_dir / f"{base_name}_{i}.jpg"
+        for i in range(3):  # 0-indexed: HDR0, HDR1, HDR2
+            photo_path = temp_photos_dir / f"{base_name}_HDR{i}.jpg"
             img = Image.new('RGB', (640, 480), color='red')
             img.save(photo_path, "JPEG")
             photos.append(photo_path)
 
-        # Test detection on middle photo
+        # Test detection on middle photo (HDR1)
         metadata = metadata_service.get_photo_metadata(photos[1])
         deployment = metadata['deployment']
 
         assert deployment['series_type'] == 'hdr'
         assert deployment['series_count'] == 3
-        assert deployment['series_index'] == 2
+        assert deployment['series_index'] == 1  # 0-indexed
 
     def test_focus_bracket_series_detection_pattern(self, metadata_service, temp_photos_dir):
-        """Test focus bracket series detection with standard pattern"""
-        # Create focus bracket series
+        """Test focus bracket series detection with standard pattern (ManFocus_{name}_FB{N}.jpg)"""
+        # Create focus bracket series with correct TakePhoto.py pattern
         base_name = "mothbox_2024_11_01__10_30_00"
         photos = []
-        for i in range(1, 6):
-            photo_path = temp_photos_dir / f"{base_name}_focus_{i}.jpg"
+        for i in range(5):  # 0-indexed: FB0, FB1, FB2, FB3, FB4
+            photo_path = temp_photos_dir / f"ManFocus_{base_name}_FB{i}.jpg"
             img = Image.new('RGB', (640, 480), color='blue')
             img.save(photo_path, "JPEG")
             photos.append(photo_path)
 
-        # Test detection on first photo
+        # Test detection on first photo (FB0)
         metadata = metadata_service.get_photo_metadata(photos[0])
         deployment = metadata['deployment']
 
         assert deployment['series_type'] == 'focus_bracket'
         assert deployment['series_count'] == 5
-        assert deployment['series_index'] == 1
+        assert deployment['series_index'] == 0  # 0-indexed
 
     def test_single_photo_not_part_of_series(self, metadata_service, temp_photos_dir):
         """Test single photo that's not part of any series"""
@@ -819,36 +821,36 @@ class TestSeriesDetectionEdgeCases:
         assert deployment['series_type'] is None
 
     def test_missing_series_files_incomplete(self, metadata_service, temp_photos_dir):
-        """Test series with missing files (e.g., 1of3, 3of3 but no 2of3)"""
+        """Test series with missing files (e.g., HDR0, HDR2 but no HDR1)"""
         # Create incomplete HDR series (missing middle photo)
         base_name = "mothbox_2024_11_01__12_00_00"
-        photo1 = temp_photos_dir / f"{base_name}_1.jpg"
-        photo3 = temp_photos_dir / f"{base_name}_3.jpg"
+        photo0 = temp_photos_dir / f"{base_name}_HDR0.jpg"
+        photo2 = temp_photos_dir / f"{base_name}_HDR2.jpg"
 
         img = Image.new('RGB', (640, 480), color='orange')
-        img.save(photo1, "JPEG")
-        img.save(photo3, "JPEG")
+        img.save(photo0, "JPEG")
+        img.save(photo2, "JPEG")
 
         # Test detection - should still detect as series with count=2
-        metadata = metadata_service.get_photo_metadata(photo1)
+        metadata = metadata_service.get_photo_metadata(photo0)
         deployment = metadata['deployment']
 
         assert deployment['series_type'] == 'hdr'
         assert deployment['series_count'] == 2  # Only 2 files exist
-        assert deployment['series_index'] == 1
+        assert deployment['series_index'] == 0  # 0-indexed
 
     def test_series_glob_failure_handling(self, metadata_service, temp_photos_dir):
         """Test handling when glob operation fails during series detection"""
-        # Create a focus bracket photo (focus bracket returns early with series info even on glob failure)
-        photo_path = temp_photos_dir / "mothbox_2024_11_01__13_00_00_focus_5.jpg"
+        # Create a focus bracket photo with correct TakePhoto.py pattern
+        photo_path = temp_photos_dir / "ManFocus_mothbox_2024_11_01__13_00_00_FB5.jpg"
         img = Image.new('RGB', (640, 480), color='purple')
         img.save(photo_path, "JPEG")
 
-        # Mock glob on parent_dir to raise OSError after pattern is matched
+        # Mock glob on parent_dir to raise OSError when listing jpg files
         original_glob = Path.glob
         def mock_glob(self, pattern):
-            # Only raise error when called during series detection
-            if "_focus_" in str(pattern):
+            # The implementation uses "*.jpg" or "*.JPG" to count series files
+            if pattern in ("*.jpg", "*.JPG"):
                 raise OSError("Permission denied")
             return original_glob(self, pattern)
 
@@ -860,14 +862,14 @@ class TestSeriesDetectionEdgeCases:
             # series_count is None due to glob failure, but type and index are still detected
             assert deployment['series_type'] == 'focus_bracket'
             assert deployment['series_count'] is None  # Glob failed
-            assert deployment['series_index'] == 5
+            assert deployment['series_index'] == 5  # 0-indexed
 
     def test_series_with_different_naming_conventions(self, metadata_service, temp_photos_dir):
-        """Test series with non-standard naming conventions"""
-        # Create photos with different naming pattern
+        """Test series with non-standard device naming conventions"""
+        # Create photos with different device name but correct HDR pattern
         photos = []
-        for i in range(1, 4):
-            photo_path = temp_photos_dir / f"custom_device_2024_11_01__14_00_00_{i}.jpg"
+        for i in range(3):  # 0-indexed: HDR0, HDR1, HDR2
+            photo_path = temp_photos_dir / f"custom_device_2024_11_01__14_00_00_HDR{i}.jpg"
             img = Image.new('RGB', (640, 480), color='pink')
             img.save(photo_path, "JPEG")
             photos.append(photo_path)
@@ -878,26 +880,26 @@ class TestSeriesDetectionEdgeCases:
 
         assert deployment['series_type'] == 'hdr'
         assert deployment['series_count'] == 3
-        assert deployment['series_index'] == 1
+        assert deployment['series_index'] == 0  # 0-indexed
 
     def test_large_series_10_plus_photos(self, metadata_service, temp_photos_dir):
         """Test series with 10+ photos (e.g., extensive focus bracket)"""
-        # Create large focus bracket series
+        # Create large focus bracket series with correct TakePhoto.py pattern
         base_name = "mothbox_2024_11_01__15_00_00"
         photos = []
-        for i in range(1, 13):  # 12 photos
-            photo_path = temp_photos_dir / f"{base_name}_focus_{i}.jpg"
+        for i in range(12):  # 0-indexed: FB0 through FB11
+            photo_path = temp_photos_dir / f"ManFocus_{base_name}_FB{i}.jpg"
             img = Image.new('RGB', (640, 480), color='cyan')
             img.save(photo_path, "JPEG")
             photos.append(photo_path)
 
-        # Test detection on middle photo
+        # Test detection on middle photo (FB5)
         metadata = metadata_service.get_photo_metadata(photos[5])
         deployment = metadata['deployment']
 
         assert deployment['series_type'] == 'focus_bracket'
         assert deployment['series_count'] == 12
-        assert deployment['series_index'] == 6
+        assert deployment['series_index'] == 5  # 0-indexed
 
 
 # ============================================================================

--- a/Firmware/Tests/unit/test_series_api.py
+++ b/Firmware/Tests/unit/test_series_api.py
@@ -1,0 +1,374 @@
+"""
+Unit tests for Series API endpoints (Issue #110 - Phase 3)
+
+Tests REST API endpoints for series queries.
+TDD approach: tests written first, then implementation.
+
+Coverage Target: 90%+
+"""
+
+import pytest
+import json
+from pathlib import Path
+from unittest.mock import Mock, patch, MagicMock
+from flask import Flask
+
+
+# Import will fail until implementation exists - that's expected in TDD
+try:
+    from routes.gallery import gallery_bp
+    from services.series_service import SeriesService, PhotoSeries
+    IMPLEMENTATION_EXISTS = True
+except ImportError:
+    IMPLEMENTATION_EXISTS = False
+    gallery_bp = None
+    SeriesService = None
+    PhotoSeries = None
+
+
+# Skip all tests if implementation doesn't exist yet (TDD red phase)
+pytestmark = pytest.mark.skipif(
+    not IMPLEMENTATION_EXISTS,
+    reason="Implementation not yet created (TDD red phase)"
+)
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+@pytest.fixture
+def temp_photos_dir(tmp_path, monkeypatch):
+    """Temporary PHOTOS_DIR for tests."""
+    photos_dir = tmp_path / "photos"
+    photos_dir.mkdir()
+
+    import mothbox_paths
+    monkeypatch.setattr(mothbox_paths, 'PHOTOS_DIR', photos_dir)
+
+    import routes.gallery
+    monkeypatch.setattr(routes.gallery, 'PHOTOS_DIR', photos_dir)
+
+    return photos_dir
+
+
+@pytest.fixture
+def sample_hdr_series(temp_photos_dir):
+    """Create sample HDR series."""
+    base = "moth_2024_01_15__10_00_00"
+    photos = []
+    for i in range(3):
+        p = temp_photos_dir / f"{base}_HDR{i}.jpg"
+        p.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+        photos.append(p)
+    return photos
+
+
+@pytest.fixture
+def sample_fb_series(temp_photos_dir):
+    """Create sample Focus Bracket series."""
+    base = "ManFocus_moth_2024_01_15__11_00_00_000000"
+    photos = []
+    for i in range(5):
+        p = temp_photos_dir / f"{base}_FB{i}.jpg"
+        p.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+        photos.append(p)
+    return photos
+
+
+@pytest.fixture
+def gallery_app(temp_photos_dir):
+    """Flask app with gallery blueprint."""
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+
+    # Create a mock series service
+    mock_service = Mock(spec=SeriesService)
+    app.config['SERIES_SERVICE'] = mock_service
+
+    app.register_blueprint(gallery_bp, url_prefix='/api/gallery')
+    return app
+
+
+@pytest.fixture
+def gallery_client(gallery_app):
+    """Test client for gallery routes."""
+    return gallery_app.test_client()
+
+
+@pytest.fixture
+def mock_photo_series(temp_photos_dir):
+    """Create mock PhotoSeries objects."""
+    return [
+        PhotoSeries(
+            series_id="hdr_moth_2024_01_15__10_00_00",
+            series_type="hdr",
+            base_name="moth_2024_01_15__10_00_00",
+            photos=[
+                temp_photos_dir / "moth_2024_01_15__10_00_00_HDR0.jpg",
+                temp_photos_dir / "moth_2024_01_15__10_00_00_HDR1.jpg",
+                temp_photos_dir / "moth_2024_01_15__10_00_00_HDR2.jpg",
+            ],
+            count=3,
+            cover_photo=temp_photos_dir / "moth_2024_01_15__10_00_00_HDR0.jpg"
+        ),
+        PhotoSeries(
+            series_id="focus_bracket_ManFocus_moth_2024_01_15__11_00_00_000000",
+            series_type="focus_bracket",
+            base_name="ManFocus_moth_2024_01_15__11_00_00_000000",
+            photos=[
+                temp_photos_dir / "ManFocus_moth_2024_01_15__11_00_00_000000_FB0.jpg",
+                temp_photos_dir / "ManFocus_moth_2024_01_15__11_00_00_000000_FB1.jpg",
+            ],
+            count=2,
+            cover_photo=temp_photos_dir / "ManFocus_moth_2024_01_15__11_00_00_000000_FB0.jpg"
+        ),
+    ]
+
+
+# ============================================================================
+# Test GET /series Endpoint
+# ============================================================================
+
+class TestSeriesListEndpoint:
+    """Tests for GET /api/gallery/series endpoint."""
+
+    def test_list_series_empty(self, gallery_app, gallery_client, temp_photos_dir):
+        """GET /series returns empty list when no series exist."""
+        # Configure mock
+        gallery_app.config['SERIES_SERVICE'].get_series_for_directory.return_value = []
+
+        response = gallery_client.get('/api/gallery/series')
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert 'series' in data
+        assert data['series'] == []
+
+    def test_list_series_returns_series(self, gallery_app, gallery_client, mock_photo_series, temp_photos_dir):
+        """GET /series returns series with correct structure."""
+        gallery_app.config['SERIES_SERVICE'].get_series_for_directory.return_value = mock_photo_series
+
+        response = gallery_client.get('/api/gallery/series')
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert 'series' in data
+        assert len(data['series']) == 2
+
+        # Check first series structure
+        series = data['series'][0]
+        assert 'series_id' in series
+        assert 'series_type' in series
+        assert 'count' in series
+        assert 'cover_photo' in series
+        assert 'photos' in series
+
+    def test_list_series_with_pagination(self, gallery_app, gallery_client, mock_photo_series):
+        """GET /series?page=1&per_page=10 returns paginated results."""
+        gallery_app.config['SERIES_SERVICE'].get_series_for_directory.return_value = mock_photo_series
+
+        response = gallery_client.get('/api/gallery/series?page=1&per_page=10')
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert 'pagination' in data
+        assert data['pagination']['page'] == 1
+        assert data['pagination']['per_page'] == 10
+
+    def test_list_series_filter_by_type(self, gallery_app, gallery_client, mock_photo_series):
+        """GET /series?type=hdr filters by series type."""
+        # Only return HDR series
+        hdr_series = [s for s in mock_photo_series if s.series_type == "hdr"]
+        gallery_app.config['SERIES_SERVICE'].get_series_for_directory.return_value = hdr_series
+
+        response = gallery_client.get('/api/gallery/series?type=hdr')
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert all(s['series_type'] == 'hdr' for s in data['series'])
+
+    def test_list_series_invalid_page(self, gallery_app, gallery_client):
+        """GET /series?page=-1 returns 400."""
+        response = gallery_client.get('/api/gallery/series?page=-1')
+
+        assert response.status_code == 400
+        data = json.loads(response.data)
+        assert 'error' in data
+
+    def test_list_series_service_unavailable(self, gallery_app, gallery_client):
+        """GET /series returns 503 when service unavailable."""
+        gallery_app.config['SERIES_SERVICE'] = None
+
+        response = gallery_client.get('/api/gallery/series')
+
+        assert response.status_code == 503
+        data = json.loads(response.data)
+        assert 'error' in data
+
+
+# ============================================================================
+# Test GET /series/<series_id> Endpoint
+# ============================================================================
+
+class TestSeriesDetailEndpoint:
+    """Tests for GET /api/gallery/series/<series_id> endpoint."""
+
+    def test_get_series_by_id(self, gallery_app, gallery_client, mock_photo_series, temp_photos_dir):
+        """GET /series/<id> returns specific series."""
+        series_id = mock_photo_series[0].series_id
+        gallery_app.config['SERIES_SERVICE'].get_series_by_id.return_value = mock_photo_series[0]
+
+        response = gallery_client.get(f'/api/gallery/series/{series_id}')
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data['series_id'] == series_id
+        assert data['series_type'] == 'hdr'
+        assert data['count'] == 3
+
+    def test_get_series_not_found(self, gallery_app, gallery_client):
+        """GET /series/<id> returns 404 for nonexistent series."""
+        gallery_app.config['SERIES_SERVICE'].get_series_by_id.return_value = None
+
+        response = gallery_client.get('/api/gallery/series/nonexistent_id')
+
+        assert response.status_code == 404
+        data = json.loads(response.data)
+        assert 'error' in data
+
+    def test_get_series_includes_photos(self, gallery_app, gallery_client, mock_photo_series, temp_photos_dir):
+        """GET /series/<id> includes photo list."""
+        series_id = mock_photo_series[0].series_id
+        gallery_app.config['SERIES_SERVICE'].get_series_by_id.return_value = mock_photo_series[0]
+
+        response = gallery_client.get(f'/api/gallery/series/{series_id}')
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert 'photos' in data
+        assert len(data['photos']) == 3
+
+    def test_get_series_includes_cover_photo(self, gallery_app, gallery_client, mock_photo_series, temp_photos_dir):
+        """GET /series/<id> includes cover photo path."""
+        series_id = mock_photo_series[0].series_id
+        gallery_app.config['SERIES_SERVICE'].get_series_by_id.return_value = mock_photo_series[0]
+
+        response = gallery_client.get(f'/api/gallery/series/{series_id}')
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert 'cover_photo' in data
+        assert 'HDR0' in data['cover_photo']
+
+
+# ============================================================================
+# Test Series Cache Endpoints
+# ============================================================================
+
+class TestSeriesCacheEndpoints:
+    """Tests for series cache management endpoints."""
+
+    def test_get_series_statistics(self, gallery_app, gallery_client):
+        """GET /series/stats returns cache statistics."""
+        gallery_app.config['SERIES_SERVICE'].get_statistics.return_value = {
+            'cache_entries': 5,
+            'cache_hits': 42,
+            'cache_misses': 8,
+            'total_series': 10,
+            'series_by_type': {'hdr': 6, 'focus_bracket': 4}
+        }
+
+        response = gallery_client.get('/api/gallery/series/stats')
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data['cache_hits'] == 42
+        assert data['total_series'] == 10
+
+    def test_invalidate_series_cache(self, gallery_app, gallery_client):
+        """POST /series/cache/invalidate clears cache."""
+        response = gallery_client.post(
+            '/api/gallery/series/cache/invalidate',
+            data=json.dumps({}),
+            content_type='application/json'
+        )
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data['success'] is True
+
+        # Verify service was called
+        gallery_app.config['SERIES_SERVICE'].invalidate_cache.assert_called_once()
+
+    def test_invalidate_series_cache_service_unavailable(self, gallery_app, gallery_client):
+        """POST /series/cache/invalidate returns 503 when service unavailable."""
+        gallery_app.config['SERIES_SERVICE'] = None
+
+        response = gallery_client.post(
+            '/api/gallery/series/cache/invalidate',
+            data=json.dumps({}),
+            content_type='application/json'
+        )
+
+        assert response.status_code == 503
+
+
+# ============================================================================
+# Test Photo Path Handling
+# ============================================================================
+
+class TestSeriesPhotoPathHandling:
+    """Tests for photo path security and formatting."""
+
+    def test_series_photo_paths_relative(self, gallery_app, gallery_client, mock_photo_series, temp_photos_dir):
+        """Series photo paths should be relative to PHOTOS_DIR."""
+        gallery_app.config['SERIES_SERVICE'].get_series_by_id.return_value = mock_photo_series[0]
+
+        response = gallery_client.get(f'/api/gallery/series/{mock_photo_series[0].series_id}')
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+
+        # Photo paths should be relative (no absolute paths exposed)
+        for photo in data['photos']:
+            assert not photo.startswith('/var')
+            assert not photo.startswith('/home')
+
+    def test_cover_photo_path_relative(self, gallery_app, gallery_client, mock_photo_series, temp_photos_dir):
+        """Cover photo path should be relative."""
+        gallery_app.config['SERIES_SERVICE'].get_series_by_id.return_value = mock_photo_series[0]
+
+        response = gallery_client.get(f'/api/gallery/series/{mock_photo_series[0].series_id}')
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+
+        # Cover photo should be relative
+        assert not data['cover_photo'].startswith('/var')
+
+
+# ============================================================================
+# Test Error Handling
+# ============================================================================
+
+class TestSeriesErrorHandling:
+    """Tests for error handling in series endpoints."""
+
+    def test_service_exception_returns_500(self, gallery_app, gallery_client):
+        """Service exceptions should return 500."""
+        gallery_app.config['SERIES_SERVICE'].get_series_for_directory.side_effect = Exception("Service error")
+
+        response = gallery_client.get('/api/gallery/series')
+
+        assert response.status_code == 500
+        data = json.loads(response.data)
+        assert 'error' in data
+
+    def test_invalid_series_type_filter(self, gallery_app, gallery_client):
+        """Invalid type filter should return 400."""
+        response = gallery_client.get('/api/gallery/series?type=invalid_type')
+
+        assert response.status_code == 400
+        data = json.loads(response.data)
+        assert 'error' in data

--- a/Firmware/Tests/unit/test_series_detection_lib.py
+++ b/Firmware/Tests/unit/test_series_detection_lib.py
@@ -1,0 +1,552 @@
+"""
+Unit tests for series detection library (Issue #110 - Phase 3)
+
+Tests HDR and Focus Bracket photo series detection from filenames.
+TDD approach: tests written first, then implementation.
+
+Coverage Target: 90%+
+"""
+
+import pytest
+from pathlib import Path
+from dataclasses import dataclass
+
+
+# ============================================================================
+# Expected Interface (TDD - define before implementation)
+# ============================================================================
+
+# Import will fail until implementation exists - that's expected in TDD
+try:
+    from webui.backend.lib.series_detection import (
+        SeriesInfo,
+        SeriesType,
+        detect_series_type,
+        get_series_id,
+        group_photos_into_series,
+        HDR_PATTERN,
+        FB_PATTERN,
+    )
+    IMPLEMENTATION_EXISTS = True
+except ImportError:
+    IMPLEMENTATION_EXISTS = False
+    # Define stubs for test discovery
+    SeriesInfo = None
+    SeriesType = None
+    detect_series_type = None
+    get_series_id = None
+    group_photos_into_series = None
+    HDR_PATTERN = None
+    FB_PATTERN = None
+
+
+# Skip all tests if implementation doesn't exist yet (TDD red phase)
+pytestmark = pytest.mark.skipif(
+    not IMPLEMENTATION_EXISTS,
+    reason="Implementation not yet created (TDD red phase)"
+)
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+@pytest.fixture
+def sample_hdr_series(tmp_path):
+    """Create sample HDR photo series for testing."""
+    base = "moth_2024_01_15__10_00_00"
+    photos = []
+    for i in range(3):
+        p = tmp_path / f"{base}_HDR{i}.jpg"
+        p.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+        photos.append(p)
+    return photos
+
+
+@pytest.fixture
+def sample_fb_series(tmp_path):
+    """Create sample Focus Bracket photo series for testing."""
+    base = "ManFocus_moth_2024_01_15__11_00_00_000000"
+    photos = []
+    for i in range(5):
+        p = tmp_path / f"{base}_FB{i}.jpg"
+        p.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+        photos.append(p)
+    return photos
+
+
+@pytest.fixture
+def mixed_photos(tmp_path):
+    """Create a mix of HDR, FB, and regular photos."""
+    photos = []
+
+    # HDR series (3 photos)
+    for i in range(3):
+        p = tmp_path / f"moth_2024_01_15__10_00_00_HDR{i}.jpg"
+        p.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+        photos.append(p)
+
+    # Focus bracket series (5 photos)
+    for i in range(5):
+        p = tmp_path / f"ManFocus_moth_2024_01_15__11_00_00_000000_FB{i}.jpg"
+        p.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+        photos.append(p)
+
+    # Regular photos (not part of any series)
+    regular_names = [
+        "moth_2024_01_15__12_00_00.jpg",
+        "moth_2024_01_15__13_00_00.jpg",
+    ]
+    for name in regular_names:
+        p = tmp_path / name
+        p.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+        photos.append(p)
+
+    return photos
+
+
+# ============================================================================
+# Test SeriesInfo Data Class
+# ============================================================================
+
+class TestSeriesInfoDataClass:
+    """Tests for SeriesInfo data class structure."""
+
+    def test_series_info_has_required_fields(self):
+        """SeriesInfo should have series_type, base_name, and index fields."""
+        info = SeriesInfo(series_type="hdr", base_name="moth_2024_01_15__10_00_00", index=0)
+        assert info.series_type == "hdr"
+        assert info.base_name == "moth_2024_01_15__10_00_00"
+        assert info.index == 0
+
+    def test_series_info_equality(self):
+        """SeriesInfo instances with same values should be equal."""
+        info1 = SeriesInfo(series_type="hdr", base_name="test", index=1)
+        info2 = SeriesInfo(series_type="hdr", base_name="test", index=1)
+        assert info1 == info2
+
+    def test_series_info_different_types_not_equal(self):
+        """SeriesInfo with different types should not be equal."""
+        info1 = SeriesInfo(series_type="hdr", base_name="test", index=1)
+        info2 = SeriesInfo(series_type="focus_bracket", base_name="test", index=1)
+        assert info1 != info2
+
+
+# ============================================================================
+# Test HDR Pattern Detection
+# ============================================================================
+
+class TestHDRDetection:
+    """Tests for HDR series detection."""
+
+    def test_detect_hdr_basic_pattern(self):
+        """Detect basic HDR filename pattern."""
+        result = detect_series_type("moth_2024_01_15__10_00_00_HDR0.jpg")
+        assert result is not None
+        assert result.series_type == "hdr"
+        assert result.index == 0
+        assert "moth_2024_01_15__10_00_00" in result.base_name
+
+    def test_detect_hdr_index_1(self):
+        """Detect HDR with index 1."""
+        result = detect_series_type("moth_2024_01_15__10_00_00_HDR1.jpg")
+        assert result is not None
+        assert result.series_type == "hdr"
+        assert result.index == 1
+
+    def test_detect_hdr_index_2(self):
+        """Detect HDR with index 2."""
+        result = detect_series_type("moth_2024_01_15__10_00_00_HDR2.jpg")
+        assert result is not None
+        assert result.series_type == "hdr"
+        assert result.index == 2
+
+    def test_detect_hdr_double_digit_index(self):
+        """Detect HDR with double-digit index (if supported)."""
+        result = detect_series_type("moth_2024_01_15__10_00_00_HDR10.jpg")
+        assert result is not None
+        assert result.series_type == "hdr"
+        assert result.index == 10
+
+    def test_detect_hdr_case_insensitive_jpg(self):
+        """Detect HDR with uppercase JPG extension."""
+        result = detect_series_type("moth_2024_01_15__10_00_00_HDR0.JPG")
+        assert result is not None
+        assert result.series_type == "hdr"
+
+    def test_detect_hdr_case_insensitive_hdr(self):
+        """Detect HDR with lowercase hdr suffix."""
+        result = detect_series_type("moth_2024_01_15__10_00_00_hdr0.jpg")
+        assert result is not None
+        assert result.series_type == "hdr"
+
+    def test_detect_hdr_with_mb_prefix(self):
+        """Detect HDR with 'mb' prefix (from TakePhoto_noAuto.py)."""
+        result = detect_series_type("mb12345_2024_01_15__10_00_00_HDR0.jpg")
+        assert result is not None
+        assert result.series_type == "hdr"
+        assert result.index == 0
+
+    def test_detect_hdr_png_extension(self):
+        """Detect HDR with PNG extension (supported by TakePhoto.py)."""
+        result = detect_series_type("moth_2024_01_15__10_00_00_HDR0.png")
+        assert result is not None
+        assert result.series_type == "hdr"
+
+    def test_hdr_base_name_extraction(self):
+        """HDR base_name should exclude the _HDR{N} suffix."""
+        result = detect_series_type("moth_2024_01_15__10_00_00_HDR1.jpg")
+        assert result is not None
+        # Base name should be the part before _HDR
+        assert result.base_name == "moth_2024_01_15__10_00_00"
+
+
+# ============================================================================
+# Test Focus Bracket Pattern Detection
+# ============================================================================
+
+class TestFocusBracketDetection:
+    """Tests for Focus Bracket series detection."""
+
+    def test_detect_fb_basic_pattern(self):
+        """Detect basic focus bracket filename pattern."""
+        result = detect_series_type("ManFocus_moth_2024_01_15__11_00_00_000000_FB0.jpg")
+        assert result is not None
+        assert result.series_type == "focus_bracket"
+        assert result.index == 0
+
+    def test_detect_fb_index_4(self):
+        """Detect focus bracket with index 4."""
+        result = detect_series_type("ManFocus_moth_2024_01_15__11_00_00_000000_FB4.jpg")
+        assert result is not None
+        assert result.series_type == "focus_bracket"
+        assert result.index == 4
+
+    def test_detect_fb_case_insensitive_jpg(self):
+        """Detect FB with uppercase JPG extension."""
+        result = detect_series_type("ManFocus_moth_2024_01_15__11_00_00_000000_FB0.JPG")
+        assert result is not None
+        assert result.series_type == "focus_bracket"
+
+    def test_detect_fb_case_insensitive_fb(self):
+        """Detect FB with lowercase fb suffix."""
+        result = detect_series_type("ManFocus_moth_2024_01_15__11_00_00_000000_fb0.jpg")
+        assert result is not None
+        assert result.series_type == "focus_bracket"
+
+    def test_detect_fb_without_microseconds(self):
+        """Detect FB without microseconds in timestamp."""
+        result = detect_series_type("ManFocus_moth_2024_01_15__11_00_00_FB0.jpg")
+        assert result is not None
+        assert result.series_type == "focus_bracket"
+        assert result.index == 0
+
+    def test_detect_16mp_manfocus(self):
+        """Detect 16MP ManFocus pattern (from TakePhoto16mp.py)."""
+        result = detect_series_type("16MPManFocus_moth_2024_01_15__11_00_00_HDR0.jpg")
+        # This is actually HDR, not FB - from TakePhoto16mp.py naming
+        assert result is not None
+        assert result.series_type == "hdr"
+
+    def test_fb_base_name_extraction(self):
+        """FB base_name should exclude the _FB{N} suffix."""
+        result = detect_series_type("ManFocus_moth_2024_01_15__11_00_00_000000_FB2.jpg")
+        assert result is not None
+        assert result.base_name == "ManFocus_moth_2024_01_15__11_00_00_000000"
+
+
+# ============================================================================
+# Test Non-Series Photos
+# ============================================================================
+
+class TestNonSeriesPhotos:
+    """Tests for photos that are NOT part of any series."""
+
+    def test_regular_photo_not_series(self):
+        """Regular photo without HDR/FB suffix returns None."""
+        result = detect_series_type("moth_2024_01_15__12_00_00.jpg")
+        assert result is None
+
+    def test_photo_with_number_not_series(self):
+        """Photo with trailing number but not HDR/FB pattern returns None."""
+        result = detect_series_type("moth_2024_01_15__12_00_00_1.jpg")
+        assert result is None
+
+    def test_photo_hdr_in_name_but_not_pattern(self):
+        """Photo with 'HDR' in name but not proper pattern returns None."""
+        result = detect_series_type("HDR_moth_2024_01_15__12_00_00.jpg")
+        assert result is None
+
+    def test_non_image_file(self):
+        """Non-image file returns None."""
+        result = detect_series_type("moth_2024_01_15__12_00_00.txt")
+        assert result is None
+
+    def test_empty_filename(self):
+        """Empty filename returns None."""
+        result = detect_series_type("")
+        assert result is None
+
+    def test_none_filename(self):
+        """None filename returns None without error."""
+        result = detect_series_type(None)
+        assert result is None
+
+
+# ============================================================================
+# Test get_series_id Function
+# ============================================================================
+
+class TestGetSeriesId:
+    """Tests for get_series_id function (used for grouping)."""
+
+    def test_hdr_series_id(self):
+        """HDR photos in same series return same ID."""
+        id0 = get_series_id("moth_2024_01_15__10_00_00_HDR0.jpg")
+        id1 = get_series_id("moth_2024_01_15__10_00_00_HDR1.jpg")
+        id2 = get_series_id("moth_2024_01_15__10_00_00_HDR2.jpg")
+
+        assert id0 is not None
+        assert id0 == id1 == id2
+
+    def test_fb_series_id(self):
+        """FB photos in same series return same ID."""
+        id0 = get_series_id("ManFocus_moth_2024_01_15__11_00_00_000000_FB0.jpg")
+        id1 = get_series_id("ManFocus_moth_2024_01_15__11_00_00_000000_FB1.jpg")
+
+        assert id0 is not None
+        assert id0 == id1
+
+    def test_different_series_different_ids(self):
+        """Different series return different IDs."""
+        hdr_id = get_series_id("moth_2024_01_15__10_00_00_HDR0.jpg")
+        fb_id = get_series_id("ManFocus_moth_2024_01_15__11_00_00_000000_FB0.jpg")
+
+        assert hdr_id != fb_id
+
+    def test_regular_photo_no_series_id(self):
+        """Regular photo returns None series ID."""
+        result = get_series_id("moth_2024_01_15__12_00_00.jpg")
+        assert result is None
+
+    def test_series_id_includes_type(self):
+        """Series ID should include type prefix for clarity."""
+        hdr_id = get_series_id("moth_2024_01_15__10_00_00_HDR0.jpg")
+        fb_id = get_series_id("ManFocus_moth_2024_01_15__11_00_00_000000_FB0.jpg")
+
+        assert hdr_id.startswith("hdr_") or "hdr" in hdr_id.lower()
+        assert fb_id.startswith("fb_") or "focus" in fb_id.lower()
+
+
+# ============================================================================
+# Test group_photos_into_series Function
+# ============================================================================
+
+class TestGroupPhotosIntoSeries:
+    """Tests for grouping photos by series."""
+
+    def test_group_hdr_series(self, sample_hdr_series):
+        """Group HDR photos into single series."""
+        groups = group_photos_into_series(sample_hdr_series)
+
+        # Should have exactly 1 series
+        assert len(groups) == 1
+
+        # Series should contain all 3 photos
+        series_id = list(groups.keys())[0]
+        assert len(groups[series_id]) == 3
+
+    def test_group_fb_series(self, sample_fb_series):
+        """Group focus bracket photos into single series."""
+        groups = group_photos_into_series(sample_fb_series)
+
+        # Should have exactly 1 series
+        assert len(groups) == 1
+
+        # Series should contain all 5 photos
+        series_id = list(groups.keys())[0]
+        assert len(groups[series_id]) == 5
+
+    def test_group_mixed_photos(self, mixed_photos, tmp_path):
+        """Group mixed photos correctly separates series and singles."""
+        groups = group_photos_into_series(mixed_photos)
+
+        # Should have 2 series (HDR + FB) and 2 singles grouped under None/individual keys
+        # Regular photos should either be excluded or grouped under None key
+        hdr_count = 0
+        fb_count = 0
+
+        for series_id, photos in groups.items():
+            if series_id and "hdr" in series_id.lower():
+                hdr_count = len(photos)
+            elif series_id and ("fb" in series_id.lower() or "focus" in series_id.lower()):
+                fb_count = len(photos)
+
+        assert hdr_count == 3, "HDR series should have 3 photos"
+        assert fb_count == 5, "FB series should have 5 photos"
+
+    def test_group_empty_list(self):
+        """Empty list returns empty dict."""
+        groups = group_photos_into_series([])
+        assert groups == {}
+
+    def test_group_no_series_photos(self, tmp_path):
+        """Photos with no series patterns returns empty dict or grouped under None."""
+        photos = []
+        for name in ["photo1.jpg", "photo2.jpg"]:
+            p = tmp_path / name
+            p.write_bytes(b'\xFF\xD8\xFF\xE0')
+            photos.append(p)
+
+        groups = group_photos_into_series(photos)
+
+        # Should have no series (empty dict) or photos under None key
+        for series_id, photos in groups.items():
+            if series_id is not None:
+                assert False, f"Unexpected series: {series_id}"
+
+    def test_group_preserves_order(self, sample_hdr_series):
+        """Grouped photos should be sorted by index."""
+        # Shuffle the input
+        shuffled = [sample_hdr_series[2], sample_hdr_series[0], sample_hdr_series[1]]
+        groups = group_photos_into_series(shuffled)
+
+        series_id = list(groups.keys())[0]
+        photos = groups[series_id]
+
+        # Photos should be sorted by index (HDR0, HDR1, HDR2)
+        for i, photo in enumerate(photos):
+            assert f"HDR{i}" in photo.name
+
+    def test_group_accepts_path_strings(self, tmp_path):
+        """Function accepts both Path objects and strings."""
+        p = tmp_path / "moth_2024_01_15__10_00_00_HDR0.jpg"
+        p.write_bytes(b'\xFF\xD8\xFF\xE0')
+
+        # Test with string
+        groups = group_photos_into_series([str(p)])
+        assert len(groups) == 1
+
+    def test_group_cross_directory(self, tmp_path):
+        """Series spanning directories should be grouped together."""
+        # Create HDR series in two different directories
+        dir1 = tmp_path / "2024-01-15"
+        dir2 = tmp_path / "2024-01-16"
+        dir1.mkdir()
+        dir2.mkdir()
+
+        # Same series base name, different directories
+        base = "moth_2024_01_15__23_59_59"
+        p1 = dir1 / f"{base}_HDR0.jpg"
+        p2 = dir2 / f"{base}_HDR1.jpg"  # Could happen if capture spans midnight
+        p1.write_bytes(b'\xFF\xD8\xFF\xE0')
+        p2.write_bytes(b'\xFF\xD8\xFF\xE0')
+
+        groups = group_photos_into_series([p1, p2])
+
+        # Should group by base_name, not directory
+        assert len(groups) == 1
+        series_id = list(groups.keys())[0]
+        assert len(groups[series_id]) == 2
+
+
+# ============================================================================
+# Test Regex Pattern Constants
+# ============================================================================
+
+class TestRegexPatterns:
+    """Tests for regex pattern constants."""
+
+    def test_hdr_pattern_compiles(self):
+        """HDR_PATTERN should be a compiled regex."""
+        import re
+        assert isinstance(HDR_PATTERN, re.Pattern)
+
+    def test_fb_pattern_compiles(self):
+        """FB_PATTERN should be a compiled regex."""
+        import re
+        assert isinstance(FB_PATTERN, re.Pattern)
+
+    def test_hdr_pattern_case_insensitive(self):
+        """HDR_PATTERN should be case-insensitive."""
+        assert HDR_PATTERN.flags & 2  # re.IGNORECASE = 2
+
+
+# ============================================================================
+# Test Edge Cases
+# ============================================================================
+
+class TestEdgeCases:
+    """Edge case tests for series detection."""
+
+    def test_very_long_filename(self):
+        """Handle very long filenames gracefully."""
+        long_name = "a" * 200 + "_2024_01_15__10_00_00_HDR0.jpg"
+        result = detect_series_type(long_name)
+        assert result is not None
+        assert result.series_type == "hdr"
+
+    def test_special_characters_in_name(self):
+        """Handle special characters in computer name."""
+        result = detect_series_type("moth-box_v2_2024_01_15__10_00_00_HDR0.jpg")
+        assert result is not None
+        assert result.series_type == "hdr"
+
+    def test_unicode_in_filename(self):
+        """Handle unicode characters in filename."""
+        result = detect_series_type("móth_2024_01_15__10_00_00_HDR0.jpg")
+        assert result is not None
+        assert result.series_type == "hdr"
+
+    def test_path_object_input(self):
+        """detect_series_type should handle Path objects."""
+        result = detect_series_type(Path("moth_2024_01_15__10_00_00_HDR0.jpg"))
+        assert result is not None
+        assert result.series_type == "hdr"
+
+    def test_full_path_input(self):
+        """detect_series_type should extract filename from full path."""
+        result = detect_series_type("/var/lib/mothbox/photos/2024-01-15/moth_2024_01_15__10_00_00_HDR0.jpg")
+        assert result is not None
+        assert result.series_type == "hdr"
+
+
+# ============================================================================
+# Performance Tests (lightweight)
+# ============================================================================
+
+class TestPerformance:
+    """Lightweight performance tests (detailed tests in performance/)."""
+
+    def test_single_detection_fast(self):
+        """Single detection should complete in <10ms."""
+        import time
+
+        start = time.perf_counter()
+        for _ in range(100):
+            detect_series_type("moth_2024_01_15__10_00_00_HDR0.jpg")
+        elapsed = time.perf_counter() - start
+
+        avg_ms = (elapsed / 100) * 1000
+        assert avg_ms < 10, f"Average detection time {avg_ms:.2f}ms exceeds 10ms target"
+
+    def test_grouping_1000_photos_fast(self, tmp_path):
+        """Grouping 1000 photos should complete in <100ms."""
+        import time
+
+        # Generate 1000 filenames (don't need actual files for string-based test)
+        filenames = []
+        for series in range(100):  # 100 series
+            for i in range(10):  # 10 photos each
+                filenames.append(f"moth_2024_01_15__{series:02d}_00_00_HDR{i}.jpg")
+
+        # Create paths (but not actual files - just test grouping logic)
+        paths = [tmp_path / f for f in filenames]
+
+        start = time.perf_counter()
+        groups = group_photos_into_series(paths)
+        elapsed = time.perf_counter() - start
+
+        elapsed_ms = elapsed * 1000
+        assert elapsed_ms < 100, f"Grouping time {elapsed_ms:.2f}ms exceeds 100ms target"
+        assert len(groups) == 100, "Should have 100 series"

--- a/Firmware/Tests/unit/test_series_service.py
+++ b/Firmware/Tests/unit/test_series_service.py
@@ -1,0 +1,531 @@
+"""
+Unit tests for Series Service (Issue #110 - Phase 3)
+
+Tests SeriesService with caching, thread-safety, and cross-directory support.
+TDD approach: tests written first, then implementation.
+
+Coverage Target: 90%+
+"""
+
+import pytest
+import threading
+import time
+from pathlib import Path
+from unittest.mock import Mock, patch, MagicMock
+from dataclasses import dataclass
+
+
+# Import will fail until implementation exists - that's expected in TDD
+try:
+    from webui.backend.services.series_service import (
+        SeriesService,
+        PhotoSeries,
+    )
+    IMPLEMENTATION_EXISTS = True
+except ImportError:
+    IMPLEMENTATION_EXISTS = False
+    SeriesService = None
+    PhotoSeries = None
+
+
+# Skip all tests if implementation doesn't exist yet (TDD red phase)
+pytestmark = pytest.mark.skipif(
+    not IMPLEMENTATION_EXISTS,
+    reason="Implementation not yet created (TDD red phase)"
+)
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+@pytest.fixture
+def temp_photos_dir(tmp_path):
+    """Create temporary photos directory with sample photos."""
+    photos_dir = tmp_path / "photos"
+    photos_dir.mkdir()
+    return photos_dir
+
+
+@pytest.fixture
+def sample_hdr_series(temp_photos_dir):
+    """Create HDR series in photos directory."""
+    base = "moth_2024_01_15__10_00_00"
+    photos = []
+    for i in range(3):
+        p = temp_photos_dir / f"{base}_HDR{i}.jpg"
+        p.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+        photos.append(p)
+    return photos
+
+
+@pytest.fixture
+def sample_fb_series(temp_photos_dir):
+    """Create Focus Bracket series in photos directory."""
+    base = "ManFocus_moth_2024_01_15__11_00_00_000000"
+    photos = []
+    for i in range(5):
+        p = temp_photos_dir / f"{base}_FB{i}.jpg"
+        p.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+        photos.append(p)
+    return photos
+
+
+@pytest.fixture
+def mixed_photos_dir(temp_photos_dir):
+    """Create directory with HDR, FB, and regular photos."""
+    # HDR series (3 photos)
+    for i in range(3):
+        p = temp_photos_dir / f"moth_2024_01_15__10_00_00_HDR{i}.jpg"
+        p.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+
+    # FB series (5 photos)
+    for i in range(5):
+        p = temp_photos_dir / f"ManFocus_moth_2024_01_15__11_00_00_000000_FB{i}.jpg"
+        p.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+
+    # Regular photos
+    for name in ["regular1.jpg", "regular2.jpg"]:
+        p = temp_photos_dir / name
+        p.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+
+    return temp_photos_dir
+
+
+@pytest.fixture
+def service(temp_photos_dir):
+    """Create SeriesService instance with short TTL for testing."""
+    return SeriesService(cache_ttl=1)  # 1 second TTL for fast testing
+
+
+# ============================================================================
+# Test PhotoSeries Data Class
+# ============================================================================
+
+class TestPhotoSeriesDataClass:
+    """Tests for PhotoSeries data class structure."""
+
+    def test_photo_series_has_required_fields(self, temp_photos_dir):
+        """PhotoSeries should have all required fields."""
+        series = PhotoSeries(
+            series_id="hdr_moth_2024_01_15__10_00_00",
+            series_type="hdr",
+            base_name="moth_2024_01_15__10_00_00",
+            photos=[temp_photos_dir / "test.jpg"],
+            count=1,
+            cover_photo=temp_photos_dir / "test.jpg"
+        )
+
+        assert series.series_id == "hdr_moth_2024_01_15__10_00_00"
+        assert series.series_type == "hdr"
+        assert series.base_name == "moth_2024_01_15__10_00_00"
+        assert len(series.photos) == 1
+        assert series.count == 1
+        assert series.cover_photo is not None
+
+
+# ============================================================================
+# Test SeriesService Initialization
+# ============================================================================
+
+class TestSeriesServiceInit:
+    """Tests for SeriesService initialization."""
+
+    def test_service_creation_default_ttl(self):
+        """SeriesService should be created with default TTL."""
+        service = SeriesService()
+        assert service is not None
+        assert service._cache_ttl == 300  # Default 5 minutes
+
+    def test_service_creation_custom_ttl(self):
+        """SeriesService should accept custom TTL."""
+        service = SeriesService(cache_ttl=60)
+        assert service._cache_ttl == 60
+
+    def test_service_starts_with_empty_cache(self):
+        """SeriesService should start with empty cache."""
+        service = SeriesService()
+        stats = service.get_statistics()
+        assert stats['cache_entries'] == 0
+
+
+# ============================================================================
+# Test get_series_for_directory
+# ============================================================================
+
+class TestGetSeriesForDirectory:
+    """Tests for get_series_for_directory method."""
+
+    def test_get_series_from_empty_directory(self, service, temp_photos_dir):
+        """Empty directory should return empty list."""
+        series_list = service.get_series_for_directory(temp_photos_dir)
+        assert series_list == []
+
+    def test_get_hdr_series(self, service, temp_photos_dir, sample_hdr_series):
+        """Should detect HDR series correctly."""
+        series_list = service.get_series_for_directory(temp_photos_dir)
+
+        assert len(series_list) == 1
+        series = series_list[0]
+        assert series.series_type == "hdr"
+        assert series.count == 3
+        assert len(series.photos) == 3
+
+    def test_get_fb_series(self, service, temp_photos_dir, sample_fb_series):
+        """Should detect Focus Bracket series correctly."""
+        series_list = service.get_series_for_directory(temp_photos_dir)
+
+        assert len(series_list) == 1
+        series = series_list[0]
+        assert series.series_type == "focus_bracket"
+        assert series.count == 5
+
+    def test_get_multiple_series(self, service, mixed_photos_dir):
+        """Should detect multiple series in directory."""
+        series_list = service.get_series_for_directory(mixed_photos_dir)
+
+        assert len(series_list) == 2
+
+        types = {s.series_type for s in series_list}
+        assert types == {"hdr", "focus_bracket"}
+
+    def test_regular_photos_excluded(self, service, mixed_photos_dir):
+        """Regular photos should not create series."""
+        series_list = service.get_series_for_directory(mixed_photos_dir)
+
+        # Should only have HDR and FB series, not regular photos
+        assert len(series_list) == 2
+
+        # Verify no single-photo "series"
+        for series in series_list:
+            assert series.count > 1
+
+    def test_series_sorted_by_timestamp(self, service, temp_photos_dir):
+        """Series should be sorted by base_name (timestamp)."""
+        # Create two HDR series with different timestamps
+        for i in range(3):
+            p = temp_photos_dir / f"moth_2024_01_15__12_00_00_HDR{i}.jpg"
+            p.write_bytes(b'\xFF\xD8\xFF\xE0')
+
+        for i in range(3):
+            p = temp_photos_dir / f"moth_2024_01_15__10_00_00_HDR{i}.jpg"
+            p.write_bytes(b'\xFF\xD8\xFF\xE0')
+
+        series_list = service.get_series_for_directory(temp_photos_dir)
+
+        assert len(series_list) == 2
+        # Should be sorted by base_name
+        assert series_list[0].base_name < series_list[1].base_name
+
+    def test_cover_photo_is_first_in_series(self, service, temp_photos_dir, sample_hdr_series):
+        """Cover photo should be the first photo in series (index 0)."""
+        series_list = service.get_series_for_directory(temp_photos_dir)
+
+        series = series_list[0]
+        assert "HDR0" in series.cover_photo.name
+
+    def test_photos_sorted_by_index(self, service, temp_photos_dir, sample_hdr_series):
+        """Photos within series should be sorted by index."""
+        series_list = service.get_series_for_directory(temp_photos_dir)
+
+        series = series_list[0]
+        for i, photo in enumerate(series.photos):
+            assert f"HDR{i}" in photo.name
+
+    def test_nonexistent_directory_returns_empty(self, service, tmp_path):
+        """Nonexistent directory should return empty list."""
+        nonexistent = tmp_path / "nonexistent"
+        series_list = service.get_series_for_directory(nonexistent)
+        assert series_list == []
+
+    def test_accepts_path_string(self, service, temp_photos_dir, sample_hdr_series):
+        """Should accept directory as string."""
+        series_list = service.get_series_for_directory(str(temp_photos_dir))
+        assert len(series_list) == 1
+
+
+# ============================================================================
+# Test Caching Behavior
+# ============================================================================
+
+class TestCaching:
+    """Tests for cache behavior."""
+
+    def test_cache_hit_on_second_call(self, service, temp_photos_dir, sample_hdr_series):
+        """Second call should use cache."""
+        # First call - cache miss
+        series1 = service.get_series_for_directory(temp_photos_dir)
+        stats1 = service.get_statistics()
+
+        # Second call - cache hit
+        series2 = service.get_series_for_directory(temp_photos_dir)
+        stats2 = service.get_statistics()
+
+        assert series1 == series2
+        assert stats2['cache_hits'] == stats1['cache_hits'] + 1
+
+    def test_cache_miss_tracked(self, service, temp_photos_dir):
+        """Cache misses should be tracked."""
+        stats1 = service.get_statistics()
+        initial_misses = stats1['cache_misses']
+
+        service.get_series_for_directory(temp_photos_dir)
+        stats2 = service.get_statistics()
+
+        assert stats2['cache_misses'] == initial_misses + 1
+
+    def test_cache_expiry_ttl(self, temp_photos_dir, sample_hdr_series):
+        """Cache should expire after TTL."""
+        service = SeriesService(cache_ttl=0.1)  # 100ms TTL
+
+        # First call
+        service.get_series_for_directory(temp_photos_dir)
+        stats1 = service.get_statistics()
+
+        # Wait for TTL to expire
+        time.sleep(0.15)
+
+        # Second call - should be cache miss
+        service.get_series_for_directory(temp_photos_dir)
+        stats2 = service.get_statistics()
+
+        # Should have two misses (initial + after expiry)
+        assert stats2['cache_misses'] == stats1['cache_misses'] + 1
+
+    def test_cache_invalidation_all(self, service, temp_photos_dir, sample_hdr_series):
+        """invalidate_cache() should clear all cache."""
+        # Populate cache
+        service.get_series_for_directory(temp_photos_dir)
+
+        stats1 = service.get_statistics()
+        assert stats1['cache_entries'] == 1
+
+        # Invalidate all
+        service.invalidate_cache()
+
+        stats2 = service.get_statistics()
+        assert stats2['cache_entries'] == 0
+
+    def test_cache_invalidation_specific_directory(self, service, tmp_path):
+        """invalidate_cache(directory) should only clear that directory."""
+        # Create two directories
+        dir1 = tmp_path / "dir1"
+        dir2 = tmp_path / "dir2"
+        dir1.mkdir()
+        dir2.mkdir()
+
+        # Add photos to both
+        (dir1 / "moth_2024_01_15__10_00_00_HDR0.jpg").write_bytes(b'\xFF\xD8\xFF\xE0')
+        (dir1 / "moth_2024_01_15__10_00_00_HDR1.jpg").write_bytes(b'\xFF\xD8\xFF\xE0')
+        (dir2 / "moth_2024_01_15__11_00_00_HDR0.jpg").write_bytes(b'\xFF\xD8\xFF\xE0')
+        (dir2 / "moth_2024_01_15__11_00_00_HDR1.jpg").write_bytes(b'\xFF\xD8\xFF\xE0')
+
+        # Populate cache for both
+        service.get_series_for_directory(dir1)
+        service.get_series_for_directory(dir2)
+
+        stats1 = service.get_statistics()
+        assert stats1['cache_entries'] == 2
+
+        # Invalidate only dir1
+        service.invalidate_cache(dir1)
+
+        stats2 = service.get_statistics()
+        assert stats2['cache_entries'] == 1
+
+
+# ============================================================================
+# Test get_series_by_id
+# ============================================================================
+
+class TestGetSeriesById:
+    """Tests for get_series_by_id method."""
+
+    def test_get_existing_series(self, service, temp_photos_dir, sample_hdr_series):
+        """Should return series by ID."""
+        # First populate cache
+        series_list = service.get_series_for_directory(temp_photos_dir)
+        series_id = series_list[0].series_id
+
+        # Get by ID
+        result = service.get_series_by_id(series_id)
+
+        assert result is not None
+        assert result.series_id == series_id
+        assert result.series_type == "hdr"
+
+    def test_get_nonexistent_series(self, service, temp_photos_dir):
+        """Should return None for nonexistent series ID."""
+        result = service.get_series_by_id("nonexistent_series_id")
+        assert result is None
+
+    def test_get_series_from_specific_directory(self, service, temp_photos_dir, sample_hdr_series):
+        """Should find series when directory hint provided."""
+        series_list = service.get_series_for_directory(temp_photos_dir)
+        series_id = series_list[0].series_id
+
+        # Get by ID with directory hint
+        result = service.get_series_by_id(series_id, directory=temp_photos_dir)
+
+        assert result is not None
+        assert result.series_id == series_id
+
+
+# ============================================================================
+# Test Thread Safety
+# ============================================================================
+
+class TestThreadSafety:
+    """Tests for thread-safe cache operations."""
+
+    def test_concurrent_reads(self, service, temp_photos_dir, sample_hdr_series):
+        """Multiple concurrent reads should work safely."""
+        results = []
+        errors = []
+
+        def read_series():
+            try:
+                series = service.get_series_for_directory(temp_photos_dir)
+                results.append(len(series))
+            except Exception as e:
+                errors.append(str(e))
+
+        threads = [threading.Thread(target=read_series) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(errors) == 0
+        assert all(r == 1 for r in results)  # All should see 1 series
+
+    def test_concurrent_invalidate_and_read(self, service, temp_photos_dir, sample_hdr_series):
+        """Concurrent invalidation and reads should work safely."""
+        errors = []
+
+        def read_and_invalidate():
+            try:
+                service.get_series_for_directory(temp_photos_dir)
+                service.invalidate_cache()
+            except Exception as e:
+                errors.append(str(e))
+
+        threads = [threading.Thread(target=read_and_invalidate) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(errors) == 0
+
+
+# ============================================================================
+# Test Statistics
+# ============================================================================
+
+class TestStatistics:
+    """Tests for get_statistics method."""
+
+    def test_statistics_structure(self, service):
+        """Statistics should have expected fields."""
+        stats = service.get_statistics()
+
+        assert 'cache_entries' in stats
+        assert 'cache_hits' in stats
+        assert 'cache_misses' in stats
+        assert 'total_series' in stats
+        assert 'series_by_type' in stats
+
+    def test_statistics_updates_after_operations(self, service, temp_photos_dir, sample_hdr_series):
+        """Statistics should update after operations."""
+        stats1 = service.get_statistics()
+        initial_misses = stats1['cache_misses']
+
+        service.get_series_for_directory(temp_photos_dir)
+
+        stats2 = service.get_statistics()
+        assert stats2['cache_misses'] == initial_misses + 1
+        assert stats2['cache_entries'] == 1
+        assert stats2['total_series'] == 1
+
+    def test_statistics_series_by_type(self, service, mixed_photos_dir):
+        """Statistics should count series by type."""
+        service.get_series_for_directory(mixed_photos_dir)
+        stats = service.get_statistics()
+
+        assert stats['series_by_type']['hdr'] == 1
+        assert stats['series_by_type']['focus_bracket'] == 1
+
+
+# ============================================================================
+# Test Cross-Directory Series
+# ============================================================================
+
+class TestCrossDirectorySeries:
+    """Tests for series spanning multiple directories."""
+
+    def test_series_spans_directories(self, service, tmp_path):
+        """Series with same base_name in different dirs should group together."""
+        dir1 = tmp_path / "2024-01-15"
+        dir2 = tmp_path / "2024-01-16"
+        dir1.mkdir()
+        dir2.mkdir()
+
+        # Same series base_name in both directories
+        base = "moth_2024_01_15__23_59_59"
+        (dir1 / f"{base}_HDR0.jpg").write_bytes(b'\xFF\xD8\xFF\xE0')
+        (dir2 / f"{base}_HDR1.jpg").write_bytes(b'\xFF\xD8\xFF\xE0')
+
+        # Scan parent directory
+        series_list = service.get_series_for_directory(tmp_path)
+
+        # Should find one series with 2 photos
+        assert len(series_list) == 1
+        assert series_list[0].count == 2
+
+
+# ============================================================================
+# Test Error Handling
+# ============================================================================
+
+class TestErrorHandling:
+    """Tests for error handling."""
+
+    def test_permission_error_handled(self, service, tmp_path, monkeypatch):
+        """Permission errors should return empty list."""
+        def raise_permission_error(*args, **kwargs):
+            raise PermissionError("Access denied")
+
+        with patch('pathlib.Path.glob', side_effect=raise_permission_error):
+            result = service.get_series_for_directory(tmp_path)
+            assert result == []
+
+    def test_io_error_handled(self, service, tmp_path, monkeypatch):
+        """I/O errors should return empty list."""
+        def raise_io_error(*args, **kwargs):
+            raise IOError("I/O error")
+
+        with patch('pathlib.Path.glob', side_effect=raise_io_error):
+            result = service.get_series_for_directory(tmp_path)
+            assert result == []
+
+
+# ============================================================================
+# Test Performance (lightweight)
+# ============================================================================
+
+class TestServicePerformance:
+    """Lightweight performance tests."""
+
+    def test_cache_hit_fast(self, service, temp_photos_dir, sample_hdr_series):
+        """Cache hit should be very fast (<10ms)."""
+        # Prime cache
+        service.get_series_for_directory(temp_photos_dir)
+
+        start = time.perf_counter()
+        for _ in range(100):
+            service.get_series_for_directory(temp_photos_dir)
+        elapsed = time.perf_counter() - start
+
+        avg_ms = (elapsed / 100) * 1000
+        assert avg_ms < 10, f"Cache hit avg {avg_ms:.2f}ms exceeds 10ms target"

--- a/Firmware/webui/backend/lib/__init__.py
+++ b/Firmware/webui/backend/lib/__init__.py
@@ -2,6 +2,7 @@
 
 This package contains shared library modules:
 - gps_exif_lib: GPS EXIF embedding and verification functions
+- series_detection: HDR/Focus Bracket photo series detection (Issue #110)
 """
 
 from .gps_exif_lib import (
@@ -22,7 +23,18 @@ from .gps_exif_lib import (
     verify_gps_exif,
 )
 
+from .series_detection import (
+    SeriesInfo,
+    SeriesType,
+    detect_series_type,
+    get_series_id,
+    group_photos_into_series,
+    HDR_PATTERN,
+    FB_PATTERN,
+)
+
 __all__ = [
+    # GPS EXIF exports
     'get_gps_data_from_controls',
     'decimal_to_dms',
     'build_gps_ifd',
@@ -38,4 +50,12 @@ __all__ = [
     'GPS_FIX_3D',
     'DEFAULT_HDOP',
     'DEFAULT_PDOP',
+    # Series detection exports
+    'SeriesInfo',
+    'SeriesType',
+    'detect_series_type',
+    'get_series_id',
+    'group_photos_into_series',
+    'HDR_PATTERN',
+    'FB_PATTERN',
 ]

--- a/Firmware/webui/backend/lib/series_detection.py
+++ b/Firmware/webui/backend/lib/series_detection.py
@@ -1,0 +1,262 @@
+"""
+Series Detection Library for Mothbox Photo Gallery (Issue #110)
+
+Detects and groups HDR and Focus Bracket photo series based on filename patterns.
+Supports cross-directory series detection (photos spanning date folders).
+
+Naming Patterns (from TakePhoto.py scripts):
+- HDR: {name}_{timestamp}_HDR{index}.jpg (e.g., moth_2024_01_15__10_00_00_HDR0.jpg)
+- Focus Bracket: ManFocus_{name}_{timestamp}_FB{index}.jpg
+
+Usage:
+    from webui.backend.lib.series_detection import (
+        detect_series_type,
+        get_series_id,
+        group_photos_into_series,
+    )
+
+    # Detect single photo
+    info = detect_series_type("moth_2024_01_15__10_00_00_HDR0.jpg")
+    if info:
+        print(f"Type: {info.series_type}, Index: {info.index}")
+
+    # Group photos by series
+    groups = group_photos_into_series(photo_paths)
+    for series_id, photos in groups.items():
+        print(f"Series {series_id}: {len(photos)} photos")
+"""
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Union
+
+
+class SeriesType(str, Enum):
+    """Enumeration of supported series types."""
+    HDR = "hdr"
+    FOCUS_BRACKET = "focus_bracket"
+
+
+@dataclass(frozen=True)
+class SeriesInfo:
+    """Information about a photo's series membership.
+
+    Attributes:
+        series_type: Type of series ("hdr" or "focus_bracket")
+        base_name: Common prefix for grouping (timestamp-based, excludes index suffix)
+        index: Zero-based position in series (0, 1, 2...)
+    """
+    series_type: str
+    base_name: str
+    index: int
+
+
+# ============================================================================
+# Regex Patterns (case-insensitive)
+# ============================================================================
+
+# HDR Pattern: {name}_{YYYY_MM_DD__HH_MM_SS}_HDR{index}.{ext}
+# Matches: moth_2024_01_15__10_00_00_HDR0.jpg, mb12345_2024_01_15__10_00_00_HDR1.png
+# Groups: (1) base_name, (2) index, (3) extension
+HDR_PATTERN = re.compile(
+    r'^(.+_\d{4}_\d{2}_\d{2}__\d{2}_\d{2}_\d{2})_[Hh][Dd][Rr](\d+)\.(jpg|jpeg|png|bmp)$',
+    re.IGNORECASE
+)
+
+# Focus Bracket Pattern: ManFocus_{name}_{YYYY_MM_DD__HH_MM_SS}[_{microseconds}]_FB{index}.{ext}
+# Matches: ManFocus_moth_2024_01_15__11_00_00_000000_FB0.jpg
+# Also matches: ManFocus_moth_2024_01_15__11_00_00_FB0.jpg (without microseconds)
+# Groups: (1) base_name (including ManFocus prefix), (2) index, (3) extension
+FB_PATTERN = re.compile(
+    r'^(ManFocus_.+_\d{4}_\d{2}_\d{2}__\d{2}_\d{2}_\d{2}(?:_\d+)?)_[Ff][Bb](\d+)\.(jpg|jpeg|png|bmp)$',
+    re.IGNORECASE
+)
+
+# 16MP ManFocus with HDR suffix (from TakePhoto16mp.py)
+# Pattern: 16MPManFocus_{name}_{timestamp}_HDR{index}.jpg
+MP16_HDR_PATTERN = re.compile(
+    r'^(16MPManFocus_.+_\d{4}_\d{2}_\d{2}__\d{2}_\d{2}_\d{2})_[Hh][Dd][Rr](\d+)\.(jpg|jpeg|png|bmp)$',
+    re.IGNORECASE
+)
+
+
+def _extract_filename(path: Union[str, Path, None]) -> str | None:
+    """Extract filename from path (handles str, Path, or None).
+
+    Args:
+        path: File path as string, Path object, or None
+
+    Returns:
+        Filename string or None if invalid input
+    """
+    if path is None:
+        return None
+
+    if isinstance(path, Path):
+        return path.name
+
+    if isinstance(path, str):
+        # Handle both full paths and bare filenames
+        if '/' in path or '\\' in path:
+            return Path(path).name
+        return path
+
+    return None
+
+
+def detect_series_type(filename: Union[str, Path, None]) -> SeriesInfo | None:
+    """Detect if a photo is part of an HDR or Focus Bracket series.
+
+    Analyzes the filename pattern to identify series membership.
+
+    Args:
+        filename: Photo filename, full path, or Path object
+
+    Returns:
+        SeriesInfo with type, base_name, and index if part of series, None otherwise
+
+    Example:
+        >>> detect_series_type("moth_2024_01_15__10_00_00_HDR0.jpg")
+        SeriesInfo(series_type='hdr', base_name='moth_2024_01_15__10_00_00', index=0)
+
+        >>> detect_series_type("regular_photo.jpg")
+        None
+    """
+    name = _extract_filename(filename)
+    if not name:
+        return None
+
+    # Try 16MP HDR pattern first (more specific)
+    match = MP16_HDR_PATTERN.match(name)
+    if match:
+        return SeriesInfo(
+            series_type=SeriesType.HDR.value,
+            base_name=match.group(1),
+            index=int(match.group(2))
+        )
+
+    # Try standard HDR pattern
+    match = HDR_PATTERN.match(name)
+    if match:
+        return SeriesInfo(
+            series_type=SeriesType.HDR.value,
+            base_name=match.group(1),
+            index=int(match.group(2))
+        )
+
+    # Try Focus Bracket pattern
+    match = FB_PATTERN.match(name)
+    if match:
+        return SeriesInfo(
+            series_type=SeriesType.FOCUS_BRACKET.value,
+            base_name=match.group(1),
+            index=int(match.group(2))
+        )
+
+    return None
+
+
+def get_series_id(filename: Union[str, Path, None]) -> str | None:
+    """Get a unique series identifier for grouping photos.
+
+    Photos from the same series will return the same ID, enabling cross-directory
+    grouping (e.g., if HDR capture spans midnight across date folders).
+
+    Args:
+        filename: Photo filename, full path, or Path object
+
+    Returns:
+        Series ID string (format: "{type}_{base_name}") or None if not in series
+
+    Example:
+        >>> get_series_id("moth_2024_01_15__10_00_00_HDR0.jpg")
+        'hdr_moth_2024_01_15__10_00_00'
+
+        >>> get_series_id("moth_2024_01_15__10_00_00_HDR1.jpg")
+        'hdr_moth_2024_01_15__10_00_00'  # Same ID for same series
+
+        >>> get_series_id("regular_photo.jpg")
+        None
+    """
+    info = detect_series_type(filename)
+    if info is None:
+        return None
+
+    return f"{info.series_type}_{info.base_name}"
+
+
+def group_photos_into_series(
+    photo_paths: list[Union[str, Path]]
+) -> dict[str, list[Path]]:
+    """Group photos by their series membership.
+
+    Analyzes filenames and groups photos that belong to the same HDR or
+    Focus Bracket series. Photos not in any series are excluded from results.
+    Supports cross-directory grouping (series can span date folders).
+
+    Args:
+        photo_paths: List of photo paths (str or Path objects)
+
+    Returns:
+        Dictionary mapping series_id to sorted list of photo Paths.
+        Photos within each series are sorted by index (HDR0, HDR1, HDR2...).
+        Photos not in any series are excluded.
+
+    Example:
+        >>> paths = [
+        ...     Path("moth_2024_01_15__10_00_00_HDR0.jpg"),
+        ...     Path("moth_2024_01_15__10_00_00_HDR1.jpg"),
+        ...     Path("regular_photo.jpg"),  # Excluded
+        ... ]
+        >>> groups = group_photos_into_series(paths)
+        >>> len(groups)
+        1
+        >>> list(groups.keys())
+        ['hdr_moth_2024_01_15__10_00_00']
+    """
+    if not photo_paths:
+        return {}
+
+    # Group by series_id
+    groups: dict[str, list[tuple[int, Path]]] = {}
+
+    for path in photo_paths:
+        # Normalize to Path
+        if isinstance(path, str):
+            path = Path(path)
+
+        info = detect_series_type(path)
+        if info is None:
+            continue  # Skip non-series photos
+
+        series_id = f"{info.series_type}_{info.base_name}"
+
+        if series_id not in groups:
+            groups[series_id] = []
+
+        groups[series_id].append((info.index, path))
+
+    # Sort each series by index and extract paths
+    result: dict[str, list[Path]] = {}
+    for series_id, indexed_photos in groups.items():
+        sorted_photos = sorted(indexed_photos, key=lambda x: x[0])
+        result[series_id] = [photo for _, photo in sorted_photos]
+
+    return result
+
+
+# ============================================================================
+# Module exports
+# ============================================================================
+
+__all__ = [
+    'SeriesType',
+    'SeriesInfo',
+    'detect_series_type',
+    'get_series_id',
+    'group_photos_into_series',
+    'HDR_PATTERN',
+    'FB_PATTERN',
+]

--- a/Firmware/webui/backend/routes/gallery.py
+++ b/Firmware/webui/backend/routes/gallery.py
@@ -17,6 +17,10 @@ Endpoints:
 - GET /cache/warm/status - Get warming task status
 - POST /cache/warm/cancel/<task_id> - Cancel warming task
 - GET /photos/paginated - List photos with pagination
+- GET /series - List photo series (HDR/Focus Bracket) with pagination
+- GET /series/<series_id> - Get specific series details
+- GET /series/stats - Get series cache statistics
+- POST /series/cache/invalidate - Invalidate series cache
 """
 
 import logging
@@ -706,3 +710,240 @@ def _reset_cache():
     global _metadata_cache
     with _cache_lock:
         _metadata_cache = None
+
+
+# ============================================================================
+# Series Endpoints (Issue #110 - Phase 3)
+# ============================================================================
+
+# Valid series types for filtering
+VALID_SERIES_TYPES = {"hdr", "focus_bracket"}
+
+
+@gallery_bp.route("/series", methods=["GET"])
+def list_series():
+    """
+    List photo series (HDR and Focus Bracket) with pagination and filtering.
+
+    Query Parameters:
+        page (int): Page number (1-indexed, default: 1)
+        per_page (int): Items per page (1-100, default: 50)
+        type (str): Filter by series type (hdr, focus_bracket)
+
+    Returns:
+        JSON response with:
+        - series: List of series objects
+        - pagination: Pagination metadata
+
+    Example:
+        GET /series?page=1&per_page=50&type=hdr
+
+    Status Codes:
+        200: Success
+        400: Invalid parameters
+        503: Series service unavailable
+    """
+    # Get series service from app config
+    series_service = current_app.config.get('SERIES_SERVICE')
+
+    if not series_service:
+        return jsonify({"error": "Series service not available"}), 503
+
+    # Parse pagination parameters
+    try:
+        page = request.args.get('page', 1, type=int)
+        per_page = request.args.get('per_page', 50, type=int)
+
+        if page < 1:
+            return jsonify({"error": "Page must be >= 1"}), 400
+        if per_page < 1 or per_page > 100:
+            return jsonify({"error": "per_page must be 1-100"}), 400
+
+    except (ValueError, TypeError) as e:
+        return jsonify({"error": f"Invalid pagination parameter: {e}"}), 400
+
+    # Parse type filter
+    series_type_filter = request.args.get('type')
+    if series_type_filter and series_type_filter not in VALID_SERIES_TYPES:
+        return jsonify({
+            "error": f"Invalid type: {series_type_filter}. Valid: {', '.join(sorted(VALID_SERIES_TYPES))}"
+        }), 400
+
+    try:
+        # Get all series from directory
+        series_list = series_service.get_series_for_directory(PHOTOS_DIR)
+
+        # Apply type filter if specified
+        if series_type_filter:
+            series_list = [s for s in series_list if s.series_type == series_type_filter]
+
+        # Calculate pagination
+        total = len(series_list)
+        start_idx = (page - 1) * per_page
+        end_idx = start_idx + per_page
+        paginated_series = series_list[start_idx:end_idx]
+
+        # Convert to JSON-serializable format
+        series_data = []
+        for series in paginated_series:
+            # Convert paths to relative strings
+            photos_relative = [
+                str(p.relative_to(PHOTOS_DIR)) if p.is_relative_to(PHOTOS_DIR) else p.name
+                for p in series.photos
+            ]
+            cover_relative = (
+                str(series.cover_photo.relative_to(PHOTOS_DIR))
+                if series.cover_photo.is_relative_to(PHOTOS_DIR)
+                else series.cover_photo.name
+            )
+
+            series_data.append({
+                "series_id": series.series_id,
+                "series_type": series.series_type,
+                "base_name": series.base_name,
+                "count": series.count,
+                "cover_photo": cover_relative,
+                "photos": photos_relative,
+            })
+
+        return jsonify({
+            "series": series_data,
+            "pagination": {
+                "page": page,
+                "per_page": per_page,
+                "total": total,
+                "has_next": end_idx < total,
+                "has_previous": page > 1,
+            }
+        })
+
+    except Exception as e:
+        logger.error(f"Error listing series: {e}", exc_info=True)
+        return jsonify({"error": "Failed to list series"}), 500
+
+
+@gallery_bp.route("/series/<series_id>", methods=["GET"])
+def get_series(series_id):
+    """
+    Get details for a specific photo series.
+
+    Path Parameters:
+        series_id: Series identifier (e.g., "hdr_moth_2024_01_15__10_00_00")
+
+    Returns:
+        JSON response with series details including all photo paths.
+
+    Example:
+        GET /series/hdr_moth_2024_01_15__10_00_00
+
+    Status Codes:
+        200: Success
+        404: Series not found
+        503: Series service unavailable
+    """
+    series_service = current_app.config.get('SERIES_SERVICE')
+
+    if not series_service:
+        return jsonify({"error": "Series service not available"}), 503
+
+    try:
+        # First ensure directory is scanned
+        series_service.get_series_for_directory(PHOTOS_DIR)
+
+        # Get series by ID
+        series = series_service.get_series_by_id(series_id)
+
+        if not series:
+            return jsonify({"error": "Series not found", "series_id": series_id}), 404
+
+        # Convert paths to relative strings
+        photos_relative = [
+            str(p.relative_to(PHOTOS_DIR)) if p.is_relative_to(PHOTOS_DIR) else p.name
+            for p in series.photos
+        ]
+        cover_relative = (
+            str(series.cover_photo.relative_to(PHOTOS_DIR))
+            if series.cover_photo.is_relative_to(PHOTOS_DIR)
+            else series.cover_photo.name
+        )
+
+        return jsonify({
+            "series_id": series.series_id,
+            "series_type": series.series_type,
+            "base_name": series.base_name,
+            "count": series.count,
+            "cover_photo": cover_relative,
+            "photos": photos_relative,
+        })
+
+    except Exception as e:
+        logger.error(f"Error getting series {series_id}: {e}", exc_info=True)
+        return jsonify({"error": "Failed to get series"}), 500
+
+
+@gallery_bp.route("/series/stats", methods=["GET"])
+def get_series_stats():
+    """
+    Get series cache statistics.
+
+    Returns:
+        JSON response with cache statistics.
+
+    Status Codes:
+        200: Success
+        503: Series service unavailable
+    """
+    series_service = current_app.config.get('SERIES_SERVICE')
+
+    if not series_service:
+        return jsonify({"error": "Series service not available"}), 503
+
+    try:
+        stats = series_service.get_statistics()
+        return jsonify(stats)
+
+    except Exception as e:
+        logger.error(f"Error getting series stats: {e}", exc_info=True)
+        return jsonify({"error": "Failed to get statistics"}), 500
+
+
+@gallery_bp.route("/series/cache/invalidate", methods=["POST"])
+def invalidate_series_cache():
+    """
+    Invalidate series cache (requires CSRF token).
+
+    Request body (JSON, optional):
+        directory (str): Specific directory to invalidate (optional)
+
+    Returns:
+        JSON response with success status.
+
+    Status Codes:
+        200: Success
+        503: Series service unavailable
+    """
+    series_service = current_app.config.get('SERIES_SERVICE')
+
+    if not series_service:
+        return jsonify({"error": "Series service not available"}), 503
+
+    try:
+        data = request.get_json() or {}
+        directory = data.get('directory')
+
+        if directory:
+            # Validate path security
+            dir_path = validate_photo_path(directory, PHOTOS_DIR)
+            if dir_path is None:
+                return jsonify({"error": "Invalid directory path"}), 400
+            series_service.invalidate_cache(dir_path)
+            message = f"Invalidated series cache for {directory}"
+        else:
+            series_service.invalidate_cache()
+            message = "Invalidated entire series cache"
+
+        return jsonify({"success": True, "message": message})
+
+    except Exception as e:
+        logger.error(f"Error invalidating series cache: {e}", exc_info=True)
+        return jsonify({"error": "Failed to invalidate cache"}), 500

--- a/Firmware/webui/backend/services/metadata_service.py
+++ b/Firmware/webui/backend/services/metadata_service.py
@@ -631,9 +631,10 @@ class MetadataService:
         """
         Detect if photo is part of a series (HDR or focus bracket).
 
-        Analyzes filename patterns to identify series type, count, and index:
-        - HDR: mothbox_YYYY_MM_DD__HH_MM_SS_N.jpg (e.g., _1, _2, _3)
-        - Focus bracket: mothbox_YYYY_MM_DD__HH_MM_SS_focus_N.jpg
+        Uses the series_detection library to analyze filename patterns.
+        Patterns match actual TakePhoto.py output:
+        - HDR: {name}_{timestamp}_HDR{index}.jpg (e.g., moth_2024_01_15__10_00_00_HDR0.jpg)
+        - Focus bracket: ManFocus_{name}_{timestamp}_FB{index}.jpg
 
         SECURITY NOTE: photo_path should be pre-validated by caller.
         The parent directory access is safe because photo_path was validated.
@@ -645,54 +646,53 @@ class MetadataService:
             tuple: (series_type, series_count, series_index)
                    series_type: 'hdr', 'focus_bracket', or None
                    series_count: Total photos in series or None
-                   series_index: 1-indexed position in series or None
+                   series_index: 0-indexed position in series or None
         """
         try:
-            filename = photo_path.stem
+            # Import series detection library (Issue #110)
+            from webui.backend.lib.series_detection import (
+                detect_series_type,
+                get_series_id,
+            )
 
-            # Check for focus bracket pattern: *_focus_N
-            focus_match = re.search(r'_focus_(\d+)$', filename)
-            if focus_match:
-                series_index = int(focus_match.group(1))
+            # Detect series type from filename
+            info = detect_series_type(photo_path)
+            if info is None:
+                return None, None, None
 
-                # Count total focus bracket files in same directory
-                # Safe: photo_path was validated, so parent_dir is also within allowed directory
-                base_pattern = re.sub(r'_focus_\d+$', '', filename)
-                parent_dir = photo_path.parent
-                try:
-                    series_files = list(parent_dir.glob(f"{base_pattern}_focus_*.jpg"))
-                    series_count = len(series_files)
-                except OSError as e:
-                    logger.warning(f"Failed to glob series files: {e}")
-                    series_count = None
+            series_type = info.series_type
+            series_index = info.index
 
-                return 'focus_bracket', series_count, series_index
+            # Count total series files in same directory
+            # Safe: photo_path was validated, so parent_dir is also within allowed directory
+            parent_dir = photo_path.parent
+            try:
+                # Get series ID for this photo to count matching files
+                series_id = get_series_id(photo_path)
+                if series_id is None:
+                    return series_type, None, series_index
 
-            # Check for HDR pattern: *_N where N is single digit
-            # Ensure it's not part of timestamp (avoid matching date/time numbers)
-            hdr_match = re.search(r'_(\d)$', filename)
-            if hdr_match:
-                series_index = int(hdr_match.group(1))
+                # Count files with same series ID in directory
+                series_count = 0
+                for jpg_file in parent_dir.glob("*.jpg"):
+                    if get_series_id(jpg_file) == series_id:
+                        series_count += 1
 
-                # Count total HDR files in same directory
-                # Safe: photo_path was validated, so parent_dir is also within allowed directory
-                base_pattern = re.sub(r'_\d$', '', filename)
-                parent_dir = photo_path.parent
-                try:
-                    series_files = list(parent_dir.glob(f"{base_pattern}_*.jpg"))
+                # Also check uppercase extension
+                for jpg_file in parent_dir.glob("*.JPG"):
+                    if get_series_id(jpg_file) == series_id:
+                        series_count += 1
 
-                    # Filter to only single-digit suffixes (HDR series)
-                    hdr_files = [f for f in series_files if re.search(r'_\d\.jpg$', f.name)]
-                    series_count = len(hdr_files)
-                except OSError as e:
-                    logger.warning(f"Failed to glob series files: {e}")
-                    series_count = None
+                return series_type, series_count, series_index
 
-                if series_count > 1:
-                    return 'hdr', series_count, series_index
+            except OSError as e:
+                logger.warning(f"Failed to glob series files: {e}")
+                return series_type, None, series_index
 
-        except (AttributeError, TypeError, re.error) as e:
-            # Gracefully handle pattern matching errors (regex failures, None values)
+        except ImportError as e:
+            logger.warning(f"Series detection library not available: {e}")
+            return None, None, None
+        except (AttributeError, TypeError) as e:
+            # Gracefully handle pattern matching errors (None values, etc.)
             logger.debug(f"Series detection failed: {e}")
-
-        return None, None, None
+            return None, None, None

--- a/Firmware/webui/backend/services/series_service.py
+++ b/Firmware/webui/backend/services/series_service.py
@@ -1,0 +1,268 @@
+"""
+Series Service for Mothbox Photo Gallery (Issue #110)
+
+Provides cached series detection with thread-safety and cross-directory support.
+
+Usage:
+    from webui.backend.services.series_service import SeriesService
+
+    service = SeriesService(cache_ttl=300)  # 5 minute cache
+
+    # Get all series in a directory
+    series_list = service.get_series_for_directory("/var/lib/mothbox/photos")
+
+    # Get specific series by ID
+    series = service.get_series_by_id("hdr_moth_2024_01_15__10_00_00")
+
+    # Invalidate cache
+    service.invalidate_cache()  # All
+    service.invalidate_cache(directory)  # Specific directory
+"""
+
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Union
+
+from webui.backend.lib.series_detection import (
+    detect_series_type,
+    get_series_id,
+    group_photos_into_series,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PhotoSeries:
+    """Represents a photo series (HDR or Focus Bracket).
+
+    Attributes:
+        series_id: Unique identifier for grouping (e.g., "hdr_moth_2024_01_15__10_00_00")
+        series_type: Type of series ("hdr" or "focus_bracket")
+        base_name: Common prefix from filename (timestamp-based)
+        photos: List of photo paths in series, sorted by index
+        count: Number of photos in series
+        cover_photo: First photo in series (index 0), used for thumbnails
+    """
+    series_id: str
+    series_type: str
+    base_name: str
+    photos: list[Path]
+    count: int
+    cover_photo: Path
+
+
+@dataclass
+class _CacheEntry:
+    """Internal cache entry with timestamp for TTL expiration."""
+    series_list: list[PhotoSeries]
+    timestamp: float
+    directory: Path
+
+
+class SeriesService:
+    """Service for detecting and caching photo series.
+
+    Thread-safe with configurable cache TTL. Supports cross-directory
+    series detection (photos can span date folders).
+
+    Attributes:
+        _cache_ttl: Time-to-live for cache entries in seconds
+    """
+
+    def __init__(self, cache_ttl: int = 300):
+        """Initialize SeriesService.
+
+        Args:
+            cache_ttl: Cache time-to-live in seconds (default 5 minutes)
+        """
+        self._cache_ttl = cache_ttl
+        self._cache: dict[str, _CacheEntry] = {}
+        self._lock = threading.Lock()
+        self._stats = {
+            'cache_hits': 0,
+            'cache_misses': 0,
+        }
+
+    def get_series_for_directory(
+        self,
+        directory: Union[str, Path]
+    ) -> list[PhotoSeries]:
+        """Get all photo series in a directory.
+
+        Scans directory recursively for photos and groups them by series.
+        Results are cached for performance.
+
+        Args:
+            directory: Directory to scan (string or Path)
+
+        Returns:
+            List of PhotoSeries objects, sorted by base_name (timestamp)
+        """
+        directory = Path(directory) if isinstance(directory, str) else directory
+        cache_key = str(directory.resolve())
+
+        with self._lock:
+            # Check cache
+            entry = self._cache.get(cache_key)
+            if entry and (time.time() - entry.timestamp) < self._cache_ttl:
+                self._stats['cache_hits'] += 1
+                logger.debug(f"Cache hit for {directory}")
+                return entry.series_list
+
+            self._stats['cache_misses'] += 1
+
+        # Cache miss - scan directory
+        logger.debug(f"Cache miss for {directory}, scanning...")
+        series_list = self._scan_directory(directory)
+
+        with self._lock:
+            self._cache[cache_key] = _CacheEntry(
+                series_list=series_list,
+                timestamp=time.time(),
+                directory=directory
+            )
+
+        return series_list
+
+    def _scan_directory(self, directory: Path) -> list[PhotoSeries]:
+        """Scan directory for photo series.
+
+        Args:
+            directory: Directory to scan
+
+        Returns:
+            List of PhotoSeries, sorted by base_name
+        """
+        if not directory.exists():
+            return []
+
+        try:
+            # Find all JPEG photos recursively
+            photos = list(directory.rglob("*.jpg")) + list(directory.rglob("*.JPG"))
+            photos.extend(directory.rglob("*.jpeg"))
+            photos.extend(directory.rglob("*.JPEG"))
+
+            if not photos:
+                return []
+
+            # Group by series
+            groups = group_photos_into_series(photos)
+
+            # Convert to PhotoSeries objects
+            series_list: list[PhotoSeries] = []
+            for series_id, photo_paths in groups.items():
+                if len(photo_paths) < 2:
+                    continue  # Skip single photos
+
+                # Determine series type from first photo
+                info = detect_series_type(photo_paths[0])
+                if not info:
+                    continue
+
+                series = PhotoSeries(
+                    series_id=series_id,
+                    series_type=info.series_type,
+                    base_name=info.base_name,
+                    photos=photo_paths,
+                    count=len(photo_paths),
+                    cover_photo=photo_paths[0]  # First photo (index 0)
+                )
+                series_list.append(series)
+
+            # Sort by base_name (which contains timestamp)
+            series_list.sort(key=lambda s: s.base_name)
+
+            logger.debug(f"Found {len(series_list)} series in {directory}")
+            return series_list
+
+        except (PermissionError, IOError, OSError) as e:
+            logger.warning(f"Error scanning {directory}: {e}")
+            return []
+
+    def get_series_by_id(
+        self,
+        series_id: str,
+        directory: Union[str, Path, None] = None
+    ) -> PhotoSeries | None:
+        """Get a specific series by ID.
+
+        Searches cached data for the series. If directory is provided,
+        scans that directory first to ensure cache is populated.
+
+        Args:
+            series_id: Series identifier (e.g., "hdr_moth_2024_01_15__10_00_00")
+            directory: Optional directory hint to search
+
+        Returns:
+            PhotoSeries if found, None otherwise
+        """
+        if directory:
+            self.get_series_for_directory(directory)
+
+        with self._lock:
+            for entry in self._cache.values():
+                for series in entry.series_list:
+                    if series.series_id == series_id:
+                        return series
+
+        return None
+
+    def invalidate_cache(self, directory: Union[str, Path, None] = None) -> None:
+        """Invalidate cache entries.
+
+        Args:
+            directory: If provided, only invalidate that directory's cache.
+                      If None, invalidate entire cache.
+        """
+        with self._lock:
+            if directory is None:
+                self._cache.clear()
+                logger.debug("Invalidated entire series cache")
+            else:
+                cache_key = str(Path(directory).resolve())
+                if cache_key in self._cache:
+                    del self._cache[cache_key]
+                    logger.debug(f"Invalidated cache for {directory}")
+
+    def get_statistics(self) -> dict:
+        """Get cache statistics.
+
+        Returns:
+            Dictionary with cache metrics including:
+            - cache_entries: Number of cached directories
+            - cache_hits: Total cache hit count
+            - cache_misses: Total cache miss count
+            - total_series: Total series across all cached directories
+            - series_by_type: Count of series by type (hdr, focus_bracket)
+        """
+        with self._lock:
+            total_series = 0
+            series_by_type: dict[str, int] = {}
+
+            for entry in self._cache.values():
+                for series in entry.series_list:
+                    total_series += 1
+                    t = series.series_type
+                    series_by_type[t] = series_by_type.get(t, 0) + 1
+
+            return {
+                'cache_entries': len(self._cache),
+                'cache_hits': self._stats['cache_hits'],
+                'cache_misses': self._stats['cache_misses'],
+                'total_series': total_series,
+                'series_by_type': series_by_type,
+            }
+
+
+# ============================================================================
+# Module exports
+# ============================================================================
+
+__all__ = [
+    'SeriesService',
+    'PhotoSeries',
+]

--- a/Firmware/webui/docs/dev/api/gallery.md
+++ b/Firmware/webui/docs/dev/api/gallery.md
@@ -1,7 +1,7 @@
 # Gallery API Documentation
 
-**Last Updated**: 2025-11-10
-**Version**: Phase 1 (v5.1.0)
+**Last Updated**: 2025-11-29
+**Version**: Phase 3 (v5.2.0)
 **Base URL**: `/api/gallery`
 
 ---
@@ -12,9 +12,10 @@
 2. [Authentication](#authentication)
 3. [Error Responses](#error-responses)
 4. [Photo Endpoints](#photo-endpoints)
-5. [Cache Management Endpoints](#cache-management-endpoints)
-6. [Pagination Contract](#pagination-contract)
-7. [Performance Characteristics](#performance-characteristics)
+5. [Series Endpoints](#series-endpoints) *(NEW - Issue #110)*
+6. [Cache Management Endpoints](#cache-management-endpoints)
+7. [Pagination Contract](#pagination-contract)
+8. [Performance Characteristics](#performance-characteristics)
 
 ---
 
@@ -447,6 +448,303 @@ fetch('/api/gallery/photos')
 **With**:
 ```javascript
 fetch('/api/gallery/photos/paginated?limit=50&offset=0')
+```
+
+---
+
+## Series Endpoints
+
+Photo series (HDR and Focus Bracket) are automatically detected based on TakePhoto.py naming patterns.
+
+**Naming Patterns**:
+- **HDR**: `{name}_{YYYY_MM_DD__HH_MM_SS}_HDR{index}.jpg` (e.g., `moth_2024_01_15__10_30_00_HDR0.jpg`)
+- **Focus Bracket**: `ManFocus_{name}_{YYYY_MM_DD__HH_MM_SS}_FB{index}.jpg` (e.g., `ManFocus_moth_2024_01_15__10_30_00_FB0.jpg`)
+
+**Implementation**: `webui/backend/services/series_service.py`, `webui/backend/lib/series_detection.py`
+
+---
+
+### 10. List Series
+
+Retrieve all photo series in the photos directory.
+
+**Endpoint**: `GET /api/gallery/series`
+
+**Implementation**: `webui/backend/routes/gallery.py`
+
+#### Request
+
+**Query Parameters**:
+
+| Parameter | Type | Required | Default | Validation | Description |
+|-----------|------|----------|---------|------------|-------------|
+| `page` | integer | No | 1 | ≥1 | Page number |
+| `per_page` | integer | No | 50 | 1-200 | Items per page |
+| `type` | string | No | None | `hdr`, `focus_bracket` | Filter by series type |
+
+#### Response
+
+**Success (200)**:
+
+```json
+{
+  "series": [
+    {
+      "series_id": "hdr_moth_2024_01_15__10_00_00",
+      "series_type": "hdr",
+      "base_name": "moth_2024_01_15__10_00_00",
+      "count": 3,
+      "cover_photo": "moth_2024_01_15__10_00_00_HDR0.jpg",
+      "photos": [
+        "moth_2024_01_15__10_00_00_HDR0.jpg",
+        "moth_2024_01_15__10_00_00_HDR1.jpg",
+        "moth_2024_01_15__10_00_00_HDR2.jpg"
+      ]
+    },
+    {
+      "series_id": "focus_bracket_ManFocus_moth_2024_01_15__11_00_00",
+      "series_type": "focus_bracket",
+      "base_name": "ManFocus_moth_2024_01_15__11_00_00",
+      "count": 5,
+      "cover_photo": "ManFocus_moth_2024_01_15__11_00_00_FB0.jpg",
+      "photos": [
+        "ManFocus_moth_2024_01_15__11_00_00_FB0.jpg",
+        "ManFocus_moth_2024_01_15__11_00_00_FB1.jpg",
+        "ManFocus_moth_2024_01_15__11_00_00_FB2.jpg",
+        "ManFocus_moth_2024_01_15__11_00_00_FB3.jpg",
+        "ManFocus_moth_2024_01_15__11_00_00_FB4.jpg"
+      ]
+    }
+  ],
+  "pagination": {
+    "page": 1,
+    "per_page": 50,
+    "total": 2,
+    "has_next": false
+  }
+}
+```
+
+**Error Responses**:
+
+```json
+// 400 - Invalid page number
+{
+  "error": "Invalid page: -1. Page must be >= 1"
+}
+
+// 400 - Invalid type filter
+{
+  "error": "Invalid type: 'invalid'. Valid types: hdr, focus_bracket"
+}
+
+// 503 - Service unavailable
+{
+  "error": "Series service unavailable"
+}
+
+// 500 - Internal error
+{
+  "error": "Internal server error"
+}
+```
+
+#### Examples
+
+**List all series**:
+```bash
+curl "http://localhost:5000/api/gallery/series"
+```
+
+**Filter by type**:
+```bash
+curl "http://localhost:5000/api/gallery/series?type=hdr"
+```
+
+**Paginate results**:
+```bash
+curl "http://localhost:5000/api/gallery/series?page=2&per_page=20"
+```
+
+#### Performance
+
+- **Cold cache**: 100-500ms (directory scan)
+- **Warm cache**: <10ms (in-memory lookup)
+- **1000 photos**: <100ms grouping time
+
+---
+
+### 11. Get Series Details
+
+Retrieve details for a specific photo series by ID.
+
+**Endpoint**: `GET /api/gallery/series/<series_id>`
+
+#### Request
+
+**Path Parameters**:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `series_id` | string | Yes | Series identifier (e.g., `hdr_moth_2024_01_15__10_00_00`) |
+
+#### Response
+
+**Success (200)**:
+
+```json
+{
+  "series_id": "hdr_moth_2024_01_15__10_00_00",
+  "series_type": "hdr",
+  "base_name": "moth_2024_01_15__10_00_00",
+  "count": 3,
+  "cover_photo": "moth_2024_01_15__10_00_00_HDR0.jpg",
+  "photos": [
+    "moth_2024_01_15__10_00_00_HDR0.jpg",
+    "moth_2024_01_15__10_00_00_HDR1.jpg",
+    "moth_2024_01_15__10_00_00_HDR2.jpg"
+  ]
+}
+```
+
+**Error Responses**:
+
+```json
+// 404 - Series not found
+{
+  "error": "Series not found: hdr_invalid_id"
+}
+
+// 503 - Service unavailable
+{
+  "error": "Series service unavailable"
+}
+```
+
+#### Examples
+
+**Get specific series**:
+```bash
+curl "http://localhost:5000/api/gallery/series/hdr_moth_2024_01_15__10_00_00"
+```
+
+**React component**:
+```jsx
+const { data: series } = useQuery({
+  queryKey: ['series', seriesId],
+  queryFn: () =>
+    fetch(`/api/gallery/series/${seriesId}`).then(r => r.json())
+});
+
+return (
+  <div>
+    <h2>{series.series_type.toUpperCase()} Series ({series.count} photos)</h2>
+    <div className="grid grid-cols-3">
+      {series.photos.map(photo => (
+        <img
+          key={photo}
+          src={`/api/gallery/thumbnail/${photo}?size=256`}
+          alt={photo}
+        />
+      ))}
+    </div>
+  </div>
+);
+```
+
+---
+
+### 12. Get Series Statistics
+
+Retrieve cache statistics for the series service.
+
+**Endpoint**: `GET /api/gallery/series/stats`
+
+#### Response
+
+**Success (200)**:
+
+```json
+{
+  "cache_entries": 5,
+  "cache_hits": 42,
+  "cache_misses": 8,
+  "total_series": 10,
+  "series_by_type": {
+    "hdr": 6,
+    "focus_bracket": 4
+  }
+}
+```
+
+**Field Descriptions**:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `cache_entries` | integer | Number of cached directory scans |
+| `cache_hits` | integer | Total cache hit count |
+| `cache_misses` | integer | Total cache miss count |
+| `total_series` | integer | Total series across all cached directories |
+| `series_by_type` | object | Count of series by type |
+
+#### Examples
+
+**Get statistics**:
+```bash
+curl "http://localhost:5000/api/gallery/series/stats"
+```
+
+---
+
+### 13. Invalidate Series Cache
+
+Manually invalidate the series detection cache.
+
+**Endpoint**: `POST /api/gallery/series/cache/invalidate`
+
+#### Request
+
+**Headers**:
+- `Content-Type`: `application/json`
+- `X-CSRFToken`: CSRF token (required)
+
+**Body** (JSON):
+
+```json
+{
+  "directory": "/var/lib/mothbox/photos"  // Optional: specific directory
+}
+```
+
+- If `directory` is not provided, the entire cache is invalidated.
+
+#### Response
+
+**Success (200)**:
+
+```json
+{
+  "success": true
+}
+```
+
+**Error Responses**:
+
+```json
+// 503 - Service unavailable
+{
+  "error": "Series service unavailable"
+}
+```
+
+#### Examples
+
+**Invalidate entire cache**:
+```bash
+curl -X POST "http://localhost:5000/api/gallery/series/cache/invalidate" \
+  -H "Content-Type: application/json" \
+  -H "X-CSRFToken: YOUR_CSRF_TOKEN" \
+  -d '{}'
 ```
 
 ---


### PR DESCRIPTION
## Summary

Implements automatic detection and grouping of HDR and Focus Bracket photo series based on TakePhoto.py naming patterns (Issue #110, Phase 3 - Gallery Enhancement).

- Add core series detection library with pattern matching for HDR (`*_HDR{N}.jpg`) and Focus Bracket (`ManFocus_*_FB{N}.jpg`) naming conventions
- Add SeriesService with thread-safe in-memory caching (5-minute TTL)
- Add REST API endpoints for series queries (`/api/gallery/series`, `/api/gallery/series/<id>`, `/api/gallery/series/stats`)
- Fix `metadata_service._detect_series_info()` which had incorrect regex patterns that didn't match actual TakePhoto.py output
- Update test fixtures to use correct 0-indexed naming patterns

## Test plan

- [x] Run unit tests: `pytest Tests/unit/test_series_detection_lib.py Tests/unit/test_series_service.py Tests/unit/test_series_api.py -v` (96 tests)
- [x] Run metadata service tests: `pytest Tests/unit/test_metadata_service.py -v` (61 tests)
- [x] Run performance tests: `pytest Tests/performance/test_series_detection_performance.py -v` (16 tests)
- [x] Verify coverage ≥85%: Combined coverage is 94.52%
- [x] Verify performance targets: <10ms single parsing, <100ms for 1000 photos grouping, >80% cache hit ratio