### PR TITLE
feat: Interactive Hover Popup with 3x3 Thumbnail Preview (Issue #117)

### DIFF
--- a/Firmware/Tests/unit/test_clustering_api.py
+++ b/Firmware/Tests/unit/test_clustering_api.py
@@ -527,3 +527,153 @@ class TestErrorHandling:
         assert response.status_code == 200
         data = json.loads(response.data)
         assert data['metadata']['radius_m'] == 0
+
+
+# ============================================================================
+# Tags Support Tests (Issue #117 - Subtask 1)
+# ============================================================================
+
+class TestTagsInClusteringAPI:
+    """Test tags field support in clustering API responses."""
+
+    def test_cluster_photos_include_tags(self, client, gallery_app):
+        """Cluster photos include tags field in response."""
+        # Setup mock with tags
+        clustering_service = gallery_app.config['CLUSTERING_SERVICE']
+        clustering_service.get_clustered_locations.return_value = ClusteringResult(
+            clusters=[
+                PhotoCluster(
+                    cluster_id="cluster_37.7749N_122.4194W_2",
+                    center_lat=37.7749,
+                    center_lon=-122.4194,
+                    photos=[
+                        PhotoLocation("photo1.jpg", 37.7749, -122.4194, "2024-01-15T10:00:00", tags=["moth", "night"]),
+                        PhotoLocation("photo2.jpg", 37.7750, -122.4195, "2024-01-15T11:00:00", tags=["beetle", "day"])
+                    ],
+                    date_range=("2024-01-15T10:00:00", "2024-01-15T11:00:00")
+                )
+            ],
+            unclustered=[],
+            total_photos=2,
+            total_clusters=1,
+            radius_m=100,
+            processing_time_ms=45.2
+        )
+
+        response = client.get('/api/gallery/locations/clustered')
+        data = json.loads(response.data)
+
+        # Check cluster photos have tags
+        assert len(data['clusters']) == 1
+        cluster = data['clusters'][0]
+        photos = cluster['photos']
+
+        assert len(photos) == 2
+        photo1 = next(p for p in photos if p['photo_id'] == 'photo1.jpg')
+        photo2 = next(p for p in photos if p['photo_id'] == 'photo2.jpg')
+
+        assert 'tags' in photo1
+        assert photo1['tags'] == ["moth", "night"]
+        assert 'tags' in photo2
+        assert photo2['tags'] == ["beetle", "day"]
+
+    def test_unclustered_photos_include_tags(self, client, gallery_app):
+        """Unclustered photos include tags field in response."""
+        clustering_service = gallery_app.config['CLUSTERING_SERVICE']
+        clustering_service.get_clustered_locations.return_value = ClusteringResult(
+            clusters=[],
+            unclustered=[
+                PhotoLocation("photo1.jpg", 37.7749, -122.4194, "2024-01-15T10:00:00", tags=["moth", "solo"]),
+                PhotoLocation("photo2.jpg", 38.0000, -123.0000, "2024-01-15T12:00:00", tags=["butterfly"])
+            ],
+            total_photos=2,
+            total_clusters=0,
+            radius_m=100,
+            processing_time_ms=10.0
+        )
+
+        response = client.get('/api/gallery/locations/clustered')
+        data = json.loads(response.data)
+
+        # Check unclustered photos have tags
+        assert len(data['unclustered']) == 2
+        photo1 = next(p for p in data['unclustered'] if p['photo_id'] == 'photo1.jpg')
+        photo2 = next(p for p in data['unclustered'] if p['photo_id'] == 'photo2.jpg')
+
+        assert 'tags' in photo1
+        assert photo1['tags'] == ["moth", "solo"]
+        assert 'tags' in photo2
+        assert photo2['tags'] == ["butterfly"]
+
+    def test_photos_without_tags_return_none(self, client, gallery_app):
+        """Photos without tags return None for tags field."""
+        clustering_service = gallery_app.config['CLUSTERING_SERVICE']
+        clustering_service.get_clustered_locations.return_value = ClusteringResult(
+            clusters=[
+                PhotoCluster(
+                    cluster_id="cluster_37.7749N_122.4194W_2",
+                    center_lat=37.7749,
+                    center_lon=-122.4194,
+                    photos=[
+                        PhotoLocation("photo1.jpg", 37.7749, -122.4194, "2024-01-15T10:00:00"),  # No tags
+                        PhotoLocation("photo2.jpg", 37.7750, -122.4195, "2024-01-15T11:00:00")   # No tags
+                    ],
+                    date_range=("2024-01-15T10:00:00", "2024-01-15T11:00:00")
+                )
+            ],
+            unclustered=[],
+            total_photos=2,
+            total_clusters=1,
+            radius_m=100,
+            processing_time_ms=45.2
+        )
+
+        response = client.get('/api/gallery/locations/clustered')
+        data = json.loads(response.data)
+
+        # Check photos have tags field but value is None
+        cluster = data['clusters'][0]
+        photos = cluster['photos']
+
+        assert len(photos) == 2
+        for photo in photos:
+            assert 'tags' in photo
+            assert photo['tags'] is None
+
+    def test_mixed_tags_none_and_values(self, client, gallery_app):
+        """Mix of photos with and without tags handled correctly."""
+        clustering_service = gallery_app.config['CLUSTERING_SERVICE']
+        clustering_service.get_clustered_locations.return_value = ClusteringResult(
+            clusters=[
+                PhotoCluster(
+                    cluster_id="cluster_37.7749N_122.4194W_3",
+                    center_lat=37.7749,
+                    center_lon=-122.4194,
+                    photos=[
+                        PhotoLocation("photo1.jpg", 37.7749, -122.4194, "2024-01-15T10:00:00", tags=["moth"]),
+                        PhotoLocation("photo2.jpg", 37.7750, -122.4195, "2024-01-15T11:00:00"),  # No tags
+                        PhotoLocation("photo3.jpg", 37.7751, -122.4196, "2024-01-15T12:00:00", tags=["beetle", "day"])
+                    ],
+                    date_range=("2024-01-15T10:00:00", "2024-01-15T12:00:00")
+                )
+            ],
+            unclustered=[],
+            total_photos=3,
+            total_clusters=1,
+            radius_m=100,
+            processing_time_ms=50.0
+        )
+
+        response = client.get('/api/gallery/locations/clustered')
+        data = json.loads(response.data)
+
+        cluster = data['clusters'][0]
+        photos = cluster['photos']
+
+        photo1 = next(p for p in photos if p['photo_id'] == 'photo1.jpg')
+        photo2 = next(p for p in photos if p['photo_id'] == 'photo2.jpg')
+        photo3 = next(p for p in photos if p['photo_id'] == 'photo3.jpg')
+
+        assert photo1['tags'] == ["moth"]
+        assert photo2['tags'] is None
+        assert photo3['tags'] == ["beetle", "day"]

--- a/Firmware/Tests/unit/test_geo_clustering_lib.py
+++ b/Firmware/Tests/unit/test_geo_clustering_lib.py
@@ -642,3 +642,134 @@ class TestInputValidation:
 
         assert center_lat == 0.0
         assert center_lon == 0.0
+
+
+# ============================================================================
+# 9. Tags Support Tests (Issue #117 - Subtask 1)
+# ============================================================================
+
+class TestTagsSupport:
+    """Test tags field support in PhotoLocation and clustering."""
+
+    def test_photo_location_with_tags(self):
+        """PhotoLocation accepts tags field."""
+        photo = PhotoLocation(
+            photo_id="photo1.jpg",
+            lat=37.7749,
+            lon=-122.4194,
+            timestamp="2024-01-15T10:00:00",
+            tags=["moth", "night", "hdr"]
+        )
+
+        assert photo.tags == ["moth", "night", "hdr"]
+
+    def test_photo_location_without_tags(self):
+        """PhotoLocation tags field defaults to None."""
+        photo = PhotoLocation(
+            photo_id="photo1.jpg",
+            lat=37.7749,
+            lon=-122.4194
+        )
+
+        assert photo.tags is None
+
+    def test_clustering_preserves_tags(self):
+        """cluster_locations() preserves tags through clustering."""
+        locations = [
+            {
+                "photo_id": "photo1.jpg",
+                "lat": 37.7749,
+                "lon": -122.4194,
+                "tags": ["moth", "night"]
+            },
+            {
+                "photo_id": "photo2.jpg",
+                "lat": 37.7750,
+                "lon": -122.4195,
+                "tags": ["beetle", "day"]
+            },
+        ]
+
+        result = cluster_locations(locations, radius_m=100)
+
+        # Should form one cluster
+        assert result.total_clusters == 1
+        cluster = result.clusters[0]
+
+        # Tags should be preserved in photos
+        photo1 = next(p for p in cluster.photos if p.photo_id == "photo1.jpg")
+        photo2 = next(p for p in cluster.photos if p.photo_id == "photo2.jpg")
+
+        assert photo1.tags == ["moth", "night"]
+        assert photo2.tags == ["beetle", "day"]
+
+    def test_clustering_handles_missing_tags(self):
+        """cluster_locations() handles photos without tags."""
+        locations = [
+            {
+                "photo_id": "photo1.jpg",
+                "lat": 37.7749,
+                "lon": -122.4194,
+                "tags": ["moth"]
+            },
+            {
+                "photo_id": "photo2.jpg",
+                "lat": 37.7750,
+                "lon": -122.4195
+                # No tags field
+            },
+        ]
+
+        result = cluster_locations(locations, radius_m=100)
+
+        # Should form one cluster
+        assert result.total_clusters == 1
+        cluster = result.clusters[0]
+
+        # Tags should be preserved/None
+        photo1 = next(p for p in cluster.photos if p.photo_id == "photo1.jpg")
+        photo2 = next(p for p in cluster.photos if p.photo_id == "photo2.jpg")
+
+        assert photo1.tags == ["moth"]
+        assert photo2.tags is None
+
+    def test_unclustered_photos_preserve_tags(self):
+        """Unclustered photos preserve their tags."""
+        locations = [
+            {
+                "photo_id": "photo1.jpg",
+                "lat": 37.7749,
+                "lon": -122.4194,
+                "tags": ["moth", "solo"]
+            }
+        ]
+
+        result = cluster_locations(locations, radius_m=100)
+
+        # Single photo should be unclustered
+        assert len(result.unclustered) == 1
+        photo = result.unclustered[0]
+
+        assert photo.tags == ["moth", "solo"]
+
+    def test_empty_tags_list(self):
+        """Empty tags list is preserved."""
+        locations = [
+            {
+                "photo_id": "photo1.jpg",
+                "lat": 37.7749,
+                "lon": -122.4194,
+                "tags": []
+            },
+            {
+                "photo_id": "photo2.jpg",
+                "lat": 37.7750,
+                "lon": -122.4195,
+                "tags": []
+            },
+        ]
+
+        result = cluster_locations(locations, radius_m=100)
+
+        cluster = result.clusters[0]
+        assert all(p.tags == [] for p in cluster.photos)

--- a/Firmware/webui/backend/app.py
+++ b/Firmware/webui/backend/app.py
@@ -153,27 +153,31 @@ else:
     app.config['CACHE_WARMER'] = None
     print("⚠️  Cache warmer not initialized (thumbnail cache unavailable)")
 
-# Initialize series service (Issue #110)
-from services.series_service import SeriesService
+# Initialize services using lazy getters (avoids circular imports)
+# Services are lazily initialized on first access via get_*_service() functions
+from services import get_series_service, get_clustering_service, get_locations_service
 
 try:
-    series_service = SeriesService(cache_ttl=300)  # 5 minute cache
-    app.config['SERIES_SERVICE'] = series_service
+    # Pre-initialize services and store in app.config for routes that need direct access
+    app.config['SERIES_SERVICE'] = get_series_service()
     print("✓ Series service initialized")
 except Exception as e:
     print(f"⚠️  Failed to initialize series service: {e}")
     app.config['SERIES_SERVICE'] = None
 
-# Initialize clustering service (Issue #115)
-from services.clustering_service import ClusteringService
-
 try:
-    clustering_service = ClusteringService(cache_ttl=300)  # 5 minute cache
-    app.config['CLUSTERING_SERVICE'] = clustering_service
+    app.config['CLUSTERING_SERVICE'] = get_clustering_service()
     print("✓ Clustering service initialized")
 except Exception as e:
     print(f"⚠️  Failed to initialize clustering service: {e}")
     app.config['CLUSTERING_SERVICE'] = None
+
+try:
+    app.config['LOCATIONS_SERVICE'] = get_locations_service()
+    print("✓ Locations service initialized")
+except Exception as e:
+    print(f"⚠️  Failed to initialize locations service: {e}")
+    app.config['LOCATIONS_SERVICE'] = None
 
 # Import route blueprints
 from routes.camera import camera_bp

--- a/Firmware/webui/backend/lib/geo_clustering.py
+++ b/Firmware/webui/backend/lib/geo_clustering.py
@@ -51,12 +51,14 @@ class PhotoLocation:
         lon: Longitude in decimal degrees (-180 to 180)
         timestamp: Optional ISO format timestamp (YYYY-MM-DDTHH:MM:SS)
         filepath: Optional full path to photo file
+        tags: Optional list of tags/labels for the photo (Issue #117)
     """
     photo_id: str
     lat: float
     lon: float
     timestamp: str | None = None
     filepath: Path | None = None
+    tags: list[str] | None = None
 
 
 @dataclass
@@ -356,6 +358,7 @@ def cluster_locations(
         lon = loc.get("lon")
         timestamp = loc.get("timestamp")
         filepath = loc.get("filepath")
+        tags = loc.get("tags")  # Issue #117: Extract tags
 
         # Skip if missing required fields
         if not photo_id or lat is None or lon is None:
@@ -371,7 +374,8 @@ def cluster_locations(
             lat=float(lat),
             lon=float(lon),
             timestamp=timestamp,
-            filepath=Path(filepath) if filepath else None
+            filepath=Path(filepath) if filepath else None,
+            tags=tags  # Issue #117: Pass through tags
         ))
 
     n = len(photo_locations)

--- a/Firmware/webui/backend/routes/camera.py
+++ b/Firmware/webui/backend/routes/camera.py
@@ -1,8 +1,11 @@
 """Camera control endpoints"""
 
+import logging
 import subprocess
 from datetime import datetime
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 # Setup path to import mothbox_paths
 # Import camera control mapping
@@ -529,6 +532,29 @@ def capture_photo():
                     from routes.system import invalidate_photo_count_cache
 
                     invalidate_photo_count_cache()
+
+                    # Invalidate location-related caches so map view shows new photo
+                    try:
+                        from webui.backend.app import (
+                            clustering_service,
+                            series_service,
+                            locations_service
+                        )
+
+                        if clustering_service:
+                            clustering_service.invalidate_cache(PHOTOS_DIR)
+                        if series_service:
+                            series_service.invalidate_cache(PHOTOS_DIR)
+                        if locations_service:
+                            locations_service.invalidate_cache(PHOTOS_DIR)
+
+                        logger.debug("Invalidated location/clustering/series caches after photo capture")
+                    except ImportError:
+                        # Services not yet initialized - this is fine during startup
+                        pass
+                    except Exception as cache_error:
+                        # Log but don't fail capture on cache invalidation errors
+                        logger.warning(f"Failed to invalidate caches: {cache_error}")
 
                     # Build success response with Focus Bracket / HDR metadata
                     response_data = {

--- a/Firmware/webui/backend/routes/camera.py
+++ b/Firmware/webui/backend/routes/camera.py
@@ -535,23 +535,17 @@ def capture_photo():
 
                     # Invalidate location-related caches so map view shows new photo
                     try:
-                        from webui.backend.app import (
-                            clustering_service,
-                            series_service,
-                            locations_service
+                        from services import (
+                            get_clustering_service,
+                            get_series_service,
+                            get_locations_service
                         )
 
-                        if clustering_service:
-                            clustering_service.invalidate_cache(PHOTOS_DIR)
-                        if series_service:
-                            series_service.invalidate_cache(PHOTOS_DIR)
-                        if locations_service:
-                            locations_service.invalidate_cache(PHOTOS_DIR)
+                        get_clustering_service().invalidate_cache(PHOTOS_DIR)
+                        get_series_service().invalidate_cache(PHOTOS_DIR)
+                        get_locations_service().invalidate_cache(PHOTOS_DIR)
 
                         logger.debug("Invalidated location/clustering/series caches after photo capture")
-                    except ImportError:
-                        # Services not yet initialized - this is fine during startup
-                        pass
                     except Exception as cache_error:
                         # Log but don't fail capture on cache invalidation errors
                         logger.warning(f"Failed to invalidate caches: {cache_error}")

--- a/Firmware/webui/backend/routes/gallery.py
+++ b/Firmware/webui/backend/routes/gallery.py
@@ -1187,7 +1187,8 @@ def get_clustered_locations():
                     'photo_id': photo.photo_id,
                     'lat': photo.lat,
                     'lon': photo.lon,
-                    'timestamp': photo.timestamp
+                    'timestamp': photo.timestamp,
+                    'tags': photo.tags  # Issue #117: Include tags
                 })
 
             # Build cluster object
@@ -1214,7 +1215,8 @@ def get_clustered_locations():
                 'photo_id': photo.photo_id,
                 'lat': photo.lat,
                 'lon': photo.lon,
-                'timestamp': photo.timestamp
+                'timestamp': photo.timestamp,
+                'tags': photo.tags  # Issue #117: Include tags
             })
 
         # Build response

--- a/Firmware/webui/backend/services/__init__.py
+++ b/Firmware/webui/backend/services/__init__.py
@@ -2,9 +2,60 @@
 Services package for Mothbox web UI backend
 
 Contains business logic services that can be used by route handlers.
+Provides lazy-initialization getters for singleton services to avoid circular imports.
 """
 
 from .photo_service import PaginationError, PhotoService
 from .thumbnail_cache import ThumbnailCache, ThumbnailError
 
-__all__ = ['PhotoService', 'PaginationError', 'ThumbnailCache', 'ThumbnailError']
+# Lazy-initialized singleton service instances
+_clustering_service = None
+_series_service = None
+_locations_service = None
+
+
+def get_clustering_service():
+    """
+    Get the singleton ClusteringService instance.
+    Lazily initializes on first call to avoid circular imports.
+    """
+    global _clustering_service
+    if _clustering_service is None:
+        from .clustering_service import ClusteringService
+        _clustering_service = ClusteringService(cache_ttl=300)
+    return _clustering_service
+
+
+def get_series_service():
+    """
+    Get the singleton SeriesService instance.
+    Lazily initializes on first call to avoid circular imports.
+    """
+    global _series_service
+    if _series_service is None:
+        from .series_service import SeriesService
+        _series_service = SeriesService(cache_ttl=300)
+    return _series_service
+
+
+def get_locations_service():
+    """
+    Get the singleton LocationsService instance.
+    Lazily initializes on first call to avoid circular imports.
+    """
+    global _locations_service
+    if _locations_service is None:
+        from .locations_service import LocationsService
+        _locations_service = LocationsService(cache_ttl=300)
+    return _locations_service
+
+
+__all__ = [
+    'PhotoService',
+    'PaginationError',
+    'ThumbnailCache',
+    'ThumbnailError',
+    'get_clustering_service',
+    'get_series_service',
+    'get_locations_service',
+]

--- a/Firmware/webui/frontend/src/components/MapView.jsx
+++ b/Firmware/webui/frontend/src/components/MapView.jsx
@@ -7,6 +7,7 @@ import markerIconRetina from 'leaflet/dist/images/marker-icon-2x.png'
 import markerShadow from 'leaflet/dist/images/marker-shadow.png'
 import { MAP_CONFIG, CLUSTERING_CONFIG } from '../constants/config'
 import MarkerHoverPopup from './MarkerHoverPopup'
+import ErrorBoundary from './ErrorBoundary'
 import { useHoverPopup } from '../hooks/useHoverPopup'
 
 /**
@@ -336,14 +337,36 @@ function MapView({
         <BoundsUpdater locations={normalizedLocations} clusters={normalizedClusters} />
       </MapContainer>
 
-      {/* Hover popup overlay */}
-      <MarkerHoverPopup
-        cluster={targetCluster}
-        isVisible={isVisible}
-        position={position}
-        onPhotoClick={onPhotoClick}
-        onClose={handleMouseLeave}
-      />
+      {/* Hover popup overlay - wrapped in ErrorBoundary for graceful degradation */}
+      <ErrorBoundary
+        fallback={({ onClose }) => (
+          <div
+            className="fixed bg-white rounded-lg shadow-xl border border-gray-200 p-4"
+            style={{
+              left: position?.x || 0,
+              top: position?.y || 0,
+              zIndex: 1100,
+            }}
+          >
+            <p className="text-red-600 text-sm mb-2">Failed to load preview</p>
+            <button
+              onClick={onClose}
+              className="text-gray-500 hover:text-gray-700 text-sm underline"
+            >
+              Close
+            </button>
+          </div>
+        )}
+        onReset={handleMouseLeave}
+      >
+        <MarkerHoverPopup
+          cluster={targetCluster}
+          isVisible={isVisible}
+          position={position}
+          onPhotoClick={onPhotoClick}
+          onClose={handleMouseLeave}
+        />
+      </ErrorBoundary>
 
       {/* Clustering controls - only show if settings provided */}
       {clusterSettings && onClusterEnabledChange && onClusterRadiusChange && (

--- a/Firmware/webui/frontend/src/components/MapView.jsx
+++ b/Firmware/webui/frontend/src/components/MapView.jsx
@@ -6,6 +6,8 @@ import markerIcon from 'leaflet/dist/images/marker-icon.png'
 import markerIconRetina from 'leaflet/dist/images/marker-icon-2x.png'
 import markerShadow from 'leaflet/dist/images/marker-shadow.png'
 import { MAP_CONFIG, CLUSTERING_CONFIG } from '../constants/config'
+import MarkerHoverPopup from './MarkerHoverPopup'
+import { useHoverPopup } from '../hooks/useHoverPopup'
 
 /**
  * ClusteringControls - UI controls for geographic clustering settings
@@ -58,7 +60,7 @@ function ClusteringControls({ settings, onEnabledChange, onRadiusChange }) {
  * Displays a circular badge with the number of photos in the cluster.
  * Clicking opens a popup with thumbnails and metadata.
  */
-function ClusterMarker({ cluster, onPhotoClick }) {
+function ClusterMarker({ cluster, onPhotoClick, onMouseEnter, onMouseLeave }) {
   // Create custom cluster icon
   const icon = L.divIcon({
     className: 'cluster-marker',
@@ -69,7 +71,14 @@ function ClusterMarker({ cluster, onPhotoClick }) {
   })
 
   return (
-    <Marker position={[cluster.center.lat, cluster.center.lon]} icon={icon}>
+    <Marker
+      position={[cluster.center.lat, cluster.center.lon]}
+      icon={icon}
+      eventHandlers={{
+        mouseover: (e) => onMouseEnter?.(cluster, e.originalEvent),
+        mouseout: () => onMouseLeave?.(),
+      }}
+    >
       <Popup maxWidth={250}>
         <div className="cluster-popup">
           <h4 className="font-semibold text-sm mb-1">{cluster.count} photos</h4>
@@ -177,6 +186,16 @@ function MapView({
   isLoading = false,
   className = '',
 }) {
+  // Hover popup state management
+  const {
+    isVisible,
+    targetCluster,
+    position,
+    handleMouseEnter,
+    handleMouseLeave,
+    handleClick,
+  } = useHoverPopup()
+
   // Normalize locations and clusters (handle null/undefined)
   const normalizedLocations = locations || []
   const normalizedClusters = clusters || []
@@ -268,6 +287,8 @@ function MapView({
             key={cluster.cluster_id}
             cluster={cluster}
             onPhotoClick={onPhotoClick}
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}
           />
         ))}
 
@@ -314,6 +335,15 @@ function MapView({
 
         <BoundsUpdater locations={normalizedLocations} clusters={normalizedClusters} />
       </MapContainer>
+
+      {/* Hover popup overlay */}
+      <MarkerHoverPopup
+        cluster={targetCluster}
+        isVisible={isVisible}
+        position={position}
+        onPhotoClick={onPhotoClick}
+        onClose={handleMouseLeave}
+      />
 
       {/* Clustering controls - only show if settings provided */}
       {clusterSettings && onClusterEnabledChange && onClusterRadiusChange && (

--- a/Firmware/webui/frontend/src/components/MarkerHoverPopup.jsx
+++ b/Firmware/webui/frontend/src/components/MarkerHoverPopup.jsx
@@ -30,10 +30,13 @@ function MarkerHoverPopup({
   onClose,
 }) {
   const popupRef = useRef(null)
+  const animationTimerRef = useRef(null)
+  const previousActiveElementRef = useRef(null)
   const [shouldRender, setShouldRender] = useState(false)
   const [isAnimating, setIsAnimating] = useState(false)
 
   // Handle animation state for smooth enter/exit transitions
+  // Uses ref for timer to ensure cleanup on unmount
   useEffect(() => {
     if (isVisible) {
       // Show popup in DOM
@@ -46,10 +49,16 @@ function MarkerHoverPopup({
       // Start fade-out animation
       setIsAnimating(false)
       // Remove from DOM after animation completes
-      const timer = setTimeout(() => {
+      animationTimerRef.current = setTimeout(() => {
         setShouldRender(false)
       }, HOVER_POPUP_CONFIG.ANIMATION_DURATION)
-      return () => clearTimeout(timer)
+    }
+
+    return () => {
+      if (animationTimerRef.current) {
+        clearTimeout(animationTimerRef.current)
+        animationTimerRef.current = null
+      }
     }
   }, [isVisible])
 
@@ -100,10 +109,16 @@ function MarkerHoverPopup({
     return () => document.removeEventListener('keydown', handleTabKey)
   }, [isVisible])
 
-  // Focus popup when it becomes visible (for accessibility)
+  // Focus management - save previous focus and restore on close (for accessibility)
   useEffect(() => {
     if (isVisible && popupRef.current) {
+      // Save previously focused element before moving focus to popup
+      previousActiveElementRef.current = document.activeElement
       popupRef.current.focus()
+    } else if (!isVisible && previousActiveElementRef.current) {
+      // Restore focus when popup closes
+      previousActiveElementRef.current.focus?.()
+      previousActiveElementRef.current = null
     }
   }, [isVisible])
 

--- a/Firmware/webui/frontend/src/components/MarkerHoverPopup.jsx
+++ b/Firmware/webui/frontend/src/components/MarkerHoverPopup.jsx
@@ -1,0 +1,219 @@
+import React, { useEffect, useRef, useState } from 'react'
+import PropTypes from 'prop-types'
+import ThumbnailGrid from './ThumbnailGrid'
+import { HOVER_POPUP_CONFIG } from '../constants/config'
+
+/**
+ * MarkerHoverPopup - Displays photo preview popup when hovering over map markers
+ *
+ * Shows a popup with photo thumbnails, count, date range, and tags for a cluster
+ * of photos at a specific location. Positioned absolutely in viewport coordinates.
+ * Features smooth fade-in/fade-out animations for better UX.
+ *
+ * @component
+ * @example
+ * ```jsx
+ * <MarkerHoverPopup
+ *   cluster={clusterData}
+ *   isVisible={true}
+ *   position={{ x: 100, y: 200 }}
+ *   onPhotoClick={(photo) => console.log('Photo clicked:', photo)}
+ *   onClose={() => console.log('Close popup')}
+ * />
+ * ```
+ */
+function MarkerHoverPopup({
+  cluster,
+  isVisible,
+  position,
+  onPhotoClick,
+  onClose,
+}) {
+  const popupRef = useRef(null)
+  const [shouldRender, setShouldRender] = useState(false)
+  const [isAnimating, setIsAnimating] = useState(false)
+
+  // Handle animation state for smooth enter/exit transitions
+  useEffect(() => {
+    if (isVisible) {
+      // Show popup in DOM
+      setShouldRender(true)
+      // Trigger fade-in animation on next frame (ensures DOM is ready)
+      requestAnimationFrame(() => {
+        setIsAnimating(true)
+      })
+    } else {
+      // Start fade-out animation
+      setIsAnimating(false)
+      // Remove from DOM after animation completes
+      const timer = setTimeout(() => {
+        setShouldRender(false)
+      }, HOVER_POPUP_CONFIG.ANIMATION_DURATION)
+      return () => clearTimeout(timer)
+    }
+  }, [isVisible])
+
+  // Handle escape key to close popup
+  useEffect(() => {
+    if (!isVisible) return
+
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        onClose?.()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isVisible, onClose])
+
+  // Focus trap - Tab key cycles within popup
+  useEffect(() => {
+    if (!isVisible) return
+
+    const handleTabKey = (e) => {
+      if (e.key !== 'Tab') return
+
+      // Get all focusable elements in popup
+      const focusableElements = popupRef.current?.querySelectorAll(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      )
+
+      if (!focusableElements?.length) return
+
+      const firstElement = focusableElements[0]
+      const lastElement = focusableElements[focusableElements.length - 1]
+
+      // Shift+Tab on first element -> focus last element
+      if (e.shiftKey && document.activeElement === firstElement) {
+        e.preventDefault()
+        lastElement.focus()
+      }
+      // Tab on last element -> focus first element
+      else if (!e.shiftKey && document.activeElement === lastElement) {
+        e.preventDefault()
+        firstElement.focus()
+      }
+    }
+
+    document.addEventListener('keydown', handleTabKey)
+    return () => document.removeEventListener('keydown', handleTabKey)
+  }, [isVisible])
+
+  // Focus popup when it becomes visible (for accessibility)
+  useEffect(() => {
+    if (isVisible && popupRef.current) {
+      popupRef.current.focus()
+    }
+  }, [isVisible])
+
+  // Don't render if not in DOM or no cluster data
+  if (!shouldRender || !cluster) return null
+
+  /**
+   * Format date range for display
+   * - Shows single date if earliest equals latest
+   * - Shows range if different dates
+   * - Shows "No date info" if data is missing
+   */
+  const formatDateRange = () => {
+    const { earliest, latest } = cluster.date_range || {}
+    if (!earliest) return 'No date info'
+    if (earliest === latest) return earliest
+    return `${earliest} - ${latest}`
+  }
+
+  /**
+   * Extract unique tags from all photos in cluster
+   * Limits to 5 tags for display
+   */
+  const getUniqueTags = () => {
+    if (!cluster.photos) return []
+    const allTags = cluster.photos.flatMap((p) => p.tags || [])
+    return [...new Set(allTags)].slice(0, 5)
+  }
+
+  const uniqueTags = getUniqueTags()
+  const hasPhotosWithTags = cluster.photos?.some((p) => p.tags?.length > 0)
+
+  return (
+    <div
+      ref={popupRef}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Photo preview for ${cluster.count} photos at this location`}
+      tabIndex={-1}
+      className={`
+        fixed bg-white rounded-lg shadow-xl border border-gray-200
+        transition-opacity
+        ${isAnimating ? 'opacity-100' : 'opacity-0'}
+      `}
+      style={{
+        left: position?.x || 0,
+        top: position?.y || 0,
+        width: HOVER_POPUP_CONFIG.POPUP_WIDTH,
+        zIndex: HOVER_POPUP_CONFIG.Z_INDEX,
+        transitionDuration: `${HOVER_POPUP_CONFIG.ANIMATION_DURATION}ms`,
+      }}
+    >
+      {/* Header - Photo count and date range */}
+      <div className="p-3 border-b border-gray-100">
+        <h4 className="font-semibold text-sm text-gray-800">
+          {cluster.count} photos
+        </h4>
+        <p className="text-xs text-gray-500 mt-0.5">{formatDateRange()}</p>
+      </div>
+
+      {/* Thumbnail Grid */}
+      <div className="p-2">
+        <ThumbnailGrid
+          photos={cluster.photos}
+          onPhotoClick={onPhotoClick}
+          thumbnailSize={HOVER_POPUP_CONFIG.THUMBNAIL_SIZE}
+          maxPhotos={HOVER_POPUP_CONFIG.MAX_PHOTOS}
+        />
+      </div>
+
+      {/* Tags (only shown if any photos have tags) */}
+      {hasPhotosWithTags && (
+        <div className="px-3 pb-2">
+          <div className="flex flex-wrap gap-1">
+            {uniqueTags.map((tag) => (
+              <span
+                key={tag}
+                className="px-2 py-0.5 bg-gray-100 text-xs text-gray-600 rounded"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+MarkerHoverPopup.propTypes = {
+  cluster: PropTypes.shape({
+    cluster_id: PropTypes.string,
+    center: PropTypes.shape({
+      lat: PropTypes.number,
+      lon: PropTypes.number,
+    }),
+    count: PropTypes.number.isRequired,
+    photos: PropTypes.array,
+    date_range: PropTypes.shape({
+      earliest: PropTypes.string,
+      latest: PropTypes.string,
+    }),
+  }),
+  isVisible: PropTypes.bool.isRequired,
+  position: PropTypes.shape({
+    x: PropTypes.number,
+    y: PropTypes.number,
+  }),
+  onPhotoClick: PropTypes.func,
+  onClose: PropTypes.func,
+}
+
+export default MarkerHoverPopup

--- a/Firmware/webui/frontend/src/components/MarkerHoverPopup.jsx
+++ b/Firmware/webui/frontend/src/components/MarkerHoverPopup.jsx
@@ -32,8 +32,17 @@ function MarkerHoverPopup({
   const popupRef = useRef(null)
   const animationTimerRef = useRef(null)
   const previousActiveElementRef = useRef(null)
+  const isMountedRef = useRef(true)
   const [shouldRender, setShouldRender] = useState(false)
   const [isAnimating, setIsAnimating] = useState(false)
+
+  // Track component mount state to prevent setState on unmounted component
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
 
   // Handle animation state for smooth enter/exit transitions
   // Uses ref for timer to ensure cleanup on unmount
@@ -43,14 +52,18 @@ function MarkerHoverPopup({
       setShouldRender(true)
       // Trigger fade-in animation on next frame (ensures DOM is ready)
       requestAnimationFrame(() => {
-        setIsAnimating(true)
+        if (isMountedRef.current) {
+          setIsAnimating(true)
+        }
       })
     } else {
       // Start fade-out animation
       setIsAnimating(false)
       // Remove from DOM after animation completes
       animationTimerRef.current = setTimeout(() => {
-        setShouldRender(false)
+        if (isMountedRef.current) {
+          setShouldRender(false)
+        }
       }, HOVER_POPUP_CONFIG.ANIMATION_DURATION)
     }
 

--- a/Firmware/webui/frontend/src/components/ThumbnailGrid.jsx
+++ b/Firmware/webui/frontend/src/components/ThumbnailGrid.jsx
@@ -61,6 +61,16 @@ function ThumbnailGrid({
   const [focusedIndex, setFocusedIndex] = useState(0)
   const buttonRefs = useRef([])
 
+  // Calculate grid columns from config (used for keyboard navigation)
+  const gridColumns = HOVER_POPUP_CONFIG.GRID_SIZE
+
+  // Mapping of grid sizes to Tailwind classes (required for JIT purging)
+  const gridColsClass = {
+    2: 'grid-cols-2',
+    3: 'grid-cols-3',
+    4: 'grid-cols-4',
+  }[gridColumns] || 'grid-cols-3'
+
   // Setup swipe navigation if enabled
   const { currentPage, totalPages, startIndex, endIndex, handlers } = useSwipeNavigation({
     totalItems: photos?.length || 0,
@@ -82,7 +92,6 @@ function ThumbnailGrid({
    */
   const handleKeyDown = useCallback(
     (e, index) => {
-      const gridSize = 3 // 3 columns
       const maxIndex = displayPhotos.length - 1
       let newIndex = index
 
@@ -94,10 +103,10 @@ function ThumbnailGrid({
           newIndex = Math.max(index - 1, 0)
           break
         case 'ArrowDown':
-          newIndex = Math.min(index + gridSize, maxIndex)
+          newIndex = Math.min(index + gridColumns, maxIndex)
           break
         case 'ArrowUp':
-          newIndex = Math.max(index - gridSize, 0)
+          newIndex = Math.max(index - gridColumns, 0)
           break
         case 'Home':
           newIndex = 0
@@ -118,13 +127,13 @@ function ThumbnailGrid({
       setFocusedIndex(newIndex)
       buttonRefs.current[newIndex]?.focus()
     },
-    [displayPhotos, onPhotoClick]
+    [displayPhotos, onPhotoClick, gridColumns]
   )
 
   // Loading state - show skeleton loaders
   if (isLoading) {
     return (
-      <div className={`grid grid-cols-3 gap-1 ${className}`}>
+      <div className={`grid ${gridColsClass} gap-1 ${className}`}>
         {Array.from({ length: maxPhotos }).map((_, index) => (
           <ThumbnailSkeleton key={index} size={thumbnailSize} />
         ))}
@@ -145,7 +154,7 @@ function ThumbnailGrid({
   return (
     <div className="relative">
       <div
-        className={`grid grid-cols-3 gap-1 ${className}`}
+        className={`grid ${gridColsClass} gap-1 ${className}`}
         {...(enableSwipe ? handlers : {})}
       >
         {displayPhotos.map((photo, index) => (

--- a/Firmware/webui/frontend/src/components/ThumbnailGrid.jsx
+++ b/Firmware/webui/frontend/src/components/ThumbnailGrid.jsx
@@ -1,0 +1,213 @@
+import React, { useState, useRef, useCallback } from 'react'
+import PropTypes from 'prop-types'
+import ThumbnailSkeleton from './ThumbnailSkeleton'
+import { HOVER_POPUP_CONFIG } from '../constants/config'
+import { useSwipeNavigation } from '../hooks/useSwipeNavigation'
+
+/**
+ * ThumbnailGrid - 3x3 grid of photo thumbnails
+ *
+ * Displays a responsive grid of photo thumbnails with loading states,
+ * progressive image loading, and click handlers. Used in hover popups
+ * and cluster previews to show multiple photos at a location.
+ *
+ * @component
+ * @param {Object} props - Component props
+ * @param {Array<Object>} [props.photos=[]] - Array of photo objects
+ * @param {string} props.photos[].photo_id - Photo identifier (required)
+ * @param {number} [props.photos[].lat] - Latitude coordinate
+ * @param {number} [props.photos[].lon] - Longitude coordinate
+ * @param {string} [props.photos[].timestamp] - Photo timestamp
+ * @param {Array<string>} [props.photos[].tags] - Photo tags
+ * @param {number} [props.maxPhotos=9] - Maximum photos to display in grid
+ * @param {number} [props.thumbnailSize=128] - Size of each thumbnail in pixels
+ * @param {Function} [props.onPhotoClick] - Callback when thumbnail is clicked
+ * @param {boolean} [props.isLoading=false] - Show skeleton loaders
+ * @param {string} [props.className=''] - Additional CSS classes
+ * @param {boolean} [props.enableSwipe=false] - Enable swipe navigation for mobile
+ * @param {boolean} [props.showPagination=false] - Show page indicators when swiping enabled
+ *
+ * @example
+ * // Basic usage with photo array
+ * <ThumbnailGrid
+ *   photos={photos}
+ *   onPhotoClick={(photo) => console.log('Clicked:', photo.photo_id)}
+ * />
+ *
+ * @example
+ * // Loading state with custom size
+ * <ThumbnailGrid
+ *   photos={photos}
+ *   isLoading={true}
+ *   thumbnailSize={256}
+ *   maxPhotos={6}
+ * />
+ *
+ * @example
+ * // Empty state
+ * <ThumbnailGrid photos={[]} />
+ */
+function ThumbnailGrid({
+  photos = [],
+  maxPhotos = HOVER_POPUP_CONFIG.MAX_PHOTOS,
+  thumbnailSize = HOVER_POPUP_CONFIG.THUMBNAIL_SIZE,
+  onPhotoClick,
+  isLoading = false,
+  className = '',
+  enableSwipe = false,
+  showPagination = false,
+}) {
+  // State for keyboard navigation
+  const [focusedIndex, setFocusedIndex] = useState(0)
+  const buttonRefs = useRef([])
+
+  // Setup swipe navigation if enabled
+  const { currentPage, totalPages, startIndex, endIndex, handlers } = useSwipeNavigation({
+    totalItems: photos?.length || 0,
+    visibleItems: maxPhotos,
+  })
+
+  // Display photos based on swipe navigation or simple slice
+  const displayPhotos = enableSwipe
+    ? photos?.slice(startIndex, endIndex) || []
+    : photos?.slice(0, maxPhotos) || []
+
+  const remainingCount = enableSwipe
+    ? (photos?.length || 0) - endIndex
+    : (photos?.length || 0) - maxPhotos
+
+  /**
+   * Handle keyboard navigation within the grid
+   * Supports arrow keys, Home, End, Enter, and Space
+   */
+  const handleKeyDown = useCallback(
+    (e, index) => {
+      const gridSize = 3 // 3 columns
+      const maxIndex = displayPhotos.length - 1
+      let newIndex = index
+
+      switch (e.key) {
+        case 'ArrowRight':
+          newIndex = Math.min(index + 1, maxIndex)
+          break
+        case 'ArrowLeft':
+          newIndex = Math.max(index - 1, 0)
+          break
+        case 'ArrowDown':
+          newIndex = Math.min(index + gridSize, maxIndex)
+          break
+        case 'ArrowUp':
+          newIndex = Math.max(index - gridSize, 0)
+          break
+        case 'Home':
+          newIndex = 0
+          break
+        case 'End':
+          newIndex = maxIndex
+          break
+        case 'Enter':
+        case ' ':
+          e.preventDefault()
+          onPhotoClick?.(displayPhotos[index])
+          return
+        default:
+          return
+      }
+
+      e.preventDefault()
+      setFocusedIndex(newIndex)
+      buttonRefs.current[newIndex]?.focus()
+    },
+    [displayPhotos, onPhotoClick]
+  )
+
+  // Loading state - show skeleton loaders
+  if (isLoading) {
+    return (
+      <div className={`grid grid-cols-3 gap-1 ${className}`}>
+        {Array.from({ length: maxPhotos }).map((_, index) => (
+          <ThumbnailSkeleton key={index} size={thumbnailSize} />
+        ))}
+      </div>
+    )
+  }
+
+  // Empty state - no photos available
+  if (!photos || photos.length === 0) {
+    return (
+      <div className={`text-sm text-gray-500 text-center p-4 ${className}`}>
+        No photos available
+      </div>
+    )
+  }
+
+  // Render photo grid
+  return (
+    <div className="relative">
+      <div
+        className={`grid grid-cols-3 gap-1 ${className}`}
+        {...(enableSwipe ? handlers : {})}
+      >
+        {displayPhotos.map((photo, index) => (
+          <button
+            key={photo.photo_id}
+            ref={(el) => (buttonRefs.current[index] = el)}
+            type="button"
+            tabIndex={index === focusedIndex ? 0 : -1}
+            onClick={() => onPhotoClick?.(photo)}
+            onKeyDown={(e) => handleKeyDown(e, index)}
+            className="focus:outline-none focus:ring-2 focus:ring-blue-500 rounded overflow-hidden"
+          >
+            <img
+              src={`/api/gallery/thumbnail/${photo.photo_id}?size=${thumbnailSize}`}
+              alt={photo.photo_id}
+              loading="lazy"
+              className="w-full h-full object-cover cursor-pointer hover:opacity-80 transition-opacity"
+              style={{ width: thumbnailSize, height: thumbnailSize }}
+            />
+          </button>
+        ))}
+        {remainingCount > 0 && (
+          <div className="col-span-3 text-xs text-gray-500 text-center mt-1">
+            +{remainingCount} more photos
+          </div>
+        )}
+      </div>
+
+      {/* Pagination indicators (only shown when swipe is enabled and showPagination is true) */}
+      {enableSwipe && showPagination && totalPages > 1 && (
+        <div className="flex justify-center gap-1 mt-2">
+          {Array.from({ length: totalPages }).map((_, index) => (
+            <div
+              key={index}
+              className={`w-2 h-2 rounded-full transition-colors ${
+                index === currentPage ? 'bg-blue-500' : 'bg-gray-300'
+              }`}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+ThumbnailGrid.propTypes = {
+  photos: PropTypes.arrayOf(
+    PropTypes.shape({
+      photo_id: PropTypes.string.isRequired,
+      lat: PropTypes.number,
+      lon: PropTypes.number,
+      timestamp: PropTypes.string,
+      tags: PropTypes.arrayOf(PropTypes.string),
+    })
+  ),
+  maxPhotos: PropTypes.number,
+  thumbnailSize: PropTypes.number,
+  onPhotoClick: PropTypes.func,
+  isLoading: PropTypes.bool,
+  className: PropTypes.string,
+  enableSwipe: PropTypes.bool,
+  showPagination: PropTypes.bool,
+}
+
+export default ThumbnailGrid

--- a/Firmware/webui/frontend/src/components/ThumbnailSkeleton.jsx
+++ b/Firmware/webui/frontend/src/components/ThumbnailSkeleton.jsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { HOVER_POPUP_CONFIG } from '../constants/config'
+
+/**
+ * ThumbnailSkeleton - Pulsing skeleton loader for thumbnail images
+ *
+ * Displays an animated placeholder while thumbnail images are loading,
+ * providing visual feedback during asynchronous data fetching.
+ *
+ * @component
+ * @param {Object} props - Component props
+ * @param {number} [props.size=128] - Size in pixels (width and height)
+ * @param {string} [props.className=''] - Additional CSS classes to apply
+ *
+ * @example
+ * // Default 128px skeleton
+ * <ThumbnailSkeleton />
+ *
+ * @example
+ * // Custom size with additional styling
+ * <ThumbnailSkeleton size={256} className="shadow-md" />
+ */
+function ThumbnailSkeleton({ size = HOVER_POPUP_CONFIG.THUMBNAIL_SIZE, className = '' }) {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-label="Loading thumbnail"
+      className={`bg-gray-200 animate-pulse rounded-lg ${className}`}
+      style={{ width: size, height: size }}
+    />
+  )
+}
+
+ThumbnailSkeleton.propTypes = {
+  size: PropTypes.number,
+  className: PropTypes.string,
+}
+
+export default ThumbnailSkeleton

--- a/Firmware/webui/frontend/src/components/__tests__/MapView.test.jsx
+++ b/Firmware/webui/frontend/src/components/__tests__/MapView.test.jsx
@@ -52,7 +52,41 @@ vi.mock('leaflet', () => ({
         this.options = options
       }
     },
+    divIcon: vi.fn((options) => ({
+      options,
+      _getIconUrl: vi.fn(),
+    })),
   },
+}))
+
+// Mock MarkerHoverPopup component
+vi.mock('../MarkerHoverPopup', () => ({
+  default: ({ cluster, isVisible, position, onPhotoClick, onClose }) => (
+    <div
+      data-testid="marker-hover-popup"
+      data-visible={isVisible}
+      data-cluster-id={cluster?.cluster_id}
+    >
+      {isVisible && cluster && (
+        <div>
+          <span>Cluster: {cluster.cluster_id}</span>
+          <span>Count: {cluster.count}</span>
+        </div>
+      )}
+    </div>
+  ),
+}))
+
+// Mock useHoverPopup hook
+vi.mock('../../hooks/useHoverPopup', () => ({
+  useHoverPopup: () => ({
+    isVisible: false,
+    targetCluster: null,
+    position: { x: 0, y: 0 },
+    handleMouseEnter: vi.fn(),
+    handleMouseLeave: vi.fn(),
+    handleClick: vi.fn(),
+  }),
 }))
 
 describe('MapView', () => {
@@ -424,6 +458,79 @@ describe('MapView', () => {
       const mapWrapper = container.firstChild
       // Should have minimum height
       expect(mapWrapper.className).toContain('h-')
+    })
+  })
+
+  describe('Hover Popup Integration', () => {
+    const mockClusters = [
+      {
+        cluster_id: 'cluster_1',
+        center: { lat: 37.7749, lon: -122.4194 },
+        count: 3,
+        photos: [
+          {
+            photo_id: 'photo1.jpg',
+            thumbnail_url: '/api/gallery/photos/photo1.jpg/thumbnail',
+            timestamp: '2024-01-15 10:30:00',
+            lat: 37.7749,
+            lon: -122.4194,
+          },
+          {
+            photo_id: 'photo2.jpg',
+            thumbnail_url: '/api/gallery/photos/photo2.jpg/thumbnail',
+            timestamp: '2024-01-15 11:00:00',
+            lat: 37.7750,
+            lon: -122.4195,
+          },
+        ],
+        date_range: {
+          earliest: '2024-01-15',
+          latest: '2024-01-15',
+        },
+      },
+    ]
+
+    it('renders MarkerHoverPopup component', () => {
+      const { container } = render(
+        <MapView
+          locations={[]}
+          clusters={mockClusters}
+          onPhotoClick={mockOnPhotoClick}
+        />
+      )
+
+      // MarkerHoverPopup should be in the DOM (even if not visible)
+      // Check for the popup container with data-testid
+      const popup = container.querySelector('[data-testid="marker-hover-popup"]')
+      expect(popup).toBeInTheDocument()
+    })
+
+    it('ClusterMarker has mouseover handler', () => {
+      render(
+        <MapView
+          locations={[]}
+          clusters={mockClusters}
+          onPhotoClick={mockOnPhotoClick}
+        />
+      )
+
+      // Verify that markers are rendered (hover handlers are attached via eventHandlers prop)
+      const markers = screen.getAllByTestId('marker')
+      expect(markers.length).toBeGreaterThan(0)
+    })
+
+    it('ClusterMarker has mouseout handler', () => {
+      render(
+        <MapView
+          locations={[]}
+          clusters={mockClusters}
+          onPhotoClick={mockOnPhotoClick}
+        />
+      )
+
+      // Verify that markers are rendered (hover handlers are attached via eventHandlers prop)
+      const markers = screen.getAllByTestId('marker')
+      expect(markers.length).toBeGreaterThan(0)
     })
   })
 })

--- a/Firmware/webui/frontend/src/components/__tests__/MarkerHoverPopup.integration.test.jsx
+++ b/Firmware/webui/frontend/src/components/__tests__/MarkerHoverPopup.integration.test.jsx
@@ -1,0 +1,480 @@
+/**
+ * MarkerHoverPopup Integration Tests
+ *
+ * Tests for the complete hover popup workflow including desktop hover,
+ * keyboard navigation, and edge case handling.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import MarkerHoverPopup from '../MarkerHoverPopup'
+import { HOVER_POPUP_CONFIG } from '../../constants/config'
+
+describe('MarkerHoverPopup Integration Tests', () => {
+  // Mock cluster with realistic data
+  const mockCluster = {
+    cluster_id: 'cluster_37.7749N_122.4194W_5',
+    center: { lat: 37.7749, lon: -122.4194 },
+    count: 15,
+    photos: Array.from({ length: 15 }, (_, i) => ({
+      photo_id: `photo_${i}.jpg`,
+      lat: 37.7749 + i * 0.0001,
+      lon: -122.4194 + i * 0.0001,
+      timestamp: `2024-01-${15 + i}T10:00:00`,
+      tags: i % 3 === 0 ? ['moth', 'night'] : null,
+    })),
+    date_range: {
+      earliest: '2024-01-15',
+      latest: '2024-01-29',
+    },
+  }
+
+  const mockPosition = { x: 100, y: 100 }
+
+  beforeEach(() => {
+    // Mock requestAnimationFrame for synchronous testing
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      cb(0)
+      return 0
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('Desktop hover workflow', () => {
+    it('shows popup with cluster data on hover', () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={vi.fn()}
+          onClose={vi.fn()}
+        />
+      )
+
+      // Verify popup is rendered
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+      // Verify cluster data displayed
+      expect(screen.getByText('15 photos')).toBeInTheDocument()
+      expect(screen.getByText(/2024-01-15.*2024-01-29/)).toBeInTheDocument()
+
+      // Verify thumbnails (max 9 shown from config)
+      const buttons = screen.getAllByRole('button')
+      expect(buttons.length).toBe(HOVER_POPUP_CONFIG.MAX_PHOTOS)
+
+      // Verify "+N more" indicator
+      expect(screen.getByText('+6 more photos')).toBeInTheDocument()
+    })
+
+    it('triggers onPhotoClick when thumbnail clicked', () => {
+      const onPhotoClick = vi.fn()
+
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={onPhotoClick}
+          onClose={vi.fn()}
+        />
+      )
+
+      // Click first thumbnail
+      const buttons = screen.getAllByRole('button')
+      fireEvent.click(buttons[0])
+
+      expect(onPhotoClick).toHaveBeenCalledTimes(1)
+      expect(onPhotoClick).toHaveBeenCalledWith(mockCluster.photos[0])
+    })
+
+    it('closes popup on Escape key', () => {
+      const onClose = vi.fn()
+
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={vi.fn()}
+          onClose={onClose}
+        />
+      )
+
+      // Press Escape
+      fireEvent.keyDown(document, { key: 'Escape' })
+
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('Keyboard navigation workflow', () => {
+    it('navigates thumbnails with arrow keys', () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={vi.fn()}
+          onClose={vi.fn()}
+        />
+      )
+
+      const buttons = screen.getAllByRole('button')
+
+      // Focus first button
+      buttons[0].focus()
+      expect(document.activeElement).toBe(buttons[0])
+
+      // Arrow right
+      fireEvent.keyDown(buttons[0], { key: 'ArrowRight' })
+      expect(document.activeElement).toBe(buttons[1])
+
+      // Arrow down (move by 3 in grid)
+      fireEvent.keyDown(buttons[1], { key: 'ArrowDown' })
+      expect(document.activeElement).toBe(buttons[4])
+    })
+
+    it('activates thumbnail with Enter key', () => {
+      const onPhotoClick = vi.fn()
+
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={onPhotoClick}
+          onClose={vi.fn()}
+        />
+      )
+
+      const buttons = screen.getAllByRole('button')
+      buttons[0].focus()
+
+      fireEvent.keyDown(buttons[0], { key: 'Enter' })
+
+      expect(onPhotoClick).toHaveBeenCalledTimes(1)
+      expect(onPhotoClick).toHaveBeenCalledWith(mockCluster.photos[0])
+    })
+
+    it('activates thumbnail with Space key', () => {
+      const onPhotoClick = vi.fn()
+
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={onPhotoClick}
+          onClose={vi.fn()}
+        />
+      )
+
+      const buttons = screen.getAllByRole('button')
+      buttons[2].focus()
+
+      fireEvent.keyDown(buttons[2], { key: ' ' })
+
+      expect(onPhotoClick).toHaveBeenCalledTimes(1)
+      expect(onPhotoClick).toHaveBeenCalledWith(mockCluster.photos[2])
+    })
+
+    it('navigates to first/last with Home/End keys', () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={vi.fn()}
+          onClose={vi.fn()}
+        />
+      )
+
+      const buttons = screen.getAllByRole('button')
+
+      // Focus middle button
+      buttons[4].focus()
+
+      // Home key -> first button
+      fireEvent.keyDown(buttons[4], { key: 'Home' })
+      expect(document.activeElement).toBe(buttons[0])
+
+      // End key -> last button
+      fireEvent.keyDown(buttons[0], { key: 'End' })
+      expect(document.activeElement).toBe(buttons[8])
+    })
+  })
+
+  describe('Edge cases', () => {
+    it('handles cluster with tags correctly', () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={vi.fn()}
+          onClose={vi.fn()}
+        />
+      )
+
+      // Check that tags are displayed (photos at indices 0, 3, 6, 9, 12 have tags)
+      expect(screen.getByText('moth')).toBeInTheDocument()
+      expect(screen.getByText('night')).toBeInTheDocument()
+    })
+
+    it('handles empty cluster gracefully', () => {
+      const emptyCluster = {
+        ...mockCluster,
+        count: 0,
+        photos: [],
+      }
+
+      render(
+        <MarkerHoverPopup
+          cluster={emptyCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={vi.fn()}
+          onClose={vi.fn()}
+        />
+      )
+
+      expect(screen.getByText('0 photos')).toBeInTheDocument()
+      expect(screen.getByText('No photos available')).toBeInTheDocument()
+    })
+
+    it('handles very large cluster with "+N more" indicator', () => {
+      const largeCluster = {
+        ...mockCluster,
+        count: 150,
+        photos: Array.from({ length: 150 }, (_, i) => ({
+          photo_id: `photo_${i}.jpg`,
+          lat: 37.7749,
+          lon: -122.4194,
+          timestamp: '2024-01-15T10:00:00',
+        })),
+      }
+
+      render(
+        <MarkerHoverPopup
+          cluster={largeCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={vi.fn()}
+          onClose={vi.fn()}
+        />
+      )
+
+      // Should only show max photos from config
+      const buttons = screen.getAllByRole('button')
+      expect(buttons.length).toBe(HOVER_POPUP_CONFIG.MAX_PHOTOS)
+
+      // Should show correct remaining count
+      expect(screen.getByText('+141 more photos')).toBeInTheDocument()
+    })
+
+    it('handles cluster with no date range', () => {
+      const clusterNoDate = {
+        ...mockCluster,
+        date_range: null,
+      }
+
+      render(
+        <MarkerHoverPopup
+          cluster={clusterNoDate}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={vi.fn()}
+          onClose={vi.fn()}
+        />
+      )
+
+      expect(screen.getByText('No date info')).toBeInTheDocument()
+    })
+
+    it('handles cluster with same date range (single date)', () => {
+      const singleDateCluster = {
+        ...mockCluster,
+        date_range: {
+          earliest: '2024-01-15',
+          latest: '2024-01-15',
+        },
+      }
+
+      render(
+        <MarkerHoverPopup
+          cluster={singleDateCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={vi.fn()}
+          onClose={vi.fn()}
+        />
+      )
+
+      // Should show single date, not range
+      expect(screen.getByText('2024-01-15')).toBeInTheDocument()
+    })
+
+    it('handles missing optional callbacks gracefully', () => {
+      expect(() => {
+        render(
+          <MarkerHoverPopup
+            cluster={mockCluster}
+            isVisible={true}
+            position={mockPosition}
+            onPhotoClick={undefined}
+            onClose={undefined}
+          />
+        )
+      }).not.toThrow()
+
+      // Try clicking thumbnail without callback
+      const buttons = screen.getAllByRole('button')
+      expect(() => {
+        fireEvent.click(buttons[0])
+      }).not.toThrow()
+
+      // Try pressing Escape without callback
+      expect(() => {
+        fireEvent.keyDown(document, { key: 'Escape' })
+      }).not.toThrow()
+    })
+  })
+
+  describe('Complete user workflows', () => {
+    it('complete workflow: show popup -> navigate thumbnails -> click photo', () => {
+      const onPhotoClick = vi.fn()
+      const onClose = vi.fn()
+
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={onPhotoClick}
+          onClose={onClose}
+        />
+      )
+
+      // Verify popup is visible
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+      // Navigate through thumbnails with keyboard
+      const buttons = screen.getAllByRole('button')
+      buttons[0].focus()
+
+      fireEvent.keyDown(buttons[0], { key: 'ArrowRight' })
+      expect(document.activeElement).toBe(buttons[1])
+
+      fireEvent.keyDown(buttons[1], { key: 'ArrowRight' })
+      expect(document.activeElement).toBe(buttons[2])
+
+      // Click thumbnail with Enter
+      fireEvent.keyDown(buttons[2], { key: 'Enter' })
+      expect(onPhotoClick).toHaveBeenCalledWith(mockCluster.photos[2])
+
+      // Close with Escape
+      fireEvent.keyDown(document, { key: 'Escape' })
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
+
+    it('complete workflow: show popup -> click thumbnail -> close', () => {
+      const onPhotoClick = vi.fn()
+      const onClose = vi.fn()
+
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={onPhotoClick}
+          onClose={onClose}
+        />
+      )
+
+      // Click thumbnail directly
+      const buttons = screen.getAllByRole('button')
+      fireEvent.click(buttons[5])
+
+      expect(onPhotoClick).toHaveBeenCalledWith(mockCluster.photos[5])
+
+      // Press Escape to close
+      fireEvent.keyDown(document, { key: 'Escape' })
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
+
+    it('accessibility workflow: popup has proper ARIA attributes', () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={vi.fn()}
+          onClose={vi.fn()}
+        />
+      )
+
+      const dialog = screen.getByRole('dialog')
+
+      expect(dialog).toHaveAttribute('tabIndex', '-1')
+      expect(dialog).toHaveAttribute('role', 'dialog')
+      expect(dialog).toHaveAttribute('aria-modal', 'true')
+      expect(dialog).toHaveAttribute(
+        'aria-label',
+        'Photo preview for 15 photos at this location'
+      )
+    })
+  })
+
+  describe('Styling and configuration', () => {
+    it('applies correct z-index from config', () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={vi.fn()}
+          onClose={vi.fn()}
+        />
+      )
+
+      const dialog = screen.getByRole('dialog')
+      expect(dialog).toHaveStyle({ zIndex: '1100' })
+    })
+
+    it('applies correct popup width from config', () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={vi.fn()}
+          onClose={vi.fn()}
+        />
+      )
+
+      const dialog = screen.getByRole('dialog')
+      expect(dialog).toHaveStyle({ width: `${HOVER_POPUP_CONFIG.POPUP_WIDTH}px` })
+    })
+
+    it('applies position from props', () => {
+      const customPosition = { x: 250, y: 350 }
+
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={customPosition}
+          onPhotoClick={vi.fn()}
+          onClose={vi.fn()}
+        />
+      )
+
+      const dialog = screen.getByRole('dialog')
+      expect(dialog).toHaveStyle({ left: '250px', top: '350px' })
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/components/__tests__/MarkerHoverPopup.test.jsx
+++ b/Firmware/webui/frontend/src/components/__tests__/MarkerHoverPopup.test.jsx
@@ -1,0 +1,970 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import MarkerHoverPopup from '../MarkerHoverPopup'
+
+describe('MarkerHoverPopup', () => {
+  const mockCluster = {
+    cluster_id: 'cluster_1',
+    center: { lat: 37.7749, lon: -122.4194 },
+    count: 3,
+    photos: [
+      {
+        photo_id: 'photo1.jpg',
+        thumbnail_url: '/api/gallery/photos/photo1.jpg/thumbnail',
+        timestamp: '2024-01-15 10:30:00',
+        tags: ['moth', 'night'],
+      },
+      {
+        photo_id: 'photo2.jpg',
+        thumbnail_url: '/api/gallery/photos/photo2.jpg/thumbnail',
+        timestamp: '2024-01-15 11:00:00',
+        tags: ['butterfly'],
+      },
+      {
+        photo_id: 'photo3.jpg',
+        thumbnail_url: '/api/gallery/photos/photo3.jpg/thumbnail',
+        timestamp: '2024-01-15 12:00:00',
+        tags: [],
+      },
+    ],
+    date_range: {
+      earliest: '2024-01-15',
+      latest: '2024-01-15',
+    },
+  }
+
+  const mockPosition = { x: 100, y: 200 }
+  const mockOnPhotoClick = vi.fn()
+  const mockOnClose = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('Visibility', () => {
+    it('renders when isVisible=true', () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+      expect(screen.getByText('3 photos')).toBeInTheDocument()
+    })
+
+    it('returns null when isVisible=false', () => {
+      const { container } = render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={false}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      expect(container.firstChild).toBeNull()
+    })
+
+    it('returns null when cluster is null', () => {
+      const { container } = render(
+        <MarkerHoverPopup
+          cluster={null}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      expect(container.firstChild).toBeNull()
+    })
+
+    it('returns null when cluster is undefined', () => {
+      const { container } = render(
+        <MarkerHoverPopup
+          cluster={undefined}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      expect(container.firstChild).toBeNull()
+    })
+  })
+
+  describe('Content Display', () => {
+    it('displays cluster photo count', () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      expect(screen.getByText('3 photos')).toBeInTheDocument()
+    })
+
+    it('displays single date when earliest equals latest', () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      expect(screen.getByText('2024-01-15')).toBeInTheDocument()
+    })
+
+    it('displays date range when earliest differs from latest', () => {
+      const clusterWithRange = {
+        ...mockCluster,
+        date_range: {
+          earliest: '2024-01-15',
+          latest: '2024-01-20',
+        },
+      }
+
+      render(
+        <MarkerHoverPopup
+          cluster={clusterWithRange}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      expect(screen.getByText('2024-01-15 - 2024-01-20')).toBeInTheDocument()
+    })
+
+    it('displays "No date info" when date_range is missing', () => {
+      const clusterWithoutDates = {
+        ...mockCluster,
+        date_range: null,
+      }
+
+      render(
+        <MarkerHoverPopup
+          cluster={clusterWithoutDates}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      expect(screen.getByText('No date info')).toBeInTheDocument()
+    })
+
+    it('displays "No date info" when earliest is missing', () => {
+      const clusterWithoutEarliest = {
+        ...mockCluster,
+        date_range: {
+          earliest: null,
+          latest: '2024-01-15',
+        },
+      }
+
+      render(
+        <MarkerHoverPopup
+          cluster={clusterWithoutEarliest}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      expect(screen.getByText('No date info')).toBeInTheDocument()
+    })
+  })
+
+  describe('ThumbnailGrid Integration', () => {
+    it('renders ThumbnailGrid with cluster photos', () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      // ThumbnailGrid should render images for each photo
+      const images = screen.getAllByRole('img')
+      expect(images.length).toBeGreaterThan(0)
+    })
+
+    it('passes onPhotoClick to ThumbnailGrid', () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      // Click first thumbnail
+      const images = screen.getAllByRole('img')
+      fireEvent.click(images[0])
+
+      expect(mockOnPhotoClick).toHaveBeenCalledWith(mockCluster.photos[0])
+    })
+  })
+
+  describe('Keyboard Interaction', () => {
+    it('calls onClose when Escape key is pressed', () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      fireEvent.keyDown(document, { key: 'Escape' })
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not call onClose for other keys', () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      fireEvent.keyDown(document, { key: 'Enter' })
+      fireEvent.keyDown(document, { key: 'Space' })
+      fireEvent.keyDown(document, { key: 'Tab' })
+
+      expect(mockOnClose).not.toHaveBeenCalled()
+    })
+
+    it('does not add escape listener when not visible', () => {
+      const { rerender } = render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={false}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      fireEvent.keyDown(document, { key: 'Escape' })
+      expect(mockOnClose).not.toHaveBeenCalled()
+
+      // Make visible
+      rerender(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      fireEvent.keyDown(document, { key: 'Escape' })
+      expect(mockOnClose).toHaveBeenCalledTimes(1)
+    })
+
+    it('cleans up escape listener on unmount', () => {
+      const { unmount } = render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      unmount()
+
+      fireEvent.keyDown(document, { key: 'Escape' })
+      expect(mockOnClose).not.toHaveBeenCalled()
+    })
+
+    it('handles missing onClose gracefully', () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={undefined}
+        />
+      )
+
+      // Should not throw error
+      expect(() => {
+        fireEvent.keyDown(document, { key: 'Escape' })
+      }).not.toThrow()
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('has role="dialog"', () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      const dialog = screen.getByRole('dialog')
+      expect(dialog).toBeInTheDocument()
+    })
+
+    it('has aria-modal="true"', () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      const dialog = screen.getByRole('dialog')
+      expect(dialog).toHaveAttribute('aria-modal', 'true')
+    })
+
+    it('has descriptive aria-label', () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      const dialog = screen.getByRole('dialog')
+      expect(dialog).toHaveAttribute(
+        'aria-label',
+        'Photo preview for 3 photos at this location'
+      )
+    })
+
+    it('is focusable with tabIndex=-1', () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      const dialog = screen.getByRole('dialog')
+      expect(dialog).toHaveAttribute('tabIndex', '-1')
+    })
+
+    it('attempts to focus when visible', async () => {
+      const focusSpy = vi.fn()
+
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      // Wait for popup to render
+      const dialog = await screen.findByRole('dialog')
+
+      // Verify popup is focusable (has tabIndex=-1)
+      expect(dialog).toHaveAttribute('tabIndex', '-1')
+
+      // In real browser, focus() would be called - we can verify element exists and is focusable
+      // Note: jsdom doesn't fully support focus(), but the element is properly set up
+      expect(dialog).toBeInTheDocument()
+    })
+  })
+
+  describe('Positioning and Styling', () => {
+    it('applies correct position via style', () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      const dialog = screen.getByRole('dialog')
+      expect(dialog).toHaveStyle({
+        left: '100px',
+        top: '200px',
+      })
+    })
+
+    it('defaults to 0,0 when position is null', () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={null}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      const dialog = screen.getByRole('dialog')
+      expect(dialog).toHaveStyle({
+        left: '0px',
+        top: '0px',
+      })
+    })
+
+    it('defaults to 0,0 when position is undefined', () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={undefined}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      const dialog = screen.getByRole('dialog')
+      expect(dialog).toHaveStyle({
+        left: '0px',
+        top: '0px',
+      })
+    })
+
+    it('applies correct z-index from config', () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      const dialog = screen.getByRole('dialog')
+      // Z_INDEX should be 1100 from HOVER_POPUP_CONFIG
+      expect(dialog).toHaveStyle({ zIndex: '1100' })
+    })
+
+    it('has opacity-100 class when visible', async () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      // Wait for requestAnimationFrame to trigger opacity-100
+      await waitFor(() => {
+        const dialog = screen.getByRole('dialog')
+        expect(dialog).toHaveClass('opacity-100')
+      })
+    })
+
+    it('has fixed positioning', () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      const dialog = screen.getByRole('dialog')
+      expect(dialog).toHaveClass('fixed')
+    })
+  })
+
+  describe('Animation States', () => {
+    it('has transition-opacity class for smooth animations', () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      const dialog = screen.getByRole('dialog')
+      expect(dialog).toHaveClass('transition-opacity')
+    })
+
+    it('applies correct animation duration from config', () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      const dialog = screen.getByRole('dialog')
+      // ANIMATION_DURATION is 100ms in HOVER_POPUP_CONFIG
+      expect(dialog).toHaveStyle({ transitionDuration: '100ms' })
+    })
+
+    it('has opacity-100 when isVisible becomes true', async () => {
+      const { rerender } = render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={false}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      // Make visible
+      rerender(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      // Wait for requestAnimationFrame to apply opacity-100
+      await waitFor(() => {
+        const dialog = screen.getByRole('dialog')
+        expect(dialog).toHaveClass('opacity-100')
+      })
+    })
+
+    it('has opacity-0 when isVisible becomes false (fade-out)', async () => {
+      const { rerender } = render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      // Wait for initial fade-in to complete
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toHaveClass('opacity-100')
+      })
+
+      // Hide (start fade-out animation)
+      rerender(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={false}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      // Should immediately have opacity-0 class (fade-out animation)
+      const dialog = screen.getByRole('dialog')
+      expect(dialog).toHaveClass('opacity-0')
+    })
+
+    it('removes from DOM after fade-out animation completes', async () => {
+      vi.useFakeTimers()
+
+      const { rerender, container } = render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      // Wait for initial fade-in (uses requestAnimationFrame)
+      await act(async () => {
+        await vi.runAllTimersAsync()
+      })
+
+      // Verify popup is visible
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+      // Hide popup
+      rerender(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={false}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      // Still in DOM during animation (opacity-0)
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+      // Fast-forward past animation duration (100ms)
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(100)
+      })
+
+      // Should be removed from DOM
+      expect(container.firstChild).toBeNull()
+
+      vi.useRealTimers()
+    })
+
+    it('maintains no layout shift during fade animation', () => {
+      const { rerender } = render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      const dialog = screen.getByRole('dialog')
+      const initialWidth = dialog.style.width
+      const initialPosition = {
+        left: dialog.style.left,
+        top: dialog.style.top,
+      }
+
+      // Hide (trigger fade-out)
+      rerender(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={false}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      // Verify size and position unchanged during animation
+      const fadingDialog = screen.getByRole('dialog')
+      expect(fadingDialog.style.width).toBe(initialWidth)
+      expect(fadingDialog.style.left).toBe(initialPosition.left)
+      expect(fadingDialog.style.top).toBe(initialPosition.top)
+    })
+  })
+
+  describe('Tags Display', () => {
+    it('shows tags when photos have tags', () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      expect(screen.getByText('moth')).toBeInTheDocument()
+      expect(screen.getByText('night')).toBeInTheDocument()
+      expect(screen.getByText('butterfly')).toBeInTheDocument()
+    })
+
+    it('does not show tags section when no photos have tags', () => {
+      const clusterWithoutTags = {
+        ...mockCluster,
+        photos: mockCluster.photos.map((p) => ({ ...p, tags: [] })),
+      }
+
+      render(
+        <MarkerHoverPopup
+          cluster={clusterWithoutTags}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      // Tags should not be rendered
+      expect(screen.queryByText('moth')).not.toBeInTheDocument()
+      expect(screen.queryByText('butterfly')).not.toBeInTheDocument()
+    })
+
+    it('deduplicates tags from multiple photos', () => {
+      const clusterWithDuplicateTags = {
+        ...mockCluster,
+        photos: [
+          { ...mockCluster.photos[0], tags: ['moth', 'night'] },
+          { ...mockCluster.photos[1], tags: ['moth', 'butterfly'] },
+          { ...mockCluster.photos[2], tags: ['night'] },
+        ],
+      }
+
+      render(
+        <MarkerHoverPopup
+          cluster={clusterWithDuplicateTags}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      const mothTags = screen.getAllByText('moth')
+      const nightTags = screen.getAllByText('night')
+
+      // Each tag should appear only once
+      expect(mothTags).toHaveLength(1)
+      expect(nightTags).toHaveLength(1)
+    })
+
+    it('limits tags to 5', () => {
+      const clusterWithManyTags = {
+        ...mockCluster,
+        photos: [
+          { ...mockCluster.photos[0], tags: ['tag1', 'tag2', 'tag3'] },
+          { ...mockCluster.photos[1], tags: ['tag4', 'tag5', 'tag6'] },
+          { ...mockCluster.photos[2], tags: ['tag7', 'tag8'] },
+        ],
+      }
+
+      const { container } = render(
+        <MarkerHoverPopup
+          cluster={clusterWithManyTags}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      // Count tag elements
+      const tagElements = container.querySelectorAll('.px-2.py-0\\.5.bg-gray-100')
+      expect(tagElements).toHaveLength(5)
+    })
+
+    it('handles photos with undefined tags', () => {
+      const clusterWithUndefinedTags = {
+        ...mockCluster,
+        photos: [
+          { ...mockCluster.photos[0], tags: undefined },
+          { ...mockCluster.photos[1], tags: ['butterfly'] },
+        ],
+      }
+
+      render(
+        <MarkerHoverPopup
+          cluster={clusterWithUndefinedTags}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      // Should show butterfly tag, not crash
+      expect(screen.getByText('butterfly')).toBeInTheDocument()
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('handles cluster with no photos', () => {
+      const clusterWithNoPhotos = {
+        ...mockCluster,
+        count: 0,
+        photos: [],
+      }
+
+      render(
+        <MarkerHoverPopup
+          cluster={clusterWithNoPhotos}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      expect(screen.getByText('0 photos')).toBeInTheDocument()
+    })
+
+    it('handles cluster with undefined photos array', () => {
+      const clusterWithUndefinedPhotos = {
+        ...mockCluster,
+        photos: undefined,
+      }
+
+      render(
+        <MarkerHoverPopup
+          cluster={clusterWithUndefinedPhotos}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+
+    it('handles missing onPhotoClick gracefully', () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={undefined}
+          onClose={mockOnClose}
+        />
+      )
+
+      // Should render without errors
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+  })
+
+  describe('Focus Trap', () => {
+    it('traps Tab key within popup (forward)', () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      const buttons = screen.getAllByRole('button')
+      const firstButton = buttons[0]
+      const lastButton = buttons[buttons.length - 1]
+
+      // Focus last button
+      lastButton.focus()
+      expect(document.activeElement).toBe(lastButton)
+
+      // Press Tab - should cycle to first button
+      fireEvent.keyDown(document, { key: 'Tab', shiftKey: false })
+      expect(document.activeElement).toBe(firstButton)
+    })
+
+    it('traps Tab key within popup (backward)', () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      const buttons = screen.getAllByRole('button')
+      const firstButton = buttons[0]
+      const lastButton = buttons[buttons.length - 1]
+
+      // Focus first button
+      firstButton.focus()
+      expect(document.activeElement).toBe(firstButton)
+
+      // Press Shift+Tab - should cycle to last button
+      fireEvent.keyDown(document, { key: 'Tab', shiftKey: true })
+      expect(document.activeElement).toBe(lastButton)
+    })
+
+    it('does not trap Tab when focus is on middle element', () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={true}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      const buttons = screen.getAllByRole('button')
+      if (buttons.length < 3) return // Skip if not enough buttons
+
+      const middleButton = buttons[1]
+      middleButton.focus()
+
+      // Tab should not be prevented when on middle element
+      const event = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true })
+      const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+      document.dispatchEvent(event)
+
+      // preventDefault should not be called for middle elements
+      expect(preventDefaultSpy).not.toHaveBeenCalled()
+    })
+
+    it('does not add Tab trap when not visible', () => {
+      render(
+        <MarkerHoverPopup
+          cluster={mockCluster}
+          isVisible={false}
+          position={mockPosition}
+          onPhotoClick={mockOnPhotoClick}
+          onClose={mockOnClose}
+        />
+      )
+
+      // Tab key should not be trapped when popup is not visible
+      const event = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true })
+      const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+      document.dispatchEvent(event)
+
+      expect(preventDefaultSpy).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/components/__tests__/ThumbnailGrid.test.jsx
+++ b/Firmware/webui/frontend/src/components/__tests__/ThumbnailGrid.test.jsx
@@ -1,0 +1,559 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ThumbnailGrid from '../ThumbnailGrid'
+import { HOVER_POPUP_CONFIG } from '../../constants/config'
+
+describe('ThumbnailGrid', () => {
+  const mockPhotos = [
+    {
+      photo_id: 'photo1.jpg',
+      lat: 37.7749,
+      lon: -122.4194,
+      timestamp: '2024-01-15T10:30:00',
+      tags: ['moth', 'night'],
+    },
+    {
+      photo_id: 'photo2.jpg',
+      lat: 37.7750,
+      lon: -122.4195,
+      timestamp: '2024-01-15T10:31:00',
+      tags: ['butterfly'],
+    },
+    {
+      photo_id: 'photo3.jpg',
+      lat: 37.7751,
+      lon: -122.4196,
+      timestamp: '2024-01-15T10:32:00',
+      tags: ['beetle'],
+    },
+    {
+      photo_id: 'photo4.jpg',
+      lat: 37.7752,
+      lon: -122.4197,
+      timestamp: '2024-01-15T10:33:00',
+      tags: [],
+    },
+    {
+      photo_id: 'photo5.jpg',
+      lat: 37.7753,
+      lon: -122.4198,
+      timestamp: '2024-01-15T10:34:00',
+      tags: ['moth'],
+    },
+    {
+      photo_id: 'photo6.jpg',
+      lat: 37.7754,
+      lon: -122.4199,
+      timestamp: '2024-01-15T10:35:00',
+      tags: [],
+    },
+    {
+      photo_id: 'photo7.jpg',
+      lat: 37.7755,
+      lon: -122.4200,
+      timestamp: '2024-01-15T10:36:00',
+      tags: ['dragonfly'],
+    },
+    {
+      photo_id: 'photo8.jpg',
+      lat: 37.7756,
+      lon: -122.4201,
+      timestamp: '2024-01-15T10:37:00',
+      tags: [],
+    },
+    {
+      photo_id: 'photo9.jpg',
+      lat: 37.7757,
+      lon: -122.4202,
+      timestamp: '2024-01-15T10:38:00',
+      tags: ['spider'],
+    },
+    {
+      photo_id: 'photo10.jpg',
+      lat: 37.7758,
+      lon: -122.4203,
+      timestamp: '2024-01-15T10:39:00',
+      tags: [],
+    },
+    {
+      photo_id: 'photo11.jpg',
+      lat: 37.7759,
+      lon: -122.4204,
+      timestamp: '2024-01-15T10:40:00',
+      tags: ['wasp'],
+    },
+  ]
+
+  let mockOnPhotoClick
+
+  beforeEach(() => {
+    mockOnPhotoClick = vi.fn()
+  })
+
+  describe('Rendering', () => {
+    it('renders correct number of thumbnails up to maxPhotos', () => {
+      render(<ThumbnailGrid photos={mockPhotos} maxPhotos={9} onPhotoClick={mockOnPhotoClick} />)
+
+      const images = screen.getAllByRole('img')
+      expect(images).toHaveLength(9)
+    })
+
+    it('renders all photos when photos.length < maxPhotos', () => {
+      const fewPhotos = mockPhotos.slice(0, 5)
+      render(<ThumbnailGrid photos={fewPhotos} maxPhotos={9} onPhotoClick={mockOnPhotoClick} />)
+
+      const images = screen.getAllByRole('img')
+      expect(images).toHaveLength(5)
+    })
+
+    it('uses default maxPhotos from config when not specified', () => {
+      render(<ThumbnailGrid photos={mockPhotos} onPhotoClick={mockOnPhotoClick} />)
+
+      const images = screen.getAllByRole('img')
+      expect(images).toHaveLength(HOVER_POPUP_CONFIG.MAX_PHOTOS)
+    })
+
+    it('each thumbnail has correct src URL', () => {
+      render(<ThumbnailGrid photos={mockPhotos} maxPhotos={9} onPhotoClick={mockOnPhotoClick} />)
+
+      const images = screen.getAllByRole('img')
+      images.forEach((img, index) => {
+        const photoId = mockPhotos[index].photo_id
+        expect(img).toHaveAttribute(
+          'src',
+          `/api/gallery/thumbnail/${photoId}?size=${HOVER_POPUP_CONFIG.THUMBNAIL_SIZE}`
+        )
+      })
+    })
+
+    it('each thumbnail has alt text', () => {
+      render(<ThumbnailGrid photos={mockPhotos} maxPhotos={9} onPhotoClick={mockOnPhotoClick} />)
+
+      const images = screen.getAllByRole('img')
+      images.forEach((img, index) => {
+        expect(img).toHaveAttribute('alt', mockPhotos[index].photo_id)
+      })
+    })
+
+    it('uses custom thumbnailSize when provided', () => {
+      const customSize = 256
+      render(
+        <ThumbnailGrid
+          photos={mockPhotos}
+          maxPhotos={9}
+          thumbnailSize={customSize}
+          onPhotoClick={mockOnPhotoClick}
+        />
+      )
+
+      const images = screen.getAllByRole('img')
+      images.forEach((img, index) => {
+        const photoId = mockPhotos[index].photo_id
+        expect(img).toHaveAttribute('src', `/api/gallery/thumbnail/${photoId}?size=${customSize}`)
+      })
+    })
+
+    it('applies additional className', () => {
+      const { container } = render(
+        <ThumbnailGrid
+          photos={mockPhotos}
+          maxPhotos={9}
+          onPhotoClick={mockOnPhotoClick}
+          className="custom-class"
+        />
+      )
+
+      const gridContainer = container.querySelector('.grid')
+      expect(gridContainer).toHaveClass('custom-class')
+    })
+
+    it('has 3x3 grid layout classes', () => {
+      const { container } = render(
+        <ThumbnailGrid photos={mockPhotos} maxPhotos={9} onPhotoClick={mockOnPhotoClick} />
+      )
+
+      const gridContainer = container.querySelector('.grid')
+      expect(gridContainer).toHaveClass('grid')
+      expect(gridContainer).toHaveClass('grid-cols-3')
+      expect(gridContainer).toHaveClass('gap-1')
+    })
+  })
+
+  describe('More Photos Indicator', () => {
+    it('shows "+N more" text when photos > maxPhotos', () => {
+      render(<ThumbnailGrid photos={mockPhotos} maxPhotos={9} onPhotoClick={mockOnPhotoClick} />)
+
+      const remainingText = screen.getByText('+2 more photos')
+      expect(remainingText).toBeInTheDocument()
+    })
+
+    it('does not show "+N more" when photos.length === maxPhotos', () => {
+      const exactPhotos = mockPhotos.slice(0, 9)
+      render(
+        <ThumbnailGrid photos={exactPhotos} maxPhotos={9} onPhotoClick={mockOnPhotoClick} />
+      )
+
+      const remainingText = screen.queryByText(/\+\d+ more photos/)
+      expect(remainingText).not.toBeInTheDocument()
+    })
+
+    it('does not show "+N more" when photos.length < maxPhotos', () => {
+      const fewPhotos = mockPhotos.slice(0, 5)
+      render(<ThumbnailGrid photos={fewPhotos} maxPhotos={9} onPhotoClick={mockOnPhotoClick} />)
+
+      const remainingText = screen.queryByText(/\+\d+ more photos/)
+      expect(remainingText).not.toBeInTheDocument()
+    })
+
+    it('calculates remaining count correctly', () => {
+      // 11 total photos, 9 max = +2 more
+      render(<ThumbnailGrid photos={mockPhotos} maxPhotos={9} onPhotoClick={mockOnPhotoClick} />)
+      expect(screen.getByText('+2 more photos')).toBeInTheDocument()
+
+      // 11 total photos, 5 max = +6 more
+      const { rerender } = render(
+        <ThumbnailGrid photos={mockPhotos} maxPhotos={5} onPhotoClick={mockOnPhotoClick} />
+      )
+      expect(screen.getByText('+6 more photos')).toBeInTheDocument()
+    })
+  })
+
+  describe('Loading State', () => {
+    it('shows skeleton loaders when isLoading is true', () => {
+      render(
+        <ThumbnailGrid photos={mockPhotos} maxPhotos={9} isLoading={true} onPhotoClick={mockOnPhotoClick} />
+      )
+
+      const skeletons = screen.getAllByRole('status')
+      expect(skeletons).toHaveLength(9)
+      skeletons.forEach((skeleton) => {
+        expect(skeleton).toHaveAttribute('aria-busy', 'true')
+        expect(skeleton).toHaveAttribute('aria-label', 'Loading thumbnail')
+      })
+    })
+
+    it('shows correct number of skeletons based on maxPhotos', () => {
+      render(
+        <ThumbnailGrid photos={mockPhotos} maxPhotos={6} isLoading={true} onPhotoClick={mockOnPhotoClick} />
+      )
+
+      const skeletons = screen.getAllByRole('status')
+      expect(skeletons).toHaveLength(6)
+    })
+
+    it('does not show actual images when loading', () => {
+      render(
+        <ThumbnailGrid photos={mockPhotos} maxPhotos={9} isLoading={true} onPhotoClick={mockOnPhotoClick} />
+      )
+
+      const images = screen.queryAllByRole('img')
+      expect(images).toHaveLength(0)
+    })
+
+    it('shows images when isLoading is false', () => {
+      render(
+        <ThumbnailGrid photos={mockPhotos} maxPhotos={9} isLoading={false} onPhotoClick={mockOnPhotoClick} />
+      )
+
+      const images = screen.getAllByRole('img')
+      expect(images).toHaveLength(9)
+      const skeletons = screen.queryAllByRole('status')
+      expect(skeletons).toHaveLength(0)
+    })
+  })
+
+  describe('Empty State', () => {
+    it('handles empty photos array gracefully', () => {
+      render(<ThumbnailGrid photos={[]} maxPhotos={9} onPhotoClick={mockOnPhotoClick} />)
+
+      expect(screen.getByText('No photos available')).toBeInTheDocument()
+      const images = screen.queryAllByRole('img')
+      expect(images).toHaveLength(0)
+    })
+
+    it('handles undefined photos gracefully', () => {
+      render(<ThumbnailGrid photos={undefined} maxPhotos={9} onPhotoClick={mockOnPhotoClick} />)
+
+      expect(screen.getByText('No photos available')).toBeInTheDocument()
+      const images = screen.queryAllByRole('img')
+      expect(images).toHaveLength(0)
+    })
+
+    it('handles null photos gracefully', () => {
+      render(<ThumbnailGrid photos={null} maxPhotos={9} onPhotoClick={mockOnPhotoClick} />)
+
+      expect(screen.getByText('No photos available')).toBeInTheDocument()
+      const images = screen.queryAllByRole('img')
+      expect(images).toHaveLength(0)
+    })
+
+    it('applies className to empty state container', () => {
+      const { container } = render(
+        <ThumbnailGrid photos={[]} maxPhotos={9} onPhotoClick={mockOnPhotoClick} className="custom-empty" />
+      )
+
+      const emptyContainer = container.querySelector('.custom-empty')
+      expect(emptyContainer).toBeInTheDocument()
+      expect(emptyContainer).toHaveTextContent('No photos available')
+    })
+  })
+
+  describe('Click Handling', () => {
+    it('calls onPhotoClick with correct photo when thumbnail is clicked', async () => {
+      const user = userEvent.setup()
+      render(<ThumbnailGrid photos={mockPhotos} maxPhotos={9} onPhotoClick={mockOnPhotoClick} />)
+
+      const buttons = screen.getAllByRole('button')
+      await user.click(buttons[0])
+
+      expect(mockOnPhotoClick).toHaveBeenCalledTimes(1)
+      expect(mockOnPhotoClick).toHaveBeenCalledWith(mockPhotos[0])
+    })
+
+    it('calls onPhotoClick with correct photo for different thumbnails', async () => {
+      const user = userEvent.setup()
+      render(<ThumbnailGrid photos={mockPhotos} maxPhotos={9} onPhotoClick={mockOnPhotoClick} />)
+
+      const buttons = screen.getAllByRole('button')
+
+      // Click third thumbnail
+      await user.click(buttons[2])
+      expect(mockOnPhotoClick).toHaveBeenCalledWith(mockPhotos[2])
+
+      // Click fifth thumbnail
+      await user.click(buttons[4])
+      expect(mockOnPhotoClick).toHaveBeenCalledWith(mockPhotos[4])
+    })
+
+    it('does not error when onPhotoClick is undefined', async () => {
+      const user = userEvent.setup()
+      render(<ThumbnailGrid photos={mockPhotos} maxPhotos={9} />)
+
+      const buttons = screen.getAllByRole('button')
+      await expect(user.click(buttons[0])).resolves.not.toThrow()
+    })
+
+    it('does not call onPhotoClick during loading state', () => {
+      render(
+        <ThumbnailGrid photos={mockPhotos} maxPhotos={9} isLoading={true} onPhotoClick={mockOnPhotoClick} />
+      )
+
+      const buttons = screen.queryAllByRole('button')
+      expect(buttons).toHaveLength(0)
+      expect(mockOnPhotoClick).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('each thumbnail button has proper focus styles', () => {
+      render(<ThumbnailGrid photos={mockPhotos} maxPhotos={9} onPhotoClick={mockOnPhotoClick} />)
+
+      const buttons = screen.getAllByRole('button')
+      buttons.forEach((button) => {
+        expect(button).toHaveClass('focus:outline-none')
+        expect(button).toHaveClass('focus:ring-2')
+        expect(button).toHaveClass('focus:ring-blue-500')
+      })
+    })
+
+    it('images have lazy loading attribute', () => {
+      render(<ThumbnailGrid photos={mockPhotos} maxPhotos={9} onPhotoClick={mockOnPhotoClick} />)
+
+      const images = screen.getAllByRole('img')
+      images.forEach((img) => {
+        expect(img).toHaveAttribute('loading', 'lazy')
+      })
+    })
+
+    it('buttons have type="button" to prevent form submission', () => {
+      render(<ThumbnailGrid photos={mockPhotos} maxPhotos={9} onPhotoClick={mockOnPhotoClick} />)
+
+      const buttons = screen.getAllByRole('button')
+      buttons.forEach((button) => {
+        expect(button).toHaveAttribute('type', 'button')
+      })
+    })
+
+    it('skeletons have proper ARIA attributes', () => {
+      render(
+        <ThumbnailGrid photos={mockPhotos} maxPhotos={9} isLoading={true} onPhotoClick={mockOnPhotoClick} />
+      )
+
+      const skeletons = screen.getAllByRole('status')
+      skeletons.forEach((skeleton) => {
+        expect(skeleton).toHaveAttribute('role', 'status')
+        expect(skeleton).toHaveAttribute('aria-busy', 'true')
+        expect(skeleton).toHaveAttribute('aria-label', 'Loading thumbnail')
+      })
+    })
+  })
+
+  describe('PropTypes Validation', () => {
+    it('accepts valid photo objects', () => {
+      expect(() => {
+        render(<ThumbnailGrid photos={mockPhotos} maxPhotos={9} onPhotoClick={mockOnPhotoClick} />)
+      }).not.toThrow()
+    })
+
+    it('accepts photos with optional properties', () => {
+      const minimalPhotos = [
+        {
+          photo_id: 'photo1.jpg',
+        },
+        {
+          photo_id: 'photo2.jpg',
+          lat: 37.7749,
+        },
+      ]
+
+      expect(() => {
+        render(<ThumbnailGrid photos={minimalPhotos} maxPhotos={9} onPhotoClick={mockOnPhotoClick} />)
+      }).not.toThrow()
+    })
+  })
+
+  describe('Keyboard Navigation', () => {
+    it('moves focus to next thumbnail on ArrowRight', async () => {
+      const user = userEvent.setup()
+      render(<ThumbnailGrid photos={mockPhotos} maxPhotos={9} onPhotoClick={mockOnPhotoClick} />)
+
+      const buttons = screen.getAllByRole('button')
+      await user.click(buttons[0]) // Focus first item
+
+      await user.keyboard('{ArrowRight}')
+      expect(buttons[1]).toHaveFocus()
+    })
+
+    it('moves focus to previous thumbnail on ArrowLeft', async () => {
+      const user = userEvent.setup()
+      render(<ThumbnailGrid photos={mockPhotos} maxPhotos={9} onPhotoClick={mockOnPhotoClick} />)
+
+      const buttons = screen.getAllByRole('button')
+      await user.click(buttons[2]) // Focus third item
+
+      await user.keyboard('{ArrowLeft}')
+      expect(buttons[1]).toHaveFocus()
+    })
+
+    it('moves focus down one row on ArrowDown', async () => {
+      const user = userEvent.setup()
+      render(<ThumbnailGrid photos={mockPhotos} maxPhotos={9} onPhotoClick={mockOnPhotoClick} />)
+
+      const buttons = screen.getAllByRole('button')
+      await user.click(buttons[0]) // Focus first item (index 0)
+
+      await user.keyboard('{ArrowDown}')
+      expect(buttons[3]).toHaveFocus() // Should move to index 3 (down one row)
+    })
+
+    it('moves focus up one row on ArrowUp', async () => {
+      const user = userEvent.setup()
+      render(<ThumbnailGrid photos={mockPhotos} maxPhotos={9} onPhotoClick={mockOnPhotoClick} />)
+
+      const buttons = screen.getAllByRole('button')
+      await user.click(buttons[3]) // Focus fourth item (index 3)
+
+      await user.keyboard('{ArrowUp}')
+      expect(buttons[0]).toHaveFocus() // Should move to index 0 (up one row)
+    })
+
+    it('focuses first thumbnail on Home key', async () => {
+      const user = userEvent.setup()
+      render(<ThumbnailGrid photos={mockPhotos} maxPhotos={9} onPhotoClick={mockOnPhotoClick} />)
+
+      const buttons = screen.getAllByRole('button')
+      await user.click(buttons[5]) // Focus middle item
+
+      await user.keyboard('{Home}')
+      expect(buttons[0]).toHaveFocus()
+    })
+
+    it('focuses last thumbnail on End key', async () => {
+      const user = userEvent.setup()
+      render(<ThumbnailGrid photos={mockPhotos} maxPhotos={9} onPhotoClick={mockOnPhotoClick} />)
+
+      const buttons = screen.getAllByRole('button')
+      await user.click(buttons[0]) // Focus first item
+
+      await user.keyboard('{End}')
+      expect(buttons[8]).toHaveFocus() // Last displayed item (9 total)
+    })
+
+    it('activates focused thumbnail on Enter key', async () => {
+      const user = userEvent.setup()
+      render(<ThumbnailGrid photos={mockPhotos} maxPhotos={9} onPhotoClick={mockOnPhotoClick} />)
+
+      const buttons = screen.getAllByRole('button')
+      await user.click(buttons[0]) // Focus first item
+
+      await user.keyboard('{Enter}')
+      expect(mockOnPhotoClick).toHaveBeenCalledWith(mockPhotos[0])
+    })
+
+    it('activates focused thumbnail on Space key', async () => {
+      const user = userEvent.setup()
+      render(<ThumbnailGrid photos={mockPhotos} maxPhotos={9} onPhotoClick={mockOnPhotoClick} />)
+
+      const buttons = screen.getAllByRole('button')
+      await user.click(buttons[2]) // Focus third item
+
+      await user.keyboard(' ')
+      expect(mockOnPhotoClick).toHaveBeenCalledWith(mockPhotos[2])
+    })
+
+    it('does not move beyond last item with ArrowRight', async () => {
+      const user = userEvent.setup()
+      render(<ThumbnailGrid photos={mockPhotos} maxPhotos={9} onPhotoClick={mockOnPhotoClick} />)
+
+      const buttons = screen.getAllByRole('button')
+      await user.click(buttons[8]) // Focus last item
+
+      await user.keyboard('{ArrowRight}')
+      expect(buttons[8]).toHaveFocus() // Should stay on last item
+    })
+
+    it('does not move before first item with ArrowLeft', async () => {
+      const user = userEvent.setup()
+      render(<ThumbnailGrid photos={mockPhotos} maxPhotos={9} onPhotoClick={mockOnPhotoClick} />)
+
+      const buttons = screen.getAllByRole('button')
+      await user.click(buttons[0]) // Focus first item
+
+      await user.keyboard('{ArrowLeft}')
+      expect(buttons[0]).toHaveFocus() // Should stay on first item
+    })
+
+    it('only focused item has tabIndex=0', () => {
+      render(<ThumbnailGrid photos={mockPhotos} maxPhotos={9} onPhotoClick={mockOnPhotoClick} />)
+
+      const buttons = screen.getAllByRole('button')
+      expect(buttons[0]).toHaveAttribute('tabIndex', '0')
+      buttons.slice(1).forEach((button) => {
+        expect(button).toHaveAttribute('tabIndex', '-1')
+      })
+    })
+
+    it('handles ArrowDown at bottom edge gracefully', async () => {
+      const user = userEvent.setup()
+      render(<ThumbnailGrid photos={mockPhotos} maxPhotos={9} onPhotoClick={mockOnPhotoClick} />)
+
+      const buttons = screen.getAllByRole('button')
+      await user.click(buttons[6]) // Focus item in last row
+
+      await user.keyboard('{ArrowDown}')
+      expect(buttons[8]).toHaveFocus() // Should move to last item (not beyond)
+    })
+
+    it('handles ArrowUp at top edge gracefully', async () => {
+      const user = userEvent.setup()
+      render(<ThumbnailGrid photos={mockPhotos} maxPhotos={9} onPhotoClick={mockOnPhotoClick} />)
+
+      const buttons = screen.getAllByRole('button')
+      await user.click(buttons[1]) // Focus item in first row
+
+      await user.keyboard('{ArrowUp}')
+      expect(buttons[0]).toHaveFocus() // Should move to first item (not negative)
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/components/__tests__/ThumbnailSkeleton.test.jsx
+++ b/Firmware/webui/frontend/src/components/__tests__/ThumbnailSkeleton.test.jsx
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import ThumbnailSkeleton from '../ThumbnailSkeleton'
+import { HOVER_POPUP_CONFIG } from '../../constants/config'
+
+describe('ThumbnailSkeleton', () => {
+  describe('Rendering', () => {
+    it('renders with default size (128px)', () => {
+      const { container } = render(<ThumbnailSkeleton />)
+
+      const skeleton = container.querySelector('[role="status"]')
+      expect(skeleton).toBeInTheDocument()
+      expect(skeleton).toHaveStyle({
+        width: `${HOVER_POPUP_CONFIG.THUMBNAIL_SIZE}px`,
+        height: `${HOVER_POPUP_CONFIG.THUMBNAIL_SIZE}px`,
+      })
+    })
+
+    it('renders with custom size', () => {
+      const customSize = 256
+      const { container } = render(<ThumbnailSkeleton size={customSize} />)
+
+      const skeleton = container.querySelector('[role="status"]')
+      expect(skeleton).toHaveStyle({
+        width: `${customSize}px`,
+        height: `${customSize}px`,
+      })
+    })
+
+    it('accepts additional className', () => {
+      const { container } = render(<ThumbnailSkeleton className="custom-class" />)
+
+      const skeleton = container.querySelector('[role="status"]')
+      expect(skeleton).toHaveClass('custom-class')
+    })
+
+    it('has animate-pulse class applied', () => {
+      const { container } = render(<ThumbnailSkeleton />)
+
+      const skeleton = container.querySelector('[role="status"]')
+      expect(skeleton).toHaveClass('animate-pulse')
+    })
+
+    it('has rounded corners (rounded-lg)', () => {
+      const { container } = render(<ThumbnailSkeleton />)
+
+      const skeleton = container.querySelector('[role="status"]')
+      expect(skeleton).toHaveClass('rounded-lg')
+    })
+
+    it('has gray background (bg-gray-200)', () => {
+      const { container } = render(<ThumbnailSkeleton />)
+
+      const skeleton = container.querySelector('[role="status"]')
+      expect(skeleton).toHaveClass('bg-gray-200')
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('has correct ARIA role (status)', () => {
+      render(<ThumbnailSkeleton />)
+
+      const skeleton = screen.getByRole('status')
+      expect(skeleton).toBeInTheDocument()
+    })
+
+    it('has aria-busy attribute set to true', () => {
+      render(<ThumbnailSkeleton />)
+
+      const skeleton = screen.getByRole('status')
+      expect(skeleton).toHaveAttribute('aria-busy', 'true')
+    })
+
+    it('has aria-label "Loading thumbnail"', () => {
+      render(<ThumbnailSkeleton />)
+
+      const skeleton = screen.getByRole('status')
+      expect(skeleton).toHaveAttribute('aria-label', 'Loading thumbnail')
+    })
+  })
+
+  describe('Props', () => {
+    it('uses HOVER_POPUP_CONFIG.THUMBNAIL_SIZE as default size', () => {
+      const { container } = render(<ThumbnailSkeleton />)
+
+      const skeleton = container.querySelector('[role="status"]')
+      expect(skeleton).toHaveStyle({
+        width: `${HOVER_POPUP_CONFIG.THUMBNAIL_SIZE}px`,
+        height: `${HOVER_POPUP_CONFIG.THUMBNAIL_SIZE}px`,
+      })
+    })
+
+    it('handles zero size correctly', () => {
+      const { container } = render(<ThumbnailSkeleton size={0} />)
+
+      const skeleton = container.querySelector('[role="status"]')
+      expect(skeleton).toHaveStyle({
+        width: '0px',
+        height: '0px',
+      })
+    })
+
+    it('handles large size values', () => {
+      const largeSize = 512
+      const { container } = render(<ThumbnailSkeleton size={largeSize} />)
+
+      const skeleton = container.querySelector('[role="status"]')
+      expect(skeleton).toHaveStyle({
+        width: `${largeSize}px`,
+        height: `${largeSize}px`,
+      })
+    })
+
+    it('merges className with default classes', () => {
+      const { container } = render(<ThumbnailSkeleton className="extra-class" />)
+
+      const skeleton = container.querySelector('[role="status"]')
+      expect(skeleton).toHaveClass('bg-gray-200')
+      expect(skeleton).toHaveClass('animate-pulse')
+      expect(skeleton).toHaveClass('rounded-lg')
+      expect(skeleton).toHaveClass('extra-class')
+    })
+
+    it('handles empty className string', () => {
+      const { container } = render(<ThumbnailSkeleton className="" />)
+
+      const skeleton = container.querySelector('[role="status"]')
+      expect(skeleton).toHaveClass('bg-gray-200')
+      expect(skeleton).toHaveClass('animate-pulse')
+      expect(skeleton).toHaveClass('rounded-lg')
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/constants/config.js
+++ b/Firmware/webui/frontend/src/constants/config.js
@@ -289,3 +289,33 @@ export const CLUSTERING_CONFIG = {
   DEFAULT_MIN_SIZE: 2,
   STORAGE_KEY: 'mothbox_clustering_settings',
 }
+
+/**
+ * Hover Popup Configuration (Issue #117)
+ *
+ * Configuration for the interactive hover popup on map cluster markers.
+ * Displays a 3x3 thumbnail grid preview of photos at each location.
+ *
+ * @property {number} GRID_SIZE - Grid dimensions (3 = 3x3 grid)
+ * @property {number} THUMBNAIL_SIZE - Size of thumbnails in pixels (128px for balanced quality)
+ * @property {number} DEBOUNCE_MS - Debounce delay for hover detection (ms)
+ * @property {number} SHOW_DELAY_MS - Delay before showing popup (ms)
+ * @property {number} HIDE_DELAY_MS - Delay before hiding popup to prevent flicker (ms)
+ * @property {number} MAX_PHOTOS - Maximum photos to display in grid
+ * @property {number} POPUP_WIDTH - Popup container width in pixels
+ * @property {number} Z_INDEX - Z-index for popup layering (above map, below lightbox)
+ * @property {number} SWIPE_THRESHOLD - Minimum swipe distance for mobile navigation (px)
+ * @property {number} ANIMATION_DURATION - Fade animation duration (ms)
+ */
+export const HOVER_POPUP_CONFIG = {
+  GRID_SIZE: 3,
+  THUMBNAIL_SIZE: 128,
+  DEBOUNCE_MS: 150,
+  SHOW_DELAY_MS: 100,
+  HIDE_DELAY_MS: 200,
+  MAX_PHOTOS: 9,
+  POPUP_WIDTH: 280,
+  Z_INDEX: 1100,
+  SWIPE_THRESHOLD: 50,
+  ANIMATION_DURATION: 100,
+}

--- a/Firmware/webui/frontend/src/hooks/__tests__/useHoverPopup.test.jsx
+++ b/Firmware/webui/frontend/src/hooks/__tests__/useHoverPopup.test.jsx
@@ -1,0 +1,510 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useHoverPopup } from '../useHoverPopup'
+
+/**
+ * Test suite for useHoverPopup hook
+ *
+ * This hook manages hover state for map cluster popups with debouncing,
+ * show/hide delays, and mobile touch detection.
+ */
+describe('useHoverPopup', () => {
+  beforeEach(() => {
+    // Use fake timers for testing delays
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    // Clean up timers
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  describe('Initial State', () => {
+    it('returns isVisible=false initially', () => {
+      const { result } = renderHook(() => useHoverPopup())
+
+      expect(result.current.isVisible).toBe(false)
+    })
+
+    it('returns targetCluster=null initially', () => {
+      const { result } = renderHook(() => useHoverPopup())
+
+      expect(result.current.targetCluster).toBe(null)
+    })
+
+    it('returns position=null initially', () => {
+      const { result } = renderHook(() => useHoverPopup())
+
+      expect(result.current.position).toBe(null)
+    })
+
+    it('provides handleMouseEnter function', () => {
+      const { result } = renderHook(() => useHoverPopup())
+
+      expect(result.current.handleMouseEnter).toBeTypeOf('function')
+    })
+
+    it('provides handleMouseLeave function', () => {
+      const { result } = renderHook(() => useHoverPopup())
+
+      expect(result.current.handleMouseLeave).toBeTypeOf('function')
+    })
+
+    it('provides handleClick function', () => {
+      const { result } = renderHook(() => useHoverPopup())
+
+      expect(result.current.handleClick).toBeTypeOf('function')
+    })
+
+    it('provides isMobile boolean', () => {
+      const { result } = renderHook(() => useHoverPopup())
+
+      expect(typeof result.current.isMobile).toBe('boolean')
+    })
+  })
+
+  describe('Mouse Enter Behavior', () => {
+    it('sets targetCluster immediately on mouse enter', () => {
+      const { result } = renderHook(() => useHoverPopup())
+      const mockCluster = { id: 'cluster1', count: 5 }
+      const mockEvent = { clientX: 100, clientY: 200 }
+
+      act(() => {
+        result.current.handleMouseEnter(mockCluster, mockEvent)
+      })
+
+      expect(result.current.targetCluster).toEqual(mockCluster)
+    })
+
+    it('sets position immediately on mouse enter', () => {
+      const { result } = renderHook(() => useHoverPopup())
+      const mockCluster = { id: 'cluster1', count: 5 }
+      const mockEvent = { clientX: 100, clientY: 200 }
+
+      act(() => {
+        result.current.handleMouseEnter(mockCluster, mockEvent)
+      })
+
+      expect(result.current.position).toEqual({ x: 100, y: 200 })
+    })
+
+    it('does not show popup immediately (waits for delay)', () => {
+      const { result } = renderHook(() => useHoverPopup())
+      const mockCluster = { id: 'cluster1', count: 5 }
+      const mockEvent = { clientX: 100, clientY: 200 }
+
+      act(() => {
+        result.current.handleMouseEnter(mockCluster, mockEvent)
+      })
+
+      expect(result.current.isVisible).toBe(false)
+    })
+
+    it('shows popup after SHOW_DELAY_MS', () => {
+      const { result } = renderHook(() => useHoverPopup())
+      const mockCluster = { id: 'cluster1', count: 5 }
+      const mockEvent = { clientX: 100, clientY: 200 }
+
+      act(() => {
+        result.current.handleMouseEnter(mockCluster, mockEvent)
+      })
+
+      // Fast-forward time by SHOW_DELAY_MS (100ms from config)
+      act(() => {
+        vi.advanceTimersByTime(100)
+      })
+
+      expect(result.current.isVisible).toBe(true)
+    })
+
+    it('updates targetCluster when hovering different clusters', () => {
+      const { result } = renderHook(() => useHoverPopup())
+      const mockCluster1 = { id: 'cluster1', count: 5 }
+      const mockCluster2 = { id: 'cluster2', count: 3 }
+      const mockEvent = { clientX: 100, clientY: 200 }
+
+      act(() => {
+        result.current.handleMouseEnter(mockCluster1, mockEvent)
+      })
+
+      expect(result.current.targetCluster).toEqual(mockCluster1)
+
+      act(() => {
+        result.current.handleMouseEnter(mockCluster2, mockEvent)
+      })
+
+      expect(result.current.targetCluster).toEqual(mockCluster2)
+    })
+
+    it('cancels previous show timer when hovering new cluster', () => {
+      const { result } = renderHook(() => useHoverPopup())
+      const mockCluster1 = { id: 'cluster1', count: 5 }
+      const mockCluster2 = { id: 'cluster2', count: 3 }
+      const mockEvent = { clientX: 100, clientY: 200 }
+
+      act(() => {
+        result.current.handleMouseEnter(mockCluster1, mockEvent)
+      })
+
+      // Advance time partially (50ms of 100ms delay)
+      act(() => {
+        vi.advanceTimersByTime(50)
+      })
+
+      // Hover over new cluster
+      act(() => {
+        result.current.handleMouseEnter(mockCluster2, mockEvent)
+      })
+
+      // Should not be visible yet (timer reset)
+      expect(result.current.isVisible).toBe(false)
+
+      // Advance remaining time (50ms more = 100ms total from second hover)
+      act(() => {
+        vi.advanceTimersByTime(50)
+      })
+
+      // Still not visible (need full 100ms from second hover)
+      expect(result.current.isVisible).toBe(false)
+
+      // Advance final 50ms to complete second hover delay
+      act(() => {
+        vi.advanceTimersByTime(50)
+      })
+
+      expect(result.current.isVisible).toBe(true)
+      expect(result.current.targetCluster).toEqual(mockCluster2)
+    })
+  })
+
+  describe('Mouse Leave Behavior', () => {
+    it('does not hide popup immediately (waits for delay)', () => {
+      const { result } = renderHook(() => useHoverPopup())
+      const mockCluster = { id: 'cluster1', count: 5 }
+      const mockEvent = { clientX: 100, clientY: 200 }
+
+      // Show popup
+      act(() => {
+        result.current.handleMouseEnter(mockCluster, mockEvent)
+      })
+
+      act(() => {
+        vi.advanceTimersByTime(100)
+      })
+
+      expect(result.current.isVisible).toBe(true)
+
+      // Mouse leave
+      act(() => {
+        result.current.handleMouseLeave()
+      })
+
+      // Should still be visible (waiting for hide delay)
+      expect(result.current.isVisible).toBe(true)
+    })
+
+    it('hides popup after HIDE_DELAY_MS', () => {
+      const { result } = renderHook(() => useHoverPopup())
+      const mockCluster = { id: 'cluster1', count: 5 }
+      const mockEvent = { clientX: 100, clientY: 200 }
+
+      // Show popup
+      act(() => {
+        result.current.handleMouseEnter(mockCluster, mockEvent)
+      })
+
+      act(() => {
+        vi.advanceTimersByTime(100)
+      })
+
+      expect(result.current.isVisible).toBe(true)
+
+      // Mouse leave
+      act(() => {
+        result.current.handleMouseLeave()
+      })
+
+      // Fast-forward time by HIDE_DELAY_MS (200ms from config)
+      act(() => {
+        vi.advanceTimersByTime(200)
+      })
+
+      expect(result.current.isVisible).toBe(false)
+    })
+
+    it('clears targetCluster after hide delay', () => {
+      const { result } = renderHook(() => useHoverPopup())
+      const mockCluster = { id: 'cluster1', count: 5 }
+      const mockEvent = { clientX: 100, clientY: 200 }
+
+      // Show popup
+      act(() => {
+        result.current.handleMouseEnter(mockCluster, mockEvent)
+      })
+
+      act(() => {
+        vi.advanceTimersByTime(100)
+      })
+
+      // Mouse leave
+      act(() => {
+        result.current.handleMouseLeave()
+      })
+
+      act(() => {
+        vi.advanceTimersByTime(200)
+      })
+
+      expect(result.current.targetCluster).toBe(null)
+    })
+
+    it('clears position after hide delay', () => {
+      const { result } = renderHook(() => useHoverPopup())
+      const mockCluster = { id: 'cluster1', count: 5 }
+      const mockEvent = { clientX: 100, clientY: 200 }
+
+      // Show popup
+      act(() => {
+        result.current.handleMouseEnter(mockCluster, mockEvent)
+      })
+
+      act(() => {
+        vi.advanceTimersByTime(100)
+      })
+
+      // Mouse leave
+      act(() => {
+        result.current.handleMouseLeave()
+      })
+
+      act(() => {
+        vi.advanceTimersByTime(200)
+      })
+
+      expect(result.current.position).toBe(null)
+    })
+
+    it('cancels hide timer if mouse re-enters before delay completes', () => {
+      const { result } = renderHook(() => useHoverPopup())
+      const mockCluster = { id: 'cluster1', count: 5 }
+      const mockEvent = { clientX: 100, clientY: 200 }
+
+      // Show popup
+      act(() => {
+        result.current.handleMouseEnter(mockCluster, mockEvent)
+      })
+
+      act(() => {
+        vi.advanceTimersByTime(100)
+      })
+
+      expect(result.current.isVisible).toBe(true)
+
+      // Mouse leave
+      act(() => {
+        result.current.handleMouseLeave()
+      })
+
+      // Advance time partially (100ms of 200ms delay)
+      act(() => {
+        vi.advanceTimersByTime(100)
+      })
+
+      // Should still be visible
+      expect(result.current.isVisible).toBe(true)
+
+      // Mouse re-enters
+      act(() => {
+        result.current.handleMouseEnter(mockCluster, mockEvent)
+      })
+
+      // Advance remaining hide delay time
+      act(() => {
+        vi.advanceTimersByTime(100)
+      })
+
+      // Should remain visible (hide timer was cancelled, show timer completed)
+      expect(result.current.isVisible).toBe(true)
+    })
+  })
+
+  describe('Click Behavior (Mobile)', () => {
+    it('toggles visibility on click', () => {
+      const { result } = renderHook(() => useHoverPopup())
+      const mockCluster = { id: 'cluster1', count: 5 }
+
+      // First click - show
+      act(() => {
+        result.current.handleClick(mockCluster)
+      })
+
+      expect(result.current.isVisible).toBe(true)
+      expect(result.current.targetCluster).toEqual(mockCluster)
+
+      // Second click - hide
+      act(() => {
+        result.current.handleClick(mockCluster)
+      })
+
+      expect(result.current.isVisible).toBe(false)
+    })
+
+    it('sets targetCluster on click', () => {
+      const { result } = renderHook(() => useHoverPopup())
+      const mockCluster = { id: 'cluster1', count: 5 }
+
+      act(() => {
+        result.current.handleClick(mockCluster)
+      })
+
+      expect(result.current.targetCluster).toEqual(mockCluster)
+    })
+  })
+
+  describe('Timer Cleanup', () => {
+    it('cleans up timers on unmount', () => {
+      const { result, unmount } = renderHook(() => useHoverPopup())
+      const mockCluster = { id: 'cluster1', count: 5 }
+      const mockEvent = { clientX: 100, clientY: 200 }
+
+      // Start a timer
+      act(() => {
+        result.current.handleMouseEnter(mockCluster, mockEvent)
+      })
+
+      // Unmount before timer completes
+      unmount()
+
+      // Advance timers - should not throw or cause issues
+      act(() => {
+        vi.advanceTimersByTime(100)
+      })
+
+      // No assertions needed - just verify no errors occur
+    })
+
+    it('cleans up hide timer on unmount', () => {
+      const { result, unmount } = renderHook(() => useHoverPopup())
+      const mockCluster = { id: 'cluster1', count: 5 }
+      const mockEvent = { clientX: 100, clientY: 200 }
+
+      // Show popup
+      act(() => {
+        result.current.handleMouseEnter(mockCluster, mockEvent)
+      })
+
+      act(() => {
+        vi.advanceTimersByTime(100)
+      })
+
+      // Start hide timer
+      act(() => {
+        result.current.handleMouseLeave()
+      })
+
+      // Unmount before hide timer completes
+      unmount()
+
+      // Advance timers - should not throw or cause issues
+      act(() => {
+        vi.advanceTimersByTime(200)
+      })
+
+      // No assertions needed - just verify no errors occur
+    })
+  })
+
+  describe('Mobile Detection', () => {
+    it('detects desktop when no touch events available', () => {
+      // Mock desktop environment
+      delete window.ontouchstart
+      window.matchMedia = vi.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+      }))
+
+      const { result } = renderHook(() => useHoverPopup())
+
+      expect(result.current.isMobile).toBe(false)
+    })
+
+    it('detects mobile when ontouchstart exists', () => {
+      // Mock mobile environment
+      window.ontouchstart = null
+
+      const { result } = renderHook(() => useHoverPopup())
+
+      expect(result.current.isMobile).toBe(true)
+
+      // Clean up
+      delete window.ontouchstart
+    })
+
+    it('detects mobile when pointer:coarse media query matches', () => {
+      // Mock mobile environment
+      delete window.ontouchstart
+      window.matchMedia = vi.fn().mockImplementation((query) => ({
+        matches: query === '(pointer: coarse)',
+        media: query,
+      }))
+
+      const { result } = renderHook(() => useHoverPopup())
+
+      expect(result.current.isMobile).toBe(true)
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('handles rapid hover enter/leave cycles', () => {
+      const { result } = renderHook(() => useHoverPopup())
+      const mockCluster = { id: 'cluster1', count: 5 }
+      const mockEvent = { clientX: 100, clientY: 200 }
+
+      // Rapid enter/leave cycles
+      for (let i = 0; i < 5; i++) {
+        act(() => {
+          result.current.handleMouseEnter(mockCluster, mockEvent)
+        })
+
+        act(() => {
+          vi.advanceTimersByTime(50)
+        })
+
+        act(() => {
+          result.current.handleMouseLeave()
+        })
+
+        act(() => {
+          vi.advanceTimersByTime(50)
+        })
+      }
+
+      // Should handle gracefully without errors
+      expect(result.current.isVisible).toBe(false)
+    })
+
+    it('handles null cluster gracefully', () => {
+      const { result } = renderHook(() => useHoverPopup())
+      const mockEvent = { clientX: 100, clientY: 200 }
+
+      act(() => {
+        result.current.handleMouseEnter(null, mockEvent)
+      })
+
+      expect(result.current.targetCluster).toBe(null)
+    })
+
+    it('handles missing event coordinates gracefully', () => {
+      const { result } = renderHook(() => useHoverPopup())
+      const mockCluster = { id: 'cluster1', count: 5 }
+      const mockEvent = {}
+
+      act(() => {
+        result.current.handleMouseEnter(mockCluster, mockEvent)
+      })
+
+      expect(result.current.position).toEqual({ x: undefined, y: undefined })
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/hooks/__tests__/usePopupPosition.test.jsx
+++ b/Firmware/webui/frontend/src/hooks/__tests__/usePopupPosition.test.jsx
@@ -1,0 +1,293 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { usePopupPosition } from '../usePopupPosition'
+
+describe('usePopupPosition', () => {
+  let originalInnerWidth
+  let originalInnerHeight
+
+  beforeEach(() => {
+    // Store original values
+    originalInnerWidth = window.innerWidth
+    originalInnerHeight = window.innerHeight
+
+    // Set default viewport size
+    Object.defineProperty(window, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: 1024,
+    })
+    Object.defineProperty(window, 'innerHeight', {
+      writable: true,
+      configurable: true,
+      value: 768,
+    })
+  })
+
+  afterEach(() => {
+    // Restore original values
+    Object.defineProperty(window, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: originalInnerWidth,
+    })
+    Object.defineProperty(window, 'innerHeight', {
+      writable: true,
+      configurable: true,
+      value: originalInnerHeight,
+    })
+  })
+
+  it('returns default position when not visible', () => {
+    const { result } = renderHook(() =>
+      usePopupPosition({
+        triggerPosition: { x: 100, y: 100 },
+        popupWidth: 300,
+        popupHeight: 350,
+        isVisible: false,
+      })
+    )
+
+    expect(result.current.position).toEqual({ left: 0, top: 0 })
+    expect(result.current.placement).toBe('below')
+  })
+
+  it('returns default position when triggerPosition is null', () => {
+    const { result } = renderHook(() =>
+      usePopupPosition({
+        triggerPosition: null,
+        popupWidth: 300,
+        popupHeight: 350,
+        isVisible: true,
+      })
+    )
+
+    expect(result.current.position).toEqual({ left: 0, top: 0 })
+    expect(result.current.placement).toBe('below')
+  })
+
+  it('places popup below trigger when space available', () => {
+    const { result } = renderHook(() =>
+      usePopupPosition({
+        triggerPosition: { x: 500, y: 200 },
+        popupWidth: 300,
+        popupHeight: 350,
+        offset: 10,
+        isVisible: true,
+      })
+    )
+
+    // Should place below: y + offset = 200 + 10 = 210
+    expect(result.current.position.top).toBe(210)
+    expect(result.current.placement).toBe('below')
+  })
+
+  it('places popup above trigger when no space below', () => {
+    const { result } = renderHook(() =>
+      usePopupPosition({
+        triggerPosition: { x: 500, y: 700 },
+        popupWidth: 300,
+        popupHeight: 350,
+        offset: 10,
+        isVisible: true,
+      })
+    )
+
+    // Not enough space below (768 - 700 - 10 = 58 < 350)
+    // Should place above: y - popupHeight - offset = 700 - 350 - 10 = 340
+    expect(result.current.position.top).toBe(340)
+    expect(result.current.placement).toBe('above')
+  })
+
+  it('centers popup horizontally on trigger', () => {
+    const { result } = renderHook(() =>
+      usePopupPosition({
+        triggerPosition: { x: 500, y: 200 },
+        popupWidth: 300,
+        popupHeight: 350,
+        isVisible: true,
+      })
+    )
+
+    // Should center: x - popupWidth/2 = 500 - 150 = 350
+    expect(result.current.position.left).toBe(350)
+  })
+
+  it('clamps left position to viewport edge', () => {
+    const { result } = renderHook(() =>
+      usePopupPosition({
+        triggerPosition: { x: 50, y: 200 },
+        popupWidth: 300,
+        popupHeight: 350,
+        isVisible: true,
+      })
+    )
+
+    // Would be: 50 - 150 = -100, but should clamp to margin (10)
+    expect(result.current.position.left).toBe(10)
+  })
+
+  it('clamps right position to viewport edge', () => {
+    const { result } = renderHook(() =>
+      usePopupPosition({
+        triggerPosition: { x: 1000, y: 200 },
+        popupWidth: 300,
+        popupHeight: 350,
+        isVisible: true,
+      })
+    )
+
+    // Would be: 1000 - 150 = 850
+    // Max allowed: 1024 - 300 - 10 = 714
+    expect(result.current.position.left).toBe(714)
+  })
+
+  it('clamps top position to viewport edge', () => {
+    const { result } = renderHook(() =>
+      usePopupPosition({
+        triggerPosition: { x: 500, y: 5 },
+        popupWidth: 300,
+        popupHeight: 350,
+        offset: 10,
+        isVisible: true,
+      })
+    )
+
+    // Would try to place above (not enough space below at y=5)
+    // Above would be: 5 - 350 - 10 = -355, should clamp to margin (10)
+    expect(result.current.position.top).toBeGreaterThanOrEqual(10)
+  })
+
+  it('clamps bottom position to viewport edge', () => {
+    const { result } = renderHook(() =>
+      usePopupPosition({
+        triggerPosition: { x: 500, y: 760 },
+        popupWidth: 300,
+        popupHeight: 350,
+        offset: 10,
+        isVisible: true,
+      })
+    )
+
+    // Not enough space below (768 - 760 - 10 = -2), so will place above
+    // Above: 760 - 350 - 10 = 400
+    // Max allowed when clamped: 768 - 350 - 10 = 408, but 400 is already within bounds
+    expect(result.current.position.top).toBe(400)
+  })
+
+  it('updates position on viewport resize', () => {
+    const { result, rerender } = renderHook(() =>
+      usePopupPosition({
+        triggerPosition: { x: 500, y: 200 },
+        popupWidth: 300,
+        popupHeight: 350,
+        isVisible: true,
+      })
+    )
+
+    const initialLeft = result.current.position.left
+
+    // Resize viewport
+    act(() => {
+      Object.defineProperty(window, 'innerWidth', {
+        writable: true,
+        configurable: true,
+        value: 800,
+      })
+      window.dispatchEvent(new Event('resize'))
+    })
+
+    // Force re-render to pick up state change
+    rerender()
+
+    // Position should potentially change if trigger is now near edge
+    // At minimum, hook should recalculate
+    expect(result.current.position).toBeDefined()
+  })
+
+  it('returns correct placement value when below', () => {
+    const { result } = renderHook(() =>
+      usePopupPosition({
+        triggerPosition: { x: 500, y: 200 },
+        popupWidth: 300,
+        popupHeight: 350,
+        isVisible: true,
+      })
+    )
+
+    expect(result.current.placement).toBe('below')
+  })
+
+  it('returns correct placement value when above', () => {
+    const { result } = renderHook(() =>
+      usePopupPosition({
+        triggerPosition: { x: 500, y: 700 },
+        popupWidth: 300,
+        popupHeight: 350,
+        isVisible: true,
+      })
+    )
+
+    expect(result.current.placement).toBe('above')
+  })
+
+  it('uses default popup dimensions from config', () => {
+    const { result } = renderHook(() =>
+      usePopupPosition({
+        triggerPosition: { x: 500, y: 200 },
+        isVisible: true,
+      })
+    )
+
+    // Should not throw and should return valid position
+    expect(result.current.position).toBeDefined()
+    expect(result.current.position.left).toBeGreaterThanOrEqual(0)
+    expect(result.current.position.top).toBeGreaterThanOrEqual(0)
+  })
+
+  it('handles edge case with very small viewport', () => {
+    act(() => {
+      Object.defineProperty(window, 'innerWidth', {
+        writable: true,
+        configurable: true,
+        value: 320,
+      })
+      Object.defineProperty(window, 'innerHeight', {
+        writable: true,
+        configurable: true,
+        value: 480,
+      })
+      window.dispatchEvent(new Event('resize'))
+    })
+
+    const { result } = renderHook(() =>
+      usePopupPosition({
+        triggerPosition: { x: 160, y: 240 },
+        popupWidth: 300,
+        popupHeight: 350,
+        isVisible: true,
+      })
+    )
+
+    // Should still provide valid position within bounds
+    expect(result.current.position.left).toBeGreaterThanOrEqual(10)
+    expect(result.current.position.top).toBeGreaterThanOrEqual(10)
+    expect(result.current.position.left).toBeLessThanOrEqual(320 - 10)
+    expect(result.current.position.top).toBeLessThanOrEqual(480 - 10)
+  })
+
+  it('chooses below when equal space on both sides', () => {
+    const { result } = renderHook(() =>
+      usePopupPosition({
+        triggerPosition: { x: 500, y: 384 }, // Exactly middle of 768px height
+        popupWidth: 300,
+        popupHeight: 200,
+        offset: 10,
+        isVisible: true,
+      })
+    )
+
+    // With equal space, should prefer below
+    expect(result.current.placement).toBe('below')
+  })
+})

--- a/Firmware/webui/frontend/src/hooks/__tests__/useSwipeNavigation.test.jsx
+++ b/Firmware/webui/frontend/src/hooks/__tests__/useSwipeNavigation.test.jsx
@@ -1,0 +1,404 @@
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useSwipeNavigation } from '../useSwipeNavigation'
+import { HOVER_POPUP_CONFIG } from '../../constants/config'
+
+describe('useSwipeNavigation', () => {
+  describe('Initial State', () => {
+    it('returns correct initial state', () => {
+      const { result } = renderHook(() =>
+        useSwipeNavigation({ totalItems: 27, visibleItems: 9 })
+      )
+
+      expect(result.current.currentPage).toBe(0)
+      expect(result.current.totalPages).toBe(3)
+      expect(result.current.startIndex).toBe(0)
+      expect(result.current.endIndex).toBe(9)
+      expect(result.current.handlers).toHaveProperty('onTouchStart')
+      expect(result.current.handlers).toHaveProperty('onTouchMove')
+      expect(result.current.handlers).toHaveProperty('onTouchEnd')
+      expect(typeof result.current.goToPage).toBe('function')
+      expect(typeof result.current.goNext).toBe('function')
+      expect(typeof result.current.goPrev).toBe('function')
+    })
+
+    it('uses default visibleItems from config', () => {
+      const { result } = renderHook(() => useSwipeNavigation({ totalItems: 27 }))
+
+      expect(result.current.endIndex).toBe(HOVER_POPUP_CONFIG.MAX_PHOTOS)
+    })
+  })
+
+  describe('Page Calculations', () => {
+    it('calculates totalPages correctly', () => {
+      const { result: result1 } = renderHook(() =>
+        useSwipeNavigation({ totalItems: 27, visibleItems: 9 })
+      )
+      expect(result1.current.totalPages).toBe(3) // 27 / 9 = 3
+
+      const { result: result2 } = renderHook(() =>
+        useSwipeNavigation({ totalItems: 28, visibleItems: 9 })
+      )
+      expect(result2.current.totalPages).toBe(4) // 28 / 9 = 3.11... → 4
+
+      const { result: result3 } = renderHook(() =>
+        useSwipeNavigation({ totalItems: 5, visibleItems: 9 })
+      )
+      expect(result3.current.totalPages).toBe(1) // 5 / 9 = 0.55... → 1
+    })
+
+    it('calculates startIndex and endIndex correctly for first page', () => {
+      const { result } = renderHook(() =>
+        useSwipeNavigation({ totalItems: 27, visibleItems: 9 })
+      )
+
+      expect(result.current.startIndex).toBe(0)
+      expect(result.current.endIndex).toBe(9)
+    })
+
+    it('calculates startIndex and endIndex correctly for middle page', () => {
+      const { result } = renderHook(() =>
+        useSwipeNavigation({ totalItems: 27, visibleItems: 9 })
+      )
+
+      act(() => {
+        result.current.goToPage(1)
+      })
+
+      expect(result.current.startIndex).toBe(9)
+      expect(result.current.endIndex).toBe(18)
+    })
+
+    it('calculates startIndex and endIndex correctly for last page', () => {
+      const { result } = renderHook(() =>
+        useSwipeNavigation({ totalItems: 27, visibleItems: 9 })
+      )
+
+      act(() => {
+        result.current.goToPage(2)
+      })
+
+      expect(result.current.startIndex).toBe(18)
+      expect(result.current.endIndex).toBe(27)
+    })
+
+    it('handles partial last page correctly', () => {
+      const { result } = renderHook(() =>
+        useSwipeNavigation({ totalItems: 25, visibleItems: 9 })
+      )
+
+      act(() => {
+        result.current.goToPage(2)
+      })
+
+      expect(result.current.startIndex).toBe(18)
+      expect(result.current.endIndex).toBe(25) // Only 7 items on last page
+    })
+  })
+
+  describe('Page Navigation', () => {
+    it('goNext advances to next page', () => {
+      const { result } = renderHook(() =>
+        useSwipeNavigation({ totalItems: 27, visibleItems: 9 })
+      )
+
+      act(() => {
+        result.current.goNext()
+      })
+
+      expect(result.current.currentPage).toBe(1)
+      expect(result.current.startIndex).toBe(9)
+      expect(result.current.endIndex).toBe(18)
+    })
+
+    it('goPrev goes back to previous page', () => {
+      const { result } = renderHook(() =>
+        useSwipeNavigation({ totalItems: 27, visibleItems: 9 })
+      )
+
+      act(() => {
+        result.current.goToPage(1)
+      })
+
+      act(() => {
+        result.current.goPrev()
+      })
+
+      expect(result.current.currentPage).toBe(0)
+      expect(result.current.startIndex).toBe(0)
+      expect(result.current.endIndex).toBe(9)
+    })
+
+    it('goNext does nothing on last page', () => {
+      const { result } = renderHook(() =>
+        useSwipeNavigation({ totalItems: 27, visibleItems: 9 })
+      )
+
+      act(() => {
+        result.current.goToPage(2) // Last page
+      })
+
+      act(() => {
+        result.current.goNext()
+      })
+
+      expect(result.current.currentPage).toBe(2) // Still on last page
+    })
+
+    it('goPrev does nothing on first page', () => {
+      const { result } = renderHook(() =>
+        useSwipeNavigation({ totalItems: 27, visibleItems: 9 })
+      )
+
+      act(() => {
+        result.current.goPrev()
+      })
+
+      expect(result.current.currentPage).toBe(0) // Still on first page
+    })
+
+    it('goToPage clamps to valid page range', () => {
+      const { result } = renderHook(() =>
+        useSwipeNavigation({ totalItems: 27, visibleItems: 9 })
+      )
+
+      act(() => {
+        result.current.goToPage(-1)
+      })
+      expect(result.current.currentPage).toBe(0)
+
+      act(() => {
+        result.current.goToPage(5)
+      })
+      expect(result.current.currentPage).toBe(2) // Max page = 2
+    })
+
+    it('calls onPageChange callback when page changes', () => {
+      const onPageChange = vi.fn()
+      const { result } = renderHook(() =>
+        useSwipeNavigation({ totalItems: 27, visibleItems: 9, onPageChange })
+      )
+
+      act(() => {
+        result.current.goNext()
+      })
+
+      expect(onPageChange).toHaveBeenCalledWith(9, 18)
+    })
+  })
+
+  describe('Touch Gestures', () => {
+    it('swipe left triggers goNext', () => {
+      const { result } = renderHook(() =>
+        useSwipeNavigation({ totalItems: 27, visibleItems: 9 })
+      )
+
+      // Simulate swipe left (next)
+      act(() => {
+        result.current.handlers.onTouchStart({
+          touches: [{ clientX: 200, clientY: 100 }],
+        })
+      })
+
+      act(() => {
+        result.current.handlers.onTouchMove({
+          touches: [{ clientX: 100, clientY: 100 }],
+        })
+      })
+
+      act(() => {
+        result.current.handlers.onTouchEnd()
+      })
+
+      expect(result.current.currentPage).toBe(1)
+    })
+
+    it('swipe right triggers goPrev', () => {
+      const { result } = renderHook(() =>
+        useSwipeNavigation({ totalItems: 27, visibleItems: 9 })
+      )
+
+      // Start on page 1
+      act(() => {
+        result.current.goToPage(1)
+      })
+
+      // Simulate swipe right (previous)
+      act(() => {
+        result.current.handlers.onTouchStart({
+          touches: [{ clientX: 100, clientY: 100 }],
+        })
+      })
+
+      act(() => {
+        result.current.handlers.onTouchMove({
+          touches: [{ clientX: 200, clientY: 100 }],
+        })
+      })
+
+      act(() => {
+        result.current.handlers.onTouchEnd()
+      })
+
+      expect(result.current.currentPage).toBe(0)
+    })
+
+    it('small swipe (below threshold) does nothing', () => {
+      const { result } = renderHook(() =>
+        useSwipeNavigation({ totalItems: 27, visibleItems: 9 })
+      )
+
+      // Simulate small swipe (less than SWIPE_THRESHOLD = 50px)
+      act(() => {
+        result.current.handlers.onTouchStart({
+          touches: [{ clientX: 100, clientY: 100 }],
+        })
+      })
+
+      act(() => {
+        result.current.handlers.onTouchMove({
+          touches: [{ clientX: 130, clientY: 100 }], // Only 30px
+        })
+      })
+
+      act(() => {
+        result.current.handlers.onTouchEnd()
+      })
+
+      expect(result.current.currentPage).toBe(0) // No change
+    })
+
+    it('vertical swipe does nothing', () => {
+      const { result } = renderHook(() =>
+        useSwipeNavigation({ totalItems: 27, visibleItems: 9 })
+      )
+
+      // Simulate vertical swipe
+      act(() => {
+        result.current.handlers.onTouchStart({
+          touches: [{ clientX: 100, clientY: 100 }],
+        })
+      })
+
+      act(() => {
+        result.current.handlers.onTouchMove({
+          touches: [{ clientX: 100, clientY: 200 }], // Vertical swipe (100px down)
+        })
+      })
+
+      act(() => {
+        result.current.handlers.onTouchEnd()
+      })
+
+      expect(result.current.currentPage).toBe(0) // No change
+    })
+
+    it('swipe threshold matches config constant', () => {
+      const { result } = renderHook(() =>
+        useSwipeNavigation({ totalItems: 27, visibleItems: 9 })
+      )
+
+      // Swipe exactly at threshold
+      const threshold = HOVER_POPUP_CONFIG.SWIPE_THRESHOLD
+
+      act(() => {
+        result.current.handlers.onTouchStart({
+          touches: [{ clientX: 200, clientY: 100 }],
+        })
+      })
+
+      act(() => {
+        result.current.handlers.onTouchMove({
+          touches: [{ clientX: 200 - threshold - 1, clientY: 100 }],
+        })
+      })
+
+      act(() => {
+        result.current.handlers.onTouchEnd()
+      })
+
+      expect(result.current.currentPage).toBe(1) // Should trigger
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('handles zero totalItems', () => {
+      const { result } = renderHook(() =>
+        useSwipeNavigation({ totalItems: 0, visibleItems: 9 })
+      )
+
+      expect(result.current.totalPages).toBe(0)
+      expect(result.current.startIndex).toBe(0)
+      expect(result.current.endIndex).toBe(0)
+    })
+
+    it('handles single item', () => {
+      const { result } = renderHook(() =>
+        useSwipeNavigation({ totalItems: 1, visibleItems: 9 })
+      )
+
+      expect(result.current.totalPages).toBe(1)
+      expect(result.current.startIndex).toBe(0)
+      expect(result.current.endIndex).toBe(1)
+    })
+
+    it('handles visibleItems larger than totalItems', () => {
+      const { result } = renderHook(() =>
+        useSwipeNavigation({ totalItems: 5, visibleItems: 9 })
+      )
+
+      expect(result.current.totalPages).toBe(1)
+      expect(result.current.startIndex).toBe(0)
+      expect(result.current.endIndex).toBe(5)
+    })
+
+    it('prevents navigation beyond boundaries with swipe', () => {
+      const { result } = renderHook(() =>
+        useSwipeNavigation({ totalItems: 27, visibleItems: 9 })
+      )
+
+      // Try to swipe right on first page
+      act(() => {
+        result.current.handlers.onTouchStart({
+          touches: [{ clientX: 100, clientY: 100 }],
+        })
+      })
+
+      act(() => {
+        result.current.handlers.onTouchMove({
+          touches: [{ clientX: 200, clientY: 100 }],
+        })
+      })
+
+      act(() => {
+        result.current.handlers.onTouchEnd()
+      })
+
+      expect(result.current.currentPage).toBe(0)
+
+      // Go to last page
+      act(() => {
+        result.current.goToPage(2)
+      })
+
+      // Try to swipe left on last page
+      act(() => {
+        result.current.handlers.onTouchStart({
+          touches: [{ clientX: 200, clientY: 100 }],
+        })
+      })
+
+      act(() => {
+        result.current.handlers.onTouchMove({
+          touches: [{ clientX: 100, clientY: 100 }],
+        })
+      })
+
+      act(() => {
+        result.current.handlers.onTouchEnd()
+      })
+
+      expect(result.current.currentPage).toBe(2)
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/hooks/useClusteredLocations.js
+++ b/Firmware/webui/frontend/src/hooks/useClusteredLocations.js
@@ -59,6 +59,8 @@ async function fetchClusteredLocations({ enabled, radius, minSize }) {
  *   - metadata: Clustering metadata (total photos, processing time, etc.)
  *   - isLoading: Loading state
  *   - error: Error object if failed
+ *   - isPartialResult: True if clustering timed out and returned partial results
+ *   - partialWarning: Warning message when partial results are returned
  *   - settings: Current clustering settings
  *   - setEnabled: Toggle clustering on/off
  *   - setRadius: Set clustering radius in meters
@@ -94,12 +96,18 @@ export function useClusteredLocations() {
     setSettings((prev) => ({ ...prev, minSize }))
   }, [])
 
+  // Extract partial result indicators from metadata
+  const isPartialResult = data?.metadata?.partial_result ?? false
+  const partialWarning = data?.metadata?.warning ?? null
+
   return {
     clusters: data?.clusters || [],
     unclustered: data?.unclustered || [],
     metadata: data?.metadata || {},
     isLoading,
     error,
+    isPartialResult,
+    partialWarning,
     settings,
     setEnabled,
     setRadius,

--- a/Firmware/webui/frontend/src/hooks/useHoverPopup.js
+++ b/Firmware/webui/frontend/src/hooks/useHoverPopup.js
@@ -1,0 +1,143 @@
+import { useState, useRef, useCallback, useEffect } from 'react'
+import { HOVER_POPUP_CONFIG } from '../constants/config'
+
+/**
+ * useHoverPopup Hook
+ *
+ * Manages hover state for map cluster popups with debouncing, show/hide delays,
+ * and mobile touch detection. Provides consistent hover behavior across desktop
+ * and mobile devices.
+ *
+ * @returns {Object} Popup state and handlers
+ * @returns {boolean} isVisible - Whether the popup should be displayed
+ * @returns {Object|null} targetCluster - The cluster currently being hovered
+ * @returns {Object|null} position - Popup position {x, y} relative to viewport
+ * @returns {Function} handleMouseEnter - Handler for mouse enter events
+ * @returns {Function} handleMouseLeave - Handler for mouse leave events
+ * @returns {Function} handleClick - Handler for click/tap events (mobile)
+ * @returns {boolean} isMobile - Whether the device is detected as mobile/touch
+ *
+ * @example
+ * const {
+ *   isVisible,
+ *   targetCluster,
+ *   position,
+ *   handleMouseEnter,
+ *   handleMouseLeave,
+ *   isMobile
+ * } = useHoverPopup()
+ *
+ * // Desktop: Use mouse events
+ * <ClusterMarker
+ *   onMouseEnter={(e) => handleMouseEnter(cluster, e)}
+ *   onMouseLeave={handleMouseLeave}
+ * />
+ *
+ * // Mobile: Use click events
+ * <ClusterMarker
+ *   onClick={() => handleClick(cluster)}
+ * />
+ */
+export function useHoverPopup() {
+  // State management
+  const [isVisible, setIsVisible] = useState(false)
+  const [targetCluster, setTargetCluster] = useState(null)
+  const [position, setPosition] = useState(null)
+
+  // Timer references for cleanup
+  const showTimerRef = useRef(null)
+  const hideTimerRef = useRef(null)
+
+  // Detect mobile/touch devices
+  const isMobile =
+    typeof window !== 'undefined' &&
+    ('ontouchstart' in window || window.matchMedia('(pointer: coarse)').matches)
+
+  /**
+   * Clear all pending timers
+   */
+  const clearTimers = useCallback(() => {
+    if (showTimerRef.current) {
+      clearTimeout(showTimerRef.current)
+      showTimerRef.current = null
+    }
+    if (hideTimerRef.current) {
+      clearTimeout(hideTimerRef.current)
+      hideTimerRef.current = null
+    }
+  }, [])
+
+  /**
+   * Handle mouse enter event
+   *
+   * Sets the target cluster and position immediately, then schedules
+   * the popup to be shown after SHOW_DELAY_MS.
+   *
+   * @param {Object} cluster - The cluster being hovered
+   * @param {MouseEvent} event - The mouse event containing position
+   */
+  const handleMouseEnter = useCallback(
+    (cluster, event) => {
+      // Clear any pending timers
+      clearTimers()
+
+      // Set target and position immediately
+      setTargetCluster(cluster)
+      setPosition({ x: event.clientX, y: event.clientY })
+
+      // Schedule popup to show after delay
+      showTimerRef.current = setTimeout(() => {
+        setIsVisible(true)
+      }, HOVER_POPUP_CONFIG.SHOW_DELAY_MS)
+    },
+    [clearTimers]
+  )
+
+  /**
+   * Handle mouse leave event
+   *
+   * Schedules the popup to be hidden after HIDE_DELAY_MS to prevent
+   * flickering when the mouse briefly leaves and re-enters.
+   */
+  const handleMouseLeave = useCallback(() => {
+    // Clear any pending timers
+    clearTimers()
+
+    // Schedule popup to hide after delay
+    hideTimerRef.current = setTimeout(() => {
+      setIsVisible(false)
+      setTargetCluster(null)
+      setPosition(null)
+    }, HOVER_POPUP_CONFIG.HIDE_DELAY_MS)
+  }, [clearTimers])
+
+  /**
+   * Handle click event (for mobile/touch devices)
+   *
+   * Toggles the popup visibility immediately without delays.
+   * Sets the target cluster when showing.
+   *
+   * @param {Object} cluster - The cluster being clicked
+   */
+  const handleClick = useCallback((cluster) => {
+    setTargetCluster(cluster)
+    setIsVisible((prev) => !prev)
+  }, [])
+
+  /**
+   * Cleanup timers on unmount
+   */
+  useEffect(() => {
+    return clearTimers
+  }, [clearTimers])
+
+  return {
+    isVisible,
+    targetCluster,
+    position,
+    handleMouseEnter,
+    handleMouseLeave,
+    handleClick,
+    isMobile,
+  }
+}

--- a/Firmware/webui/frontend/src/hooks/usePopupPosition.js
+++ b/Firmware/webui/frontend/src/hooks/usePopupPosition.js
@@ -1,4 +1,4 @@
-import { useMemo, useEffect, useState } from 'react'
+import { useMemo, useEffect, useState, useLayoutEffect } from 'react'
 import { HOVER_POPUP_CONFIG } from '../constants/config'
 
 /**
@@ -7,10 +7,11 @@ import { HOVER_POPUP_CONFIG } from '../constants/config'
  * @param {Object} options - Configuration options
  * @param {Object} options.triggerPosition - {x, y} position of trigger element
  * @param {number} [options.popupWidth] - Width of popup
- * @param {number} [options.popupHeight] - Estimated height of popup
+ * @param {number} [options.popupHeight] - Estimated height of popup (used as fallback)
  * @param {number} [options.offset] - Offset from trigger position
  * @param {boolean} [options.isVisible] - Whether popup is visible
- * @returns {Object} { position: {left, top}, placement: 'above'|'below' }
+ * @param {Object} [options.popupRef] - Ref to popup element for dynamic height measurement
+ * @returns {Object} { position: {left, top}, placement: 'above'|'below', measuredHeight }
  */
 export function usePopupPosition({
   triggerPosition,
@@ -18,11 +19,32 @@ export function usePopupPosition({
   popupHeight = 350,
   offset = 10,
   isVisible = false,
+  popupRef = null,
 }) {
   const [viewport, setViewport] = useState({
     width: typeof window !== 'undefined' ? window.innerWidth : 1024,
     height: typeof window !== 'undefined' ? window.innerHeight : 768,
   })
+
+  // Dynamic height measurement from actual popup element
+  const [measuredHeight, setMeasuredHeight] = useState(null)
+
+  // Measure popup height after render using useLayoutEffect
+  // This runs synchronously after DOM mutations but before paint
+  useLayoutEffect(() => {
+    if (popupRef?.current && isVisible) {
+      const rect = popupRef.current.getBoundingClientRect()
+      if (rect.height > 0) {
+        setMeasuredHeight(rect.height)
+      }
+    } else if (!isVisible) {
+      // Reset measured height when popup closes
+      setMeasuredHeight(null)
+    }
+  }, [isVisible, popupRef])
+
+  // Use measured height if available, otherwise fall back to estimated
+  const actualHeight = measuredHeight ?? popupHeight
 
   // Update viewport on resize
   useEffect(() => {
@@ -51,16 +73,16 @@ export function usePopupPosition({
     const spaceBelow = viewport.height - y - offset
     const spaceAbove = y - offset
 
-    // Determine vertical placement
+    // Determine vertical placement (use actualHeight which may be measured or estimated)
     let top
     let placement
-    if (spaceBelow >= popupHeight + margin) {
+    if (spaceBelow >= actualHeight + margin) {
       // Enough space below
       top = y + offset
       placement = 'below'
-    } else if (spaceAbove >= popupHeight + margin) {
+    } else if (spaceAbove >= actualHeight + margin) {
       // Place above
-      top = y - popupHeight - offset
+      top = y - actualHeight - offset
       placement = 'above'
     } else {
       // Not enough space either way, place where there's more room
@@ -68,7 +90,7 @@ export function usePopupPosition({
         top = y + offset
         placement = 'below'
       } else {
-        top = Math.max(margin, y - popupHeight - offset)
+        top = Math.max(margin, y - actualHeight - offset)
         placement = 'above'
       }
     }
@@ -78,13 +100,13 @@ export function usePopupPosition({
 
     // Clamp to viewport
     left = Math.max(margin, Math.min(left, viewport.width - popupWidth - margin))
-    top = Math.max(margin, Math.min(top, viewport.height - popupHeight - margin))
+    top = Math.max(margin, Math.min(top, viewport.height - actualHeight - margin))
 
     return {
       position: { left, top },
       placement,
     }
-  }, [triggerPosition, popupWidth, popupHeight, offset, isVisible, viewport])
+  }, [triggerPosition, popupWidth, actualHeight, offset, isVisible, viewport])
 
-  return { position, placement }
+  return { position, placement, measuredHeight }
 }

--- a/Firmware/webui/frontend/src/hooks/usePopupPosition.js
+++ b/Firmware/webui/frontend/src/hooks/usePopupPosition.js
@@ -1,0 +1,90 @@
+import { useMemo, useEffect, useState } from 'react'
+import { HOVER_POPUP_CONFIG } from '../constants/config'
+
+/**
+ * Hook for calculating viewport-aware popup positioning
+ *
+ * @param {Object} options - Configuration options
+ * @param {Object} options.triggerPosition - {x, y} position of trigger element
+ * @param {number} [options.popupWidth] - Width of popup
+ * @param {number} [options.popupHeight] - Estimated height of popup
+ * @param {number} [options.offset] - Offset from trigger position
+ * @param {boolean} [options.isVisible] - Whether popup is visible
+ * @returns {Object} { position: {left, top}, placement: 'above'|'below' }
+ */
+export function usePopupPosition({
+  triggerPosition,
+  popupWidth = HOVER_POPUP_CONFIG.POPUP_WIDTH,
+  popupHeight = 350,
+  offset = 10,
+  isVisible = false,
+}) {
+  const [viewport, setViewport] = useState({
+    width: typeof window !== 'undefined' ? window.innerWidth : 1024,
+    height: typeof window !== 'undefined' ? window.innerHeight : 768,
+  })
+
+  // Update viewport on resize
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const handleResize = () => {
+      setViewport({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      })
+    }
+
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [])
+
+  const { position, placement } = useMemo(() => {
+    if (!triggerPosition || !isVisible) {
+      return { position: { left: 0, top: 0 }, placement: 'below' }
+    }
+
+    const { x, y } = triggerPosition
+    const margin = 10 // Keep popup away from viewport edges
+
+    // Calculate available space
+    const spaceBelow = viewport.height - y - offset
+    const spaceAbove = y - offset
+
+    // Determine vertical placement
+    let top
+    let placement
+    if (spaceBelow >= popupHeight + margin) {
+      // Enough space below
+      top = y + offset
+      placement = 'below'
+    } else if (spaceAbove >= popupHeight + margin) {
+      // Place above
+      top = y - popupHeight - offset
+      placement = 'above'
+    } else {
+      // Not enough space either way, place where there's more room
+      if (spaceBelow >= spaceAbove) {
+        top = y + offset
+        placement = 'below'
+      } else {
+        top = Math.max(margin, y - popupHeight - offset)
+        placement = 'above'
+      }
+    }
+
+    // Determine horizontal position (try to center on trigger, but stay in bounds)
+    let left = x - popupWidth / 2
+
+    // Clamp to viewport
+    left = Math.max(margin, Math.min(left, viewport.width - popupWidth - margin))
+    top = Math.max(margin, Math.min(top, viewport.height - popupHeight - margin))
+
+    return {
+      position: { left, top },
+      placement,
+    }
+  }, [triggerPosition, popupWidth, popupHeight, offset, isVisible, viewport])
+
+  return { position, placement }
+}

--- a/Firmware/webui/frontend/src/hooks/useSwipeNavigation.jsx
+++ b/Firmware/webui/frontend/src/hooks/useSwipeNavigation.jsx
@@ -1,0 +1,123 @@
+import { useState, useCallback, useRef } from 'react'
+import { HOVER_POPUP_CONFIG } from '../constants/config'
+
+/**
+ * Custom hook for swipe-based navigation with touch gestures
+ *
+ * Provides paginated navigation with touch/swipe support for mobile devices.
+ * Calculates visible item ranges and handles swipe gestures to navigate between pages.
+ *
+ * @param {Object} options - Hook configuration
+ * @param {number} options.totalItems - Total number of items to navigate
+ * @param {number} [options.visibleItems=9] - Number of visible items per page (default from config)
+ * @param {Function} [options.onPageChange] - Callback when page changes, receives (startIndex, endIndex)
+ *
+ * @returns {Object} Navigation state and handlers
+ * @returns {number} return.currentPage - Current page number (0-indexed)
+ * @returns {number} return.totalPages - Total number of pages
+ * @returns {number} return.startIndex - First visible item index
+ * @returns {number} return.endIndex - Last visible item index (exclusive)
+ * @returns {Object} return.handlers - Touch event handlers
+ * @returns {Function} return.handlers.onTouchStart - Touch start event handler
+ * @returns {Function} return.handlers.onTouchMove - Touch move event handler
+ * @returns {Function} return.handlers.onTouchEnd - Touch end event handler
+ * @returns {Function} return.goToPage - Navigate to specific page (pageNumber)
+ * @returns {Function} return.goNext - Navigate to next page
+ * @returns {Function} return.goPrev - Navigate to previous page
+ *
+ * @example
+ * const {
+ *   currentPage,
+ *   totalPages,
+ *   handlers,
+ *   goNext,
+ *   goPrev
+ * } = useSwipeNavigation({
+ *   totalItems: 27,
+ *   visibleItems: 9,
+ *   onPageChange: (start, end) => console.log(`Showing items ${start}-${end}`)
+ * })
+ *
+ * // Apply handlers to container using spread syntax
+ * // Example: <div {...handlers}>content</div>
+ */
+export function useSwipeNavigation({
+  totalItems,
+  visibleItems = HOVER_POPUP_CONFIG.MAX_PHOTOS,
+  onPageChange,
+}) {
+  const [currentPage, setCurrentPage] = useState(0)
+  const touchStartRef = useRef({ x: 0, y: 0 })
+  const touchEndRef = useRef({ x: 0, y: 0 })
+
+  const totalPages = Math.ceil(totalItems / visibleItems)
+
+  const startIndex = currentPage * visibleItems
+  const endIndex = Math.min(startIndex + visibleItems, totalItems)
+
+  const goToPage = useCallback(
+    (page) => {
+      const newPage = Math.max(0, Math.min(page, totalPages - 1))
+      setCurrentPage(newPage)
+      const newStart = newPage * visibleItems
+      const newEnd = Math.min(newStart + visibleItems, totalItems)
+      onPageChange?.(newStart, newEnd)
+    },
+    [totalPages, visibleItems, totalItems, onPageChange]
+  )
+
+  const goNext = useCallback(() => {
+    if (currentPage < totalPages - 1) {
+      goToPage(currentPage + 1)
+    }
+  }, [currentPage, totalPages, goToPage])
+
+  const goPrev = useCallback(() => {
+    if (currentPage > 0) {
+      goToPage(currentPage - 1)
+    }
+  }, [currentPage, goToPage])
+
+  const onTouchStart = useCallback((e) => {
+    touchStartRef.current = {
+      x: e.touches[0].clientX,
+      y: e.touches[0].clientY,
+    }
+  }, [])
+
+  const onTouchMove = useCallback((e) => {
+    touchEndRef.current = {
+      x: e.touches[0].clientX,
+      y: e.touches[0].clientY,
+    }
+  }, [])
+
+  const onTouchEnd = useCallback(() => {
+    const deltaX = touchStartRef.current.x - touchEndRef.current.x
+    const deltaY = touchStartRef.current.y - touchEndRef.current.y
+
+    // Only trigger if horizontal swipe is greater than vertical
+    if (Math.abs(deltaX) > Math.abs(deltaY)) {
+      if (deltaX > HOVER_POPUP_CONFIG.SWIPE_THRESHOLD) {
+        goNext() // Swipe left = next page
+      } else if (deltaX < -HOVER_POPUP_CONFIG.SWIPE_THRESHOLD) {
+        goPrev() // Swipe right = previous page
+      }
+    }
+  }, [goNext, goPrev])
+
+  return {
+    currentPage,
+    totalPages,
+    startIndex,
+    endIndex,
+    handlers: {
+      onTouchStart,
+      onTouchMove,
+      onTouchEnd,
+    },
+    goToPage,
+    goNext,
+    goPrev,
+  }
+}

--- a/Firmware/webui/frontend/src/pages/MapPage.jsx
+++ b/Firmware/webui/frontend/src/pages/MapPage.jsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react'
 import { Link } from 'react-router-dom'
-import { ArrowLeftIcon } from '@heroicons/react/24/outline'
+import { ArrowLeftIcon, ExclamationTriangleIcon, ArrowPathIcon } from '@heroicons/react/24/outline'
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { getPhotosPaginated } from '../utils/api'
 import { QUERY_KEYS } from '../utils/queryKeys'
@@ -62,9 +62,12 @@ export default function MapPage() {
     unclustered,
     metadata,
     isLoading: isLoadingClustered,
+    isPartialResult,
+    partialWarning,
     settings,
     setEnabled,
     setRadius,
+    refetch,
   } = useClusteredLocations()
 
   // Calculate total counts for display
@@ -129,6 +132,29 @@ export default function MapPage() {
           )}
         </div>
       </header>
+
+      {/* Partial results warning banner */}
+      {isPartialResult && (
+        <div
+          role="alert"
+          className="bg-yellow-100 border-b border-yellow-300 px-4 py-2 flex items-center justify-between"
+        >
+          <div className="flex items-center gap-2 text-yellow-800">
+            <ExclamationTriangleIcon className="h-5 w-5 flex-shrink-0" />
+            <span className="text-sm">
+              {partialWarning || 'Some locations may be missing due to timeout'}
+            </span>
+          </div>
+          <button
+            onClick={() => refetch()}
+            className="flex items-center gap-1 text-sm text-yellow-800 hover:text-yellow-900 hover:bg-yellow-200 px-2 py-1 rounded transition-colors"
+            aria-label="Retry loading all locations"
+          >
+            <ArrowPathIcon className="h-4 w-4" />
+            Retry
+          </button>
+        </div>
+      )}
 
       {/* Map fills remaining screen space */}
       <div className="flex-1 relative">


### PR DESCRIPTION
## Summary
- Implement interactive hover popups for map cluster markers displaying a 3x3 thumbnail grid preview
- Add 128px thumbnails with skeleton loading states and smooth fade animations
- Include species tags in popup via backend enhancement to clustering API
- Support mobile touch with horizontal swipe navigation through photos
- Auto-adjust popup positioning to stay within viewport bounds
- Full keyboard accessibility with arrow keys, Home/End, Enter/Space navigation
- Focus trap for accessible Tab navigation within popup

## Test plan
- [ ] Verify hover popups appear when hovering over cluster markers on desktop
- [ ] Verify popup displays correct photo count, date range, and thumbnails
- [ ] Verify clicking a thumbnail opens the lightbox for that photo
- [ ] Verify Escape key closes the popup
- [ ] Verify arrow key navigation moves focus between thumbnails in grid
- [ ] Verify popup repositions to stay within viewport near screen edges
- [ ] Verify mobile tap shows popup and tap outside closes it
- [ ] Verify horizontal swipe on mobile navigates through photos beyond visible 9
- [ ] Verify skeleton loading states show while thumbnails are loading
- [ ] Run `npm test` in frontend - all 858 tests should pass

Closes #117