### PR TITLE
feat(gallery): Add comprehensive metadata editing panel (Issue #109)

### DIFF
--- a/Firmware/Tests/integration/test_sidecar_concurrent.py
+++ b/Firmware/Tests/integration/test_sidecar_concurrent.py
@@ -243,7 +243,7 @@ class TestReadWhileWrite:
             # Each read should be valid
             assert isinstance(result.tags, list), "tags should be list"
             assert isinstance(result.species, str), "species should be string"
-            assert result.version == "1.0", "version should be valid"
+            assert result.version == "1.1", "version should be valid"
 
     def test_concurrent_readers_during_write(self, tmp_path):
         """Multiple readers during write should all get consistent data."""
@@ -290,7 +290,7 @@ class TestReadWhileWrite:
         assert len(valid_reads) > 0, "Should have some valid reads"
 
         for result in valid_reads:
-            assert result.version == "1.0"
+            assert result.version == "1.1"
             assert isinstance(result.tags, list)
 
 

--- a/Firmware/Tests/unit/test_sidecar_metadata_lib.py
+++ b/Firmware/Tests/unit/test_sidecar_metadata_lib.py
@@ -327,6 +327,69 @@ class TestSchemaV11NewFields:
             validate_schema(metadata_dict)
         assert "reference_url" in str(exc_info.value).lower()
 
+    def test_schema_rejects_url_without_hostname(self, sample_photo):
+        """Schema should reject species_reference_url without hostname."""
+        # Test http:// without hostname
+        metadata_dict = {
+            "version": "1.1",
+            "photo_filename": "test.jpg",
+            "created_at": "2024-11-06T10:30:00Z",
+            "modified_at": "2024-11-06T10:30:00Z",
+            "tags": [],
+            "custom": {},
+            "species_reference_url": "http://"  # Invalid - no hostname
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            validate_schema(metadata_dict)
+        assert "reference_url" in str(exc_info.value).lower()
+
+        # Test https:// without hostname
+        metadata_dict["species_reference_url"] = "https://"
+        with pytest.raises(ValidationError) as exc_info:
+            validate_schema(metadata_dict)
+        assert "reference_url" in str(exc_info.value).lower()
+
+    def test_schema_rejects_url_with_spaces(self, sample_photo):
+        """Schema should reject species_reference_url with spaces in hostname."""
+        metadata_dict = {
+            "version": "1.1",
+            "photo_filename": "test.jpg",
+            "created_at": "2024-11-06T10:30:00Z",
+            "modified_at": "2024-11-06T10:30:00Z",
+            "tags": [],
+            "custom": {},
+            "species_reference_url": "http://not a valid url"  # Invalid - spaces
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            validate_schema(metadata_dict)
+        assert "reference_url" in str(exc_info.value).lower()
+
+    def test_schema_accepts_valid_url_with_path(self, sample_photo):
+        """Schema should accept valid URL with path."""
+        metadata_dict = {
+            "version": "1.1",
+            "photo_filename": "test.jpg",
+            "created_at": "2024-11-06T10:30:00Z",
+            "modified_at": "2024-11-06T10:30:00Z",
+            "tags": [],
+            "custom": {},
+            "species_reference_url": "https://example.com/path/to/resource"
+        }
+        assert validate_schema(metadata_dict) is True
+
+    def test_schema_accepts_valid_url_with_query(self, sample_photo):
+        """Schema should accept valid URL with query parameters."""
+        metadata_dict = {
+            "version": "1.1",
+            "photo_filename": "test.jpg",
+            "created_at": "2024-11-06T10:30:00Z",
+            "modified_at": "2024-11-06T10:30:00Z",
+            "tags": [],
+            "custom": {},
+            "species_reference_url": "https://example.com?q=search&page=1"
+        }
+        assert validate_schema(metadata_dict) is True
+
     def test_confidence_enum_values(self, sample_photo):
         """All valid species_confidence enum values should be accepted."""
         valid_values = ["certain", "probable", "possible", "unknown"]

--- a/Firmware/Tests/unit/test_sidecar_metadata_lib.py
+++ b/Firmware/Tests/unit/test_sidecar_metadata_lib.py
@@ -238,13 +238,170 @@ class TestSchemaVersion:
         """SCHEMA_VERSION should be a string."""
         assert isinstance(SCHEMA_VERSION, str)
 
-    def test_schema_version_is_1_0(self):
-        """SCHEMA_VERSION should be '1.0' for initial release."""
-        assert SCHEMA_VERSION == "1.0"
+    def test_schema_version_is_1_1(self):
+        """SCHEMA_VERSION should be '1.1' for current release (Issue #109)."""
+        assert SCHEMA_VERSION == "1.1"
 
     def test_backup_extension_constant(self):
         """BACKUP_EXTENSION should be '.bak'."""
         assert BACKUP_EXTENSION == ".bak"
+
+
+# ============================================================================
+# Test Schema v1.1 New Fields (Issue #109 - TDD)
+# ============================================================================
+
+class TestSchemaV11NewFields:
+    """Tests for new fields in schema version 1.1 (Issue #109)."""
+
+    def test_schema_accepts_species_confidence(self, sample_photo):
+        """Schema should accept species_confidence field with valid enum values."""
+        metadata_dict = {
+            "version": "1.1",
+            "photo_filename": "test.jpg",
+            "created_at": "2024-11-06T10:30:00Z",
+            "modified_at": "2024-11-06T10:30:00Z",
+            "tags": [],
+            "custom": {},
+            "species": "Actias luna",
+            "species_confidence": "certain"
+        }
+        # Should not raise ValidationError
+        assert validate_schema(metadata_dict) is True
+
+    def test_schema_accepts_common_name(self, sample_photo):
+        """Schema should accept species_common_name field."""
+        metadata_dict = {
+            "version": "1.1",
+            "photo_filename": "test.jpg",
+            "created_at": "2024-11-06T10:30:00Z",
+            "modified_at": "2024-11-06T10:30:00Z",
+            "tags": [],
+            "custom": {},
+            "species_common_name": "Luna Moth"
+        }
+        # Should not raise ValidationError
+        assert validate_schema(metadata_dict) is True
+
+    def test_schema_accepts_reference_url(self, sample_photo):
+        """Schema should accept species_reference_url field with valid URL."""
+        metadata_dict = {
+            "version": "1.1",
+            "photo_filename": "test.jpg",
+            "created_at": "2024-11-06T10:30:00Z",
+            "modified_at": "2024-11-06T10:30:00Z",
+            "tags": [],
+            "custom": {},
+            "species_reference_url": "https://inaturalist.org/taxa/47921"
+        }
+        # Should not raise ValidationError
+        assert validate_schema(metadata_dict) is True
+
+    def test_schema_rejects_invalid_confidence(self, sample_photo):
+        """Schema should reject species_confidence with invalid enum value."""
+        metadata_dict = {
+            "version": "1.1",
+            "photo_filename": "test.jpg",
+            "created_at": "2024-11-06T10:30:00Z",
+            "modified_at": "2024-11-06T10:30:00Z",
+            "tags": [],
+            "custom": {},
+            "species_confidence": "maybe"  # Invalid - not in enum
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            validate_schema(metadata_dict)
+        assert "species_confidence" in str(exc_info.value).lower()
+
+    def test_schema_rejects_invalid_reference_url(self, sample_photo):
+        """Schema should reject species_reference_url with non-http URL."""
+        metadata_dict = {
+            "version": "1.1",
+            "photo_filename": "test.jpg",
+            "created_at": "2024-11-06T10:30:00Z",
+            "modified_at": "2024-11-06T10:30:00Z",
+            "tags": [],
+            "custom": {},
+            "species_reference_url": "ftp://example.com"  # Invalid - not http/https
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            validate_schema(metadata_dict)
+        assert "reference_url" in str(exc_info.value).lower()
+
+    def test_confidence_enum_values(self, sample_photo):
+        """All valid species_confidence enum values should be accepted."""
+        valid_values = ["certain", "probable", "possible", "unknown"]
+
+        for confidence in valid_values:
+            metadata_dict = {
+                "version": "1.1",
+                "photo_filename": "test.jpg",
+                "created_at": "2024-11-06T10:30:00Z",
+                "modified_at": "2024-11-06T10:30:00Z",
+                "tags": [],
+                "custom": {},
+                "species_confidence": confidence
+            }
+            # Should not raise ValidationError for any valid enum value
+            assert validate_schema(metadata_dict) is True
+
+    def test_schema_version_1_1(self, sample_photo):
+        """Schema should accept version field with '1.1'."""
+        metadata_dict = {
+            "version": "1.1",
+            "photo_filename": "test.jpg",
+            "created_at": "2024-11-06T10:30:00Z",
+            "modified_at": "2024-11-06T10:30:00Z",
+            "tags": [],
+            "custom": {}
+        }
+        # Should not raise ValidationError
+        assert validate_schema(metadata_dict) is True
+
+    def test_all_v11_fields_together(self, sample_photo):
+        """Schema should accept all v1.1 fields together."""
+        metadata_dict = {
+            "version": "1.1",
+            "photo_filename": "test.jpg",
+            "created_at": "2024-11-06T10:30:00Z",
+            "modified_at": "2024-11-06T10:30:00Z",
+            "tags": ["moth"],
+            "species": "Actias luna",
+            "species_confidence": "certain",
+            "species_common_name": "Luna Moth",
+            "species_reference_url": "https://inaturalist.org/taxa/47921",
+            "custom": {"location": "backyard"}
+        }
+        # Should not raise ValidationError
+        assert validate_schema(metadata_dict) is True
+
+    def test_v11_fields_are_optional(self, sample_photo):
+        """New v1.1 fields should be optional."""
+        # Minimal v1.1 metadata without new fields
+        metadata_dict = {
+            "version": "1.1",
+            "photo_filename": "test.jpg",
+            "created_at": "2024-11-06T10:30:00Z",
+            "modified_at": "2024-11-06T10:30:00Z",
+            "tags": [],
+            "custom": {}
+        }
+        # Should not raise ValidationError
+        assert validate_schema(metadata_dict) is True
+
+    def test_common_name_max_length(self, sample_photo):
+        """species_common_name should respect max length constraint."""
+        metadata_dict = {
+            "version": "1.1",
+            "photo_filename": "test.jpg",
+            "created_at": "2024-11-06T10:30:00Z",
+            "modified_at": "2024-11-06T10:30:00Z",
+            "tags": [],
+            "custom": {},
+            "species_common_name": "a" * 201  # Exceeds 200 char limit
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            validate_schema(metadata_dict)
+        assert "common_name" in str(exc_info.value).lower()
 
 
 # ============================================================================

--- a/Firmware/webui/backend/lib/sidecar_metadata.py
+++ b/Firmware/webui/backend/lib/sidecar_metadata.py
@@ -20,7 +20,7 @@ Schema Version: 1.1 (backward compatible with 1.0)
 - modified_by: User identifier for last modification (string | None)
 - species_confidence: Confidence level (string | None, enum: "certain", "probable", "possible", "unknown") [v1.1+]
 - species_common_name: Common name for species (string | None, max 200 chars) [v1.1+]
-- species_reference_url: Reference URL (string | None, must start with http:// or https://) [v1.1+]
+- species_reference_url: Reference URL (string | None, valid http/https URL with hostname) [v1.1+]
 
 Usage:
     from webui.backend.lib.sidecar_metadata import (
@@ -64,6 +64,7 @@ import time
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -383,9 +384,16 @@ def validate_schema(data: dict) -> bool:
         url = data["species_reference_url"]
         if len(url) > MAX_REFERENCE_URL_LENGTH:
             raise ValidationError(f"species_reference_url exceeds maximum length ({MAX_REFERENCE_URL_LENGTH} chars)")
-        # Validate URL starts with http:// or https://
-        if not (url.startswith("http://") or url.startswith("https://")):
-            raise ValidationError("species_reference_url must start with http:// or https://")
+        # Validate URL format using urlparse (not just prefix check)
+        # Also check for spaces in URL (urlparse accepts them but they're invalid)
+        if ' ' in url:
+            raise ValidationError("species_reference_url must be a valid http:// or https:// URL")
+        try:
+            parsed = urlparse(url)
+            if not (parsed.scheme in ('http', 'https') and parsed.netloc):
+                raise ValidationError("species_reference_url must be a valid http:// or https:// URL")
+        except ValueError:
+            raise ValidationError("species_reference_url must be a valid http:// or https:// URL")
 
     return True
 

--- a/Firmware/webui/backend/lib/sidecar_metadata.py
+++ b/Firmware/webui/backend/lib/sidecar_metadata.py
@@ -1,5 +1,5 @@
 """
-Sidecar Metadata Library for Mothbox Photo Gallery (Issue #102)
+Sidecar Metadata Library for Mothbox Photo Gallery (Issue #102, #109)
 
 Stores photo-level metadata (tags, species, notes) in JSON sidecar files.
 Each photo can have an associated {photo}.json file with structured metadata.
@@ -8,8 +8,8 @@ File Naming:
 - Photo: photo.jpg
 - Sidecar: photo.jpg.json
 
-Schema Version: 1.0
-- version: Schema version (string, "1.0")
+Schema Version: 1.1 (backward compatible with 1.0)
+- version: Schema version (string, "1.0" or "1.1")
 - photo_filename: Original photo filename (string)
 - created_at: Timestamp of sidecar creation (ISO 8601 string)
 - modified_at: Timestamp of last modification (ISO 8601 string)
@@ -18,6 +18,9 @@ Schema Version: 1.0
 - notes: User notes (string | None, max 10000 chars)
 - custom: Custom key-value metadata (dict, max 100 keys)
 - modified_by: User identifier for last modification (string | None)
+- species_confidence: Confidence level (string | None, enum: "certain", "probable", "possible", "unknown") [v1.1+]
+- species_common_name: Common name for species (string | None, max 200 chars) [v1.1+]
+- species_reference_url: Reference URL (string | None, must start with http:// or https://) [v1.1+]
 
 Usage:
     from webui.backend.lib.sidecar_metadata import (
@@ -30,6 +33,15 @@ Usage:
 
     # Create new metadata
     metadata = create_metadata("photo.jpg", tags=["moth", "night"])
+
+    # Create with v1.1 fields
+    metadata = create_metadata(
+        "photo.jpg",
+        species="Actias luna",
+        species_confidence="certain",
+        species_common_name="Luna Moth",
+        species_reference_url="https://inaturalist.org/taxa/47921"
+    )
 
     # Read existing metadata
     metadata = read_metadata("photo.jpg")
@@ -59,7 +71,8 @@ logger = logging.getLogger(__name__)
 # Constants
 # ============================================================================
 
-SCHEMA_VERSION = "1.0"
+SCHEMA_VERSION = "1.1"  # Current schema version
+SUPPORTED_VERSIONS = ["1.0", "1.1"]  # All supported versions for backward compatibility
 BACKUP_EXTENSION = ".bak"
 
 # Validation limits
@@ -68,6 +81,11 @@ MAX_SPECIES_LENGTH = 200
 MAX_NOTES_LENGTH = 10000
 MAX_CUSTOM_KEYS = 100
 MAX_CUSTOM_DEPTH = 5  # Maximum nesting depth for custom values
+MAX_COMMON_NAME_LENGTH = 200  # Maximum length for species_common_name
+MAX_REFERENCE_URL_LENGTH = 500  # Maximum length for species_reference_url
+
+# Enum values for species_confidence (Issue #109)
+SPECIES_CONFIDENCE_VALUES = ["certain", "probable", "possible", "unknown"]
 
 # API limits
 MAX_BULK_FILES = 100  # Maximum files per bulk update request
@@ -95,7 +113,7 @@ class SidecarMetadata:
     """Photo sidecar metadata structure.
 
     Attributes:
-        version: Schema version (currently "1.0")
+        version: Schema version (currently "1.1")
         photo_filename: Original photo filename
         created_at: ISO 8601 timestamp of creation
         modified_at: ISO 8601 timestamp of last modification
@@ -104,6 +122,9 @@ class SidecarMetadata:
         notes: User notes (optional)
         custom: Custom metadata dictionary (optional)
         modified_by: User identifier for last modification (optional)
+        species_confidence: Confidence level for species ID (optional, v1.1+)
+        species_common_name: Common name for species (optional, v1.1+)
+        species_reference_url: Reference URL for species (optional, v1.1+)
     """
     version: str
     photo_filename: str
@@ -114,6 +135,9 @@ class SidecarMetadata:
     notes: str | None
     custom: dict
     modified_by: str | None
+    species_confidence: str | None = None
+    species_common_name: str | None = None
+    species_reference_url: str | None = None
 
     def to_dict(self) -> dict:
         """Convert metadata to dictionary for JSON serialization.
@@ -142,7 +166,10 @@ class SidecarMetadata:
             species=data.get("species"),
             notes=data.get("notes"),
             custom=data.get("custom", {}),
-            modified_by=data.get("modified_by")
+            modified_by=data.get("modified_by"),
+            species_confidence=data.get("species_confidence"),
+            species_common_name=data.get("species_common_name"),
+            species_reference_url=data.get("species_reference_url")
         )
 
 
@@ -297,6 +324,8 @@ def validate_schema(data: dict) -> bool:
     Example:
         >>> validate_schema({"version": "1.0", "tags": [], ...})
         True
+        >>> validate_schema({"version": "1.1", "tags": [], ...})
+        True
     """
     # Check required fields
     required_fields = ["version", "photo_filename", "created_at", "modified_at", "tags", "custom"]
@@ -304,9 +333,9 @@ def validate_schema(data: dict) -> bool:
         if field not in data:
             raise ValidationError(f"Missing required field: {field}")
 
-    # Check version support
-    if data["version"] != SCHEMA_VERSION:
-        raise ValidationError(f"Unsupported schema version: {data['version']} (supported: {SCHEMA_VERSION})")
+    # Check version support (allow both 1.0 and 1.1 for backward compatibility)
+    if data["version"] not in SUPPORTED_VERSIONS:
+        raise ValidationError(f"Unsupported schema version: {data['version']} (supported: {', '.join(SUPPORTED_VERSIONS)})")
 
     # Validate tags
     if not isinstance(data["tags"], list):
@@ -338,6 +367,25 @@ def validate_schema(data: dict) -> bool:
 
         if not _is_valid_custom_value(value):
             raise ValidationError(f"custom value type not allowed for key '{key}'")
+
+    # Validate schema v1.1 fields (Issue #109)
+    if data.get("species_confidence") is not None:
+        if data["species_confidence"] not in SPECIES_CONFIDENCE_VALUES:
+            raise ValidationError(
+                f"species_confidence must be one of {SPECIES_CONFIDENCE_VALUES}, got '{data['species_confidence']}'"
+            )
+
+    if data.get("species_common_name") is not None:
+        if len(data["species_common_name"]) > MAX_COMMON_NAME_LENGTH:
+            raise ValidationError(f"species_common_name exceeds maximum length ({MAX_COMMON_NAME_LENGTH} chars)")
+
+    if data.get("species_reference_url") is not None:
+        url = data["species_reference_url"]
+        if len(url) > MAX_REFERENCE_URL_LENGTH:
+            raise ValidationError(f"species_reference_url exceeds maximum length ({MAX_REFERENCE_URL_LENGTH} chars)")
+        # Validate URL starts with http:// or https://
+        if not (url.startswith("http://") or url.startswith("https://")):
+            raise ValidationError("species_reference_url must start with http:// or https://")
 
     return True
 
@@ -544,7 +592,10 @@ def create_metadata(
     species: str | None = None,
     notes: str | None = None,
     custom: dict | None = None,
-    modified_by: str | None = None
+    modified_by: str | None = None,
+    species_confidence: str | None = None,
+    species_common_name: str | None = None,
+    species_reference_url: str | None = None
 ) -> SidecarMetadata:
     """Create new metadata for photo.
 
@@ -557,6 +608,9 @@ def create_metadata(
         notes: User notes
         custom: Custom metadata dictionary
         modified_by: User identifier
+        species_confidence: Confidence level (v1.1+)
+        species_common_name: Common name (v1.1+)
+        species_reference_url: Reference URL (v1.1+)
 
     Returns:
         New SidecarMetadata instance
@@ -583,7 +637,10 @@ def create_metadata(
         species=species,
         notes=notes,
         custom=custom or {},
-        modified_by=modified_by
+        modified_by=modified_by,
+        species_confidence=species_confidence,
+        species_common_name=species_common_name,
+        species_reference_url=species_reference_url
     )
 
 
@@ -841,7 +898,9 @@ __all__ = [
     "SidecarMetadata",
     # Constants
     "SCHEMA_VERSION",
+    "SUPPORTED_VERSIONS",
     "BACKUP_EXTENSION",
+    "SPECIES_CONFIDENCE_VALUES",
     # Exceptions
     "ValidationError",
     "LockTimeoutError",

--- a/Firmware/webui/frontend/src/components/PhotoGridItem.jsx
+++ b/Firmware/webui/frontend/src/components/PhotoGridItem.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, memo, useCallback } from 'react'
 import { GALLERY_CONFIG } from '../constants/config'
 import ProgressiveImage from './ProgressiveImage'
 import QuickTagButton from './gallery/QuickTagButton'
@@ -17,18 +17,18 @@ import QuickTagButton from './gallery/QuickTagButton'
  * @param {string} props.photo.date - ISO date string
  * @param {Function} props.onClick - Click handler for viewing photo
  */
-export default function PhotoGridItem({ photo, onClick }) {
+function PhotoGridItem({ photo, onClick }) {
   const [isHovered, setIsHovered] = useState(false)
   const [isTagDropdownOpen, setIsTagDropdownOpen] = useState(false)
 
-  const handlePhotoClick = () => {
+  const handlePhotoClick = useCallback(() => {
     if (isTagDropdownOpen) {
       // Close dropdown when clicking photo area
       setIsTagDropdownOpen(false)
     } else {
       onClick(photo)
     }
-  }
+  }, [isTagDropdownOpen, onClick, photo])
 
   return (
     <div
@@ -72,3 +72,5 @@ export default function PhotoGridItem({ photo, onClick }) {
     </div>
   )
 }
+
+export default memo(PhotoGridItem)

--- a/Firmware/webui/frontend/src/components/StackedPhotoCard.jsx
+++ b/Firmware/webui/frontend/src/components/StackedPhotoCard.jsx
@@ -1,7 +1,16 @@
 import PropTypes from 'prop-types'
-import { useCallback } from 'react'
+import { useCallback, memo } from 'react'
 import LazyImage from './LazyImage'
 import { GALLERY_CONFIG } from '../constants/config'
+
+// Move constants outside component to prevent recreation on each render
+const Z_INDEX_CLASSES = ['z-10', 'z-20', 'z-30']
+const OFFSETS = [
+  'translate-x-2 translate-y-2',
+  'translate-x-1 translate-y-1',
+  'translate-x-0 translate-y-0',
+]
+const SHADOWS = ['shadow-sm', 'shadow-md', 'shadow-lg']
 
 /**
  * StackedPhotoCard Component
@@ -33,7 +42,7 @@ import { GALLERY_CONFIG } from '../constants/config'
  * @param {Function} [props.onPhotoClick] - Handler when opening photo (receives cover photo)
  * @param {boolean} [props.isLoading=false] - Show loading skeleton state
  */
-export default function StackedPhotoCard({
+function StackedPhotoCard({
   series,
   onCardClick,
   onPhotoClick,
@@ -122,17 +131,6 @@ export default function StackedPhotoCard({
     )
   }
 
-  // Z-index values for proper stacking order (back to front)
-  const zIndexClasses = ['z-10', 'z-20', 'z-30']
-  // Offset values for stacked effect (back to front)
-  const offsets = [
-    'translate-x-2 translate-y-2',
-    'translate-x-1 translate-y-1',
-    'translate-x-0 translate-y-0',
-  ]
-  // Shadow intensity (back to front)
-  const shadows = ['shadow-sm', 'shadow-md', 'shadow-lg']
-
   // Reverse for rendering (back layers first, front last)
   const renderOrder = [...stackedPhotos].reverse()
 
@@ -149,9 +147,9 @@ export default function StackedPhotoCard({
       {renderOrder.map((photo, renderIndex) => {
         // Calculate actual index (reverse of render order)
         const actualIndex = stackedPhotos.length - 1 - renderIndex
-        const zIndex = zIndexClasses[actualIndex] || 'z-10'
-        const offset = offsets[actualIndex] || offsets[0]
-        const shadow = shadows[actualIndex] || shadows[0]
+        const zIndex = Z_INDEX_CLASSES[actualIndex] || 'z-10'
+        const offset = OFFSETS[actualIndex] || OFFSETS[0]
+        const shadow = SHADOWS[actualIndex] || SHADOWS[0]
         const isFront = actualIndex === stackedPhotos.length - 1
         // Handle both string paths and photo objects for key
         const photoKey = typeof photo === 'string' ? photo : photo.path
@@ -203,3 +201,5 @@ StackedPhotoCard.propTypes = {
   onPhotoClick: PropTypes.func,
   isLoading: PropTypes.bool,
 }
+
+export default memo(StackedPhotoCard)

--- a/Firmware/webui/frontend/src/components/ThumbnailGrid.jsx
+++ b/Firmware/webui/frontend/src/components/ThumbnailGrid.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback } from 'react'
+import React, { useState, useRef, useCallback, useMemo, memo } from 'react'
 import PropTypes from 'prop-types'
 import ThumbnailSkeleton from './ThumbnailSkeleton'
 import { HOVER_POPUP_CONFIG } from '../constants/config'
@@ -77,14 +77,18 @@ function ThumbnailGrid({
     visibleItems: maxPhotos,
   })
 
-  // Display photos based on swipe navigation or simple slice
-  const displayPhotos = enableSwipe
-    ? photos?.slice(startIndex, endIndex) || []
-    : photos?.slice(0, maxPhotos) || []
+  // Memoize display photos and remaining count to avoid recalculation
+  const { displayPhotos, remainingCount } = useMemo(() => {
+    const display = enableSwipe
+      ? photos?.slice(startIndex, endIndex) || []
+      : photos?.slice(0, maxPhotos) || []
 
-  const remainingCount = enableSwipe
-    ? (photos?.length || 0) - endIndex
-    : (photos?.length || 0) - maxPhotos
+    const remaining = enableSwipe
+      ? (photos?.length || 0) - endIndex
+      : (photos?.length || 0) - maxPhotos
+
+    return { displayPhotos: display, remainingCount: remaining }
+  }, [photos, enableSwipe, startIndex, endIndex, maxPhotos])
 
   /**
    * Handle keyboard navigation within the grid
@@ -223,4 +227,4 @@ ThumbnailGrid.propTypes = {
   showPagination: PropTypes.bool,
 }
 
-export default ThumbnailGrid
+export default memo(ThumbnailGrid)

--- a/Firmware/webui/frontend/src/components/gallery/QuickTagButton.jsx
+++ b/Firmware/webui/frontend/src/components/gallery/QuickTagButton.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, useEffect } from 'react'
+import { useState, useRef, useCallback, useEffect, memo } from 'react'
 import PropTypes from 'prop-types'
 import { TagIcon } from '@heroicons/react/24/outline'
 import QuickTagDropdown from './QuickTagDropdown'
@@ -108,4 +108,4 @@ QuickTagButton.propTypes = {
   onDropdownOpenChange: PropTypes.func,
 }
 
-export default QuickTagButton
+export default memo(QuickTagButton)

--- a/Firmware/webui/frontend/src/components/gallery/QuickTagDropdown.jsx
+++ b/Firmware/webui/frontend/src/components/gallery/QuickTagDropdown.jsx
@@ -5,6 +5,7 @@ import { XMarkIcon, CheckIcon, MagnifyingGlassIcon } from '@heroicons/react/20/s
 import TagChip from './TagChip'
 import useTags from '../../hooks/useTags'
 import useSidecarMetadata from '../../hooks/useSidecarMetadata'
+import { METADATA_VALIDATION } from '../../constants/config'
 
 function QuickTagDropdown({ filename, isOpen, onClose, anchorEl }) {
   const dropdownRef = useRef(null)
@@ -264,6 +265,7 @@ function QuickTagDropdown({ filename, isOpen, onClose, anchorEl }) {
                 value={searchQuery}
                 onChange={handleSearchChange}
                 onKeyDown={handleSearchKeyDown}
+                maxLength={METADATA_VALIDATION.MAX_TAG_LENGTH}
                 className="w-full pl-9 pr-3 py-2 text-sm border border-gray-300 dark:border-gray-600
                            rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100
                            focus:ring-2 focus:ring-blue-500 focus:border-blue-500"

--- a/Firmware/webui/frontend/src/components/gallery/TagChip.jsx
+++ b/Firmware/webui/frontend/src/components/gallery/TagChip.jsx
@@ -1,3 +1,4 @@
+import { memo, useCallback, useMemo } from 'react'
 import PropTypes from 'prop-types'
 import { XMarkIcon } from '@heroicons/react/20/solid'
 
@@ -34,39 +35,44 @@ function TagChip({
   size = 'sm',
   className = '',
 }) {
-  const sizeClasses = {
-    sm: 'text-xs px-2 py-0.5',
-    md: 'text-sm px-3 py-1',
-  }
+  // Memoize computed class strings
+  const { baseClasses, stateClasses } = useMemo(() => {
+    const sizeClasses = {
+      sm: 'text-xs px-2 py-0.5',
+      md: 'text-sm px-3 py-1',
+    }
 
-  const baseClasses = `
-    inline-flex items-center gap-1 rounded-full font-medium
-    transition-colors duration-150
-    ${sizeClasses[size]}
-  `.trim().replace(/\s+/g, ' ')
+    const base = `
+      inline-flex items-center gap-1 rounded-full font-medium
+      transition-colors duration-150
+      ${sizeClasses[size]}
+    `.trim().replace(/\s+/g, ' ')
 
-  const stateClasses = selected
-    ? 'bg-blue-500 text-white dark:bg-blue-600'
-    : 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200 hover:bg-blue-200 dark:hover:bg-blue-800'
+    const state = selected
+      ? 'bg-blue-500 text-white dark:bg-blue-600'
+      : 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200 hover:bg-blue-200 dark:hover:bg-blue-800'
 
-  const handleClick = () => {
+    return { baseClasses: base, stateClasses: state }
+  }, [size, selected])
+
+  const handleClick = useCallback(() => {
     if (onClick) {
       onClick()
     }
-  }
+  }, [onClick])
 
-  const handleRemove = (e) => {
+  const handleRemove = useCallback((e) => {
     e.stopPropagation()
     if (onRemove) {
       onRemove()
     }
-  }
+  }, [onRemove])
 
-  const handleRemoveKeyDown = (e) => {
+  const handleRemoveKeyDown = useCallback((e) => {
     if (e.key === 'Enter') {
       handleRemove(e)
     }
-  }
+  }, [handleRemove])
 
   return (
     <button
@@ -115,4 +121,4 @@ TagChip.propTypes = {
   className: PropTypes.string,
 }
 
-export default TagChip
+export default memo(TagChip)

--- a/Firmware/webui/frontend/src/components/metadata/AccordionSection.jsx
+++ b/Firmware/webui/frontend/src/components/metadata/AccordionSection.jsx
@@ -40,12 +40,15 @@ export default function AccordionSection({
           className={`w-5 h-5 text-gray-500 transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
         />
       </div>
+      {/* Using grid-template-rows for smoother animation than max-height */}
       <div
         id={contentId}
-        className={`overflow-hidden transition-all duration-200 ${isExpanded ? 'max-h-[2000px] opacity-100' : 'max-h-0 opacity-0'}`}
+        className={`grid transition-[grid-template-rows,opacity] duration-200 ${isExpanded ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'}`}
       >
-        <div className="p-3 pt-0">
-          {children}
+        <div className="overflow-hidden">
+          <div className="p-3 pt-0">
+            {children}
+          </div>
         </div>
       </div>
     </div>

--- a/Firmware/webui/frontend/src/components/metadata/AccordionSection.jsx
+++ b/Firmware/webui/frontend/src/components/metadata/AccordionSection.jsx
@@ -1,0 +1,61 @@
+import { useState } from 'react'
+import PropTypes from 'prop-types'
+import { ChevronDownIcon } from '@heroicons/react/24/outline'
+
+export default function AccordionSection({
+  title,
+  icon,
+  defaultExpanded = true,
+  children,
+  className = ''
+}) {
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded)
+  const contentId = `accordion-content-${title.toLowerCase().replace(/\s+/g, '-')}`
+
+  const handleToggle = () => setIsExpanded(!isExpanded)
+
+  const handleKeyDown = (e) => {
+    if (e.key === ' ' || e.key === 'Enter') {
+      e.preventDefault()
+      handleToggle()
+    }
+  }
+
+  return (
+    <div className={`border-b border-gray-200 dark:border-gray-700 ${className}`}>
+      <div
+        role="button"
+        tabIndex={0}
+        aria-expanded={isExpanded}
+        aria-controls={contentId}
+        onClick={handleToggle}
+        onKeyDown={handleKeyDown}
+        className="flex items-center justify-between w-full p-3 text-left hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-500"
+      >
+        <div className="flex items-center gap-2">
+          {icon && <span className="w-5 h-5 text-gray-500">{icon}</span>}
+          <span className="font-medium text-gray-900 dark:text-gray-100">{title}</span>
+        </div>
+        <ChevronDownIcon
+          className={`w-5 h-5 text-gray-500 transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
+        />
+      </div>
+      <div
+        id={contentId}
+        className={`overflow-hidden transition-all duration-200 ${isExpanded ? 'max-h-[2000px] opacity-100' : 'max-h-0 opacity-0'}`}
+      >
+        <div className="p-3 pt-0">
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+AccordionSection.propTypes = {
+  title: PropTypes.string.isRequired,
+  icon: PropTypes.node,
+  defaultExpanded: PropTypes.bool,
+  children: PropTypes.node,
+  className: PropTypes.string,
+}

--- a/Firmware/webui/frontend/src/components/metadata/MetadataCustomFields.jsx
+++ b/Firmware/webui/frontend/src/components/metadata/MetadataCustomFields.jsx
@@ -1,0 +1,117 @@
+import { useState } from 'react'
+import PropTypes from 'prop-types'
+import { PlusIcon, TrashIcon } from '@heroicons/react/24/outline'
+
+export default function MetadataCustomFields({
+  fields = {},
+  onChange,
+  maxFields = 100,
+  disabled = false
+}) {
+  const [keyError, setKeyError] = useState(null)
+
+  const entries = Object.entries(fields)
+  const canAddMore = entries.length < maxFields
+
+  const handleKeyChange = (oldKey, newKey) => {
+    // Check for duplicate keys
+    if (newKey && newKey !== oldKey && fields.hasOwnProperty(newKey)) {
+      setKeyError(`Key "${newKey}" already exists`)
+      return
+    }
+    setKeyError(null)
+
+    const newFields = { ...fields }
+    const value = newFields[oldKey]
+    delete newFields[oldKey]
+    if (newKey) {
+      newFields[newKey] = value
+    }
+    onChange(newFields)
+  }
+
+  const handleValueChange = (key, value) => {
+    onChange({ ...fields, [key]: value })
+  }
+
+  const handleAdd = () => {
+    if (!canAddMore) return
+    // Generate unique temp key
+    let tempKey = 'field_1'
+    let i = 1
+    while (fields.hasOwnProperty(tempKey)) {
+      i++
+      tempKey = `field_${i}`
+    }
+    onChange({ ...fields, [tempKey]: '' })
+  }
+
+  const handleDelete = (key) => {
+    const newFields = { ...fields }
+    delete newFields[key]
+    onChange(newFields)
+    setKeyError(null)
+  }
+
+  return (
+    <div className="space-y-2">
+      {entries.length === 0 ? (
+        <p className="text-sm text-gray-500">No custom fields</p>
+      ) : (
+        <div className="space-y-2">
+          {entries.map(([key, value], index) => (
+            <div key={index} className="flex gap-2 items-start">
+              <input
+                type="text"
+                value={key}
+                onChange={(e) => handleKeyChange(key, e.target.value)}
+                placeholder="Field name"
+                disabled={disabled}
+                className="flex-1 px-2 py-1 text-sm border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:border-gray-600"
+              />
+              <input
+                type="text"
+                value={value}
+                onChange={(e) => handleValueChange(key, e.target.value)}
+                placeholder="Value"
+                disabled={disabled}
+                className="flex-1 px-2 py-1 text-sm border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:border-gray-600"
+              />
+              <button
+                type="button"
+                onClick={() => handleDelete(key)}
+                disabled={disabled}
+                className="p-1 text-gray-400 hover:text-red-500 disabled:opacity-50"
+                aria-label={`Delete field ${key}`}
+              >
+                <TrashIcon className="w-4 h-4" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {keyError && (
+        <p className="text-xs text-red-500">{keyError}</p>
+      )}
+
+      <button
+        type="button"
+        onClick={handleAdd}
+        disabled={disabled || !canAddMore}
+        className="inline-flex items-center gap-1 text-sm text-blue-600 hover:text-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        <PlusIcon className="w-4 h-4" />
+        Add custom field
+        {!canAddMore && <span className="text-gray-400">(max {maxFields})</span>}
+      </button>
+    </div>
+  )
+}
+
+MetadataCustomFields.propTypes = {
+  fields: PropTypes.object,
+  onChange: PropTypes.func.isRequired,
+  maxFields: PropTypes.number,
+  disabled: PropTypes.bool,
+}

--- a/Firmware/webui/frontend/src/components/metadata/MetadataEXIF.jsx
+++ b/Firmware/webui/frontend/src/components/metadata/MetadataEXIF.jsx
@@ -1,0 +1,209 @@
+import PropTypes from 'prop-types'
+import MetadataField from './MetadataField'
+import { CameraIcon, SunIcon, MapPinIcon } from '@heroicons/react/24/outline'
+import {
+  formatISO,
+  formatAperture,
+  formatTimestamp,
+  formatDecimalCoordinate,
+} from '../../utils/metadataFormatters'
+
+/**
+ * MetadataEXIF Component
+ *
+ * Displays read-only EXIF metadata from photos in a consolidated view.
+ * Consolidates content from CameraTab, CaptureTab, and DeploymentTab into
+ * three main sections: Camera, Capture Settings, and Location/Deployment.
+ *
+ * All fields are READ-ONLY with copy-to-clipboard functionality for most values.
+ *
+ * @component
+ * @param {Object} props - Component props
+ * @param {Object} props.data - Full metadata object from backend API
+ * @param {Object} [props.data.camera] - Camera information
+ * @param {string} [props.data.camera.make] - Camera manufacturer
+ * @param {string} [props.data.camera.model] - Camera model
+ * @param {string} [props.data.camera.lens] - Lens model
+ * @param {Object} [props.data.capture] - Capture settings
+ * @param {number} [props.data.capture.iso] - ISO sensitivity
+ * @param {string} [props.data.capture.exposure_time] - Exposure time (e.g., "1/500")
+ * @param {number} [props.data.capture.f_number] - Aperture f-number
+ * @param {string} [props.data.capture.focal_length] - Focal length (e.g., "6.0mm")
+ * @param {string} [props.data.capture.exposure_mode] - Exposure mode
+ * @param {string} [props.data.capture.white_balance] - White balance setting
+ * @param {string} [props.data.capture.timestamp] - Capture timestamp
+ * @param {Object} [props.data.location] - GPS location data
+ * @param {number} [props.data.location.latitude] - Latitude in decimal degrees
+ * @param {number} [props.data.location.longitude] - Longitude in decimal degrees
+ * @param {number} [props.data.location.altitude] - Altitude in meters
+ * @param {Object} [props.data.deployment] - Deployment information
+ * @param {string} [props.data.deployment.mothbox_id] - Mothbox device ID
+ * @param {string} [props.data.deployment.firmware_version] - Firmware version
+ *
+ * @example
+ * const metadata = {
+ *   camera: { make: 'Arducam', model: 'OwlSight 64MP', lens: '6mm Wide Angle' },
+ *   capture: { iso: 400, exposure_time: '1/500', f_number: 2.8 },
+ *   location: { latitude: 37.7749, longitude: -122.4194, altitude: 10.5 },
+ *   deployment: { mothbox_id: 'mothbox-backyard', firmware_version: '5' }
+ * };
+ * <MetadataEXIF data={metadata} />
+ */
+export default function MetadataEXIF({ data = {} }) {
+  const camera = data.camera || {}
+  const capture = data.capture || {}
+  const location = data.location || {}
+  const deployment = data.deployment || {}
+
+  /**
+   * Format GPS coordinates as "lat° N/S, lon° E/W"
+   * @param {number|null|undefined} lat - Latitude in decimal degrees
+   * @param {number|null|undefined} lon - Longitude in decimal degrees
+   * @returns {string|null} Formatted GPS string or null if invalid
+   */
+  const formatGPS = (lat, lon) => {
+    if (lat == null || lon == null) return null
+
+    const latDir = lat >= 0 ? 'N' : 'S'
+    const lonDir = lon >= 0 ? 'E' : 'W'
+
+    // Use formatDecimalCoordinate for consistent 6 decimal places
+    const latFormatted = formatDecimalCoordinate(Math.abs(lat))
+    const lonFormatted = formatDecimalCoordinate(Math.abs(lon))
+
+    return `${latFormatted}° ${latDir}, ${lonFormatted}° ${lonDir}`
+  }
+
+  /**
+   * Format altitude as "Xm" or "X.Xm"
+   * @param {number|null|undefined} alt - Altitude in meters
+   * @returns {string|null} Formatted altitude or null if invalid
+   */
+  const formatAltitude = (alt) => {
+    if (alt == null) return null
+    // Don't show decimal for whole numbers
+    const formatted = alt % 1 === 0 ? alt.toString() : alt.toFixed(1)
+    return `${formatted}m`
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Camera Section */}
+      <div>
+        <h4 className="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+          <CameraIcon className="w-4 h-4" />
+          Camera
+        </h4>
+        <div className="space-y-1 pl-6">
+          <MetadataField label="Make" value={camera.make} copyable />
+          <MetadataField label="Model" value={camera.model} copyable />
+          <MetadataField label="Lens" value={camera.lens} copyable />
+        </div>
+      </div>
+
+      {/* Capture Settings Section */}
+      <div>
+        <h4 className="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+          <SunIcon className="w-4 h-4" />
+          Capture Settings
+        </h4>
+        <div className="space-y-1 pl-6">
+          <MetadataField
+            label="ISO"
+            value={capture.iso !== undefined && capture.iso !== null ? formatISO(capture.iso) : null}
+            copyable
+          />
+          <MetadataField
+            label="Shutter Speed"
+            value={capture.exposure_time}
+            copyable
+          />
+          <MetadataField
+            label="Aperture"
+            value={capture.f_number !== undefined && capture.f_number !== null ? formatAperture(capture.f_number) : null}
+            copyable
+          />
+          <MetadataField
+            label="Focal Length"
+            value={capture.focal_length}
+            copyable
+          />
+          <MetadataField
+            label="Exposure Mode"
+            value={capture.exposure_mode}
+            copyable
+          />
+          <MetadataField
+            label="White Balance"
+            value={capture.white_balance}
+            copyable
+          />
+          <MetadataField
+            label="Captured"
+            value={formatTimestamp(capture.timestamp)}
+            copyable
+          />
+        </div>
+      </div>
+
+      {/* Location/Deployment Section */}
+      <div>
+        <h4 className="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+          <MapPinIcon className="w-4 h-4" />
+          Location &amp; Deployment
+        </h4>
+        <div className="space-y-1 pl-6">
+          <MetadataField
+            label="GPS"
+            value={formatGPS(location.latitude, location.longitude)}
+            copyable
+          />
+          <MetadataField
+            label="Altitude"
+            value={formatAltitude(location.altitude)}
+            copyable
+          />
+          <MetadataField
+            label="Deployment"
+            value={deployment.mothbox_id}
+            copyable
+          />
+          <MetadataField
+            label="Device"
+            value={deployment.firmware_version}
+            copyable
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+MetadataEXIF.propTypes = {
+  data: PropTypes.shape({
+    camera: PropTypes.shape({
+      make: PropTypes.string,
+      model: PropTypes.string,
+      lens: PropTypes.string,
+      sensor: PropTypes.string,
+    }),
+    capture: PropTypes.shape({
+      iso: PropTypes.number,
+      exposure_time: PropTypes.string,
+      f_number: PropTypes.number,
+      focal_length: PropTypes.string,
+      exposure_mode: PropTypes.string,
+      white_balance: PropTypes.string,
+      timestamp: PropTypes.string,
+    }),
+    location: PropTypes.shape({
+      latitude: PropTypes.number,
+      longitude: PropTypes.number,
+      altitude: PropTypes.number,
+    }),
+    deployment: PropTypes.shape({
+      mothbox_id: PropTypes.string,
+      firmware_version: PropTypes.string,
+    }),
+  }),
+}

--- a/Firmware/webui/frontend/src/components/metadata/MetadataNotes.jsx
+++ b/Firmware/webui/frontend/src/components/metadata/MetadataNotes.jsx
@@ -1,11 +1,12 @@
 import { useRef, useEffect, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import { ClockIcon } from '@heroicons/react/24/outline'
+import { METADATA_VALIDATION } from '../../constants/config'
 
 export default function MetadataNotes({
   value = '',
   onChange,
-  maxLength = 5000,
+  maxLength = METADATA_VALIDATION.MAX_NOTES_LENGTH,
   disabled = false
 }) {
   const textareaRef = useRef(null)

--- a/Firmware/webui/frontend/src/components/metadata/MetadataNotes.jsx
+++ b/Firmware/webui/frontend/src/components/metadata/MetadataNotes.jsx
@@ -1,0 +1,105 @@
+import { useRef, useEffect, useCallback } from 'react'
+import PropTypes from 'prop-types'
+import { ClockIcon } from '@heroicons/react/24/outline'
+
+export default function MetadataNotes({
+  value = '',
+  onChange,
+  maxLength = 5000,
+  disabled = false
+}) {
+  const textareaRef = useRef(null)
+
+  // Auto-expand textarea based on content
+  const adjustHeight = useCallback(() => {
+    const textarea = textareaRef.current
+    if (textarea) {
+      textarea.style.height = 'auto'
+      textarea.style.height = `${Math.max(80, textarea.scrollHeight)}px`
+    }
+  }, [])
+
+  useEffect(() => {
+    adjustHeight()
+  }, [value, adjustHeight])
+
+  const handleChange = (e) => {
+    const newValue = e.target.value
+    // Only allow changes if under max length
+    if (newValue.length <= maxLength) {
+      onChange(newValue)
+    }
+  }
+
+  const handleKeyDown = (e) => {
+    // Ctrl+Enter blurs textarea (triggers auto-save)
+    if (e.key === 'Enter' && e.ctrlKey) {
+      e.preventDefault()
+      textareaRef.current?.blur()
+    }
+  }
+
+  const insertTimestamp = () => {
+    const now = new Date()
+    // Format: YYYY-MM-DD HH:mm -
+    const timestamp = now.toISOString().slice(0, 16).replace('T', ' ') + ' - '
+    const cursorPos = textareaRef.current?.selectionStart || value.length
+    const newValue = value.slice(0, cursorPos) + timestamp + value.slice(cursorPos)
+    onChange(newValue)
+
+    // Set cursor after timestamp
+    setTimeout(() => {
+      if (textareaRef.current) {
+        const newPos = cursorPos + timestamp.length
+        textareaRef.current.focus()
+        textareaRef.current.setSelectionRange(newPos, newPos)
+      }
+    }, 0)
+  }
+
+  const charCount = value.length
+  const isNearLimit = charCount >= maxLength * 0.9
+  const isAtLimit = charCount >= maxLength
+
+  return (
+    <div className="space-y-2">
+      <div className="flex justify-between items-center">
+        <button
+          type="button"
+          onClick={insertTimestamp}
+          disabled={disabled}
+          className="inline-flex items-center gap-1 text-xs text-gray-600 hover:text-blue-600 disabled:opacity-50"
+          title="Insert timestamp"
+        >
+          <ClockIcon className="w-4 h-4" />
+          Add timestamp
+        </button>
+        <span className={`text-xs ${isNearLimit ? (isAtLimit ? 'text-red-500' : 'text-yellow-500') : 'text-gray-400'}`}>
+          {charCount.toLocaleString()} / {maxLength.toLocaleString()} characters
+        </span>
+      </div>
+
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        placeholder="Add notes about this photo..."
+        disabled={disabled}
+        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 resize-none overflow-hidden whitespace-pre-wrap dark:bg-gray-800 dark:border-gray-600 min-h-[80px]"
+        style={{ whiteSpace: 'pre-wrap' }}
+      />
+
+      <p className="text-xs text-gray-400">
+        Ctrl+Enter to finish editing
+      </p>
+    </div>
+  )
+}
+
+MetadataNotes.propTypes = {
+  value: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  maxLength: PropTypes.number,
+  disabled: PropTypes.bool,
+}

--- a/Firmware/webui/frontend/src/components/metadata/MetadataPanel.jsx
+++ b/Firmware/webui/frontend/src/components/metadata/MetadataPanel.jsx
@@ -101,9 +101,11 @@ export default function MetadataPanel({ photoPath, className = '', onClose }) {
 
   // Keyboard shortcut handler
   const handleKeyDown = useCallback((e) => {
-    // Check if the event originated from within the panel
+    // Focus check required: This handler is attached to document (not panel element)
+    // because we need to intercept Ctrl+S before browser's save dialog. Without this
+    // check, shortcuts would trigger even when focus is outside the panel (e.g., gallery).
     if (!panelRef.current?.contains(document.activeElement)) {
-      return  // Don't handle shortcuts if panel isn't focused
+      return
     }
 
     // Ctrl+S or Cmd+S - Immediate save

--- a/Firmware/webui/frontend/src/components/metadata/MetadataPanel.jsx
+++ b/Firmware/webui/frontend/src/components/metadata/MetadataPanel.jsx
@@ -1,61 +1,174 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import PropTypes from 'prop-types'
-import * as Tabs from '@radix-ui/react-tabs'
+import { TagIcon, BugAntIcon, DocumentTextIcon, CameraIcon, AdjustmentsHorizontalIcon, XMarkIcon } from '@heroicons/react/24/outline'
 import usePhotoMetadata from '../../hooks/usePhotoMetadata'
-import CameraTab from './CameraTab'
-import CaptureTab from './CaptureTab'
-import TagsTab from './TagsTab'
-import DeploymentTab from './DeploymentTab'
+import useSidecarMetadata from '../../hooks/useSidecarMetadata'
+import useAutoSave from '../../hooks/useAutoSave'
+import AccordionSection from './AccordionSection'
+import SaveStatusIndicator from './SaveStatusIndicator'
+import MetadataTags from './MetadataTags'
+import MetadataSpecies from './MetadataSpecies'
+import MetadataNotes from './MetadataNotes'
+import MetadataCustomFields from './MetadataCustomFields'
+import MetadataEXIF from './MetadataEXIF'
 import MetadataSkeleton from './MetadataSkeleton'
 
 /**
- * MetadataPanel - Container component for photo metadata display
+ * MetadataPanel - Container component for photo metadata display and editing
  *
- * Orchestrates all 4 metadata tabs (Camera, Capture, Tags, Deployment)
- * using Radix UI Tabs for accessible tab navigation. Fetches metadata using the
- * usePhotoMetadata hook and handles loading/error states.
- * Note: Location data is now merged into the Deployment tab.
+ * Orchestrates all metadata sections using accordion UI with auto-save functionality.
+ * Fetches both EXIF metadata (read-only) and sidecar metadata (editable) and provides
+ * seamless editing experience with debounced auto-save.
  *
  * Features:
- * - Responsive layout (vertical tabs on mobile, horizontal on desktop)
- * - Fast tab switching (<100ms requirement)
+ * - Accordion-based UI with collapsible sections
+ * - Auto-save with 2-second debounce
+ * - Optimistic updates for instant feedback
+ * - Real-time save status indicator
  * - Loading skeleton during data fetch
- * - Error handling with retry suggestions
+ * - Error handling with retry capability
  * - Full keyboard navigation support
- * - ARIA attributes for accessibility
  *
  * @param {string} photoPath - Full path to the photo file
  * @param {string} [className] - Optional additional CSS classes
+ * @param {Function} [onClose] - Optional callback when panel is closed (for Escape or Ctrl+Enter shortcuts)
  *
  * @example
  * <MetadataPanel photoPath="/var/lib/mothbox/photos/photo.jpg" />
  */
-export default function MetadataPanel({ photoPath, className = '' }) {
-  // State for active tab (defaults to 'camera')
-  const [activeTab, setActiveTab] = useState('camera')
+export default function MetadataPanel({ photoPath, className = '', onClose }) {
+  // Ref for panel container to check focus
+  const panelRef = useRef(null)
+  // Get filename from path for sidecar operations
+  const filename = photoPath ? photoPath.split('/').pop() : null
 
-  // Retry tracking state (consistent with PhotoLightbox UX)
-  const [retryCount, setRetryCount] = useState(0)
-  const MAX_RETRIES = 3
+  // Mobile drawer state
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false)
 
-  // Fetch metadata using custom hook
-  const { data: metadata, isLoading, isError, refetch } = usePhotoMetadata(photoPath)
+  // Fetch EXIF metadata (read-only)
+  const { data: exifData, isLoading: exifLoading, isError: exifError, refetch: refetchExif } = usePhotoMetadata(photoPath)
 
-  // Reset retry count when photo changes
+  // Fetch and mutate sidecar metadata (editable)
+  const {
+    data: sidecarData,
+    isLoading: sidecarLoading,
+    updateMetadata
+  } = useSidecarMetadata(filename)
+
+  // Local state for editable fields
+  const [editableData, setEditableData] = useState({
+    tags: [],
+    species: '',
+    species_confidence: 'unknown',
+    species_common_name: '',
+    species_reference_url: '',
+    notes: '',
+    custom: {}
+  })
+
+  // Sync local state with fetched sidecar data
   useEffect(() => {
-    setRetryCount(0)
-  }, [photoPath])
+    if (sidecarData) {
+      setEditableData({
+        tags: sidecarData.user_tags || [],
+        species: sidecarData.species || '',
+        species_confidence: sidecarData.species_confidence || 'unknown',
+        species_common_name: sidecarData.species_common_name || '',
+        species_reference_url: sidecarData.species_reference_url || '',
+        notes: sidecarData.notes || '',
+        custom: sidecarData.custom || {}
+      })
+    }
+  }, [sidecarData])
 
-  // Shared tab trigger styling (DRY principle)
-  const TAB_TRIGGER_CLASSES = `
-    px-4 py-2 text-sm font-medium transition-all duration-75
-    border-b-2 md:border-b-0 md:border-r-2 border-transparent
-    hover:bg-gray-50 dark:hover:bg-gray-800
-    data-[state=active]:border-blue-600 data-[state=active]:text-blue-600
-    data-[state=active]:dark:border-blue-400 data-[state=active]:dark:text-blue-400
-    text-gray-700 dark:text-gray-300
-    focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2
-  `
+  // Auto-save hook with 2-second debounce
+  const { status: saveStatus, error: saveError, saveNow } = useAutoSave({
+    data: editableData,
+    onSave: async (data) => {
+      await updateMetadata({
+        user_tags: data.tags,
+        species: data.species,
+        species_confidence: data.species_confidence,
+        species_common_name: data.species_common_name,
+        species_reference_url: data.species_reference_url,
+        notes: data.notes,
+        custom: data.custom
+      })
+    },
+    delay: 2000,
+    enabled: !!filename
+  })
+
+  // Keyboard shortcut handler
+  const handleKeyDown = useCallback((e) => {
+    // Check if the event originated from within the panel
+    if (!panelRef.current?.contains(document.activeElement)) {
+      return  // Don't handle shortcuts if panel isn't focused
+    }
+
+    // Ctrl+S or Cmd+S - Immediate save
+    if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+      e.preventDefault()
+      saveNow()
+    }
+
+    // Ctrl+Enter or Cmd+Enter - Save and close
+    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+      e.preventDefault()
+      saveNow()
+      onClose?.()
+    }
+
+    // Escape - Close panel
+    if (e.key === 'Escape') {
+      onClose?.()
+    }
+  }, [saveNow, onClose])
+
+  // Add event listener for keyboard shortcuts
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [handleKeyDown])
+
+  // Update handlers for each section
+  const handleTagAdd = (tag) => {
+    setEditableData(prev => ({
+      ...prev,
+      tags: [...prev.tags, tag]
+    }))
+  }
+
+  const handleTagRemove = (tag) => {
+    setEditableData(prev => ({
+      ...prev,
+      tags: prev.tags.filter(t => t !== tag)
+    }))
+  }
+
+  const handleSpeciesChange = (field, value) => {
+    setEditableData(prev => {
+      // Map field names to state keys
+      const fieldMap = {
+        'species': 'species',
+        'confidence': 'species_confidence',
+        'commonName': 'species_common_name',
+        'referenceUrl': 'species_reference_url'
+      }
+      const stateKey = fieldMap[field] || field
+      return { ...prev, [stateKey]: value }
+    })
+  }
+
+  const handleNotesChange = (value) => {
+    setEditableData(prev => ({ ...prev, notes: value }))
+  }
+
+  const handleCustomFieldsChange = (fields) => {
+    setEditableData(prev => ({ ...prev, custom: fields }))
+  }
+
+  const isLoading = exifLoading || sidecarLoading
 
   // Loading state - show skeleton
   if (isLoading) {
@@ -63,7 +176,7 @@ export default function MetadataPanel({ photoPath, className = '' }) {
   }
 
   // Error state - show error message with retry button
-  if (isError) {
+  if (exifError) {
     return (
       <div className={`p-4 text-center ${className}`}>
         <p className="text-red-600 dark:text-red-400 font-semibold mb-2">
@@ -72,88 +185,130 @@ export default function MetadataPanel({ photoPath, className = '' }) {
         <p className="text-gray-600 dark:text-gray-400 text-sm mb-4">
           Please try again or check if the photo exists.
         </p>
-        {retryCount >= MAX_RETRIES ? (
-          <p className="mt-4 text-sm text-red-500 dark:text-red-400 max-w-md mx-auto">
-            Maximum retry attempts reached ({MAX_RETRIES}). The metadata may be unavailable or
-            the server may be experiencing issues.
-          </p>
-        ) : (
-          <button
-            onClick={() => {
-              setRetryCount((prev) => prev + 1)
-              refetch()
-            }}
-            className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
-          >
-            Retry {retryCount > 0 && `(${retryCount}/${MAX_RETRIES})`}
-          </button>
-        )}
+        <button
+          onClick={() => refetchExif()}
+          className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
+        >
+          Retry
+        </button>
       </div>
     )
   }
 
-  // Success state - render tabs
+  // Success state - render accordion sections
   return (
-    <Tabs.Root
-      value={activeTab}
-      onValueChange={setActiveTab}
-      className={`flex flex-col md:flex-row ${className}`}
-    >
-      {/* Tab List - vertical on mobile, horizontal on desktop */}
-      <Tabs.List
-        aria-label="Photo metadata tabs"
-        className="flex flex-row md:flex-col border-b md:border-b-0 md:border-r border-gray-200 dark:border-gray-700"
+    <>
+      {/* Mobile Toggle Button */}
+      <button
+        onClick={() => setIsDrawerOpen(true)}
+        className="md:hidden fixed bottom-4 right-4 z-40 p-4 bg-blue-600 text-white rounded-full shadow-lg hover:bg-blue-700 transition-colors"
+        aria-label="Open metadata panel"
+        data-testid="mobile-toggle-button"
       >
-        <Tabs.Trigger
-          value="camera"
-          className={TAB_TRIGGER_CLASSES}
-        >
-          Camera
-        </Tabs.Trigger>
-        <Tabs.Trigger
-          value="capture"
-          className={TAB_TRIGGER_CLASSES}
-        >
-          Capture
-        </Tabs.Trigger>
-        <Tabs.Trigger
-          value="tags"
-          className={TAB_TRIGGER_CLASSES}
-        >
-          Tags
-        </Tabs.Trigger>
-        <Tabs.Trigger
-          value="deployment"
-          className={TAB_TRIGGER_CLASSES}
-        >
-          Deployment
-        </Tabs.Trigger>
-      </Tabs.List>
+        <DocumentTextIcon className="w-6 h-6" />
+      </button>
 
-      {/* Tab Content - scrollable area for metadata */}
-      {/* max-h-[60vh]: Responsive height constraint that adapts to viewport size */}
-      <div className="flex-1 overflow-y-auto max-h-[60vh]">
-        <Tabs.Content value="camera" className="p-4">
-          <CameraTab data={metadata} />
-        </Tabs.Content>
+      {/* Mobile Overlay */}
+      {isDrawerOpen && (
+        <div
+          className="md:hidden fixed inset-0 bg-black/50 z-40"
+          onClick={() => setIsDrawerOpen(false)}
+          data-testid="mobile-overlay"
+          aria-hidden="true"
+        />
+      )}
 
-        <Tabs.Content value="capture" className="p-4">
-          <CaptureTab data={metadata} />
-        </Tabs.Content>
+      {/* Panel - Desktop: sidebar, Mobile: drawer */}
+      <div
+        ref={panelRef}
+        data-testid="metadata-panel"
+        role="dialog"
+        aria-label="Photo metadata"
+        className={`
+          ${className}
+          ${isDrawerOpen ? 'fixed inset-x-0 bottom-0 z-50 max-h-[80vh] bg-white dark:bg-gray-900 rounded-t-2xl shadow-lg transform translate-y-0 transition-transform' : 'hidden'}
+          md:block md:relative md:bg-white md:dark:bg-gray-900 flex flex-col
+        `}
+        tabIndex={-1}
+      >
+        {/* Mobile Header with Close */}
+        {isDrawerOpen && (
+          <div
+            className="md:hidden flex items-center justify-between p-3 border-b border-gray-200 dark:border-gray-700"
+            data-testid="drawer-mobile-header"
+          >
+            <span className="font-medium">Photo Metadata</span>
+            <button
+              onClick={() => setIsDrawerOpen(false)}
+              className="p-1 hover:bg-gray-100 dark:hover:bg-gray-800 rounded"
+              aria-label="Close metadata panel"
+              data-testid="drawer-close-button"
+            >
+              <XMarkIcon className="w-5 h-5" />
+            </button>
+          </div>
+        )}
 
-        <Tabs.Content value="tags" className="p-4">
-          <TagsTab data={metadata} />
-        </Tabs.Content>
+        {/* Save Status */}
+        <div className="px-3 py-2 border-b border-gray-200 dark:border-gray-700">
+          <SaveStatusIndicator
+            status={saveStatus}
+            onRetry={saveNow}
+            errorMessage={saveError?.message}
+          />
+          {/* Keyboard Shortcuts Hint */}
+          <p className="text-xs text-gray-400 dark:text-gray-500 mt-2">
+            <kbd className="px-1 py-0.5 text-xs font-semibold text-gray-800 bg-gray-100 border border-gray-200 rounded dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600">Ctrl+S</kbd> to save,
+            <kbd className="px-1 py-0.5 text-xs font-semibold text-gray-800 bg-gray-100 border border-gray-200 rounded dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600 ml-1">Ctrl+Enter</kbd> to save & close{onClose ? ', ' : ''}
+            {onClose && <><kbd className="px-1 py-0.5 text-xs font-semibold text-gray-800 bg-gray-100 border border-gray-200 rounded dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600 ml-1">Esc</kbd> to close</>}
+          </p>
+        </div>
 
-        <Tabs.Content value="deployment" className="p-4">
-          <DeploymentTab data={metadata} />
-        </Tabs.Content>
+        {/* Accordion Sections */}
+        <div className="flex-1 overflow-y-auto">
+          <AccordionSection title="Tags" icon={<TagIcon className="w-5 h-5" />} defaultExpanded>
+            <MetadataTags
+              tags={editableData.tags}
+              onAddTag={handleTagAdd}
+              onRemoveTag={handleTagRemove}
+            />
+          </AccordionSection>
+
+          <AccordionSection title="Species" icon={<BugAntIcon className="w-5 h-5" />}>
+            <MetadataSpecies
+              species={editableData.species}
+              confidence={editableData.species_confidence}
+              commonName={editableData.species_common_name}
+              referenceUrl={editableData.species_reference_url}
+              onChange={handleSpeciesChange}
+            />
+          </AccordionSection>
+
+          <AccordionSection title="Notes" icon={<DocumentTextIcon className="w-5 h-5" />}>
+            <MetadataNotes
+              value={editableData.notes}
+              onChange={handleNotesChange}
+            />
+          </AccordionSection>
+
+          <AccordionSection title="EXIF Data" icon={<CameraIcon className="w-5 h-5" />}>
+            <MetadataEXIF data={exifData} />
+          </AccordionSection>
+
+          <AccordionSection title="Custom Fields" icon={<AdjustmentsHorizontalIcon className="w-5 h-5" />}>
+            <MetadataCustomFields
+              fields={editableData.custom}
+              onChange={handleCustomFieldsChange}
+            />
+          </AccordionSection>
+        </div>
       </div>
-    </Tabs.Root>
+    </>
   )
 }
 
 MetadataPanel.propTypes = {
   photoPath: PropTypes.string.isRequired,
   className: PropTypes.string,
+  onClose: PropTypes.func,
 }

--- a/Firmware/webui/frontend/src/components/metadata/MetadataPanel.jsx
+++ b/Firmware/webui/frontend/src/components/metadata/MetadataPanel.jsx
@@ -133,22 +133,22 @@ export default function MetadataPanel({ photoPath, className = '', onClose }) {
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [handleKeyDown])
 
-  // Update handlers for each section
-  const handleTagAdd = (tag) => {
+  // Update handlers for each section - memoized to prevent child re-renders
+  const handleTagAdd = useCallback((tag) => {
     setEditableData(prev => ({
       ...prev,
       tags: [...prev.tags, tag]
     }))
-  }
+  }, [])
 
-  const handleTagRemove = (tag) => {
+  const handleTagRemove = useCallback((tag) => {
     setEditableData(prev => ({
       ...prev,
       tags: prev.tags.filter(t => t !== tag)
     }))
-  }
+  }, [])
 
-  const handleSpeciesChange = (field, value) => {
+  const handleSpeciesChange = useCallback((field, value) => {
     setEditableData(prev => {
       // Map field names to state keys
       const fieldMap = {
@@ -160,15 +160,15 @@ export default function MetadataPanel({ photoPath, className = '', onClose }) {
       const stateKey = fieldMap[field] || field
       return { ...prev, [stateKey]: value }
     })
-  }
+  }, [])
 
-  const handleNotesChange = (value) => {
+  const handleNotesChange = useCallback((value) => {
     setEditableData(prev => ({ ...prev, notes: value }))
-  }
+  }, [])
 
-  const handleCustomFieldsChange = (fields) => {
+  const handleCustomFieldsChange = useCallback((fields) => {
     setEditableData(prev => ({ ...prev, custom: fields }))
-  }
+  }, [])
 
   const isLoading = exifLoading || sidecarLoading
 

--- a/Firmware/webui/frontend/src/components/metadata/MetadataSkeleton.jsx
+++ b/Firmware/webui/frontend/src/components/metadata/MetadataSkeleton.jsx
@@ -18,6 +18,7 @@ export default function MetadataSkeleton({ rows = 6, className = '' }) {
       className={`animate-pulse ${className}`}
       role="status"
       aria-label="Loading photo metadata"
+      data-testid="metadata-skeleton"
     >
       <div className="space-y-3">
         {Array.from({ length: rows }).map((_, index) => (

--- a/Firmware/webui/frontend/src/components/metadata/MetadataSpecies.jsx
+++ b/Firmware/webui/frontend/src/components/metadata/MetadataSpecies.jsx
@@ -1,0 +1,184 @@
+import { useState, useEffect } from 'react'
+import PropTypes from 'prop-types'
+import { MagnifyingGlassIcon, LinkIcon } from '@heroicons/react/24/outline'
+import useSpecies from '../../hooks/useSpecies'
+
+const CONFIDENCE_OPTIONS = [
+  { value: 'certain', label: 'Certain' },
+  { value: 'probable', label: 'Probable' },
+  { value: 'possible', label: 'Possible' },
+  { value: 'unknown', label: 'Unknown' },
+]
+
+export default function MetadataSpecies({
+  species = '',
+  confidence = 'unknown',
+  commonName = '',
+  referenceUrl = '',
+  onChange,
+  disabled = false
+}) {
+  const [inputValue, setInputValue] = useState(species)
+  const [urlInputValue, setUrlInputValue] = useState(referenceUrl)
+  const [showSuggestions, setShowSuggestions] = useState(false)
+  const [urlError, setUrlError] = useState('')
+
+  // Sync local state with prop changes (e.g., when sidecar data loads async)
+  useEffect(() => {
+    setInputValue(species)
+  }, [species])
+
+  useEffect(() => {
+    setUrlInputValue(referenceUrl)
+  }, [referenceUrl])
+
+  const { data: speciesData } = useSpecies({ sort: 'count', order: 'desc', limit: 20 })
+
+  const suggestions = speciesData?.species
+    ?.filter(s => s.name.toLowerCase().includes(inputValue.toLowerCase()))
+    ?.slice(0, 5) || []
+
+  const handleSpeciesChange = (value) => {
+    setInputValue(value)
+    onChange('species', value)
+  }
+
+  const handleSelectSuggestion = (name) => {
+    setInputValue(name)
+    onChange('species', name)
+    setShowSuggestions(false)
+  }
+
+  const validateUrl = (url) => {
+    if (!url) {
+      setUrlError('')
+      return true
+    }
+    if (!url.startsWith('http://') && !url.startsWith('https://')) {
+      setUrlError('URL must start with http:// or https://')
+      return false
+    }
+    setUrlError('')
+    return true
+  }
+
+  const handleUrlChange = (value) => {
+    setUrlInputValue(value)
+    validateUrl(value)
+    onChange('referenceUrl', value)
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* Species Name with Autocomplete */}
+      <div>
+        <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+          Scientific Name
+        </label>
+        <div className="relative">
+          <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+            <MagnifyingGlassIcon className="w-4 h-4 text-gray-400" />
+          </div>
+          <input
+            type="text"
+            value={inputValue}
+            onChange={(e) => {
+              setInputValue(e.target.value)
+              setShowSuggestions(true)
+            }}
+            onBlur={() => {
+              setTimeout(() => setShowSuggestions(false), 200)
+              handleSpeciesChange(inputValue)
+            }}
+            onFocus={() => setShowSuggestions(true)}
+            placeholder="e.g., Actias luna"
+            disabled={disabled}
+            className="w-full pl-9 pr-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:border-gray-600"
+          />
+
+          {showSuggestions && suggestions.length > 0 && inputValue && (
+            <ul className="absolute z-10 w-full mt-1 bg-white border border-gray-300 rounded-md shadow-lg dark:bg-gray-800 dark:border-gray-600 max-h-48 overflow-auto">
+              {suggestions.map((s) => (
+                <li
+                  key={s.name}
+                  onClick={() => handleSelectSuggestion(s.name)}
+                  className="px-3 py-2 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700"
+                >
+                  {s.name} <span className="text-gray-400">({s.count})</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      {/* Common Name */}
+      <div>
+        <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+          Common Name
+        </label>
+        <input
+          type="text"
+          value={commonName}
+          onChange={(e) => onChange('commonName', e.target.value)}
+          placeholder="e.g., Luna Moth"
+          disabled={disabled}
+          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:border-gray-600"
+        />
+      </div>
+
+      {/* Confidence Level */}
+      <div>
+        <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+          Confidence
+        </label>
+        <select
+          value={confidence}
+          onChange={(e) => onChange('confidence', e.target.value)}
+          disabled={disabled}
+          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:border-gray-600"
+        >
+          {CONFIDENCE_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Reference URL */}
+      <div>
+        <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+          Reference Link
+        </label>
+        <div className="relative">
+          <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+            <LinkIcon className="w-4 h-4 text-gray-400" />
+          </div>
+          <input
+            type="url"
+            value={urlInputValue}
+            onChange={(e) => handleUrlChange(e.target.value)}
+            placeholder="https://inaturalist.org/..."
+            disabled={disabled}
+            className={`w-full pl-9 pr-3 py-2 border rounded-md focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 ${
+              urlError ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'
+            }`}
+          />
+        </div>
+        {urlError && (
+          <p className="mt-1 text-xs text-red-500">{urlError}</p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+MetadataSpecies.propTypes = {
+  species: PropTypes.string,
+  confidence: PropTypes.oneOf(['certain', 'probable', 'possible', 'unknown']),
+  commonName: PropTypes.string,
+  referenceUrl: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+}

--- a/Firmware/webui/frontend/src/components/metadata/MetadataSpecies.jsx
+++ b/Firmware/webui/frontend/src/components/metadata/MetadataSpecies.jsx
@@ -1,15 +1,8 @@
 import { useState, useEffect, useMemo, useCallback } from 'react'
 import PropTypes from 'prop-types'
-import { MagnifyingGlassIcon, LinkIcon } from '@heroicons/react/24/outline'
+import { MagnifyingGlassIcon, LinkIcon, ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline'
 import useSpecies from '../../hooks/useSpecies'
-import { METADATA_VALIDATION } from '../../constants/config'
-
-const CONFIDENCE_OPTIONS = [
-  { value: 'certain', label: 'Certain' },
-  { value: 'probable', label: 'Probable' },
-  { value: 'possible', label: 'Possible' },
-  { value: 'unknown', label: 'Unknown' },
-]
+import { METADATA_VALIDATION, SPECIES_CONFIG } from '../../constants/config'
 
 export default function MetadataSpecies({
   species = '',
@@ -55,12 +48,22 @@ export default function MetadataSpecies({
       setUrlError('')
       return true
     }
-    if (!url.startsWith('http://') && !url.startsWith('https://')) {
-      setUrlError('URL must start with http:// or https://')
+    try {
+      const parsed = new URL(url)
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        setUrlError('URL must start with http:// or https://')
+        return false
+      }
+      if (!parsed.hostname) {
+        setUrlError('URL must include a hostname')
+        return false
+      }
+      setUrlError('')
+      return true
+    } catch {
+      setUrlError('Invalid URL format')
       return false
     }
-    setUrlError('')
-    return true
   }, [])
 
   const handleUrlChange = useCallback((value) => {
@@ -82,6 +85,11 @@ export default function MetadataSpecies({
           </div>
           <input
             type="text"
+            role="combobox"
+            aria-expanded={showSuggestions && suggestions.length > 0 && !!inputValue}
+            aria-controls="species-suggestions"
+            aria-autocomplete="list"
+            aria-haspopup="listbox"
             value={inputValue}
             onChange={(e) => {
               setInputValue(e.target.value)
@@ -99,10 +107,17 @@ export default function MetadataSpecies({
           />
 
           {showSuggestions && suggestions.length > 0 && inputValue && (
-            <ul className="absolute z-10 w-full mt-1 bg-white border border-gray-300 rounded-md shadow-lg dark:bg-gray-800 dark:border-gray-600 max-h-48 overflow-auto">
+            <ul
+              id="species-suggestions"
+              role="listbox"
+              aria-label="Species suggestions"
+              className="absolute z-10 w-full mt-1 bg-white border border-gray-300 rounded-md shadow-lg dark:bg-gray-800 dark:border-gray-600 max-h-48 overflow-auto"
+            >
               {suggestions.map((s) => (
                 <li
                   key={s.name}
+                  role="option"
+                  aria-selected={false}
                   onMouseDown={(e) => {
                     e.preventDefault() // Prevents blur before selection
                     handleSelectSuggestion(s.name)
@@ -144,7 +159,7 @@ export default function MetadataSpecies({
           disabled={disabled}
           className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:border-gray-600"
         >
-          {CONFIDENCE_OPTIONS.map((opt) => (
+          {SPECIES_CONFIG.CONFIDENCE_OPTIONS.map((opt) => (
             <option key={opt.value} value={opt.value}>
               {opt.label}
             </option>
@@ -168,10 +183,21 @@ export default function MetadataSpecies({
             placeholder="https://inaturalist.org/..."
             disabled={disabled}
             maxLength={METADATA_VALIDATION.MAX_REFERENCE_URL_LENGTH}
-            className={`w-full pl-9 pr-3 py-2 border rounded-md focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 ${
+            className={`w-full pl-9 ${urlInputValue && !urlError ? 'pr-10' : 'pr-3'} py-2 border rounded-md focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 ${
               urlError ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'
             }`}
           />
+          {urlInputValue && !urlError && (
+            <a
+              href={urlInputValue}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="absolute inset-y-0 right-0 pr-3 flex items-center text-blue-500 hover:text-blue-700"
+              aria-label="Visit reference link"
+            >
+              <ArrowTopRightOnSquareIcon className="w-4 h-4" />
+            </a>
+          )}
         </div>
         {urlError && (
           <p className="mt-1 text-xs text-red-500">{urlError}</p>

--- a/Firmware/webui/frontend/src/components/metadata/MetadataSpecies.jsx
+++ b/Firmware/webui/frontend/src/components/metadata/MetadataSpecies.jsx
@@ -1,7 +1,8 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import { MagnifyingGlassIcon, LinkIcon } from '@heroicons/react/24/outline'
 import useSpecies from '../../hooks/useSpecies'
+import { METADATA_VALIDATION } from '../../constants/config'
 
 const CONFIDENCE_OPTIONS = [
   { value: 'certain', label: 'Certain' },
@@ -26,30 +27,30 @@ export default function MetadataSpecies({
   // Sync local state with prop changes (e.g., when sidecar data loads async)
   useEffect(() => {
     setInputValue(species)
-  }, [species])
-
-  useEffect(() => {
     setUrlInputValue(referenceUrl)
-  }, [referenceUrl])
+  }, [species, referenceUrl])
 
   const { data: speciesData } = useSpecies({ sort: 'count', order: 'desc', limit: 20 })
 
-  const suggestions = speciesData?.species
-    ?.filter(s => s.name.toLowerCase().includes(inputValue.toLowerCase()))
-    ?.slice(0, 5) || []
+  // Memoize filtered suggestions to avoid recalculation on every render
+  const suggestions = useMemo(() =>
+    speciesData?.species
+      ?.filter(s => s.name.toLowerCase().includes(inputValue.toLowerCase()))
+      ?.slice(0, 5) || []
+  , [speciesData, inputValue])
 
-  const handleSpeciesChange = (value) => {
+  const handleSpeciesChange = useCallback((value) => {
     setInputValue(value)
     onChange('species', value)
-  }
+  }, [onChange])
 
-  const handleSelectSuggestion = (name) => {
+  const handleSelectSuggestion = useCallback((name) => {
     setInputValue(name)
     onChange('species', name)
     setShowSuggestions(false)
-  }
+  }, [onChange])
 
-  const validateUrl = (url) => {
+  const validateUrl = useCallback((url) => {
     if (!url) {
       setUrlError('')
       return true
@@ -60,13 +61,13 @@ export default function MetadataSpecies({
     }
     setUrlError('')
     return true
-  }
+  }, [])
 
-  const handleUrlChange = (value) => {
+  const handleUrlChange = useCallback((value) => {
     setUrlInputValue(value)
     validateUrl(value)
     onChange('referenceUrl', value)
-  }
+  }, [onChange, validateUrl])
 
   return (
     <div className="space-y-3">
@@ -87,12 +88,13 @@ export default function MetadataSpecies({
               setShowSuggestions(true)
             }}
             onBlur={() => {
-              setTimeout(() => setShowSuggestions(false), 200)
+              setShowSuggestions(false)
               handleSpeciesChange(inputValue)
             }}
             onFocus={() => setShowSuggestions(true)}
             placeholder="e.g., Actias luna"
             disabled={disabled}
+            maxLength={METADATA_VALIDATION.MAX_SPECIES_LENGTH}
             className="w-full pl-9 pr-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:border-gray-600"
           />
 
@@ -101,7 +103,10 @@ export default function MetadataSpecies({
               {suggestions.map((s) => (
                 <li
                   key={s.name}
-                  onClick={() => handleSelectSuggestion(s.name)}
+                  onMouseDown={(e) => {
+                    e.preventDefault() // Prevents blur before selection
+                    handleSelectSuggestion(s.name)
+                  }}
                   className="px-3 py-2 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700"
                 >
                   {s.name} <span className="text-gray-400">({s.count})</span>
@@ -123,6 +128,7 @@ export default function MetadataSpecies({
           onChange={(e) => onChange('commonName', e.target.value)}
           placeholder="e.g., Luna Moth"
           disabled={disabled}
+          maxLength={METADATA_VALIDATION.MAX_COMMON_NAME_LENGTH}
           className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:border-gray-600"
         />
       </div>
@@ -161,6 +167,7 @@ export default function MetadataSpecies({
             onChange={(e) => handleUrlChange(e.target.value)}
             placeholder="https://inaturalist.org/..."
             disabled={disabled}
+            maxLength={METADATA_VALIDATION.MAX_REFERENCE_URL_LENGTH}
             className={`w-full pl-9 pr-3 py-2 border rounded-md focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 ${
               urlError ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'
             }`}

--- a/Firmware/webui/frontend/src/components/metadata/MetadataTags.jsx
+++ b/Firmware/webui/frontend/src/components/metadata/MetadataTags.jsx
@@ -1,0 +1,129 @@
+import { useState, useRef } from 'react'
+import PropTypes from 'prop-types'
+import { XMarkIcon, ClipboardDocumentIcon } from '@heroicons/react/24/outline'
+import useTags from '../../hooks/useTags'
+
+export default function MetadataTags({
+  tags = [],
+  onAddTag,
+  onRemoveTag,
+  onCopyToNext,
+  disabled = false,
+}) {
+  const [inputValue, setInputValue] = useState('')
+  const [showSuggestions, setShowSuggestions] = useState(false)
+  const inputRef = useRef(null)
+
+  // Fetch available tags for autocomplete
+  const { data: tagsData } = useTags({ sort: 'count', order: 'desc', limit: 20 })
+
+  // Filter suggestions based on input
+  const suggestions =
+    tagsData?.tags
+      ?.filter((t) => t.name.toLowerCase().includes(inputValue.toLowerCase()))
+      ?.filter((t) => !tags.some((existing) => existing.toLowerCase() === t.name.toLowerCase()))
+      ?.slice(0, 5) || []
+
+  const handleAddTag = (tag) => {
+    const trimmed = tag.trim()
+    // Reject empty/whitespace tags
+    if (!trimmed) return
+    // Prevent duplicates (case-insensitive)
+    if (tags.some((t) => t.toLowerCase() === trimmed.toLowerCase())) return
+
+    onAddTag(trimmed)
+    setInputValue('')
+    setShowSuggestions(false)
+  }
+
+  const handleKeyDown = (e) => {
+    if (e.key === ',' || e.key === 'Enter') {
+      e.preventDefault()
+      handleAddTag(inputValue)
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      {/* Tag Chips */}
+      <div className="flex flex-wrap gap-2">
+        {tags.map((tag) => (
+          <span
+            key={tag}
+            className="inline-flex items-center gap-1 px-2 py-1 bg-blue-100 text-blue-800 text-sm rounded-full dark:bg-blue-900 dark:text-blue-200"
+          >
+            {tag}
+            <button
+              type="button"
+              onClick={() => onRemoveTag(tag)}
+              disabled={disabled}
+              className="hover:text-blue-600 focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
+              aria-label={`Remove tag ${tag}`}
+            >
+              <XMarkIcon className="w-4 h-4" />
+            </button>
+          </span>
+        ))}
+        {tags.length === 0 && (
+          <span className="text-gray-400 text-sm">Add tags...</span>
+        )}
+      </div>
+
+      {/* Input with Autocomplete */}
+      <div className="relative">
+        <input
+          ref={inputRef}
+          type="text"
+          value={inputValue}
+          onChange={(e) => {
+            setInputValue(e.target.value)
+            setShowSuggestions(true)
+          }}
+          onKeyDown={handleKeyDown}
+          onFocus={() => setShowSuggestions(true)}
+          onBlur={() => setTimeout(() => setShowSuggestions(false), 200)}
+          placeholder="Type to add tags..."
+          disabled={disabled}
+          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent dark:bg-gray-800 dark:border-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
+        />
+
+        {/* Suggestions Dropdown */}
+        {showSuggestions && suggestions.length > 0 && inputValue && !disabled && (
+          <ul className="absolute z-10 w-full mt-1 bg-white border border-gray-300 rounded-md shadow-lg dark:bg-gray-800 dark:border-gray-600 max-h-60 overflow-auto">
+            {suggestions.map((suggestion) => (
+              <li
+                key={suggestion.name}
+                onClick={() => handleAddTag(suggestion.name)}
+                className="px-3 py-2 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 flex justify-between items-center"
+              >
+                <span>{suggestion.name}</span>
+                <span className="text-gray-400 text-sm">({suggestion.count})</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* Copy to Next Button */}
+      {onCopyToNext && (
+        <button
+          type="button"
+          onClick={onCopyToNext}
+          disabled={disabled || tags.length === 0}
+          className="inline-flex items-center gap-1 text-sm text-gray-600 hover:text-blue-600 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <ClipboardDocumentIcon className="w-4 h-4" />
+          Copy tags to next photo
+        </button>
+      )}
+    </div>
+  )
+}
+
+MetadataTags.propTypes = {
+  tags: PropTypes.arrayOf(PropTypes.string),
+  onAddTag: PropTypes.func.isRequired,
+  onRemoveTag: PropTypes.func.isRequired,
+  onCopyToNext: PropTypes.func,
+  disabled: PropTypes.bool,
+}

--- a/Firmware/webui/frontend/src/components/metadata/MetadataTags.jsx
+++ b/Firmware/webui/frontend/src/components/metadata/MetadataTags.jsx
@@ -1,7 +1,8 @@
-import { useState, useRef } from 'react'
+import { useState, useRef, useMemo, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import { XMarkIcon, ClipboardDocumentIcon } from '@heroicons/react/24/outline'
 import useTags from '../../hooks/useTags'
+import { METADATA_VALIDATION } from '../../constants/config'
 
 export default function MetadataTags({
   tags = [],
@@ -17,14 +18,15 @@ export default function MetadataTags({
   // Fetch available tags for autocomplete
   const { data: tagsData } = useTags({ sort: 'count', order: 'desc', limit: 20 })
 
-  // Filter suggestions based on input
-  const suggestions =
+  // Memoize filtered suggestions to avoid expensive filtering on every render
+  const suggestions = useMemo(() =>
     tagsData?.tags
       ?.filter((t) => t.name.toLowerCase().includes(inputValue.toLowerCase()))
       ?.filter((t) => !tags.some((existing) => existing.toLowerCase() === t.name.toLowerCase()))
       ?.slice(0, 5) || []
+  , [tagsData, inputValue, tags])
 
-  const handleAddTag = (tag) => {
+  const handleAddTag = useCallback((tag) => {
     const trimmed = tag.trim()
     // Reject empty/whitespace tags
     if (!trimmed) return
@@ -34,14 +36,14 @@ export default function MetadataTags({
     onAddTag(trimmed)
     setInputValue('')
     setShowSuggestions(false)
-  }
+  }, [tags, onAddTag])
 
-  const handleKeyDown = (e) => {
+  const handleKeyDown = useCallback((e) => {
     if (e.key === ',' || e.key === 'Enter') {
       e.preventDefault()
       handleAddTag(inputValue)
     }
-  }
+  }, [handleAddTag, inputValue])
 
   return (
     <div className="space-y-2">
@@ -81,9 +83,10 @@ export default function MetadataTags({
           }}
           onKeyDown={handleKeyDown}
           onFocus={() => setShowSuggestions(true)}
-          onBlur={() => setTimeout(() => setShowSuggestions(false), 200)}
+          onBlur={() => setShowSuggestions(false)}
           placeholder="Type to add tags..."
           disabled={disabled}
+          maxLength={METADATA_VALIDATION.MAX_TAG_LENGTH}
           className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent dark:bg-gray-800 dark:border-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
         />
 
@@ -93,7 +96,10 @@ export default function MetadataTags({
             {suggestions.map((suggestion) => (
               <li
                 key={suggestion.name}
-                onClick={() => handleAddTag(suggestion.name)}
+                onMouseDown={(e) => {
+                  e.preventDefault() // Prevents blur before selection
+                  handleAddTag(suggestion.name)
+                }}
                 className="px-3 py-2 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 flex justify-between items-center"
               >
                 <span>{suggestion.name}</span>

--- a/Firmware/webui/frontend/src/components/metadata/SaveStatusIndicator.jsx
+++ b/Firmware/webui/frontend/src/components/metadata/SaveStatusIndicator.jsx
@@ -1,0 +1,68 @@
+import { useState, useEffect } from 'react'
+import PropTypes from 'prop-types'
+import { CheckCircleIcon, ExclamationCircleIcon } from '@heroicons/react/24/outline'
+
+export default function SaveStatusIndicator({ status, onRetry, errorMessage }) {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    if (status === 'idle') {
+      setVisible(false)
+      return
+    }
+
+    setVisible(true)
+
+    if (status === 'saved') {
+      const timer = setTimeout(() => setVisible(false), 2000)
+      return () => clearTimeout(timer)
+    }
+  }, [status])
+
+  if (!visible) return null
+
+  return (
+    <div
+      className="flex items-center gap-2 text-sm"
+      aria-live="polite"
+      role="status"
+    >
+      {status === 'saving' && (
+        <>
+          <div className="w-4 h-4 border-2 border-gray-300 border-t-blue-500 rounded-full animate-spin" />
+          <span className="text-gray-600 dark:text-gray-400">Saving...</span>
+        </>
+      )}
+
+      {status === 'saved' && (
+        <>
+          <CheckCircleIcon className="w-4 h-4 text-green-500" />
+          <span className="text-green-600 dark:text-green-400">Saved</span>
+        </>
+      )}
+
+      {status === 'error' && (
+        <>
+          <ExclamationCircleIcon className="w-4 h-4 text-red-500" />
+          <span className="text-red-600 dark:text-red-400">
+            {errorMessage || 'Save failed'}
+          </span>
+          {onRetry && (
+            <button
+              onClick={onRetry}
+              className="ml-2 text-blue-600 hover:text-blue-700 underline"
+            >
+              Retry
+            </button>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+SaveStatusIndicator.propTypes = {
+  status: PropTypes.oneOf(['idle', 'saving', 'saved', 'error']).isRequired,
+  onRetry: PropTypes.func,
+  errorMessage: PropTypes.string,
+}

--- a/Firmware/webui/frontend/src/components/metadata/__tests__/AccordionSection.test.jsx
+++ b/Firmware/webui/frontend/src/components/metadata/__tests__/AccordionSection.test.jsx
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import AccordionSection from '../AccordionSection'
+import { TagIcon } from '@heroicons/react/24/outline'
+
+// Mock ChevronDownIcon
+vi.mock('@heroicons/react/24/outline', () => ({
+  ChevronDownIcon: ({ className }) => <div data-testid="chevron-icon" className={className}>ChevronDown</div>,
+  TagIcon: () => <div data-testid="tag-icon">Tag</div>,
+}))
+
+describe('AccordionSection', () => {
+  it('test_renders_header_and_content', () => {
+    render(
+      <AccordionSection title="Test Section" icon={<TagIcon />}>
+        <div>Test Content</div>
+      </AccordionSection>
+    )
+
+    expect(screen.getByText('Test Section')).toBeInTheDocument()
+    expect(screen.getByTestId('tag-icon')).toBeInTheDocument()
+    expect(screen.getByText('Test Content')).toBeInTheDocument()
+    expect(screen.getByTestId('chevron-icon')).toBeInTheDocument()
+  })
+
+  it('test_starts_expanded_by_default', () => {
+    render(
+      <AccordionSection title="Test Section">
+        <div>Test Content</div>
+      </AccordionSection>
+    )
+
+    const content = screen.getByText('Test Content')
+    expect(content).toBeVisible()
+
+    const header = screen.getByRole('button')
+    expect(header).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('test_starts_collapsed_when_defaultExpanded_false', () => {
+    render(
+      <AccordionSection title="Test Section" defaultExpanded={false}>
+        <div>Test Content</div>
+      </AccordionSection>
+    )
+
+    const header = screen.getByRole('button')
+    expect(header).toHaveAttribute('aria-expanded', 'false')
+
+    // Content div should have max-h-0 class when collapsed
+    const contentContainer = screen.getByText('Test Content').parentElement.parentElement
+    expect(contentContainer.className).toContain('max-h-0')
+  })
+
+  it('test_toggles_on_header_click', () => {
+    render(
+      <AccordionSection title="Test Section" defaultExpanded={true}>
+        <div>Test Content</div>
+      </AccordionSection>
+    )
+
+    const header = screen.getByRole('button')
+
+    // Initially expanded
+    expect(header).toHaveAttribute('aria-expanded', 'true')
+
+    // Click to collapse
+    fireEvent.click(header)
+    expect(header).toHaveAttribute('aria-expanded', 'false')
+
+    // Click to expand again
+    fireEvent.click(header)
+    expect(header).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('test_has_proper_aria_attributes', () => {
+    render(
+      <AccordionSection title="Test Section">
+        <div>Test Content</div>
+      </AccordionSection>
+    )
+
+    const header = screen.getByRole('button')
+
+    // Check aria-expanded
+    expect(header).toHaveAttribute('aria-expanded')
+
+    // Check aria-controls
+    expect(header).toHaveAttribute('aria-controls')
+    const controlsId = header.getAttribute('aria-controls')
+    expect(controlsId).toBeTruthy()
+
+    // Check that controlled element exists with matching id
+    const contentElement = document.getElementById(controlsId)
+    expect(contentElement).toBeInTheDocument()
+  })
+
+  it('test_keyboard_space_toggles', () => {
+    render(
+      <AccordionSection title="Test Section" defaultExpanded={true}>
+        <div>Test Content</div>
+      </AccordionSection>
+    )
+
+    const header = screen.getByRole('button')
+
+    // Initially expanded
+    expect(header).toHaveAttribute('aria-expanded', 'true')
+
+    // Press Space to collapse
+    fireEvent.keyDown(header, { key: ' ', code: 'Space' })
+    expect(header).toHaveAttribute('aria-expanded', 'false')
+
+    // Press Space to expand again
+    fireEvent.keyDown(header, { key: ' ', code: 'Space' })
+    expect(header).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('test_keyboard_enter_toggles', () => {
+    render(
+      <AccordionSection title="Test Section" defaultExpanded={true}>
+        <div>Test Content</div>
+      </AccordionSection>
+    )
+
+    const header = screen.getByRole('button')
+
+    // Initially expanded
+    expect(header).toHaveAttribute('aria-expanded', 'true')
+
+    // Press Enter to collapse
+    fireEvent.keyDown(header, { key: 'Enter', code: 'Enter' })
+    expect(header).toHaveAttribute('aria-expanded', 'false')
+
+    // Press Enter to expand again
+    fireEvent.keyDown(header, { key: 'Enter', code: 'Enter' })
+    expect(header).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('test_icon_rotates_on_expand', () => {
+    render(
+      <AccordionSection title="Test Section" defaultExpanded={false}>
+        <div>Test Content</div>
+      </AccordionSection>
+    )
+
+    const chevronIcon = screen.getByTestId('chevron-icon')
+    const header = screen.getByRole('button')
+
+    // Initially collapsed - no rotation
+    expect(chevronIcon.className).not.toContain('rotate-180')
+
+    // Click to expand - should rotate
+    fireEvent.click(header)
+    expect(chevronIcon.className).toContain('rotate-180')
+
+    // Click to collapse - rotation removed
+    fireEvent.click(header)
+    expect(chevronIcon.className).not.toContain('rotate-180')
+  })
+
+  it('test_applies_custom_className', () => {
+    const customClass = 'custom-accordion-class'
+    const { container } = render(
+      <AccordionSection title="Test Section" className={customClass}>
+        <div>Test Content</div>
+      </AccordionSection>
+    )
+
+    // The wrapper div should have the custom class
+    const wrapper = container.firstChild
+    expect(wrapper.className).toContain(customClass)
+  })
+})

--- a/Firmware/webui/frontend/src/components/metadata/__tests__/AccordionSection.test.jsx
+++ b/Firmware/webui/frontend/src/components/metadata/__tests__/AccordionSection.test.jsx
@@ -47,9 +47,9 @@ describe('AccordionSection', () => {
     const header = screen.getByRole('button')
     expect(header).toHaveAttribute('aria-expanded', 'false')
 
-    // Content div should have max-h-0 class when collapsed
-    const contentContainer = screen.getByText('Test Content').parentElement.parentElement
-    expect(contentContainer.className).toContain('max-h-0')
+    // Content grid should have grid-rows-[0fr] class when collapsed
+    const contentContainer = screen.getByText('Test Content').parentElement.parentElement.parentElement
+    expect(contentContainer.className).toContain('grid-rows-[0fr]')
   })
 
   it('test_toggles_on_header_click', () => {

--- a/Firmware/webui/frontend/src/components/metadata/__tests__/MetadataCustomFields.test.jsx
+++ b/Firmware/webui/frontend/src/components/metadata/__tests__/MetadataCustomFields.test.jsx
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import MetadataCustomFields from '../MetadataCustomFields'
+
+describe('MetadataCustomFields', () => {
+  it('test_renders_existing_key_value_pairs', () => {
+    const fields = {
+      'Location': 'Forest',
+      'Weather': 'Sunny',
+      'Temperature': '72F'
+    }
+    const onChange = vi.fn()
+
+    render(<MetadataCustomFields fields={fields} onChange={onChange} />)
+
+    // Check that all key inputs are rendered with correct values
+    expect(screen.getByDisplayValue('Location')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Forest')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Weather')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Sunny')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Temperature')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('72F')).toBeInTheDocument()
+
+    // Check that delete buttons are rendered for each field
+    const deleteButtons = screen.getAllByLabelText(/Delete field/i)
+    expect(deleteButtons).toHaveLength(3)
+  })
+
+  it('test_add_field_button_creates_new_pair', () => {
+    const fields = { 'existing': 'value' }
+    const onChange = vi.fn()
+
+    render(<MetadataCustomFields fields={fields} onChange={onChange} />)
+
+    const addButton = screen.getByRole('button', { name: /Add custom field/i })
+    fireEvent.click(addButton)
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    const newFields = onChange.mock.calls[0][0]
+
+    // Should have the existing field plus a new empty field
+    expect(Object.keys(newFields).length).toBe(2)
+    expect(newFields['existing']).toBe('value')
+
+    // New field should have an auto-generated key and empty value
+    const newKey = Object.keys(newFields).find(k => k !== 'existing')
+    expect(newKey).toBeTruthy()
+    expect(newFields[newKey]).toBe('')
+  })
+
+  it('test_editing_key_calls_onChange', () => {
+    const fields = { 'OldKey': 'value' }
+    const onChange = vi.fn()
+
+    render(<MetadataCustomFields fields={fields} onChange={onChange} />)
+
+    const keyInput = screen.getByDisplayValue('OldKey')
+    fireEvent.change(keyInput, { target: { value: 'NewKey' } })
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith({ 'NewKey': 'value' })
+  })
+
+  it('test_editing_value_calls_onChange', () => {
+    const fields = { 'key': 'OldValue' }
+    const onChange = vi.fn()
+
+    render(<MetadataCustomFields fields={fields} onChange={onChange} />)
+
+    const valueInput = screen.getByDisplayValue('OldValue')
+    fireEvent.change(valueInput, { target: { value: 'NewValue' } })
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith({ 'key': 'NewValue' })
+  })
+
+  it('test_delete_button_removes_pair', () => {
+    const fields = {
+      'Field1': 'Value1',
+      'Field2': 'Value2'
+    }
+    const onChange = vi.fn()
+
+    render(<MetadataCustomFields fields={fields} onChange={onChange} />)
+
+    const deleteButton = screen.getByLabelText('Delete field Field1')
+    fireEvent.click(deleteButton)
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith({ 'Field2': 'Value2' })
+  })
+
+  it('test_validates_unique_keys', () => {
+    const fields = {
+      'existing': 'value1',
+      'another': 'value2'
+    }
+    const onChange = vi.fn()
+
+    render(<MetadataCustomFields fields={fields} onChange={onChange} />)
+
+    // Try to change 'another' to 'existing' (duplicate)
+    const keyInput = screen.getByDisplayValue('another')
+    fireEvent.change(keyInput, { target: { value: 'existing' } })
+
+    // Should show error message
+    expect(screen.getByText('Key "existing" already exists')).toBeInTheDocument()
+
+    // onChange should not be called due to validation error
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('test_max_100_custom_fields', () => {
+    // Create 100 fields
+    const fields = {}
+    for (let i = 0; i < 100; i++) {
+      fields[`field${i}`] = `value${i}`
+    }
+    const onChange = vi.fn()
+
+    render(<MetadataCustomFields fields={fields} onChange={onChange} />)
+
+    const addButton = screen.getByRole('button', { name: /Add custom field/i })
+
+    // Button should be disabled
+    expect(addButton).toBeDisabled()
+
+    // Should show max limit message
+    expect(screen.getByText(/max 100/i)).toBeInTheDocument()
+  })
+
+  it('test_empty_state_shows_add_button', () => {
+    const onChange = vi.fn()
+
+    render(<MetadataCustomFields fields={{}} onChange={onChange} />)
+
+    // Should show empty state message
+    expect(screen.getByText('No custom fields')).toBeInTheDocument()
+
+    // Should still show add button
+    expect(screen.getByRole('button', { name: /Add custom field/i })).toBeInTheDocument()
+  })
+
+  it('test_disabled_state', () => {
+    const fields = { 'key': 'value' }
+    const onChange = vi.fn()
+
+    render(<MetadataCustomFields fields={fields} onChange={onChange} disabled={true} />)
+
+    // Input fields should be disabled
+    const keyInput = screen.getByDisplayValue('key')
+    const valueInput = screen.getByDisplayValue('value')
+    expect(keyInput).toBeDisabled()
+    expect(valueInput).toBeDisabled()
+
+    // Delete button should be disabled
+    const deleteButton = screen.getByLabelText('Delete field key')
+    expect(deleteButton).toBeDisabled()
+
+    // Add button should be disabled
+    const addButton = screen.getByRole('button', { name: /Add custom field/i })
+    expect(addButton).toBeDisabled()
+  })
+
+  it('test_key_placeholder', () => {
+    const onChange = vi.fn()
+
+    render(<MetadataCustomFields fields={{}} onChange={onChange} />)
+
+    // Click add to create a new empty field
+    const addButton = screen.getByRole('button', { name: /Add custom field/i })
+    fireEvent.click(addButton)
+
+    // Re-render with the new field
+    const newFields = onChange.mock.calls[0][0]
+    const { rerender } = render(<MetadataCustomFields fields={newFields} onChange={onChange} />)
+
+    // Should show "Field name" placeholder
+    const keyInput = screen.getByPlaceholderText('Field name')
+    expect(keyInput).toBeInTheDocument()
+  })
+
+  it('test_value_placeholder', () => {
+    const onChange = vi.fn()
+
+    render(<MetadataCustomFields fields={{}} onChange={onChange} />)
+
+    // Click add to create a new empty field
+    const addButton = screen.getByRole('button', { name: /Add custom field/i })
+    fireEvent.click(addButton)
+
+    // Re-render with the new field
+    const newFields = onChange.mock.calls[0][0]
+    const { rerender } = render(<MetadataCustomFields fields={newFields} onChange={onChange} />)
+
+    // Should show "Value" placeholder
+    const valueInput = screen.getByPlaceholderText('Value')
+    expect(valueInput).toBeInTheDocument()
+  })
+})

--- a/Firmware/webui/frontend/src/components/metadata/__tests__/MetadataEXIF.test.jsx
+++ b/Firmware/webui/frontend/src/components/metadata/__tests__/MetadataEXIF.test.jsx
@@ -1,0 +1,323 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import MetadataEXIF from '../MetadataEXIF'
+
+describe('MetadataEXIF', () => {
+  let clipboardWriteTextSpy
+
+  const mockData = {
+    camera: {
+      make: 'Arducam',
+      model: 'OwlSight 64MP',
+      lens: '6mm Wide Angle',
+      sensor: 'IMX682',
+    },
+    capture: {
+      iso: 400,
+      exposure_time: '1/500',
+      f_number: 2.8,
+      focal_length: '6.0mm',
+      exposure_mode: 'Manual',
+      white_balance: 'Daylight',
+      timestamp: '2024-01-15T10:30:00Z',
+    },
+    location: {
+      latitude: 37.7749,
+      longitude: -122.4194,
+      altitude: 10.5,
+    },
+    deployment: {
+      mothbox_id: 'mothbox-backyard',
+      firmware_version: '5',
+    },
+  }
+
+  beforeEach(() => {
+    // Mock clipboard API
+    clipboardWriteTextSpy = vi.fn().mockResolvedValue()
+    Object.defineProperty(navigator, 'clipboard', {
+      value: {
+        writeText: clipboardWriteTextSpy,
+      },
+      writable: true,
+      configurable: true,
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('Camera Info Section', () => {
+    it('test_renders_camera_info_section', () => {
+      render(<MetadataEXIF data={mockData} />)
+
+      // Check section header
+      expect(screen.getByText('Camera')).toBeInTheDocument()
+
+      // Check camera fields
+      expect(screen.getByText('Make')).toBeInTheDocument()
+      expect(screen.getByText('Arducam')).toBeInTheDocument()
+
+      expect(screen.getByText('Model')).toBeInTheDocument()
+      expect(screen.getByText('OwlSight 64MP')).toBeInTheDocument()
+
+      expect(screen.getByText('Lens')).toBeInTheDocument()
+      expect(screen.getByText('6mm Wide Angle')).toBeInTheDocument()
+    })
+  })
+
+  describe('Capture Settings Section', () => {
+    it('test_renders_capture_settings_section', () => {
+      render(<MetadataEXIF data={mockData} />)
+
+      // Check section header
+      expect(screen.getByText('Capture Settings')).toBeInTheDocument()
+
+      // Check capture fields
+      expect(screen.getByText('ISO')).toBeInTheDocument()
+      expect(screen.getByText('ISO 400')).toBeInTheDocument()
+
+      expect(screen.getByText('Shutter Speed')).toBeInTheDocument()
+      expect(screen.getByText('1/500')).toBeInTheDocument()
+
+      expect(screen.getByText('Aperture')).toBeInTheDocument()
+      expect(screen.getByText('f/2.8')).toBeInTheDocument()
+
+      expect(screen.getByText('Focal Length')).toBeInTheDocument()
+      expect(screen.getByText('6.0mm')).toBeInTheDocument()
+
+      expect(screen.getByText('Exposure Mode')).toBeInTheDocument()
+      expect(screen.getByText('Manual')).toBeInTheDocument()
+
+      expect(screen.getByText('White Balance')).toBeInTheDocument()
+      expect(screen.getByText('Daylight')).toBeInTheDocument()
+    })
+  })
+
+  describe('Deployment/Location Section', () => {
+    it('test_renders_deployment_info_section', () => {
+      render(<MetadataEXIF data={mockData} />)
+
+      // Check section header
+      expect(screen.getByText('Location & Deployment')).toBeInTheDocument()
+
+      // Check deployment fields
+      expect(screen.getByText('Deployment')).toBeInTheDocument()
+      expect(screen.getByText('mothbox-backyard')).toBeInTheDocument()
+
+      expect(screen.getByText('Device')).toBeInTheDocument()
+      expect(screen.getByText('5')).toBeInTheDocument()
+    })
+  })
+
+  describe('Read-Only Behavior', () => {
+    it('test_all_fields_are_read_only', () => {
+      const { container } = render(<MetadataEXIF data={mockData} />)
+
+      // Should not have any input, textarea, or contenteditable elements
+      const inputs = container.querySelectorAll('input')
+      const textareas = container.querySelectorAll('textarea')
+      const contentEditables = container.querySelectorAll('[contenteditable="true"]')
+
+      expect(inputs.length).toBe(0)
+      expect(textareas.length).toBe(0)
+      expect(contentEditables.length).toBe(0)
+    })
+  })
+
+  describe('Copy Functionality', () => {
+    it('test_copy_button_works_for_each_field', async () => {
+      render(<MetadataEXIF data={mockData} />)
+
+      // Find all copy buttons (clipboard icons)
+      const copyButtons = screen.getAllByRole('button', { name: /copy to clipboard/i })
+      expect(copyButtons.length).toBeGreaterThan(0)
+
+      // Test copying the camera make
+      const firstCopyButton = copyButtons[0]
+
+      await act(async () => {
+        firstCopyButton.click()
+        await clipboardWriteTextSpy.mock.results[0].value
+      })
+
+      // Verify clipboard API was called
+      expect(clipboardWriteTextSpy).toHaveBeenCalled()
+
+      // Check for success icon
+      await waitFor(() => {
+        const checkIcon = screen.getByLabelText(/copied to clipboard/i)
+        expect(checkIcon).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('Missing Data Handling', () => {
+    it('test_handles_missing_data_gracefully', () => {
+      const emptyData = {}
+      render(<MetadataEXIF data={emptyData} />)
+
+      // Should show N/A for missing fields
+      const naElements = screen.getAllByText('N/A')
+      expect(naElements.length).toBeGreaterThan(0)
+    })
+
+    it('test_handles_null_values', () => {
+      const dataWithNulls = {
+        camera: {
+          make: null,
+          model: null,
+          lens: null,
+        },
+        capture: {
+          iso: null,
+          exposure_time: null,
+        },
+      }
+      render(<MetadataEXIF data={dataWithNulls} />)
+
+      // Should show N/A for null values
+      const naElements = screen.getAllByText('N/A')
+      expect(naElements.length).toBeGreaterThan(0)
+    })
+
+    it('test_handles_undefined_data_prop', () => {
+      render(<MetadataEXIF data={undefined} />)
+
+      // Should render without crashing
+      expect(screen.getByText('Camera')).toBeInTheDocument()
+    })
+  })
+
+  describe('GPS Coordinate Formatting', () => {
+    it('test_formats_gps_coordinates', () => {
+      render(<MetadataEXIF data={mockData} />)
+
+      // Should format GPS coordinates as "lat° N/S, lon° E/W"
+      expect(screen.getByText('GPS')).toBeInTheDocument()
+
+      // Check for formatted GPS string (37.7749° N, 122.4194° W)
+      const gpsText = screen.getByText(/37\.7749.*°.*N.*122\.4194.*°.*W/i)
+      expect(gpsText).toBeInTheDocument()
+    })
+
+    it('test_handles_missing_gps_coordinates', () => {
+      const dataWithoutGPS = {
+        ...mockData,
+        location: {},
+      }
+      render(<MetadataEXIF data={dataWithoutGPS} />)
+
+      // GPS field should show N/A
+      expect(screen.getByText('GPS')).toBeInTheDocument()
+    })
+
+    it('test_formats_altitude', () => {
+      render(<MetadataEXIF data={mockData} />)
+
+      // Should show altitude in meters
+      expect(screen.getByText('Altitude')).toBeInTheDocument()
+      expect(screen.getByText('10.5m')).toBeInTheDocument()
+    })
+  })
+
+  describe('Date/Time Formatting', () => {
+    it('test_formats_date_time', () => {
+      render(<MetadataEXIF data={mockData} />)
+
+      // Should format timestamp
+      expect(screen.getByText('Captured')).toBeInTheDocument()
+
+      // Should show formatted date (locale-dependent)
+      // The timestamp '2024-01-15T10:30:00Z' should be formatted
+      // We just check that it's rendered and not showing 'N/A'
+      const { container } = render(<MetadataEXIF data={mockData} />)
+      const capturedText = container.textContent
+
+      // Check that 'Captured' label exists and formatted date is present (not 'N/A')
+      expect(capturedText).toContain('Captured')
+      // The formatted date will contain numbers (year/month/day)
+      expect(capturedText).toMatch(/\d/)
+    })
+
+    it('test_handles_invalid_timestamp', () => {
+      const dataWithInvalidTimestamp = {
+        ...mockData,
+        capture: {
+          ...mockData.capture,
+          timestamp: 'invalid-date',
+        },
+      }
+      render(<MetadataEXIF data={dataWithInvalidTimestamp} />)
+
+      // Should show N/A for invalid timestamp
+      expect(screen.getByText('Captured')).toBeInTheDocument()
+    })
+  })
+
+  describe('Section Headers', () => {
+    it('test_shows_section_headers', () => {
+      render(<MetadataEXIF data={mockData} />)
+
+      // Check all three section headers exist
+      expect(screen.getByText('Camera')).toBeInTheDocument()
+      expect(screen.getByText('Capture Settings')).toBeInTheDocument()
+      expect(screen.getByText('Location & Deployment')).toBeInTheDocument()
+    })
+
+    it('test_section_headers_have_icons', () => {
+      const { container } = render(<MetadataEXIF data={mockData} />)
+
+      // Check that section headers have icons (svg elements)
+      const headers = container.querySelectorAll('h4')
+      expect(headers.length).toBe(3)
+
+      headers.forEach(header => {
+        const icon = header.querySelector('svg')
+        expect(icon).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('test_handles_zero_values_correctly', () => {
+      const dataWithZeros = {
+        ...mockData,
+        capture: {
+          ...mockData.capture,
+          iso: 0,
+        },
+        location: {
+          latitude: 0,
+          longitude: 0,
+          altitude: 0,
+        },
+      }
+      render(<MetadataEXIF data={dataWithZeros} />)
+
+      // Zero ISO is invalid photographically, should show N/A
+      expect(screen.getByText('ISO')).toBeInTheDocument()
+      // formatISO(0) returns "N/A" because ISO <= 0 is invalid
+
+      // But zero coordinates are valid (Null Island)
+      expect(screen.getByText('0.000000° N, 0.000000° E')).toBeInTheDocument()
+      expect(screen.getByText('0m')).toBeInTheDocument()
+    })
+
+    it('test_handles_negative_coordinates', () => {
+      const dataWithNegativeCoords = {
+        ...mockData,
+        location: {
+          latitude: -37.7749,
+          longitude: -122.4194,
+        },
+      }
+      render(<MetadataEXIF data={dataWithNegativeCoords} />)
+
+      // Should show S and W for negative coordinates
+      const gpsText = screen.getByText(/37\.7749.*°.*S.*122\.4194.*°.*W/i)
+      expect(gpsText).toBeInTheDocument()
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/components/metadata/__tests__/MetadataNotes.test.jsx
+++ b/Firmware/webui/frontend/src/components/metadata/__tests__/MetadataNotes.test.jsx
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import MetadataNotes from '../MetadataNotes'
+
+describe('MetadataNotes', () => {
+  let mockOnChange
+
+  beforeEach(() => {
+    mockOnChange = vi.fn()
+  })
+
+  it('test_renders_textarea_with_current_value', () => {
+    const testValue = 'These are my current notes'
+    render(<MetadataNotes value={testValue} onChange={mockOnChange} />)
+
+    const textarea = screen.getByPlaceholderText(/add notes about this photo/i)
+    expect(textarea).toBeInTheDocument()
+    expect(textarea.value).toBe(testValue)
+  })
+
+  it('test_textarea_auto_expands_on_content', async () => {
+    const { rerender } = render(<MetadataNotes value="" onChange={mockOnChange} />)
+
+    const textarea = screen.getByPlaceholderText(/add notes about this photo/i)
+
+    // Mock scrollHeight to simulate actual browser behavior
+    Object.defineProperty(textarea, 'scrollHeight', {
+      configurable: true,
+      value: 150
+    })
+
+    // Add multi-line content
+    const longText = 'Line 1\nLine 2\nLine 3\nLine 4\nLine 5'
+    rerender(<MetadataNotes value={longText} onChange={mockOnChange} />)
+
+    await waitFor(() => {
+      // Height should be set based on scrollHeight (minimum 80px)
+      const heightValue = parseInt(textarea.style.height)
+      expect(heightValue).toBeGreaterThanOrEqual(80)
+      // With mocked scrollHeight of 150, should use that value
+      expect(heightValue).toBe(150)
+    })
+  })
+
+  it('test_shows_character_count', () => {
+    const testValue = 'Hello World'
+    render(<MetadataNotes value={testValue} onChange={mockOnChange} />)
+
+    // Should show character count
+    expect(screen.getByText(/11.*5,000 characters/i)).toBeInTheDocument()
+  })
+
+  it('test_calls_onChange_on_input', async () => {
+    const user = userEvent.setup()
+    render(<MetadataNotes value="" onChange={mockOnChange} />)
+
+    const textarea = screen.getByPlaceholderText(/add notes about this photo/i)
+    await user.type(textarea, 'New text')
+
+    expect(mockOnChange).toHaveBeenCalled()
+    // Should be called once per character typed
+    expect(mockOnChange.mock.calls.length).toBeGreaterThan(0)
+  })
+
+  it('test_timestamp_button_inserts_timestamp', async () => {
+    const user = userEvent.setup()
+    const initialValue = 'Existing notes'
+    render(<MetadataNotes value={initialValue} onChange={mockOnChange} />)
+
+    const timestampButton = screen.getByRole('button', { name: /insert timestamp|add timestamp/i })
+    await user.click(timestampButton)
+
+    expect(mockOnChange).toHaveBeenCalled()
+    const newValue = mockOnChange.mock.calls[0][0]
+
+    // Should contain timestamp format YYYY-MM-DD HH:mm -
+    expect(newValue).toMatch(/\d{4}-\d{2}-\d{2} \d{2}:\d{2} - /)
+    // Should append to existing content
+    expect(newValue).toContain('Existing notes')
+  })
+
+  it('test_preserves_whitespace_and_newlines', () => {
+    const testValue = 'Line 1\n  Indented line\n\nDouble newline'
+    render(<MetadataNotes value={testValue} onChange={mockOnChange} />)
+
+    const textarea = screen.getByPlaceholderText(/add notes about this photo/i)
+    expect(textarea.value).toBe(testValue)
+
+    // Check that textarea has whitespace-pre-wrap styling
+    const styles = window.getComputedStyle(textarea)
+    expect(styles.whiteSpace).toMatch(/pre-wrap/)
+  })
+
+  it('test_placeholder_when_empty', () => {
+    render(<MetadataNotes value="" onChange={mockOnChange} />)
+
+    const textarea = screen.getByPlaceholderText(/add notes about this photo/i)
+    expect(textarea).toBeInTheDocument()
+    expect(textarea.value).toBe('')
+  })
+
+  it('test_disabled_state', async () => {
+    const user = userEvent.setup()
+    render(<MetadataNotes value="" onChange={mockOnChange} disabled={true} />)
+
+    const textarea = screen.getByPlaceholderText(/add notes about this photo/i)
+    const timestampButton = screen.getByRole('button', { name: /insert timestamp|add timestamp/i })
+
+    expect(textarea).toBeDisabled()
+    expect(timestampButton).toBeDisabled()
+
+    // Try to type - should not work
+    await user.type(textarea, 'Test')
+    expect(mockOnChange).not.toHaveBeenCalled()
+  })
+
+  it('test_max_length_indicator', () => {
+    const maxLength = 100
+    const nearLimitValue = 'x'.repeat(91) // 91% of 100
+    const atLimitValue = 'x'.repeat(100)
+
+    // Test near limit (90%+)
+    const { rerender } = render(
+      <MetadataNotes value={nearLimitValue} onChange={mockOnChange} maxLength={maxLength} />
+    )
+
+    let charCountElement = screen.getByText(/91.*100 characters/i)
+    expect(charCountElement).toHaveClass('text-yellow-500')
+
+    // Test at limit
+    rerender(<MetadataNotes value={atLimitValue} onChange={mockOnChange} maxLength={maxLength} />)
+
+    charCountElement = screen.getByText(/100.*100 characters/i)
+    expect(charCountElement).toHaveClass('text-red-500')
+  })
+
+  it('test_keyboard_ctrl_enter_blur', async () => {
+    render(<MetadataNotes value="Test" onChange={mockOnChange} />)
+
+    const textarea = screen.getByPlaceholderText(/add notes about this photo/i)
+
+    // Focus the textarea
+    textarea.focus()
+    expect(document.activeElement).toBe(textarea)
+
+    // Press Ctrl+Enter
+    fireEvent.keyDown(textarea, { key: 'Enter', ctrlKey: true })
+
+    await waitFor(() => {
+      expect(document.activeElement).not.toBe(textarea)
+    })
+  })
+
+  it('test_prevents_exceeding_max_length', async () => {
+    const user = userEvent.setup()
+    const maxLength = 10
+    const initialValue = 'x'.repeat(10)
+
+    render(<MetadataNotes value={initialValue} onChange={mockOnChange} maxLength={maxLength} />)
+
+    const textarea = screen.getByPlaceholderText(/add notes about this photo/i)
+
+    // Try to add more text
+    await user.type(textarea, 'y')
+
+    // onChange should not be called with value exceeding max length
+    if (mockOnChange.mock.calls.length > 0) {
+      const newValue = mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1][0]
+      expect(newValue.length).toBeLessThanOrEqual(maxLength)
+    }
+  })
+
+  it('test_timestamp_inserts_at_cursor_position', async () => {
+    const user = userEvent.setup()
+    const initialValue = 'Start Middle End'
+    render(<MetadataNotes value={initialValue} onChange={mockOnChange} />)
+
+    const textarea = screen.getByPlaceholderText(/add notes about this photo/i)
+
+    // Set cursor position to middle (after "Start ")
+    textarea.focus()
+    textarea.setSelectionRange(6, 6)
+
+    const timestampButton = screen.getByRole('button', { name: /insert timestamp|add timestamp/i })
+    await user.click(timestampButton)
+
+    expect(mockOnChange).toHaveBeenCalled()
+    const newValue = mockOnChange.mock.calls[0][0]
+
+    // Timestamp should be inserted at cursor position (after "Start ")
+    expect(newValue).toMatch(/^Start \d{4}-\d{2}-\d{2} \d{2}:\d{2} - Middle End$/)
+  })
+
+  it('test_displays_helpful_keyboard_hint', () => {
+    render(<MetadataNotes value="" onChange={mockOnChange} />)
+
+    expect(screen.getByText(/ctrl\+enter to finish editing/i)).toBeInTheDocument()
+  })
+})

--- a/Firmware/webui/frontend/src/components/metadata/__tests__/MetadataNotes.test.jsx
+++ b/Firmware/webui/frontend/src/components/metadata/__tests__/MetadataNotes.test.jsx
@@ -47,8 +47,8 @@ describe('MetadataNotes', () => {
     const testValue = 'Hello World'
     render(<MetadataNotes value={testValue} onChange={mockOnChange} />)
 
-    // Should show character count
-    expect(screen.getByText(/11.*5,000 characters/i)).toBeInTheDocument()
+    // Should show character count (default max is 10,000 from METADATA_VALIDATION.MAX_NOTES_LENGTH)
+    expect(screen.getByText(/11.*10,000 characters/i)).toBeInTheDocument()
   })
 
   it('test_calls_onChange_on_input', async () => {

--- a/Firmware/webui/frontend/src/components/metadata/__tests__/MetadataPanel.integration.test.jsx
+++ b/Firmware/webui/frontend/src/components/metadata/__tests__/MetadataPanel.integration.test.jsx
@@ -1,0 +1,378 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import MetadataPanel from '../MetadataPanel'
+import { clearTagsInvalidationTimeout } from '../../../hooks/useSidecarMetadata'
+
+// Mock the API layer ONLY - not hooks or components
+// This tests the real integration between MetadataPanel, useAutoSave, useSidecarMetadata, etc.
+vi.mock('../../../utils/api', () => ({
+  api: {
+    get: vi.fn(),
+  },
+  getPhotoSidecarMetadata: vi.fn(),
+  updatePhotoSidecarMetadata: vi.fn(),
+  getAllTags: vi.fn(),
+  getAllSpecies: vi.fn(),
+}))
+
+// Import mocked API after vi.mock
+import * as apiModule from '../../../utils/api'
+const api = apiModule
+
+/**
+ * Real Integration Tests for MetadataPanel
+ *
+ * These tests use the REAL hooks and components, only mocking at the API boundary.
+ * This tests that:
+ * - useSidecarMetadata properly fetches and updates data
+ * - useAutoSave properly debounces saves
+ * - MetadataTags, MetadataSpecies, MetadataNotes work together
+ * - Optimistic updates work correctly
+ */
+describe('MetadataPanel Integration Tests', () => {
+  let queryClient
+
+  const createWrapper = () => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    })
+    return function Wrapper({ children }) {
+      return (
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      )
+    }
+  }
+
+  const mockSidecarData = {
+    version: '1.1',
+    photo_filename: 'test_photo.jpg',
+    user_tags: ['moth', 'nocturnal'],
+    species: 'Actias luna',
+    species_confidence: 'probable',
+    species_common_name: 'Luna Moth',
+    species_reference_url: '',
+    notes: 'Found near porch light',
+    custom: {},
+  }
+
+  const mockExifData = {
+    camera: { make: 'Arducam', model: 'OwlSight 64MP' },
+    capture: { iso: 800, exposure_time: '1/60' },
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    // Default API responses
+    // Mock usePhotoMetadata's api.get call for EXIF data
+    api.api.get.mockResolvedValue({ data: mockExifData })
+    // Mock sidecar metadata calls
+    api.getPhotoSidecarMetadata.mockResolvedValue({ data: mockSidecarData })
+    api.updatePhotoSidecarMetadata.mockResolvedValue({ data: { ...mockSidecarData } })
+    api.getAllTags.mockResolvedValue({ data: { tags: [{ name: 'moth', count: 5 }], total: 1 } })
+    api.getAllSpecies.mockResolvedValue({ data: { species: [{ name: 'Actias luna', count: 3 }], total: 1 } })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    clearTagsInvalidationTimeout()
+    if (queryClient) {
+      queryClient.clear()
+    }
+  })
+
+  describe('Data Loading Integration', () => {
+    it('loads sidecar metadata using real useSidecarMetadata hook', async () => {
+      render(
+        <MetadataPanel photoPath="/photos/test_photo.jpg" />,
+        { wrapper: createWrapper() }
+      )
+
+      // Should show loading state initially
+      expect(screen.getByTestId('metadata-skeleton')).toBeInTheDocument()
+
+      // Wait for real data to load
+      await waitFor(() => {
+        expect(api.getPhotoSidecarMetadata).toHaveBeenCalledWith('test_photo.jpg')
+      })
+
+      // Verify data is displayed (from real hooks)
+      await waitFor(() => {
+        expect(screen.getByText('moth')).toBeInTheDocument()
+        expect(screen.getByText('nocturnal')).toBeInTheDocument()
+      })
+    })
+
+    it('displays species data from real useSidecarMetadata hook', async () => {
+      render(
+        <MetadataPanel photoPath="/photos/test_photo.jpg" />,
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      // Open Species accordion if collapsed
+      const speciesSection = screen.getByText('Species')
+      await userEvent.click(speciesSection)
+
+      // Verify species data is displayed
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('Actias luna')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('Auto-Save Integration', () => {
+    it('auto-saves after 2 second debounce using real useAutoSave hook', async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+
+      render(
+        <MetadataPanel photoPath="/photos/test_photo.jpg" />,
+        { wrapper: createWrapper() }
+      )
+
+      // Wait for initial load
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      // Notes section is expanded by default (defaultExpanded=true in AccordionSection)
+      // Find notes textarea and add text
+      const notesInput = screen.getByPlaceholderText(/Add notes about this photo/i)
+      await user.clear(notesInput)
+      await user.type(notesInput, 'New observation notes')
+
+      // API should NOT be called immediately
+      expect(api.updatePhotoSidecarMetadata).not.toHaveBeenCalled()
+
+      // Advance timers by 2 seconds (auto-save delay)
+      await act(async () => {
+        vi.advanceTimersByTime(2000)
+      })
+
+      // Now API should be called
+      await waitFor(() => {
+        expect(api.updatePhotoSidecarMetadata).toHaveBeenCalled()
+      })
+    })
+
+    it('debounces multiple rapid changes into single API call', async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+
+      render(
+        <MetadataPanel photoPath="/photos/test_photo.jpg" />,
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      // Notes section is expanded by default, find the textarea directly
+      const notesInput = screen.getByPlaceholderText(/Add notes about this photo/i)
+      await user.type(notesInput, 'A')
+
+      // Advance 500ms (less than debounce)
+      await act(async () => { vi.advanceTimersByTime(500) })
+
+      await user.type(notesInput, 'B')
+
+      // Advance 500ms more
+      await act(async () => { vi.advanceTimersByTime(500) })
+
+      await user.type(notesInput, 'C')
+
+      // Should NOT have called API yet (timer keeps resetting)
+      expect(api.updatePhotoSidecarMetadata).not.toHaveBeenCalled()
+
+      // Now wait full 2 seconds from last change
+      await act(async () => {
+        vi.advanceTimersByTime(2000)
+      })
+
+      // Should have called API exactly once with final state
+      await waitFor(() => {
+        expect(api.updatePhotoSidecarMetadata).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+
+  describe('Tag Operations Integration', () => {
+    it('adds tag using real MetadataTags component and useSidecarMetadata hook', async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+
+      render(
+        <MetadataPanel photoPath="/photos/test_photo.jpg" />,
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      // Tags section should be expanded by default
+      const tagInput = screen.getByPlaceholderText(/Type to add tags/i)
+      await user.type(tagInput, 'new-tag{Enter}')
+
+      // Tag should appear immediately (optimistic update)
+      await waitFor(() => {
+        expect(screen.getByText('new-tag')).toBeInTheDocument()
+      })
+
+      // Trigger auto-save
+      await act(async () => {
+        vi.advanceTimersByTime(2000)
+      })
+
+      // Verify API was called with new tag
+      await waitFor(() => {
+        expect(api.updatePhotoSidecarMetadata).toHaveBeenCalled()
+        const lastCall = api.updatePhotoSidecarMetadata.mock.calls.slice(-1)[0]
+        expect(lastCall[1]).toMatchObject({
+          user_tags: expect.arrayContaining(['new-tag'])
+        })
+      })
+    })
+
+    it('removes tag and updates via real integration', async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+
+      render(
+        <MetadataPanel photoPath="/photos/test_photo.jpg" />,
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('moth')).toBeInTheDocument()
+      })
+
+      // Click remove button for 'moth' tag
+      const removeButton = screen.getByRole('button', { name: /Remove tag moth/i })
+      await user.click(removeButton)
+
+      // Tag should disappear immediately (optimistic update)
+      await waitFor(() => {
+        expect(screen.queryByText('moth')).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('Error Handling Integration', () => {
+    it('handles API error and shows retry option', async () => {
+      // Make the EXIF API fail (MetadataPanel shows error state when exifError is true)
+      api.api.get.mockRejectedValueOnce(new Error('Network error'))
+      // Sidecar can still succeed
+      api.getPhotoSidecarMetadata.mockResolvedValueOnce({ data: mockSidecarData })
+
+      render(
+        <MetadataPanel photoPath="/photos/test_photo.jpg" />,
+        { wrapper: createWrapper() }
+      )
+
+      // Wait for error state
+      await waitFor(() => {
+        expect(screen.getByText(/Failed to load metadata/i)).toBeInTheDocument()
+      })
+
+      // Should show retry button
+      expect(screen.getByRole('button', { name: /Retry/i })).toBeInTheDocument()
+    })
+
+    it('shows save error in SaveStatusIndicator when update fails', async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+
+      // First load succeeds, update fails
+      api.updatePhotoSidecarMetadata.mockRejectedValueOnce(new Error('Save failed'))
+
+      render(
+        <MetadataPanel photoPath="/photos/test_photo.jpg" />,
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      // Notes section is expanded by default (defaultExpanded=true), so we can directly find the input
+      // Find the notes textarea (it has a specific placeholder)
+      const notesInput = screen.getByPlaceholderText(/Add notes about this photo/i)
+      await user.type(notesInput, 'test')
+
+      // Trigger auto-save
+      await act(async () => {
+        vi.advanceTimersByTime(2000)
+      })
+
+      // Should show error status
+      await waitFor(() => {
+        const errorElement = screen.queryByText(/error|failed/i)
+        expect(errorElement || screen.queryByRole('button', { name: /Retry/i })).toBeTruthy()
+      })
+    })
+  })
+
+  describe('Accordion Sections Integration', () => {
+    it('expands and collapses accordion sections using real AccordionSection', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <MetadataPanel photoPath="/photos/test_photo.jpg" />,
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      // Tags section should exist
+      const tagsHeader = screen.getByText('Tags')
+      expect(tagsHeader).toBeInTheDocument()
+
+      // Click to toggle Tags section
+      await user.click(tagsHeader)
+
+      // Verify header still exists (toggle worked)
+      expect(screen.getByText('Tags')).toBeInTheDocument()
+    })
+  })
+
+  describe('Keyboard Shortcuts Integration', () => {
+    it('Ctrl+S triggers immediate save', async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+
+      render(
+        <MetadataPanel photoPath="/photos/test_photo.jpg" />,
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      // Notes section is expanded by default, so we can directly find the input
+      const notesInput = screen.getByPlaceholderText(/Add notes about this photo/i)
+      await user.type(notesInput, 'test')
+
+      // API should not be called yet (still in debounce period)
+      expect(api.updatePhotoSidecarMetadata).not.toHaveBeenCalled()
+
+      // Press Ctrl+S
+      await user.keyboard('{Control>}s{/Control}')
+
+      // Should save immediately
+      await waitFor(() => {
+        expect(api.updatePhotoSidecarMetadata).toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/components/metadata/__tests__/MetadataPanel.integration.test.jsx
+++ b/Firmware/webui/frontend/src/components/metadata/__tests__/MetadataPanel.integration.test.jsx
@@ -3,7 +3,6 @@ import { render, screen, waitFor, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import MetadataPanel from '../MetadataPanel'
-import { clearTagsInvalidationTimeout } from '../../../hooks/useSidecarMetadata'
 
 // Mock the API layer ONLY - not hooks or components
 // This tests the real integration between MetadataPanel, useAutoSave, useSidecarMetadata, etc.
@@ -83,7 +82,8 @@ describe('MetadataPanel Integration Tests', () => {
 
   afterEach(() => {
     vi.useRealTimers()
-    clearTagsInvalidationTimeout()
+    // Note: Tags invalidation timeout is now managed by useRef inside the hook,
+    // so cleanup happens automatically when the component unmounts
     if (queryClient) {
       queryClient.clear()
     }

--- a/Firmware/webui/frontend/src/components/metadata/__tests__/MetadataPanel.mobile.test.jsx
+++ b/Firmware/webui/frontend/src/components/metadata/__tests__/MetadataPanel.mobile.test.jsx
@@ -1,0 +1,503 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import MetadataPanel from '../MetadataPanel'
+import * as apiModule from '../../../utils/api'
+
+// Mock the API module
+vi.mock('../../../utils/api', () => ({
+  api: {
+    get: vi.fn(),
+    put: vi.fn(),
+  },
+  getPhotoSidecarMetadata: vi.fn(),
+  updatePhotoSidecarMetadata: vi.fn(),
+}))
+
+const mockApiGet = vi.mocked(apiModule.api.get)
+const mockGetPhotoSidecarMetadata = vi.mocked(apiModule.getPhotoSidecarMetadata)
+
+// Mock child components
+vi.mock('../AccordionSection', () => ({
+  default: ({ title, children }) => (
+    <div data-testid={`accordion-section-${title.toLowerCase().replace(/\s+/g, '-')}`}>
+      <div data-testid="accordion-content">{children}</div>
+    </div>
+  ),
+}))
+
+vi.mock('../SaveStatusIndicator', () => ({
+  default: () => <div data-testid="save-status-indicator">Save Status</div>,
+}))
+
+vi.mock('../MetadataTags', () => ({
+  default: () => <div data-testid="metadata-tags">Tags</div>,
+}))
+
+vi.mock('../MetadataSpecies', () => ({
+  default: () => <div data-testid="metadata-species">Species</div>,
+}))
+
+vi.mock('../MetadataNotes', () => ({
+  default: () => <div data-testid="metadata-notes">Notes</div>,
+}))
+
+vi.mock('../MetadataCustomFields', () => ({
+  default: () => <div data-testid="metadata-custom-fields">Custom</div>,
+}))
+
+vi.mock('../MetadataEXIF', () => ({
+  default: () => <div data-testid="metadata-exif">EXIF</div>,
+}))
+
+vi.mock('../MetadataSkeleton', () => ({
+  default: () => <div data-testid="metadata-skeleton">Loading...</div>,
+}))
+
+const mockExifMetadata = {
+  camera: { make: 'Arducam', model: 'OwlSight 64MP' },
+  iso: 400,
+}
+
+const mockSidecarMetadata = {
+  user_tags: ['moth'],
+  species: 'Actias luna',
+  notes: 'Test note',
+}
+
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 0,
+        staleTime: 0,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  })
+}
+
+function TestWrapper({ children }) {
+  const queryClient = createTestQueryClient()
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}
+
+function mockSuccessfulDataLoad() {
+  mockApiGet.mockResolvedValueOnce({ data: mockExifMetadata })
+  mockGetPhotoSidecarMetadata.mockResolvedValueOnce({ data: mockSidecarMetadata })
+}
+
+describe('MetadataPanel - Mobile Drawer Behavior', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('Desktop Behavior', () => {
+    it('panel is visible on desktop', async () => {
+      mockSuccessfulDataLoad()
+
+      const { container } = render(
+        <TestWrapper>
+          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      // Panel should be visible
+      const panelContainer = container.querySelector('[data-testid="metadata-panel"]')
+      expect(panelContainer).toBeInTheDocument()
+    })
+
+    it('toggle button has md:hidden class for desktop', async () => {
+      mockSuccessfulDataLoad()
+
+      render(
+        <TestWrapper>
+          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      // Mobile toggle button should have md:hidden class (hidden on desktop)
+      // Note: JSDOM doesn't apply media queries, so we check for the class instead
+      const toggleButton = screen.getByTestId('mobile-toggle-button')
+      expect(toggleButton).toBeInTheDocument()
+      expect(toggleButton).toHaveClass('md:hidden')
+    })
+  })
+
+  describe('Mobile Behavior - Default State', () => {
+    it('panel hidden on mobile by default', async () => {
+      mockSuccessfulDataLoad()
+
+      const { container } = render(
+        <TestWrapper>
+          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      // Panel should have hidden class for mobile
+      const panelContainer = container.querySelector('[data-testid="metadata-panel"]')
+      expect(panelContainer).toHaveClass('hidden')
+    })
+
+    it('toggle button visible on mobile', async () => {
+      mockSuccessfulDataLoad()
+
+      render(
+        <TestWrapper>
+          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      // Mobile toggle button should be visible
+      const toggleButton = screen.getByTestId('mobile-toggle-button')
+      expect(toggleButton).toBeInTheDocument()
+      expect(toggleButton).toHaveAttribute('aria-label', 'Open metadata panel')
+    })
+
+    it('toggle button has floating action button styling', async () => {
+      mockSuccessfulDataLoad()
+
+      render(
+        <TestWrapper>
+          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      const toggleButton = screen.getByTestId('mobile-toggle-button')
+
+      // Check for FAB-style classes
+      expect(toggleButton).toHaveClass('fixed')
+      expect(toggleButton).toHaveClass('bottom-4')
+      expect(toggleButton).toHaveClass('right-4')
+      expect(toggleButton).toHaveClass('rounded-full')
+      expect(toggleButton).toHaveClass('z-40')
+    })
+  })
+
+  describe('Mobile Behavior - Opening Drawer', () => {
+    it('clicking toggle button shows drawer', async () => {
+      mockSuccessfulDataLoad()
+      const user = userEvent.setup()
+
+      const { container } = render(
+        <TestWrapper>
+          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      // Initially hidden
+      let panelContainer = container.querySelector('[data-testid="metadata-panel"]')
+      expect(panelContainer).toHaveClass('hidden')
+
+      // Click toggle button
+      const toggleButton = screen.getByTestId('mobile-toggle-button')
+      await user.click(toggleButton)
+
+      // Panel should now be visible
+      panelContainer = container.querySelector('[data-testid="metadata-panel"]')
+      expect(panelContainer).not.toHaveClass('hidden')
+    })
+
+    it('drawer slides up from bottom with correct styles', async () => {
+      mockSuccessfulDataLoad()
+      const user = userEvent.setup()
+
+      const { container } = render(
+        <TestWrapper>
+          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      // Open drawer
+      const toggleButton = screen.getByTestId('mobile-toggle-button')
+      await user.click(toggleButton)
+
+      // Check drawer has correct positioning classes
+      const drawer = container.querySelector('[data-testid="metadata-panel"]')
+
+      expect(drawer).toHaveClass('fixed')
+      expect(drawer).toHaveClass('inset-x-0')
+      expect(drawer).toHaveClass('bottom-0')
+      expect(drawer).toHaveClass('z-50')
+      expect(drawer.className).toContain('max-h-')
+      expect(drawer).toHaveClass('rounded-t-2xl')
+    })
+
+    it('backdrop overlay appears when drawer opens', async () => {
+      mockSuccessfulDataLoad()
+      const user = userEvent.setup()
+
+      render(
+        <TestWrapper>
+          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      // No overlay initially
+      expect(screen.queryByTestId('mobile-overlay')).not.toBeInTheDocument()
+
+      // Open drawer
+      const toggleButton = screen.getByTestId('mobile-toggle-button')
+      await user.click(toggleButton)
+
+      // Overlay should appear
+      const overlay = screen.getByTestId('mobile-overlay')
+      expect(overlay).toBeInTheDocument()
+      expect(overlay).toHaveClass('fixed')
+      expect(overlay).toHaveClass('inset-0')
+      expect(overlay.className).toContain('bg-black')
+      expect(overlay).toHaveClass('z-40')
+    })
+
+    it('drawer shows close button when open', async () => {
+      mockSuccessfulDataLoad()
+      const user = userEvent.setup()
+
+      render(
+        <TestWrapper>
+          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      // No close button when closed
+      expect(screen.queryByTestId('drawer-close-button')).not.toBeInTheDocument()
+
+      // Open drawer
+      const toggleButton = screen.getByTestId('mobile-toggle-button')
+      await user.click(toggleButton)
+
+      // Close button should appear
+      const closeButton = screen.getByTestId('drawer-close-button')
+      expect(closeButton).toBeInTheDocument()
+      expect(closeButton).toHaveAttribute('aria-label', 'Close metadata panel')
+    })
+  })
+
+  describe('Mobile Behavior - Closing Drawer', () => {
+    it('clicking close button hides drawer', async () => {
+      mockSuccessfulDataLoad()
+      const user = userEvent.setup()
+
+      const { container } = render(
+        <TestWrapper>
+          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      // Open drawer
+      const toggleButton = screen.getByTestId('mobile-toggle-button')
+      await user.click(toggleButton)
+
+      // Verify it's open
+      let panelContainer = container.querySelector('[data-testid="metadata-panel"]')
+      expect(panelContainer).not.toHaveClass('hidden')
+
+      // Close drawer
+      const closeButton = screen.getByTestId('drawer-close-button')
+      await user.click(closeButton)
+
+      // Should be hidden again
+      panelContainer = container.querySelector('[data-testid="metadata-panel"]')
+      expect(panelContainer).toHaveClass('hidden')
+    })
+
+    it('clicking backdrop closes drawer', async () => {
+      mockSuccessfulDataLoad()
+      const user = userEvent.setup()
+
+      const { container } = render(
+        <TestWrapper>
+          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      // Open drawer
+      const toggleButton = screen.getByTestId('mobile-toggle-button')
+      await user.click(toggleButton)
+
+      // Verify it's open
+      let panelContainer = container.querySelector('[data-testid="metadata-panel"]')
+      expect(panelContainer).not.toHaveClass('hidden')
+
+      // Click backdrop
+      const overlay = screen.getByTestId('mobile-overlay')
+      await user.click(overlay)
+
+      // Should be hidden again
+      panelContainer = container.querySelector('[data-testid="metadata-panel"]')
+      expect(panelContainer).toHaveClass('hidden')
+    })
+
+    it('overlay disappears when drawer closes', async () => {
+      mockSuccessfulDataLoad()
+      const user = userEvent.setup()
+
+      render(
+        <TestWrapper>
+          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      // Open drawer
+      const toggleButton = screen.getByTestId('mobile-toggle-button')
+      await user.click(toggleButton)
+
+      // Overlay present
+      expect(screen.getByTestId('mobile-overlay')).toBeInTheDocument()
+
+      // Close drawer
+      const closeButton = screen.getByTestId('drawer-close-button')
+      await user.click(closeButton)
+
+      // Overlay should be gone
+      expect(screen.queryByTestId('mobile-overlay')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Mobile Behavior - Drawer Header', () => {
+    it('drawer has mobile header with title and close button', async () => {
+      mockSuccessfulDataLoad()
+      const user = userEvent.setup()
+
+      render(
+        <TestWrapper>
+          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      // Open drawer
+      const toggleButton = screen.getByTestId('mobile-toggle-button')
+      await user.click(toggleButton)
+
+      // Check mobile header
+      const mobileHeader = screen.getByTestId('drawer-mobile-header')
+      expect(mobileHeader).toBeInTheDocument()
+      expect(mobileHeader).toHaveTextContent('Photo Metadata')
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('toggle button has accessible label', async () => {
+      mockSuccessfulDataLoad()
+
+      render(
+        <TestWrapper>
+          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      const toggleButton = screen.getByTestId('mobile-toggle-button')
+      expect(toggleButton).toHaveAttribute('aria-label', 'Open metadata panel')
+    })
+
+    it('close button has accessible label', async () => {
+      mockSuccessfulDataLoad()
+      const user = userEvent.setup()
+
+      render(
+        <TestWrapper>
+          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      // Open drawer
+      const toggleButton = screen.getByTestId('mobile-toggle-button')
+      await user.click(toggleButton)
+
+      const closeButton = screen.getByTestId('drawer-close-button')
+      expect(closeButton).toHaveAttribute('aria-label', 'Close metadata panel')
+    })
+
+    it('drawer has role and aria attributes', async () => {
+      mockSuccessfulDataLoad()
+      const user = userEvent.setup()
+
+      const { container } = render(
+        <TestWrapper>
+          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      // Open drawer
+      const toggleButton = screen.getByTestId('mobile-toggle-button')
+      await user.click(toggleButton)
+
+      // Check drawer has proper ARIA attributes
+      const drawer = container.querySelector('[data-testid="metadata-panel"]')
+      expect(drawer).toHaveAttribute('role', 'dialog')
+      expect(drawer).toHaveAttribute('aria-label', 'Photo metadata')
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/components/metadata/__tests__/MetadataPanel.test.jsx
+++ b/Firmware/webui/frontend/src/components/metadata/__tests__/MetadataPanel.test.jsx
@@ -1,46 +1,141 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import MetadataPanel from '../MetadataPanel'
-import { api } from '../../../utils/api'
+import * as apiModule from '../../../utils/api'
 
 // Mock the API module
 vi.mock('../../../utils/api', () => ({
   api: {
     get: vi.fn(),
+    put: vi.fn(),
   },
+  getPhotoSidecarMetadata: vi.fn(),
+  updatePhotoSidecarMetadata: vi.fn(),
 }))
 
-// Mock the child components
-vi.mock('../CameraTab', () => ({
-  default: ({ data }) => (
-    <div data-testid="camera-tab">
-      Camera Tab: {data ? 'loaded' : 'no data'}
+// Get mocked functions for use in tests
+const mockApiGet = vi.mocked(apiModule.api.get)
+const mockApiPut = vi.mocked(apiModule.api.put)
+const mockGetPhotoSidecarMetadata = vi.mocked(apiModule.getPhotoSidecarMetadata)
+const mockUpdatePhotoSidecarMetadata = vi.mocked(apiModule.updatePhotoSidecarMetadata)
+
+// Mock the AccordionSection component
+vi.mock('../AccordionSection', () => ({
+  default: ({ title, icon, children, defaultExpanded }) => (
+    <div data-testid={`accordion-section-${title.toLowerCase().replace(/\s+/g, '-')}`}>
+      <div data-testid="accordion-header" data-expanded={defaultExpanded}>
+        {icon}
+        <span>{title}</span>
+      </div>
+      <div data-testid="accordion-content">{children}</div>
     </div>
   ),
 }))
 
-// LocationTab is no longer used - merged into DeploymentTab
-
-vi.mock('../CaptureTab', () => ({
-  default: ({ data }) => (
-    <div data-testid="capture-tab">
-      Capture Tab: {data ? 'loaded' : 'no data'}
+// Mock the SaveStatusIndicator component
+vi.mock('../SaveStatusIndicator', () => ({
+  default: ({ status, onRetry, errorMessage }) => (
+    <div data-testid="save-status-indicator" data-status={status}>
+      {status === 'saving' && <span>Saving...</span>}
+      {status === 'saved' && <span>Saved</span>}
+      {status === 'error' && (
+        <>
+          <span>{errorMessage || 'Save failed'}</span>
+          {onRetry && (
+            <button onClick={onRetry} data-testid="retry-save-button">
+              Retry
+            </button>
+          )}
+        </>
+      )}
     </div>
   ),
 }))
 
-vi.mock('../TagsTab', () => ({
-  default: ({ data }) => (
-    <div data-testid="tags-tab">Tags Tab: {data ? 'loaded' : 'no data'}</div>
+// Mock the section components
+vi.mock('../MetadataTags', () => ({
+  default: ({ tags, onAddTag, onRemoveTag }) => (
+    <div data-testid="metadata-tags">
+      <div data-testid="tags-list">
+        {tags.map((tag) => (
+          <span key={tag} data-testid={`tag-${tag}`}>
+            {tag}
+            <button onClick={() => onRemoveTag(tag)}>Remove {tag}</button>
+          </span>
+        ))}
+      </div>
+      <button onClick={() => onAddTag('new-tag')}>Add Tag</button>
+    </div>
   ),
 }))
 
-vi.mock('../DeploymentTab', () => ({
+vi.mock('../MetadataSpecies', () => ({
+  default: ({ species, confidence, commonName, referenceUrl, onChange }) => (
+    <div data-testid="metadata-species">
+      <input
+        data-testid="species-input"
+        value={species}
+        onChange={(e) => onChange('species', e.target.value)}
+      />
+      <select
+        data-testid="confidence-select"
+        value={confidence}
+        onChange={(e) => onChange('confidence', e.target.value)}
+      >
+        <option value="certain">Certain</option>
+        <option value="probable">Probable</option>
+        <option value="possible">Possible</option>
+        <option value="unknown">Unknown</option>
+      </select>
+      <input
+        data-testid="common-name-input"
+        value={commonName}
+        onChange={(e) => onChange('commonName', e.target.value)}
+      />
+      <input
+        data-testid="reference-url-input"
+        value={referenceUrl}
+        onChange={(e) => onChange('referenceUrl', e.target.value)}
+      />
+    </div>
+  ),
+}))
+
+vi.mock('../MetadataNotes', () => ({
+  default: ({ value, onChange }) => (
+    <div data-testid="metadata-notes">
+      <textarea
+        data-testid="notes-textarea"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    </div>
+  ),
+}))
+
+vi.mock('../MetadataCustomFields', () => ({
+  default: ({ fields, onChange }) => (
+    <div data-testid="metadata-custom-fields">
+      <div data-testid="custom-fields-list">
+        {Object.entries(fields || {}).map(([key, value]) => (
+          <div key={key} data-testid={`custom-field-${key}`}>
+            {key}: {value}
+          </div>
+        ))}
+      </div>
+      <button onClick={() => onChange({ ...fields, newField: 'newValue' })}>
+        Add Custom Field
+      </button>
+    </div>
+  ),
+}))
+
+vi.mock('../MetadataEXIF', () => ({
   default: ({ data }) => (
-    <div data-testid="deployment-tab">
-      Deployment Tab: {data ? 'loaded' : 'no data'}
+    <div data-testid="metadata-exif">
+      <div>EXIF Data: {data ? 'loaded' : 'no data'}</div>
     </div>
   ),
 }))
@@ -54,55 +149,36 @@ vi.mock('../MetadataSkeleton', () => ({
 }))
 
 /**
- * Complete mock metadata structure
+ * Mock EXIF metadata structure
  */
-const mockMetadata = {
+const mockExifMetadata = {
   camera: {
-    camera: {
-      make: 'Arducam',
-      model: 'OwlSight 64MP',
-      lens_make: 'Arducam',
-      lens_model: '6mm Wide Angle',
-    },
-    iso: 400,
-    aperture: 2.8,
-    shutter_speed: 0.033333,
-    focal_length: 6.0,
-    exposure_mode: 'Manual',
-    metering_mode: 'CenterWeighted',
+    make: 'Arducam',
+    model: 'OwlSight 64MP',
+    lens_make: 'Arducam',
+    lens_model: '6mm Wide Angle',
   },
-  location: {
-    gps: {
-      lat: 45.5231,
-      lon: -122.6765,
-      altitude: 50,
-    },
-    location: {
-      city: 'Portland',
-      state: 'Oregon',
-      country: 'USA',
-    },
-  },
-  capture: {
-    datetime: '2024-01-15T22:30:45',
-    timezone: 'America/Los_Angeles',
-    flash: true,
-    hdr: false,
-    focus_bracket: true,
-    focus_bracket_count: 5,
-    focus_bracket_step: 0.5,
-  },
-  tags: {
-    species: ['Actias luna', 'Antheraea polyphemus'],
-    notes: 'Clear night, high moth activity',
+  iso: 400,
+  aperture: 2.8,
+  shutter_speed: 0.033333,
+  focal_length: 6.0,
+  exposure_mode: 'Manual',
+  metering_mode: 'CenterWeighted',
+}
+
+/**
+ * Mock sidecar metadata structure
+ */
+const mockSidecarMetadata = {
+  user_tags: ['moth', 'nocturnal'],
+  species: 'Actias luna',
+  species_confidence: 'probable',
+  species_common_name: 'Luna Moth',
+  species_reference_url: 'https://inaturalist.org/taxa/actias-luna',
+  notes: 'Clear night, high moth activity',
+  custom: {
     observer: 'Jane Doe',
-    quality: 'excellent',
-  },
-  deployment: {
-    device_id: 'mothbox-forest-01',
-    location_name: 'Forest Grove Research Station',
-    deployment_date: '2024-01-01',
-    habitat: 'deciduous forest',
+    weather: 'clear',
   },
 }
 
@@ -116,6 +192,9 @@ function createTestQueryClient() {
         retry: false,
         gcTime: 0,
         staleTime: 0,
+      },
+      mutations: {
+        retry: false,
       },
     },
   })
@@ -131,23 +210,21 @@ function TestWrapper({ children }) {
   )
 }
 
-describe('MetadataPanel', () => {
+describe('MetadataPanel (Accordion Refactor)', () => {
   beforeEach(() => {
-    // Clear all mocks before each test
     vi.clearAllMocks()
   })
 
   afterEach(() => {
-    // Clear all mocks after each test
     vi.clearAllMocks()
   })
 
-  describe('Rendering', () => {
-    it('renders all 4 tab triggers (Camera, Capture, Tags, Deployment)', async () => {
-      api.get.mockResolvedValueOnce({
-        data: mockMetadata,
-
-      })
+  describe('Rendering - Accordion Structure', () => {
+    it('renders accordion sections not tabs', async () => {
+      // Mock EXIF metadata fetch (usePhotoMetadata uses api.get)
+      mockApiGet.mockResolvedValueOnce({ data: mockExifMetadata })
+      // Mock sidecar metadata fetch (useSidecarMetadata uses getPhotoSidecarMetadata)
+      mockGetPhotoSidecarMetadata.mockResolvedValueOnce({ data: mockSidecarMetadata })
 
       render(
         <TestWrapper>
@@ -155,26 +232,95 @@ describe('MetadataPanel', () => {
         </TestWrapper>
       )
 
-      // Wait for loading to complete
       await waitFor(() => {
         expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
       })
 
-      // Check all tab triggers are present (Location merged into Deployment)
-      expect(screen.getByRole('tab', { name: /camera/i })).toBeInTheDocument()
-      expect(screen.getByRole('tab', { name: /capture/i })).toBeInTheDocument()
-      expect(screen.getByRole('tab', { name: /tags/i })).toBeInTheDocument()
-      expect(
-        screen.getByRole('tab', { name: /deployment/i })
-      ).toBeInTheDocument()
+      // Should NOT have tabs
+      expect(screen.queryByRole('tablist')).not.toBeInTheDocument()
+      expect(screen.queryByRole('tab')).not.toBeInTheDocument()
+
+      // Should have accordion sections
+      expect(screen.getByTestId('accordion-section-tags')).toBeInTheDocument()
+      expect(screen.getByTestId('accordion-section-species')).toBeInTheDocument()
+      expect(screen.getByTestId('accordion-section-notes')).toBeInTheDocument()
+      expect(screen.getByTestId('accordion-section-exif-data')).toBeInTheDocument()
+      expect(screen.getByTestId('accordion-section-custom-fields')).toBeInTheDocument()
     })
 
-    it('shows loading skeleton initially while fetching metadata', () => {
-      api.get.mockImplementation(
+    it('tags section is expanded by default', async () => {
+      mockApiGet.mockResolvedValueOnce({ data: mockExifMetadata })
+      mockGetPhotoSidecarMetadata.mockResolvedValueOnce({ data: mockSidecarMetadata })
+
+      render(
+        <TestWrapper>
+          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      const tagsSection = screen.getByTestId('accordion-section-tags')
+      const tagsHeader = within(tagsSection).getByTestId('accordion-header')
+
+      // Tags section should be expanded by default
+      expect(tagsHeader).toHaveAttribute('data-expanded', 'true')
+    })
+
+    it('all sections present', async () => {
+      mockApiGet.mockResolvedValueOnce({ data: mockExifMetadata })
+      mockGetPhotoSidecarMetadata.mockResolvedValueOnce({ data: mockSidecarMetadata })
+
+      render(
+        <TestWrapper>
+          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      // All 5 sections should be present
+      expect(screen.getByTestId('accordion-section-tags')).toBeInTheDocument()
+      expect(screen.getByTestId('accordion-section-species')).toBeInTheDocument()
+      expect(screen.getByTestId('accordion-section-notes')).toBeInTheDocument()
+      expect(screen.getByTestId('accordion-section-exif-data')).toBeInTheDocument()
+      expect(screen.getByTestId('accordion-section-custom-fields')).toBeInTheDocument()
+
+      // Verify section components are rendered
+      expect(screen.getByTestId('metadata-tags')).toBeInTheDocument()
+      expect(screen.getByTestId('metadata-species')).toBeInTheDocument()
+      expect(screen.getByTestId('metadata-notes')).toBeInTheDocument()
+      expect(screen.getByTestId('metadata-exif')).toBeInTheDocument()
+      expect(screen.getByTestId('metadata-custom-fields')).toBeInTheDocument()
+    })
+
+    it('shows save status indicator', async () => {
+      mockApiGet.mockResolvedValueOnce({ data: mockExifMetadata })
+      mockGetPhotoSidecarMetadata.mockResolvedValueOnce({ data: mockSidecarMetadata })
+
+      render(
+        <TestWrapper>
+          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      // SaveStatusIndicator should be visible
+      expect(screen.getByTestId('save-status-indicator')).toBeInTheDocument()
+    })
+
+    it('loading state shows skeleton', () => {
+      mockApiGet.mockImplementation(
         () =>
           new Promise((resolve) => {
-            // Don't resolve immediately to keep loading state
-            setTimeout(() => resolve({ ok: true, json: async () => mockMetadata }), 100)
+            setTimeout(() => resolve({ data: mockExifMetadata }), 100)
           })
       )
 
@@ -189,57 +335,10 @@ describe('MetadataPanel', () => {
       expect(screen.getByRole('status')).toBeInTheDocument()
     })
 
-    it('displays Camera tab content by default after loading', async () => {
-      api.get.mockResolvedValueOnce({
-        data: mockMetadata,
-
-      })
-
-      render(
-        <TestWrapper>
-          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
-        </TestWrapper>
-      )
-
-      // Wait for loading to complete
-      await waitFor(() => {
-        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
-      })
-
-      // Camera tab should be visible
-      expect(screen.getByTestId('camera-tab')).toBeVisible()
-
-      // Other tabs should not be visible (only Camera tab is active)
-      expect(screen.queryByTestId('capture-tab')).not.toBeInTheDocument()
-      expect(screen.queryByTestId('tags-tab')).not.toBeInTheDocument()
-      expect(screen.queryByTestId('deployment-tab')).not.toBeInTheDocument()
-    })
-
-    it('hides tab content until metadata is loaded', () => {
-      api.get.mockImplementation(
-        () =>
-          new Promise((resolve) => {
-            // Keep loading indefinitely
-            setTimeout(() => resolve({ ok: true, json: async () => mockMetadata }), 10000)
-          })
-      )
-
-      render(
-        <TestWrapper>
-          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
-        </TestWrapper>
-      )
-
-      // Should only show skeleton, no tab content
-      expect(screen.getByTestId('metadata-skeleton')).toBeInTheDocument()
-      expect(screen.queryByTestId('camera-tab')).not.toBeInTheDocument()
-    })
-
-    it('renders tab list with proper ARIA role', async () => {
-      api.get.mockResolvedValueOnce({
-        data: mockMetadata,
-
-      })
+    it('error state shows retry', async () => {
+      mockApiGet.mockRejectedValueOnce(new Error('Network error'))
+      // Mock sidecar to succeed so it doesn't hang
+      mockGetPhotoSidecarMetadata.mockResolvedValueOnce({ data: mockSidecarMetadata })
 
       render(
         <TestWrapper>
@@ -248,42 +347,20 @@ describe('MetadataPanel', () => {
       )
 
       await waitFor(() => {
-        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+        expect(screen.getByText(/failed to load metadata/i)).toBeInTheDocument()
       })
 
-      const tabList = screen.getByRole('tablist')
-      expect(tabList).toBeInTheDocument()
-      expect(tabList).toHaveAttribute('aria-label', 'Photo metadata tabs')
-    })
-
-    it('renders tab panels with proper ARIA role', async () => {
-      api.get.mockResolvedValueOnce({
-        data: mockMetadata,
-
-      })
-
-      render(
-        <TestWrapper>
-          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
-        </TestWrapper>
-      )
-
-      await waitFor(() => {
-        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
-      })
-
-      // Should have at least one visible tab panel
-      const tabPanels = screen.getAllByRole('tabpanel')
-      expect(tabPanels.length).toBeGreaterThan(0)
+      // Should show retry button
+      const retryButton = screen.getByRole('button', { name: /retry/i })
+      expect(retryButton).toBeInTheDocument()
     })
   })
 
-  describe('Tab Switching', () => {
-    it('switches to Capture tab when clicked', async () => {
-      api.get.mockResolvedValueOnce({
-        data: mockMetadata,
-
-      })
+  describe('Auto-Save Functionality', () => {
+    it('auto-save triggers on change', async () => {
+      mockApiGet.mockResolvedValueOnce({ data: mockExifMetadata })
+      mockGetPhotoSidecarMetadata.mockResolvedValueOnce({ data: mockSidecarMetadata })
+      mockUpdatePhotoSidecarMetadata.mockResolvedValue({ data: { success: true } })
 
       const user = userEvent.setup()
 
@@ -297,20 +374,59 @@ describe('MetadataPanel', () => {
         expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
       })
 
-      // Click Capture tab
-      const captureTab = screen.getByRole('tab', { name: /capture/i })
-      await user.click(captureTab)
+      // Add a tag
+      const addTagButton = screen.getByText('Add Tag')
+      await user.click(addTagButton)
 
-      // Capture tab content should now be visible
-      expect(screen.getByTestId('capture-tab')).toBeVisible()
-      expect(screen.queryByTestId('camera-tab')).not.toBeInTheDocument()
+      // Wait for debounced save (2 seconds)
+      await waitFor(
+        () => {
+          const saveIndicator = screen.getByTestId('save-status-indicator')
+          // Should show saving or saved status
+          const status = saveIndicator.getAttribute('data-status')
+          expect(['saving', 'saved']).toContain(status)
+        },
+        { timeout: 3000 }
+      )
+    })
+  })
+
+  describe('Editable Sections', () => {
+    it('editable sections call update on tags', async () => {
+      mockApiGet.mockResolvedValueOnce({ data: mockExifMetadata })
+      mockGetPhotoSidecarMetadata.mockResolvedValueOnce({ data: mockSidecarMetadata })
+      mockUpdatePhotoSidecarMetadata.mockResolvedValue({ data: { success: true } })
+
+      const user = userEvent.setup()
+
+      render(
+        <TestWrapper>
+          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      // Existing tags should be displayed
+      expect(screen.getByTestId('tag-moth')).toBeInTheDocument()
+      expect(screen.getByTestId('tag-nocturnal')).toBeInTheDocument()
+
+      // Add a tag
+      const addTagButton = screen.getByText('Add Tag')
+      await user.click(addTagButton)
+
+      // Should update local state immediately
+      await waitFor(() => {
+        expect(screen.getByTestId('tag-new-tag')).toBeInTheDocument()
+      })
     })
 
-    it('switches to Tags tab when clicked', async () => {
-      api.get.mockResolvedValueOnce({
-        data: mockMetadata,
-
-      })
+    it('editable sections call update on species', async () => {
+      mockApiGet.mockResolvedValueOnce({ data: mockExifMetadata })
+      mockGetPhotoSidecarMetadata.mockResolvedValueOnce({ data: mockSidecarMetadata })
+      mockUpdatePhotoSidecarMetadata.mockResolvedValue({ data: { success: true } })
 
       const user = userEvent.setup()
 
@@ -324,20 +440,21 @@ describe('MetadataPanel', () => {
         expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
       })
 
-      // Click Tags tab
-      const tagsTab = screen.getByRole('tab', { name: /tags/i })
-      await user.click(tagsTab)
+      // Change species
+      const speciesInput = screen.getByTestId('species-input')
+      expect(speciesInput).toHaveValue('Actias luna')
 
-      // Tags tab content should now be visible
-      expect(screen.getByTestId('tags-tab')).toBeVisible()
-      expect(screen.queryByTestId('camera-tab')).not.toBeInTheDocument()
+      await user.clear(speciesInput)
+      await user.type(speciesInput, 'Antheraea polyphemus')
+
+      // Should update local state
+      expect(speciesInput).toHaveValue('Antheraea polyphemus')
     })
 
-    it('switches to Deployment tab when clicked', async () => {
-      api.get.mockResolvedValueOnce({
-        data: mockMetadata,
-
-      })
+    it('editable sections call update on notes', async () => {
+      mockApiGet.mockResolvedValueOnce({ data: mockExifMetadata })
+      mockGetPhotoSidecarMetadata.mockResolvedValueOnce({ data: mockSidecarMetadata })
+      mockUpdatePhotoSidecarMetadata.mockResolvedValue({ data: { success: true } })
 
       const user = userEvent.setup()
 
@@ -351,50 +468,21 @@ describe('MetadataPanel', () => {
         expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
       })
 
-      // Click Deployment tab
-      const deploymentTab = screen.getByRole('tab', { name: /deployment/i })
-      await user.click(deploymentTab)
+      // Change notes
+      const notesTextarea = screen.getByTestId('notes-textarea')
+      expect(notesTextarea).toHaveValue('Clear night, high moth activity')
 
-      // Deployment tab content should now be visible
-      expect(screen.getByTestId('deployment-tab')).toBeVisible()
-      expect(screen.queryByTestId('camera-tab')).not.toBeInTheDocument()
+      await user.clear(notesTextarea)
+      await user.type(notesTextarea, 'Updated notes')
+
+      // Should update local state
+      expect(notesTextarea).toHaveValue('Updated notes')
     })
 
-    it('tab switching completes within 100ms (performance requirement)', async () => {
-      api.get.mockResolvedValueOnce({
-        data: mockMetadata,
-
-      })
-
-      const user = userEvent.setup()
-
-      render(
-        <TestWrapper>
-          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
-        </TestWrapper>
-      )
-
-      await waitFor(() => {
-        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
-      })
-
-      // Measure tab switch performance
-      const captureTab = screen.getByRole('tab', { name: /capture/i })
-      const startTime = performance.now()
-      await user.click(captureTab)
-      const endTime = performance.now()
-
-      const switchTime = endTime - startTime
-
-      // Should complete within 100ms
-      expect(switchTime).toBeLessThan(100)
-    })
-
-    it('active tab has proper aria-selected attribute', async () => {
-      api.get.mockResolvedValueOnce({
-        data: mockMetadata,
-
-      })
+    it('editable sections call update on custom fields', async () => {
+      mockApiGet.mockResolvedValueOnce({ data: mockExifMetadata })
+      mockGetPhotoSidecarMetadata.mockResolvedValueOnce({ data: mockSidecarMetadata })
+      mockUpdatePhotoSidecarMetadata.mockResolvedValue({ data: { success: true } })
 
       const user = userEvent.setup()
 
@@ -408,50 +496,28 @@ describe('MetadataPanel', () => {
         expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
       })
 
-      // Camera tab should be selected initially
-      const cameraTab = screen.getByRole('tab', { name: /camera/i })
-      expect(cameraTab).toHaveAttribute('aria-selected', 'true')
+      // Existing custom fields should be displayed
+      expect(screen.getByTestId('custom-field-observer')).toBeInTheDocument()
+      expect(screen.getByTestId('custom-field-weather')).toBeInTheDocument()
 
-      // Deployment tab should not be selected
-      const deploymentTab = screen.getByRole('tab', { name: /deployment/i })
-      expect(deploymentTab).toHaveAttribute('aria-selected', 'false')
+      // Add a custom field
+      const addCustomFieldButton = screen.getByText('Add Custom Field')
+      await user.click(addCustomFieldButton)
 
-      // Click Deployment tab
-      await user.click(deploymentTab)
-
-      // Now Deployment tab should be selected
-      expect(deploymentTab).toHaveAttribute('aria-selected', 'true')
-      expect(cameraTab).toHaveAttribute('aria-selected', 'false')
+      // Should update local state immediately
+      await waitFor(() => {
+        expect(screen.getByTestId('custom-field-newField')).toBeInTheDocument()
+      })
     })
   })
 
   describe('Data Loading', () => {
-    it('fetches metadata using usePhotoMetadata hook', async () => {
+    it('fetches EXIF and sidecar metadata on mount', async () => {
       const photoPath = '/var/lib/mothbox/photos/test.jpg'
-      api.get.mockResolvedValueOnce({
-        data: mockMetadata,
+      const filename = 'test.jpg'
 
-      })
-
-      render(
-        <TestWrapper>
-          <MetadataPanel photoPath={photoPath} />
-        </TestWrapper>
-      )
-
-      await waitFor(() => {
-        expect(api.get).toHaveBeenCalledWith(
-          `/metadata/photo/${encodeURIComponent(photoPath)}/metadata`
-        )
-      })
-    })
-
-    it('passes photoPath to usePhotoMetadata correctly', async () => {
-      const photoPath = '/var/lib/mothbox/photos/special-path/image.jpg'
-      api.get.mockResolvedValueOnce({
-        data: mockMetadata,
-
-      })
+      mockApiGet.mockResolvedValueOnce({ data: mockExifMetadata })
+      mockGetPhotoSidecarMetadata.mockResolvedValueOnce({ data: mockSidecarMetadata })
 
       render(
         <TestWrapper>
@@ -460,36 +526,18 @@ describe('MetadataPanel', () => {
       )
 
       await waitFor(() => {
-        expect(api.get).toHaveBeenCalledWith(
+        // Should fetch EXIF metadata
+        expect(mockApiGet).toHaveBeenCalledWith(
           `/metadata/photo/${encodeURIComponent(photoPath)}/metadata`
         )
+        // Should fetch sidecar metadata
+        expect(mockGetPhotoSidecarMetadata).toHaveBeenCalledWith(filename)
       })
     })
 
-    it('loading state shows MetadataSkeleton', () => {
-      api.get.mockImplementation(
-        () =>
-          new Promise((resolve) => {
-            setTimeout(() => resolve({ ok: true, json: async () => mockMetadata }), 1000)
-          })
-      )
-
-      render(
-        <TestWrapper>
-          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
-        </TestWrapper>
-      )
-
-      // Should show skeleton
-      expect(screen.getByTestId('metadata-skeleton')).toBeInTheDocument()
-      expect(screen.getByRole('status')).toBeInTheDocument()
-    })
-
-    it('success state shows tab content', async () => {
-      api.get.mockResolvedValueOnce({
-        data: mockMetadata,
-
-      })
+    it('passes EXIF data to MetadataEXIF component', async () => {
+      mockApiGet.mockResolvedValueOnce({ data: mockExifMetadata })
+      mockGetPhotoSidecarMetadata.mockResolvedValueOnce({ data: mockSidecarMetadata })
 
       render(
         <TestWrapper>
@@ -501,125 +549,17 @@ describe('MetadataPanel', () => {
         expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
       })
 
-      // Should show tab content
-      expect(screen.getByTestId('camera-tab')).toBeInTheDocument()
-      expect(screen.getByRole('tablist')).toBeInTheDocument()
-    })
-
-    it('passes metadata to tabs correctly', async () => {
-      api.get.mockResolvedValueOnce({
-        data: mockMetadata,
-
-      })
-
-      const user = userEvent.setup()
-
-      render(
-        <TestWrapper>
-          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
-        </TestWrapper>
-      )
-
-      await waitFor(() => {
-        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
-      })
-
-      // Check Camera tab receives data
-      expect(screen.getByTestId('camera-tab')).toHaveTextContent('loaded')
-
-      // Switch to Capture tab
-      await user.click(screen.getByRole('tab', { name: /capture/i }))
-      expect(screen.getByTestId('capture-tab')).toHaveTextContent('loaded')
-
-      // Switch to Tags tab
-      await user.click(screen.getByRole('tab', { name: /tags/i }))
-      expect(screen.getByTestId('tags-tab')).toHaveTextContent('loaded')
-
-      // Switch to Deployment tab (now includes location data)
-      await user.click(screen.getByRole('tab', { name: /deployment/i }))
-      expect(screen.getByTestId('deployment-tab')).toHaveTextContent('loaded')
+      // EXIF component should receive data
+      const exifComponent = screen.getByTestId('metadata-exif')
+      expect(exifComponent).toHaveTextContent('loaded')
     })
   })
 
   describe('Error Handling', () => {
-    it('handles API 404 errors gracefully', async () => {
-      const error = new Error('Request failed with status code 404')
-      error.response = {
-        status: 404,
-        statusText: 'Not Found',
-      }
-      api.get.mockRejectedValueOnce(error)
-
-      render(
-        <TestWrapper>
-          <MetadataPanel photoPath="/var/lib/mothbox/photos/missing.jpg" />
-        </TestWrapper>
-      )
-
-      await waitFor(() => {
-        expect(screen.getByText(/failed to load metadata/i)).toBeInTheDocument()
-      })
-    })
-
-    it('handles API 500 errors gracefully', async () => {
-      const error = new Error('Request failed with status code 500')
-      error.response = {
-        status: 500,
-        statusText: 'Internal Server Error',
-      }
-      api.get.mockRejectedValueOnce(error)
-
-      render(
-        <TestWrapper>
-          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
-        </TestWrapper>
-      )
-
-      await waitFor(() => {
-        expect(screen.getByText(/failed to load metadata/i)).toBeInTheDocument()
-      })
-    })
-
-    it('shows "Failed to load metadata" message on error', async () => {
-      api.get.mockRejectedValueOnce(new Error('Network error'))
-
-      render(
-        <TestWrapper>
-          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
-        </TestWrapper>
-      )
-
-      await waitFor(() => {
-        expect(screen.getByText(/failed to load metadata/i)).toBeInTheDocument()
-      })
-    })
-
-    it('shows retry suggestion on error', async () => {
-      const error = new Error('Request failed with status code 500')
-      error.response = {
-        status: 500,
-        statusText: 'Internal Server Error',
-      }
-      api.get.mockRejectedValueOnce(error)
-
-      render(
-        <TestWrapper>
-          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
-        </TestWrapper>
-      )
-
-      await waitFor(() => {
-        expect(screen.getByText(/try again/i)).toBeInTheDocument()
-      })
-    })
-
-    it('error state shows error message instead of tabs', async () => {
-      const error = new Error('Request failed with status code 500')
-      error.response = {
-        status: 500,
-        statusText: 'Internal Server Error',
-      }
-      api.get.mockRejectedValueOnce(error)
+    it('handles EXIF fetch error gracefully', async () => {
+      mockApiGet.mockRejectedValueOnce(new Error('Network error'))
+      // Mock sidecar to succeed so it doesn't hang
+      mockGetPhotoSidecarMetadata.mockResolvedValueOnce({ data: mockSidecarMetadata })
 
       render(
         <TestWrapper>
@@ -631,287 +571,46 @@ describe('MetadataPanel', () => {
         expect(screen.getByText(/failed to load metadata/i)).toBeInTheDocument()
       })
 
-      // Should not show tabs
-      expect(screen.queryByRole('tablist')).not.toBeInTheDocument()
-      expect(screen.queryByTestId('camera-tab')).not.toBeInTheDocument()
+      // Should show retry button
+      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
     })
 
-    it('shows retry button on error that triggers refetch', async () => {
+    it('retry button refetches data', async () => {
       // First call fails
-      api.get.mockRejectedValueOnce(new Error('Network error'))
+      mockApiGet.mockRejectedValueOnce(new Error('Network error'))
+      // Mock sidecar to succeed so it doesn't hang
+      mockGetPhotoSidecarMetadata.mockResolvedValueOnce({ data: mockSidecarMetadata })
 
-      const { rerender } = render(
+      render(
         <TestWrapper>
           <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
         </TestWrapper>
       )
 
-      // Wait for error state
       await waitFor(() => {
         expect(screen.getByText(/failed to load metadata/i)).toBeInTheDocument()
       })
-
-      // Retry button should be visible
-      const retryButton = screen.getByRole('button', { name: /retry/i })
-      expect(retryButton).toBeInTheDocument()
 
       // Second call succeeds
-      api.get.mockResolvedValueOnce({
-        data: mockMetadata,
+      mockApiGet.mockResolvedValueOnce({ data: mockExifMetadata })
+      mockGetPhotoSidecarMetadata.mockResolvedValueOnce({ data: mockSidecarMetadata })
 
-      })
-
-      // Click retry button
+      // Click retry
+      const retryButton = screen.getByRole('button', { name: /retry/i })
       await userEvent.click(retryButton)
 
-      // Should eventually show the tabs after successful refetch
+      // Should show accordion sections after successful retry
       await waitFor(() => {
-        expect(screen.getByRole('tablist')).toBeInTheDocument()
+        expect(screen.getByTestId('accordion-section-tags')).toBeInTheDocument()
       })
-
-      // Error message should be gone
-      expect(screen.queryByText(/failed to load metadata/i)).not.toBeInTheDocument()
-    })
-  })
-
-  describe('Responsive Layout', () => {
-    it('applies responsive layout classes', async () => {
-      api.get.mockResolvedValueOnce({
-        data: mockMetadata,
-
-      })
-
-      const { container } = render(
-        <TestWrapper>
-          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
-        </TestWrapper>
-      )
-
-      await waitFor(() => {
-        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
-      })
-
-      // Check for responsive flex classes
-      const tabsRoot = container.querySelector('[role="tablist"]').parentElement
-      expect(tabsRoot).toHaveClass('flex')
-    })
-  })
-
-  describe('Accessibility', () => {
-    it('all tabs have accessible labels', async () => {
-      api.get.mockResolvedValueOnce({
-        data: mockMetadata,
-
-      })
-
-      render(
-        <TestWrapper>
-          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
-        </TestWrapper>
-      )
-
-      await waitFor(() => {
-        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
-      })
-
-      // All tabs should have accessible names (4 tabs: Camera, Capture, Tags, Deployment)
-      expect(screen.getByRole('tab', { name: /camera/i })).toBeInTheDocument()
-      expect(screen.getByRole('tab', { name: /capture/i })).toBeInTheDocument()
-      expect(screen.getByRole('tab', { name: /tags/i })).toBeInTheDocument()
-      expect(
-        screen.getByRole('tab', { name: /deployment/i })
-      ).toBeInTheDocument()
-    })
-
-    it('tab list has proper ARIA attributes', async () => {
-      api.get.mockResolvedValueOnce({
-        data: mockMetadata,
-
-      })
-
-      render(
-        <TestWrapper>
-          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
-        </TestWrapper>
-      )
-
-      await waitFor(() => {
-        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
-      })
-
-      const tabList = screen.getByRole('tablist')
-      expect(tabList).toHaveAttribute('aria-label', 'Photo metadata tabs')
-    })
-
-    it('keyboard navigation works (test aria-selected changes)', async () => {
-      api.get.mockResolvedValueOnce({
-        data: mockMetadata,
-
-      })
-
-      const user = userEvent.setup()
-
-      render(
-        <TestWrapper>
-          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
-        </TestWrapper>
-      )
-
-      await waitFor(() => {
-        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
-      })
-
-      const cameraTab = screen.getByRole('tab', { name: /camera/i })
-      const deploymentTab = screen.getByRole('tab', { name: /deployment/i })
-
-      // Initially Camera tab should be selected
-      expect(cameraTab).toHaveAttribute('aria-selected', 'true')
-
-      // Focus the deployment tab and press Space to activate it
-      deploymentTab.focus()
-      await user.keyboard('{Space}')
-
-      // Deployment tab should now be selected
-      await waitFor(() => {
-        expect(deploymentTab).toHaveAttribute('aria-selected', 'true')
-        expect(cameraTab).toHaveAttribute('aria-selected', 'false')
-      })
-    })
-
-    it('each tab has proper aria-controls', async () => {
-      api.get.mockResolvedValueOnce({
-        data: mockMetadata,
-
-      })
-
-      render(
-        <TestWrapper>
-          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
-        </TestWrapper>
-      )
-
-      await waitFor(() => {
-        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
-      })
-
-      // Each tab should have aria-controls attribute
-      const tabs = screen.getAllByRole('tab')
-      tabs.forEach((tab) => {
-        expect(tab).toHaveAttribute('aria-controls')
-        expect(tab.getAttribute('aria-controls')).toBeTruthy()
-      })
-    })
-  })
-
-  describe('State Management', () => {
-    it('remembers selected tab when photoPath changes', async () => {
-      api.get.mockResolvedValue({
-        data: mockMetadata,
-
-      })
-
-      const user = userEvent.setup()
-
-      const { rerender } = render(
-        <TestWrapper>
-          <MetadataPanel photoPath="/var/lib/mothbox/photos/photo1.jpg" />
-        </TestWrapper>
-      )
-
-      await waitFor(() => {
-        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
-      })
-
-      // Switch to Deployment tab
-      await user.click(screen.getByRole('tab', { name: /deployment/i }))
-      expect(screen.getByTestId('deployment-tab')).toBeVisible()
-
-      // Change photo path (should remember Deployment tab)
-      rerender(
-        <TestWrapper>
-          <MetadataPanel photoPath="/var/lib/mothbox/photos/photo2.jpg" />
-        </TestWrapper>
-      )
-
-      await waitFor(() => {
-        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
-      })
-
-      // Should still be on Deployment tab
-      expect(screen.getByTestId('deployment-tab')).toBeVisible()
-      expect(
-        screen.getByRole('tab', { name: /deployment/i })
-      ).toHaveAttribute('aria-selected', 'true')
-    })
-
-    it('defaults to camera tab on initial render', async () => {
-      api.get.mockResolvedValueOnce({
-        data: mockMetadata,
-
-      })
-
-      render(
-        <TestWrapper>
-          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
-        </TestWrapper>
-      )
-
-      await waitFor(() => {
-        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
-      })
-
-      // Camera tab should be selected
-      expect(screen.getByRole('tab', { name: /camera/i })).toHaveAttribute(
-        'aria-selected',
-        'true'
-      )
-      expect(screen.getByTestId('camera-tab')).toBeVisible()
-    })
-
-    it('tab state persists across re-renders', async () => {
-      api.get.mockResolvedValueOnce({
-        data: mockMetadata,
-
-      })
-
-      const user = userEvent.setup()
-
-      const { rerender } = render(
-        <TestWrapper>
-          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
-        </TestWrapper>
-      )
-
-      await waitFor(() => {
-        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
-      })
-
-      // Switch to Capture tab
-      await user.click(screen.getByRole('tab', { name: /capture/i }))
-      expect(screen.getByTestId('capture-tab')).toBeVisible()
-
-      // Force re-render with same props
-      rerender(
-        <TestWrapper>
-          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
-        </TestWrapper>
-      )
-
-      // Should still be on Capture tab
-      expect(screen.getByTestId('capture-tab')).toBeVisible()
-      expect(screen.getByRole('tab', { name: /capture/i })).toHaveAttribute(
-        'aria-selected',
-        'true'
-      )
     })
   })
 
   describe('Edge Cases', () => {
-    it('handles null metadata gracefully', async () => {
-      api.get.mockResolvedValueOnce({
-        data: mockMetadata,
-        data: null,
-      })
+    it('handles empty sidecar data gracefully', async () => {
+      mockGetPhotoSidecarMetadata.mockResolvedValueOnce({ data: mockSidecarMetadata })
+      mockApiGet.mockResolvedValueOnce({ data: mockExifMetadata })
+      mockApiGet.mockResolvedValueOnce({ data: {} })
 
       render(
         <TestWrapper>
@@ -923,73 +622,17 @@ describe('MetadataPanel', () => {
         expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
       })
 
-      // Should still render tabs but with no data
-      expect(screen.getByRole('tablist')).toBeInTheDocument()
-      expect(screen.getByTestId('camera-tab')).toHaveTextContent('no data')
-    })
-
-    it('handles partial metadata gracefully', async () => {
-      const partialMetadata = {
-        camera: mockMetadata.camera,
-        // Missing other sections
-      }
-
-      api.get.mockResolvedValueOnce({
-        data: mockMetadata,
-        data: partialMetadata,
-      })
-
-      const user = userEvent.setup()
-
-      render(
-        <TestWrapper>
-          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
-        </TestWrapper>
-      )
-
-      await waitFor(() => {
-        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
-      })
-
-      // Camera tab should have data
-      expect(screen.getByTestId('camera-tab')).toHaveTextContent('loaded')
-    })
-
-    it('handles empty photoPath gracefully', () => {
-      render(
-        <TestWrapper>
-          <MetadataPanel photoPath="" />
-        </TestWrapper>
-      )
-
-      // Should not make API request
-      expect(api.get).not.toHaveBeenCalled()
-
-      // Should not show skeleton (query is disabled)
-      expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
-    })
-
-    it('handles undefined photoPath gracefully', () => {
-      render(
-        <TestWrapper>
-          <MetadataPanel photoPath={undefined} />
-        </TestWrapper>
-      )
-
-      // Should not make API request
-      expect(api.get).not.toHaveBeenCalled()
-
-      // Should not show skeleton (query is disabled)
-      expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      // Should still render all sections with empty/default values
+      expect(screen.getByTestId('metadata-tags')).toBeInTheDocument()
+      expect(screen.getByTestId('metadata-species')).toBeInTheDocument()
+      expect(screen.getByTestId('metadata-notes')).toBeInTheDocument()
     })
 
     it('applies custom className prop', async () => {
-      api.get.mockResolvedValueOnce({
-        data: mockMetadata,
+      mockApiGet.mockResolvedValueOnce({ data: mockExifMetadata })
+      mockGetPhotoSidecarMetadata.mockResolvedValueOnce({ data: mockSidecarMetadata })
 
-      })
-
-      const { container } = render(
+      render(
         <TestWrapper>
           <MetadataPanel
             photoPath="/var/lib/mothbox/photos/test.jpg"
@@ -1002,8 +645,263 @@ describe('MetadataPanel', () => {
         expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
       })
 
-      // Root element should have custom class
-      expect(container.firstChild).toHaveClass('custom-class')
+      // Panel element should have custom class
+      const panel = screen.getByTestId('metadata-panel')
+      expect(panel).toHaveClass('custom-class')
+    })
+  })
+
+  describe('Keyboard Shortcuts', () => {
+    it('ctrl+s triggers manual save', async () => {
+      mockApiGet.mockResolvedValueOnce({ data: mockExifMetadata })
+      mockGetPhotoSidecarMetadata.mockResolvedValueOnce({ data: mockSidecarMetadata })
+      mockUpdatePhotoSidecarMetadata.mockResolvedValue({ data: { success: true } })
+
+      const user = userEvent.setup()
+
+      render(
+        <TestWrapper>
+          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      // Make a change first
+      const notesTextarea = screen.getByTestId('notes-textarea')
+      await user.clear(notesTextarea)
+      await user.type(notesTextarea, 'New notes')
+
+      // Clear previous API calls
+      mockUpdatePhotoSidecarMetadata.mockClear()
+
+      // Press Ctrl+S
+      await user.keyboard('{Control>}s{/Control}')
+
+      // Should trigger immediate save (not wait for debounce)
+      await waitFor(
+        () => {
+          expect(mockUpdatePhotoSidecarMetadata).toHaveBeenCalled()
+        },
+        { timeout: 500 } // Should be much faster than 2 second debounce
+      )
+    })
+
+    it('cmd+s triggers manual save on mac', async () => {
+      mockApiGet.mockResolvedValueOnce({ data: mockExifMetadata })
+      mockGetPhotoSidecarMetadata.mockResolvedValueOnce({ data: mockSidecarMetadata })
+      mockUpdatePhotoSidecarMetadata.mockResolvedValue({ data: { success: true } })
+
+      const user = userEvent.setup()
+
+      render(
+        <TestWrapper>
+          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      // Make a change first
+      const notesTextarea = screen.getByTestId('notes-textarea')
+      await user.clear(notesTextarea)
+      await user.type(notesTextarea, 'New notes')
+
+      // Clear previous API calls
+      mockUpdatePhotoSidecarMetadata.mockClear()
+
+      // Press Cmd+S (Meta key for Mac)
+      await user.keyboard('{Meta>}s{/Meta}')
+
+      // Should trigger immediate save
+      await waitFor(
+        () => {
+          expect(mockUpdatePhotoSidecarMetadata).toHaveBeenCalled()
+        },
+        { timeout: 500 }
+      )
+    })
+
+    it('ctrl+enter saves and closes panel', async () => {
+      mockApiGet.mockResolvedValueOnce({ data: mockExifMetadata })
+      mockGetPhotoSidecarMetadata.mockResolvedValueOnce({ data: mockSidecarMetadata })
+      mockUpdatePhotoSidecarMetadata.mockResolvedValue({ data: { success: true } })
+
+      const onCloseMock = vi.fn()
+      const user = userEvent.setup()
+
+      render(
+        <TestWrapper>
+          <MetadataPanel
+            photoPath="/var/lib/mothbox/photos/test.jpg"
+            onClose={onCloseMock}
+          />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      // Make a change first
+      const notesTextarea = screen.getByTestId('notes-textarea')
+      await user.clear(notesTextarea)
+      await user.type(notesTextarea, 'New notes')
+
+      // Clear previous API calls
+      mockUpdatePhotoSidecarMetadata.mockClear()
+
+      // Press Ctrl+Enter
+      await user.keyboard('{Control>}{Enter}{/Control}')
+
+      // Should trigger save
+      await waitFor(
+        () => {
+          expect(mockUpdatePhotoSidecarMetadata).toHaveBeenCalled()
+        },
+        { timeout: 500 }
+      )
+
+      // Should call onClose
+      expect(onCloseMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('esc closes panel', async () => {
+      mockApiGet.mockResolvedValueOnce({ data: mockExifMetadata })
+      mockGetPhotoSidecarMetadata.mockResolvedValueOnce({ data: mockSidecarMetadata })
+
+      const onCloseMock = vi.fn()
+      const user = userEvent.setup()
+
+      render(
+        <TestWrapper>
+          <MetadataPanel
+            photoPath="/var/lib/mothbox/photos/test.jpg"
+            onClose={onCloseMock}
+          />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      // Focus inside the panel to activate shortcuts
+      const notesTextarea = screen.getByTestId('notes-textarea')
+      notesTextarea.focus()
+
+      // Press Escape
+      await user.keyboard('{Escape}')
+
+      // Should call onClose
+      expect(onCloseMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('prevents default browser save dialog', async () => {
+      mockApiGet.mockResolvedValueOnce({ data: mockExifMetadata })
+      mockGetPhotoSidecarMetadata.mockResolvedValueOnce({ data: mockSidecarMetadata })
+      mockUpdatePhotoSidecarMetadata.mockResolvedValue({ data: { success: true } })
+
+      render(
+        <TestWrapper>
+          <MetadataPanel photoPath="/var/lib/mothbox/photos/test.jpg" />
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      // Focus inside the panel to activate shortcuts
+      const notesTextarea = screen.getByTestId('notes-textarea')
+      notesTextarea.focus()
+
+      // Create a spy for preventDefault
+      const preventDefaultSpy = vi.fn()
+
+      // Manually fire keydown event with Ctrl+S
+      const event = new KeyboardEvent('keydown', {
+        key: 's',
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      })
+
+      // Spy on preventDefault
+      Object.defineProperty(event, 'preventDefault', {
+        value: preventDefaultSpy,
+        writable: true,
+      })
+
+      document.dispatchEvent(event)
+
+      // Should prevent default behavior
+      await waitFor(() => {
+        expect(preventDefaultSpy).toHaveBeenCalled()
+      })
+    })
+
+    it('shortcuts only active when panel is focused or child is focused', async () => {
+      mockApiGet.mockResolvedValueOnce({ data: mockExifMetadata })
+      mockGetPhotoSidecarMetadata.mockResolvedValueOnce({ data: mockSidecarMetadata })
+      mockUpdatePhotoSidecarMetadata.mockResolvedValue({ data: { success: true } })
+
+      const onCloseMock = vi.fn()
+
+      render(
+        <TestWrapper>
+          <div>
+            <MetadataPanel
+              photoPath="/var/lib/mothbox/photos/test.jpg"
+              onClose={onCloseMock}
+            />
+            <button data-testid="outside-button">Outside Button</button>
+          </div>
+        </TestWrapper>
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
+      })
+
+      // Focus on element outside the panel
+      const outsideButton = screen.getByTestId('outside-button')
+      outsideButton.focus()
+
+      // Press Escape while focused outside
+      const event = new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      })
+      document.dispatchEvent(event)
+
+      // Wait a bit
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      // onClose should NOT be called since focus is outside panel
+      expect(onCloseMock).not.toHaveBeenCalled()
+
+      // Now focus inside the panel
+      const notesTextarea = screen.getByTestId('notes-textarea')
+      notesTextarea.focus()
+
+      // Press Escape while focused inside
+      const event2 = new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      })
+      document.dispatchEvent(event2)
+
+      // Should call onClose now
+      await waitFor(() => {
+        expect(onCloseMock).toHaveBeenCalledTimes(1)
+      })
     })
   })
 })

--- a/Firmware/webui/frontend/src/components/metadata/__tests__/MetadataPanel.test.jsx
+++ b/Firmware/webui/frontend/src/components/metadata/__tests__/MetadataPanel.test.jsx
@@ -496,8 +496,8 @@ describe('MetadataPanel (Accordion Refactor)', () => {
         expect(screen.queryByTestId('metadata-skeleton')).not.toBeInTheDocument()
       })
 
-      // Existing custom fields should be displayed
-      expect(screen.getByTestId('custom-field-observer')).toBeInTheDocument()
+      // Wait for custom fields to appear after sidecar data syncs to local state
+      expect(await screen.findByTestId('custom-field-observer')).toBeInTheDocument()
       expect(screen.getByTestId('custom-field-weather')).toBeInTheDocument()
 
       // Add a custom field

--- a/Firmware/webui/frontend/src/components/metadata/__tests__/MetadataSpecies.test.jsx
+++ b/Firmware/webui/frontend/src/components/metadata/__tests__/MetadataSpecies.test.jsx
@@ -1,0 +1,334 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import MetadataSpecies from '../MetadataSpecies'
+
+// Mock the useSpecies hook
+vi.mock('../../../hooks/useSpecies', () => ({
+  default: vi.fn(() => ({
+    data: {
+      species: [
+        { name: 'Actias luna', count: 42 },
+        { name: 'Actias selene', count: 18 },
+        { name: 'Antheraea polyphemus', count: 35 },
+        { name: 'Automeris io', count: 27 },
+        { name: 'Callosamia promethea', count: 12 },
+      ],
+    },
+    isLoading: false,
+    error: null,
+  })),
+}))
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  })
+  return ({ children }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+describe('MetadataSpecies', () => {
+  let mockOnChange
+
+  beforeEach(() => {
+    mockOnChange = vi.fn()
+  })
+
+  it('test_renders_species_input_with_current_value', () => {
+    render(
+      <MetadataSpecies
+        species="Actias luna"
+        confidence="certain"
+        onChange={mockOnChange}
+      />,
+      { wrapper: createWrapper() }
+    )
+
+    const speciesInput = screen.getByPlaceholderText(/e.g., Actias luna/)
+    expect(speciesInput).toBeInTheDocument()
+    expect(speciesInput.value).toBe('Actias luna')
+  })
+
+  it('test_shows_autocomplete_suggestions', async () => {
+    render(
+      <MetadataSpecies
+        species=""
+        confidence="unknown"
+        onChange={mockOnChange}
+      />,
+      { wrapper: createWrapper() }
+    )
+
+    const speciesInput = screen.getByPlaceholderText(/e.g., Actias luna/)
+
+    // Type to trigger autocomplete
+    fireEvent.change(speciesInput, { target: { value: 'Actias' } })
+    fireEvent.focus(speciesInput)
+
+    // Wait for suggestions to appear
+    await waitFor(() => {
+      expect(screen.getByText(/Actias luna/)).toBeInTheDocument()
+      expect(screen.getByText(/Actias selene/)).toBeInTheDocument()
+    })
+  })
+
+  it('test_selecting_suggestion_updates_field', async () => {
+    render(
+      <MetadataSpecies
+        species=""
+        confidence="unknown"
+        onChange={mockOnChange}
+      />,
+      { wrapper: createWrapper() }
+    )
+
+    const speciesInput = screen.getByPlaceholderText(/e.g., Actias luna/)
+
+    // Type and show suggestions
+    fireEvent.change(speciesInput, { target: { value: 'Actias' } })
+    fireEvent.focus(speciesInput)
+
+    // Wait for and click suggestion
+    await waitFor(() => {
+      expect(screen.getByText(/Actias luna/)).toBeInTheDocument()
+    })
+
+    const suggestion = screen.getByText(/Actias luna/)
+    fireEvent.click(suggestion)
+
+    // Input should be updated
+    await waitFor(() => {
+      expect(speciesInput.value).toBe('Actias luna')
+      expect(mockOnChange).toHaveBeenCalledWith('species', 'Actias luna')
+    })
+  })
+
+  it('test_renders_confidence_dropdown', () => {
+    render(
+      <MetadataSpecies
+        species="Actias luna"
+        confidence="certain"
+        onChange={mockOnChange}
+      />,
+      { wrapper: createWrapper() }
+    )
+
+    const confidenceLabel = screen.getByText('Confidence')
+    expect(confidenceLabel).toBeInTheDocument()
+
+    const confidenceSelect = screen.getByDisplayValue('Certain')
+    expect(confidenceSelect).toBeInTheDocument()
+  })
+
+  it('test_confidence_options', () => {
+    render(
+      <MetadataSpecies
+        species="Actias luna"
+        confidence="certain"
+        onChange={mockOnChange}
+      />,
+      { wrapper: createWrapper() }
+    )
+
+    const confidenceSelect = screen.getByDisplayValue('Certain')
+
+    // Check all options are present
+    expect(screen.getByRole('option', { name: 'Certain' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Probable' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Possible' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Unknown' })).toBeInTheDocument()
+  })
+
+  it('test_selecting_confidence_calls_onChange', () => {
+    render(
+      <MetadataSpecies
+        species="Actias luna"
+        confidence="certain"
+        onChange={mockOnChange}
+      />,
+      { wrapper: createWrapper() }
+    )
+
+    const confidenceSelect = screen.getByDisplayValue('Certain')
+
+    fireEvent.change(confidenceSelect, { target: { value: 'probable' } })
+
+    expect(mockOnChange).toHaveBeenCalledWith('confidence', 'probable')
+  })
+
+  it('test_renders_common_name_field', () => {
+    render(
+      <MetadataSpecies
+        species="Actias luna"
+        confidence="certain"
+        commonName="Luna Moth"
+        onChange={mockOnChange}
+      />,
+      { wrapper: createWrapper() }
+    )
+
+    const commonNameLabel = screen.getByText('Common Name')
+    expect(commonNameLabel).toBeInTheDocument()
+
+    const commonNameInput = screen.getByPlaceholderText(/e.g., Luna Moth/)
+    expect(commonNameInput).toBeInTheDocument()
+    expect(commonNameInput.value).toBe('Luna Moth')
+  })
+
+  it('test_renders_reference_link_field', () => {
+    render(
+      <MetadataSpecies
+        species="Actias luna"
+        confidence="certain"
+        referenceUrl="https://inaturalist.org/taxa/47924"
+        onChange={mockOnChange}
+      />,
+      { wrapper: createWrapper() }
+    )
+
+    const referenceLabel = screen.getByText('Reference Link')
+    expect(referenceLabel).toBeInTheDocument()
+
+    const referenceInput = screen.getByPlaceholderText(/https:\/\/inaturalist.org\/.../)
+    expect(referenceInput).toBeInTheDocument()
+    expect(referenceInput.value).toBe('https://inaturalist.org/taxa/47924')
+  })
+
+  it('test_calls_onChange_on_input', () => {
+    render(
+      <MetadataSpecies
+        species="Actias luna"
+        confidence="certain"
+        commonName=""
+        onChange={mockOnChange}
+      />,
+      { wrapper: createWrapper() }
+    )
+
+    const commonNameInput = screen.getByPlaceholderText(/e.g., Luna Moth/)
+
+    fireEvent.change(commonNameInput, { target: { value: 'Luna Moth' } })
+
+    expect(mockOnChange).toHaveBeenCalledWith('commonName', 'Luna Moth')
+  })
+
+  it('test_validates_reference_url', () => {
+    render(
+      <MetadataSpecies
+        species="Actias luna"
+        confidence="certain"
+        referenceUrl=""
+        onChange={mockOnChange}
+      />,
+      { wrapper: createWrapper() }
+    )
+
+    const referenceInput = screen.getByPlaceholderText(/https:\/\/inaturalist.org\/.../)
+
+    // Invalid URL (no protocol)
+    fireEvent.change(referenceInput, { target: { value: 'inaturalist.org/taxa/47924' } })
+
+    expect(screen.getByText('URL must start with http:// or https://')).toBeInTheDocument()
+    expect(mockOnChange).toHaveBeenCalledWith('referenceUrl', 'inaturalist.org/taxa/47924')
+  })
+
+  it('test_species_blur_triggers_onChange', () => {
+    render(
+      <MetadataSpecies
+        species=""
+        confidence="unknown"
+        onChange={mockOnChange}
+      />,
+      { wrapper: createWrapper() }
+    )
+
+    const speciesInput = screen.getByPlaceholderText(/e.g., Actias luna/)
+
+    fireEvent.change(speciesInput, { target: { value: 'Actias luna' } })
+    fireEvent.blur(speciesInput)
+
+    // Wait for blur timeout
+    setTimeout(() => {
+      expect(mockOnChange).toHaveBeenCalledWith('species', 'Actias luna')
+    }, 300)
+  })
+
+  it('test_disabled_state', () => {
+    render(
+      <MetadataSpecies
+        species="Actias luna"
+        confidence="certain"
+        commonName="Luna Moth"
+        referenceUrl="https://inaturalist.org/taxa/47924"
+        onChange={mockOnChange}
+        disabled={true}
+      />,
+      { wrapper: createWrapper() }
+    )
+
+    const speciesInput = screen.getByPlaceholderText(/e.g., Actias luna/)
+    const commonNameInput = screen.getByPlaceholderText(/e.g., Luna Moth/)
+    const confidenceSelect = screen.getByDisplayValue('Certain')
+    const referenceInput = screen.getByPlaceholderText(/https:\/\/inaturalist.org\/.../)
+
+    expect(speciesInput).toBeDisabled()
+    expect(commonNameInput).toBeDisabled()
+    expect(confidenceSelect).toBeDisabled()
+    expect(referenceInput).toBeDisabled()
+  })
+
+  it('test_valid_url_clears_error', () => {
+    render(
+      <MetadataSpecies
+        species="Actias luna"
+        confidence="certain"
+        referenceUrl=""
+        onChange={mockOnChange}
+      />,
+      { wrapper: createWrapper() }
+    )
+
+    const referenceInput = screen.getByPlaceholderText(/https:\/\/inaturalist.org\/.../)
+
+    // Invalid URL first
+    fireEvent.change(referenceInput, { target: { value: 'inaturalist.org' } })
+    expect(screen.getByText('URL must start with http:// or https://')).toBeInTheDocument()
+
+    // Valid URL should clear error
+    fireEvent.change(referenceInput, { target: { value: 'https://inaturalist.org/taxa/47924' } })
+    expect(screen.queryByText('URL must start with http:// or https://')).not.toBeInTheDocument()
+  })
+
+  it('test_empty_url_clears_error', async () => {
+    render(
+      <MetadataSpecies
+        species="Actias luna"
+        confidence="certain"
+        referenceUrl=""
+        onChange={mockOnChange}
+      />,
+      { wrapper: createWrapper() }
+    )
+
+    const referenceInput = screen.getByPlaceholderText(/https:\/\/inaturalist.org\/.../)
+
+    // Set invalid URL first
+    fireEvent.change(referenceInput, { target: { value: 'invalid' } })
+
+    await waitFor(() => {
+      expect(screen.getByText('URL must start with http:// or https://')).toBeInTheDocument()
+    })
+
+    // Empty URL should clear error
+    fireEvent.change(referenceInput, { target: { value: '' } })
+
+    await waitFor(() => {
+      expect(screen.queryByText('URL must start with http:// or https://')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/components/metadata/__tests__/MetadataSpecies.test.jsx
+++ b/Firmware/webui/frontend/src/components/metadata/__tests__/MetadataSpecies.test.jsx
@@ -99,7 +99,7 @@ describe('MetadataSpecies', () => {
     })
 
     const suggestion = screen.getByText(/Actias luna/)
-    fireEvent.click(suggestion)
+    fireEvent.mouseDown(suggestion)
 
     // Input should be updated
     await waitFor(() => {

--- a/Firmware/webui/frontend/src/components/metadata/__tests__/MetadataSpecies.test.jsx
+++ b/Firmware/webui/frontend/src/components/metadata/__tests__/MetadataSpecies.test.jsx
@@ -230,11 +230,30 @@ describe('MetadataSpecies', () => {
 
     const referenceInput = screen.getByPlaceholderText(/https:\/\/inaturalist.org\/.../)
 
-    // Invalid URL (no protocol)
+    // Invalid URL (no protocol) - parsed as relative URL, throws error
     fireEvent.change(referenceInput, { target: { value: 'inaturalist.org/taxa/47924' } })
 
-    expect(screen.getByText('URL must start with http:// or https://')).toBeInTheDocument()
+    expect(screen.getByText('Invalid URL format')).toBeInTheDocument()
     expect(mockOnChange).toHaveBeenCalledWith('referenceUrl', 'inaturalist.org/taxa/47924')
+  })
+
+  it('test_validates_url_protocol', () => {
+    render(
+      <MetadataSpecies
+        species="Actias luna"
+        confidence="certain"
+        referenceUrl=""
+        onChange={mockOnChange}
+      />,
+      { wrapper: createWrapper() }
+    )
+
+    const referenceInput = screen.getByPlaceholderText(/https:\/\/inaturalist.org\/.../)
+
+    // Invalid protocol (ftp)
+    fireEvent.change(referenceInput, { target: { value: 'ftp://example.com/file' } })
+
+    expect(screen.getByText('URL must start with http:// or https://')).toBeInTheDocument()
   })
 
   it('test_species_blur_triggers_onChange', () => {
@@ -295,13 +314,13 @@ describe('MetadataSpecies', () => {
 
     const referenceInput = screen.getByPlaceholderText(/https:\/\/inaturalist.org\/.../)
 
-    // Invalid URL first
+    // Invalid URL first (no protocol, will be caught by URL parser)
     fireEvent.change(referenceInput, { target: { value: 'inaturalist.org' } })
-    expect(screen.getByText('URL must start with http:// or https://')).toBeInTheDocument()
+    expect(screen.getByText('Invalid URL format')).toBeInTheDocument()
 
     // Valid URL should clear error
     fireEvent.change(referenceInput, { target: { value: 'https://inaturalist.org/taxa/47924' } })
-    expect(screen.queryByText('URL must start with http:// or https://')).not.toBeInTheDocument()
+    expect(screen.queryByText('Invalid URL format')).not.toBeInTheDocument()
   })
 
   it('test_empty_url_clears_error', async () => {
@@ -317,18 +336,18 @@ describe('MetadataSpecies', () => {
 
     const referenceInput = screen.getByPlaceholderText(/https:\/\/inaturalist.org\/.../)
 
-    // Set invalid URL first
+    // Set invalid URL first (no protocol, will be caught by URL parser)
     fireEvent.change(referenceInput, { target: { value: 'invalid' } })
 
     await waitFor(() => {
-      expect(screen.getByText('URL must start with http:// or https://')).toBeInTheDocument()
+      expect(screen.getByText('Invalid URL format')).toBeInTheDocument()
     })
 
     // Empty URL should clear error
     fireEvent.change(referenceInput, { target: { value: '' } })
 
     await waitFor(() => {
-      expect(screen.queryByText('URL must start with http:// or https://')).not.toBeInTheDocument()
+      expect(screen.queryByText('Invalid URL format')).not.toBeInTheDocument()
     })
   })
 })

--- a/Firmware/webui/frontend/src/components/metadata/__tests__/MetadataTags.test.jsx
+++ b/Firmware/webui/frontend/src/components/metadata/__tests__/MetadataTags.test.jsx
@@ -1,0 +1,338 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import MetadataTags from '../MetadataTags'
+
+// Mock useTags hook
+vi.mock('../../../hooks/useTags', () => ({
+  default: vi.fn(() => ({
+    data: {
+      tags: [
+        { name: 'moth', count: 15 },
+        { name: 'butterfly', count: 8 },
+        { name: 'beetle', count: 12 },
+      ],
+    },
+    isLoading: false,
+    isError: false,
+  })),
+}))
+
+// Test wrapper with QueryClient
+function TestWrapper({ children }) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}
+
+describe('MetadataTags', () => {
+  const defaultProps = {
+    tags: ['existing-tag', 'another-tag'],
+    onAddTag: vi.fn(),
+    onRemoveTag: vi.fn(),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('Rendering', () => {
+    it('renders existing tags as chips', () => {
+      render(<MetadataTags {...defaultProps} />, { wrapper: TestWrapper })
+
+      expect(screen.getByText('existing-tag')).toBeInTheDocument()
+      expect(screen.getByText('another-tag')).toBeInTheDocument()
+    })
+
+    it('displays tag chips with remove button', () => {
+      render(<MetadataTags {...defaultProps} />, { wrapper: TestWrapper })
+
+      const removeButtons = screen.getAllByRole('button', { name: /Remove tag/i })
+      expect(removeButtons).toHaveLength(2)
+    })
+
+    it('renders autocomplete input field', () => {
+      render(<MetadataTags {...defaultProps} />, { wrapper: TestWrapper })
+
+      const input = screen.getByPlaceholderText(/Type to add tags/i)
+      expect(input).toBeInTheDocument()
+      expect(input).toHaveAttribute('type', 'text')
+    })
+
+    it('shows placeholder when no tags exist', () => {
+      render(<MetadataTags {...defaultProps} tags={[]} />, { wrapper: TestWrapper })
+
+      expect(screen.getByText('Add tags...')).toBeInTheDocument()
+    })
+  })
+
+  describe('Tag Removal', () => {
+    it('calls onRemoveTag when clicking remove button', async () => {
+      const user = userEvent.setup()
+      render(<MetadataTags {...defaultProps} />, { wrapper: TestWrapper })
+
+      const removeButton = screen.getByRole('button', { name: 'Remove tag existing-tag' })
+      await user.click(removeButton)
+
+      expect(defaultProps.onRemoveTag).toHaveBeenCalledWith('existing-tag')
+      expect(defaultProps.onRemoveTag).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not call onRemoveTag when disabled', async () => {
+      const user = userEvent.setup()
+      render(<MetadataTags {...defaultProps} disabled />, { wrapper: TestWrapper })
+
+      const removeButton = screen.getByRole('button', { name: 'Remove tag existing-tag' })
+      await user.click(removeButton)
+
+      expect(defaultProps.onRemoveTag).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Autocomplete', () => {
+    it('shows suggestions dropdown when typing', async () => {
+      const user = userEvent.setup()
+      render(<MetadataTags {...defaultProps} />, { wrapper: TestWrapper })
+
+      const input = screen.getByPlaceholderText(/Type to add tags/i)
+      await user.type(input, 'moth')
+
+      await waitFor(() => {
+        expect(screen.getByText(/moth/)).toBeInTheDocument()
+      })
+    })
+
+    it('displays suggestion counts', async () => {
+      const user = userEvent.setup()
+      render(<MetadataTags {...defaultProps} />, { wrapper: TestWrapper })
+
+      const input = screen.getByPlaceholderText(/Type to add tags/i)
+      await user.type(input, 'moth')
+
+      await waitFor(() => {
+        expect(screen.getByText('(15)')).toBeInTheDocument()
+      })
+    })
+
+    it('filters suggestions based on input', async () => {
+      const user = userEvent.setup()
+      render(<MetadataTags {...defaultProps} />, { wrapper: TestWrapper })
+
+      const input = screen.getByPlaceholderText(/Type to add tags/i)
+      await user.type(input, 'bee')
+
+      await waitFor(() => {
+        expect(screen.getByText(/beetle/)).toBeInTheDocument()
+        expect(screen.queryByText(/moth/)).not.toBeInTheDocument()
+      })
+    })
+
+    it('excludes already selected tags from suggestions', async () => {
+      const user = userEvent.setup()
+      render(
+        <MetadataTags {...defaultProps} tags={['moth']} />,
+        { wrapper: TestWrapper }
+      )
+
+      const input = screen.getByPlaceholderText(/Type to add tags/i)
+      await user.type(input, 'moth')
+
+      await waitFor(() => {
+        // Should not show moth in suggestions since it's already selected
+        const suggestions = screen.queryAllByText('moth')
+        // Only one instance: the existing chip, not in suggestions
+        expect(suggestions).toHaveLength(1)
+      })
+    })
+
+    it('adds tag when clicking suggestion', async () => {
+      const user = userEvent.setup()
+      render(<MetadataTags {...defaultProps} />, { wrapper: TestWrapper })
+
+      const input = screen.getByPlaceholderText(/Type to add tags/i)
+      await user.type(input, 'moth')
+
+      await waitFor(() => {
+        expect(screen.getByText(/moth/)).toBeInTheDocument()
+      })
+
+      const suggestion = screen.getByText('moth')
+      await user.click(suggestion)
+
+      expect(defaultProps.onAddTag).toHaveBeenCalledWith('moth')
+    })
+  })
+
+  describe('Keyboard Interaction', () => {
+    it('adds tag when pressing Enter', async () => {
+      const user = userEvent.setup()
+      render(<MetadataTags {...defaultProps} />, { wrapper: TestWrapper })
+
+      const input = screen.getByPlaceholderText(/Type to add tags/i)
+      await user.type(input, 'new-tag{Enter}')
+
+      expect(defaultProps.onAddTag).toHaveBeenCalledWith('new-tag')
+    })
+
+    it('adds tag when typing comma', async () => {
+      const user = userEvent.setup()
+      render(<MetadataTags {...defaultProps} />, { wrapper: TestWrapper })
+
+      const input = screen.getByPlaceholderText(/Type to add tags/i)
+      await user.type(input, 'new-tag,')
+
+      expect(defaultProps.onAddTag).toHaveBeenCalledWith('new-tag')
+    })
+
+    it('clears input after adding tag with Enter', async () => {
+      const user = userEvent.setup()
+      render(<MetadataTags {...defaultProps} />, { wrapper: TestWrapper })
+
+      const input = screen.getByPlaceholderText(/Type to add tags/i)
+      await user.type(input, 'new-tag{Enter}')
+
+      expect(input.value).toBe('')
+    })
+
+    it('clears input after adding tag with comma', async () => {
+      const user = userEvent.setup()
+      render(<MetadataTags {...defaultProps} />, { wrapper: TestWrapper })
+
+      const input = screen.getByPlaceholderText(/Type to add tags/i)
+      await user.type(input, 'new-tag,')
+
+      expect(input.value).toBe('')
+    })
+  })
+
+  describe('Duplicate Prevention', () => {
+    it('prevents adding duplicate tags (case-insensitive)', async () => {
+      const user = userEvent.setup()
+      render(<MetadataTags {...defaultProps} />, { wrapper: TestWrapper })
+
+      const input = screen.getByPlaceholderText(/Type to add tags/i)
+      await user.type(input, 'EXISTING-TAG{Enter}')
+
+      expect(defaultProps.onAddTag).not.toHaveBeenCalled()
+    })
+
+    it('prevents adding empty tags', async () => {
+      const user = userEvent.setup()
+      render(<MetadataTags {...defaultProps} />, { wrapper: TestWrapper })
+
+      const input = screen.getByPlaceholderText(/Type to add tags/i)
+      await user.type(input, '{Enter}')
+
+      expect(defaultProps.onAddTag).not.toHaveBeenCalled()
+    })
+
+    it('trims whitespace before adding', async () => {
+      const user = userEvent.setup()
+      render(<MetadataTags {...defaultProps} />, { wrapper: TestWrapper })
+
+      const input = screen.getByPlaceholderText(/Type to add tags/i)
+      await user.type(input, '  trimmed-tag  {Enter}')
+
+      expect(defaultProps.onAddTag).toHaveBeenCalledWith('trimmed-tag')
+    })
+
+    it('prevents adding whitespace-only tags', async () => {
+      const user = userEvent.setup()
+      render(<MetadataTags {...defaultProps} />, { wrapper: TestWrapper })
+
+      const input = screen.getByPlaceholderText(/Type to add tags/i)
+      await user.type(input, '   {Enter}')
+
+      expect(defaultProps.onAddTag).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Copy to Next Photo', () => {
+    it('renders copy button when onCopyToNext provided', () => {
+      const onCopyToNext = vi.fn()
+      render(
+        <MetadataTags {...defaultProps} onCopyToNext={onCopyToNext} />,
+        { wrapper: TestWrapper }
+      )
+
+      expect(screen.getByText(/Copy tags to next photo/i)).toBeInTheDocument()
+    })
+
+    it('does not render copy button when onCopyToNext not provided', () => {
+      render(<MetadataTags {...defaultProps} />, { wrapper: TestWrapper })
+
+      expect(screen.queryByText(/Copy tags to next photo/i)).not.toBeInTheDocument()
+    })
+
+    it('calls onCopyToNext when clicking copy button', async () => {
+      const user = userEvent.setup()
+      const onCopyToNext = vi.fn()
+      render(
+        <MetadataTags {...defaultProps} onCopyToNext={onCopyToNext} />,
+        { wrapper: TestWrapper }
+      )
+
+      const copyButton = screen.getByText(/Copy tags to next photo/i)
+      await user.click(copyButton)
+
+      expect(onCopyToNext).toHaveBeenCalledTimes(1)
+    })
+
+    it('disables copy button when no tags exist', () => {
+      const onCopyToNext = vi.fn()
+      render(
+        <MetadataTags {...defaultProps} tags={[]} onCopyToNext={onCopyToNext} />,
+        { wrapper: TestWrapper }
+      )
+
+      const copyButton = screen.getByText(/Copy tags to next photo/i)
+      expect(copyButton.closest('button')).toBeDisabled()
+    })
+
+    it('disables copy button when component is disabled', () => {
+      const onCopyToNext = vi.fn()
+      render(
+        <MetadataTags {...defaultProps} onCopyToNext={onCopyToNext} disabled />,
+        { wrapper: TestWrapper }
+      )
+
+      const copyButton = screen.getByText(/Copy tags to next photo/i)
+      expect(copyButton.closest('button')).toBeDisabled()
+    })
+  })
+
+  describe('Disabled State', () => {
+    it('disables input when disabled prop is true', () => {
+      render(<MetadataTags {...defaultProps} disabled />, { wrapper: TestWrapper })
+
+      const input = screen.getByPlaceholderText(/Type to add tags/i)
+      expect(input).toBeDisabled()
+    })
+
+    it('disables remove buttons when disabled', () => {
+      render(<MetadataTags {...defaultProps} disabled />, { wrapper: TestWrapper })
+
+      const removeButtons = screen.getAllByRole('button', { name: /Remove tag/i })
+      removeButtons.forEach(button => {
+        expect(button).toBeDisabled()
+      })
+    })
+
+    it('does not show suggestions when disabled', async () => {
+      const user = userEvent.setup()
+      render(<MetadataTags {...defaultProps} disabled />, { wrapper: TestWrapper })
+
+      const input = screen.getByPlaceholderText(/Type to add tags/i)
+
+      // Try to type (won't work because input is disabled)
+      await user.click(input)
+
+      expect(screen.queryByText(/moth/)).not.toBeInTheDocument()
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/components/metadata/__tests__/SaveStatusIndicator.test.jsx
+++ b/Firmware/webui/frontend/src/components/metadata/__tests__/SaveStatusIndicator.test.jsx
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react'
+import SaveStatusIndicator from '../SaveStatusIndicator'
+
+describe('SaveStatusIndicator', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('test_renders_nothing_when_idle', () => {
+    const { container } = render(<SaveStatusIndicator status="idle" />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('test_shows_saving_state', () => {
+    render(<SaveStatusIndicator status="saving" />)
+
+    expect(screen.getByText('Saving...')).toBeInTheDocument()
+
+    // Check for spinner (animated rotating element)
+    const spinner = screen.getByRole('status').querySelector('.animate-spin')
+    expect(spinner).toBeInTheDocument()
+  })
+
+  it('test_shows_saved_state_with_checkmark', () => {
+    render(<SaveStatusIndicator status="saved" />)
+
+    expect(screen.getByText('Saved')).toBeInTheDocument()
+
+    // Check for checkmark icon (SVG with specific class)
+    const icon = screen.getByRole('status').querySelector('svg')
+    expect(icon).toBeInTheDocument()
+    expect(icon).toHaveClass('text-green-500')
+  })
+
+  it('test_shows_error_state_with_message', () => {
+    render(<SaveStatusIndicator status="error" />)
+
+    expect(screen.getByText('Save failed')).toBeInTheDocument()
+
+    // Check for error icon (SVG with red color)
+    const icon = screen.getByRole('status').querySelector('svg')
+    expect(icon).toBeInTheDocument()
+    expect(icon).toHaveClass('text-red-500')
+  })
+
+  it('test_shows_retry_button_on_error', () => {
+    const onRetry = vi.fn()
+    render(<SaveStatusIndicator status="error" onRetry={onRetry} />)
+
+    const retryButton = screen.getByRole('button', { name: /retry/i })
+    expect(retryButton).toBeInTheDocument()
+  })
+
+  it('test_retry_button_calls_onRetry', () => {
+    const onRetry = vi.fn()
+    render(<SaveStatusIndicator status="error" onRetry={onRetry} />)
+
+    const retryButton = screen.getByRole('button', { name: /retry/i })
+    fireEvent.click(retryButton)
+
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+
+  it('test_hides_after_timeout_on_success', async () => {
+    const { rerender } = render(<SaveStatusIndicator status="idle" />)
+
+    // Change to saved
+    rerender(<SaveStatusIndicator status="saved" />)
+    expect(screen.getByText('Saved')).toBeInTheDocument()
+
+    // Fast-forward time by 2000ms wrapped in act
+    await act(async () => {
+      vi.advanceTimersByTime(2000)
+    })
+
+    // Component should be hidden
+    expect(screen.queryByText('Saved')).not.toBeInTheDocument()
+  })
+
+  it('test_accessible_status_announcements', () => {
+    render(<SaveStatusIndicator status="saving" />)
+
+    const statusElement = screen.getByRole('status')
+    expect(statusElement).toHaveAttribute('aria-live', 'polite')
+  })
+
+  it('test_custom_error_message', () => {
+    const customError = 'Network connection failed'
+    render(<SaveStatusIndicator status="error" errorMessage={customError} />)
+
+    expect(screen.getByText(customError)).toBeInTheDocument()
+    expect(screen.queryByText('Save failed')).not.toBeInTheDocument()
+  })
+
+  it('test_no_retry_button_when_onRetry_not_provided', () => {
+    render(<SaveStatusIndicator status="error" />)
+
+    expect(screen.queryByRole('button', { name: /retry/i })).not.toBeInTheDocument()
+  })
+
+  it('test_transitions_from_saving_to_saved', () => {
+    const { rerender } = render(<SaveStatusIndicator status="saving" />)
+    expect(screen.getByText('Saving...')).toBeInTheDocument()
+
+    rerender(<SaveStatusIndicator status="saved" />)
+    expect(screen.getByText('Saved')).toBeInTheDocument()
+    expect(screen.queryByText('Saving...')).not.toBeInTheDocument()
+  })
+
+  it('test_does_not_auto_hide_error_state', async () => {
+    render(<SaveStatusIndicator status="error" />)
+
+    expect(screen.getByText('Save failed')).toBeInTheDocument()
+
+    // Fast-forward time
+    await act(async () => {
+      vi.advanceTimersByTime(5000)
+    })
+
+    // Error should still be visible
+    expect(screen.getByText('Save failed')).toBeInTheDocument()
+  })
+
+  it('test_clears_timeout_when_transitioning_from_saved', async () => {
+    const { rerender } = render(<SaveStatusIndicator status="saved" />)
+
+    // Advance time partway
+    await act(async () => {
+      vi.advanceTimersByTime(1000)
+    })
+
+    // Change status before timeout completes
+    rerender(<SaveStatusIndicator status="saving" />)
+
+    // Advance remaining time
+    await act(async () => {
+      vi.advanceTimersByTime(1000)
+    })
+
+    // Should still show saving, not be hidden
+    expect(screen.getByText('Saving...')).toBeInTheDocument()
+  })
+})

--- a/Firmware/webui/frontend/src/constants/config.js
+++ b/Firmware/webui/frontend/src/constants/config.js
@@ -319,3 +319,23 @@ export const HOVER_POPUP_CONFIG = {
   SWIPE_THRESHOLD: 50,
   ANIMATION_DURATION: 100,
 }
+
+/**
+ * Metadata Field Validation Limits
+ *
+ * Maximum character lengths for metadata fields.
+ * Must match backend sidecar_metadata.py constants.
+ *
+ * @property {number} MAX_TAG_LENGTH - Maximum length for individual tags (50 chars)
+ * @property {number} MAX_SPECIES_LENGTH - Maximum length for species scientific name (200 chars)
+ * @property {number} MAX_COMMON_NAME_LENGTH - Maximum length for species common name (200 chars)
+ * @property {number} MAX_NOTES_LENGTH - Maximum length for notes field (10000 chars)
+ * @property {number} MAX_REFERENCE_URL_LENGTH - Maximum length for reference URL (500 chars)
+ */
+export const METADATA_VALIDATION = {
+  MAX_TAG_LENGTH: 50,
+  MAX_SPECIES_LENGTH: 200,
+  MAX_COMMON_NAME_LENGTH: 200,
+  MAX_NOTES_LENGTH: 10000,
+  MAX_REFERENCE_URL_LENGTH: 500,
+}

--- a/Firmware/webui/frontend/src/constants/config.js
+++ b/Firmware/webui/frontend/src/constants/config.js
@@ -339,3 +339,21 @@ export const METADATA_VALIDATION = {
   MAX_NOTES_LENGTH: 10000,
   MAX_REFERENCE_URL_LENGTH: 500,
 }
+
+/**
+ * Species Identification Configuration
+ *
+ * Configuration for species identification metadata fields.
+ *
+ * @property {Array<Object>} CONFIDENCE_OPTIONS - Available confidence levels for species ID
+ *   - value: Internal value stored in metadata
+ *   - label: User-facing display label
+ */
+export const SPECIES_CONFIG = {
+  CONFIDENCE_OPTIONS: [
+    { value: 'certain', label: 'Certain' },
+    { value: 'probable', label: 'Probable' },
+    { value: 'possible', label: 'Possible' },
+    { value: 'unknown', label: 'Unknown' },
+  ],
+}

--- a/Firmware/webui/frontend/src/hooks/__tests__/useAutoSave.test.jsx
+++ b/Firmware/webui/frontend/src/hooks/__tests__/useAutoSave.test.jsx
@@ -395,6 +395,46 @@ describe('useAutoSave', () => {
     expect(result.current.status).toBe('idle')
   })
 
+  it('test_detects_equality_regardless_of_key_order', async () => {
+    // Regression test: JSON.stringify would fail this because key order differs
+    const onSave = vi.fn().mockResolvedValue()
+    const { rerender } = renderHook(
+      ({ data }) => useAutoSave({ data, onSave }),
+      { initialProps: { data: { a: 1, b: 2 } } }
+    )
+
+    // Same data but different key order (would fail with JSON.stringify)
+    rerender({ data: { b: 2, a: 1 } })
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000)
+      await Promise.resolve()
+    })
+
+    // Should NOT save since data is semantically equal
+    expect(onSave).not.toHaveBeenCalled()
+  })
+
+  it('test_detects_equality_with_nested_objects_different_key_order', async () => {
+    // More complex case with nested objects
+    const onSave = vi.fn().mockResolvedValue()
+    const { rerender } = renderHook(
+      ({ data }) => useAutoSave({ data, onSave }),
+      { initialProps: { data: { outer: { a: 1, b: 2 }, c: 3 } } }
+    )
+
+    // Same data but different key order at multiple levels
+    rerender({ data: { c: 3, outer: { b: 2, a: 1 } } })
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000)
+      await Promise.resolve()
+    })
+
+    // Should NOT save since data is semantically equal
+    expect(onSave).not.toHaveBeenCalled()
+  })
+
   it('test_status_returns_to_idle_after_saved', async () => {
     const onSave = vi.fn().mockResolvedValue()
     const { result, rerender } = renderHook(

--- a/Firmware/webui/frontend/src/hooks/__tests__/useAutoSave.test.jsx
+++ b/Firmware/webui/frontend/src/hooks/__tests__/useAutoSave.test.jsx
@@ -1,0 +1,428 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import useAutoSave from '../useAutoSave'
+
+describe('useAutoSave', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('test_debounces_save_by_2_seconds', async () => {
+    const onSave = vi.fn().mockResolvedValue()
+    const { result, rerender } = renderHook(
+      ({ data }) => useAutoSave({ data, onSave }),
+      { initialProps: { data: { value: 1 } } }
+    )
+
+    // Change data
+    rerender({ data: { value: 2 } })
+
+    // Should not save immediately
+    expect(onSave).not.toHaveBeenCalled()
+    expect(result.current.status).toBe('idle')
+
+    // Advance time by 1 second - still not called
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(onSave).not.toHaveBeenCalled()
+
+    // Advance time by another 1 second - now it should be called
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+
+    // Run pending promises
+    await act(async () => {
+      await vi.runAllTimersAsync()
+    })
+
+    // Should have saved with correct data
+    expect(onSave).toHaveBeenCalledTimes(1)
+    expect(onSave).toHaveBeenCalledWith({ value: 2 })
+  })
+
+  it('test_cancels_pending_save_on_new_change', async () => {
+    const onSave = vi.fn().mockResolvedValue()
+    const { result, rerender } = renderHook(
+      ({ data }) => useAutoSave({ data, onSave }),
+      { initialProps: { data: { value: 1 } } }
+    )
+
+    // First change
+    rerender({ data: { value: 2 } })
+
+    // Advance time by 1.5 seconds
+    act(() => {
+      vi.advanceTimersByTime(1500)
+    })
+
+    // Second change (should cancel previous timer)
+    rerender({ data: { value: 3 } })
+
+    // Advance time by 1 second (total 2.5s from first change, but only 1s from second)
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+
+    // Should not have saved yet
+    expect(onSave).not.toHaveBeenCalled()
+
+    // Advance by another 1 second (now 2s from second change)
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+
+    await act(async () => {
+      await vi.runAllTimersAsync()
+    })
+
+    // Should have saved with the latest data only once
+    expect(onSave).toHaveBeenCalledTimes(1)
+    expect(onSave).toHaveBeenCalledWith({ value: 3 })
+  })
+
+  it('test_saves_immediately_with_saveNow', async () => {
+    const onSave = vi.fn().mockResolvedValue()
+    const { result, rerender } = renderHook(
+      ({ data }) => useAutoSave({ data, onSave }),
+      { initialProps: { data: { value: 1 } } }
+    )
+
+    // Change data
+    rerender({ data: { value: 2 } })
+
+    // Call saveNow immediately
+    await act(async () => {
+      result.current.saveNow()
+      // Flush promises
+      await Promise.resolve()
+    })
+
+    // Should have saved immediately without waiting for debounce
+    expect(onSave).toHaveBeenCalledTimes(1)
+    expect(onSave).toHaveBeenCalledWith({ value: 2 })
+  })
+
+  it('test_returns_save_status_idle', () => {
+    const onSave = vi.fn().mockResolvedValue()
+    const { result } = renderHook(() =>
+      useAutoSave({ data: { value: 1 }, onSave })
+    )
+
+    expect(result.current.status).toBe('idle')
+  })
+
+  it('test_returns_save_status_saving', async () => {
+    let resolvePromise
+    const onSave = vi.fn().mockImplementation(() => {
+      return new Promise((resolve) => {
+        resolvePromise = resolve
+      })
+    })
+
+    const { result, rerender } = renderHook(
+      ({ data }) => useAutoSave({ data, onSave }),
+      { initialProps: { data: { value: 1 } } }
+    )
+
+    // Change data and trigger save
+    rerender({ data: { value: 2 } })
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000)
+      await Promise.resolve() // Let the promise start
+    })
+
+    // Status should be 'saving'
+    expect(result.current.status).toBe('saving')
+
+    // Resolve the promise to clean up
+    await act(async () => {
+      resolvePromise()
+      await Promise.resolve()
+    })
+  })
+
+  it('test_returns_save_status_saved', async () => {
+    const onSave = vi.fn().mockResolvedValue()
+    const { result, rerender } = renderHook(
+      ({ data }) => useAutoSave({ data, onSave }),
+      { initialProps: { data: { value: 1 } } }
+    )
+
+    // Change data
+    rerender({ data: { value: 2 } })
+
+    // Wait for debounce
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+
+    // Run only pending promises, not the status reset timer
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    // Status should be 'saved'
+    expect(result.current.status).toBe('saved')
+  })
+
+  it('test_returns_save_status_error', async () => {
+    const error = new Error('Save failed')
+    const onSave = vi.fn().mockRejectedValue(error)
+    const { result, rerender } = renderHook(
+      ({ data }) => useAutoSave({ data, onSave }),
+      { initialProps: { data: { value: 1 } } }
+    )
+
+    // Change data
+    rerender({ data: { value: 2 } })
+
+    // Wait for debounce
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+
+    // Run pending promises
+    await act(async () => {
+      await vi.runAllTimersAsync()
+    })
+
+    // Status should be 'error'
+    expect(result.current.status).toBe('error')
+  })
+
+  it('test_clears_pending_save_on_unmount', () => {
+    const onSave = vi.fn().mockResolvedValue()
+    const { rerender, unmount } = renderHook(
+      ({ data }) => useAutoSave({ data, onSave }),
+      { initialProps: { data: { value: 1 } } }
+    )
+
+    // Change data
+    rerender({ data: { value: 2 } })
+
+    // Verify timer is set (save not called yet)
+    expect(onSave).not.toHaveBeenCalled()
+
+    // Unmount before timer fires
+    unmount()
+
+    // Advance time
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+
+    // Save should not have been called
+    expect(onSave).not.toHaveBeenCalled()
+  })
+
+  it('test_calls_onSave_with_current_data', async () => {
+    const onSave = vi.fn().mockResolvedValue()
+    const testData = { id: 1, name: 'Test', tags: ['tag1', 'tag2'] }
+    const { result, rerender } = renderHook(
+      ({ data }) => useAutoSave({ data, onSave }),
+      { initialProps: { data: { value: 1 } } }
+    )
+
+    // Change to specific data
+    rerender({ data: testData })
+
+    // Wait for debounce
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+
+    await act(async () => {
+      await vi.runAllTimersAsync()
+    })
+
+    // Verify correct data was passed
+    expect(onSave).toHaveBeenCalledTimes(1)
+    expect(onSave).toHaveBeenCalledWith(testData)
+  })
+
+  it('test_does_not_save_when_enabled_is_false', async () => {
+    const onSave = vi.fn().mockResolvedValue()
+    const { result, rerender } = renderHook(
+      ({ data }) => useAutoSave({ data, onSave, enabled: false }),
+      { initialProps: { data: { value: 1 } } }
+    )
+
+    // Change data
+    rerender({ data: { value: 2 } })
+
+    // Wait for debounce time
+    await act(async () => {
+      vi.advanceTimersByTime(2000)
+      await Promise.resolve()
+    })
+
+    // Save should not have been called
+    expect(onSave).not.toHaveBeenCalled()
+
+    // Try saveNow as well
+    await act(async () => {
+      result.current.saveNow()
+      await Promise.resolve()
+    })
+
+    // Still should not have been called
+    expect(onSave).not.toHaveBeenCalled()
+  })
+
+  it('test_returns_error_object', async () => {
+    const error = new Error('Network error')
+    const onSave = vi.fn().mockRejectedValue(error)
+    const { result, rerender } = renderHook(
+      ({ data }) => useAutoSave({ data, onSave }),
+      { initialProps: { data: { value: 1 } } }
+    )
+
+    // Initially no error
+    expect(result.current.error).toBeNull()
+
+    // Change data and trigger save
+    rerender({ data: { value: 2 } })
+
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+
+    await act(async () => {
+      await vi.runAllTimersAsync()
+    })
+
+    // Error should be available
+    expect(result.current.status).toBe('error')
+    expect(result.current.error).toBe(error)
+    expect(result.current.error.message).toBe('Network error')
+  })
+
+  it('test_clears_error_on_retry', async () => {
+    let shouldFail = true
+    const onSave = vi.fn().mockImplementation(() => {
+      if (shouldFail) {
+        return Promise.reject(new Error('First error'))
+      }
+      return Promise.resolve()
+    })
+
+    const { result, rerender } = renderHook(
+      ({ data }) => useAutoSave({ data, onSave }),
+      { initialProps: { data: { value: 1 } } }
+    )
+
+    // First save that fails
+    rerender({ data: { value: 2 } })
+
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(result.current.status).toBe('error')
+    expect(result.current.error).not.toBeNull()
+
+    // Second save that succeeds
+    shouldFail = false
+    rerender({ data: { value: 3 } })
+
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(result.current.status).toBe('saved')
+    expect(result.current.error).toBeNull()
+  })
+
+  it('test_custom_delay', async () => {
+    const onSave = vi.fn().mockResolvedValue()
+    const { rerender } = renderHook(
+      ({ data }) => useAutoSave({ data, onSave, delay: 500 }),
+      { initialProps: { data: { value: 1 } } }
+    )
+
+    // Change data
+    rerender({ data: { value: 2 } })
+
+    // Should not save at 400ms
+    act(() => {
+      vi.advanceTimersByTime(400)
+    })
+    expect(onSave).not.toHaveBeenCalled()
+
+    // Should save at 500ms
+    act(() => {
+      vi.advanceTimersByTime(100)
+    })
+
+    await act(async () => {
+      await vi.runAllTimersAsync()
+    })
+
+    expect(onSave).toHaveBeenCalledTimes(1)
+  })
+
+  it('test_does_not_save_if_data_unchanged_from_initial', async () => {
+    const onSave = vi.fn().mockResolvedValue()
+    const initialData = { value: 1 }
+    const { result } = renderHook(() =>
+      useAutoSave({ data: initialData, onSave })
+    )
+
+    // Wait for debounce time
+    await act(async () => {
+      vi.advanceTimersByTime(2000)
+      await Promise.resolve()
+    })
+
+    // Should not have saved since data hasn't changed
+    expect(onSave).not.toHaveBeenCalled()
+    expect(result.current.status).toBe('idle')
+  })
+
+  it('test_status_returns_to_idle_after_saved', async () => {
+    const onSave = vi.fn().mockResolvedValue()
+    const { result, rerender } = renderHook(
+      ({ data }) => useAutoSave({ data, onSave }),
+      { initialProps: { data: { value: 1 } } }
+    )
+
+    // Change data
+    rerender({ data: { value: 2 } })
+
+    // Wait for debounce and save
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    // Status should be 'saved'
+    expect(result.current.status).toBe('saved')
+
+    // Wait for the status reset timer (1.5 seconds)
+    await act(async () => {
+      vi.advanceTimersByTime(1500)
+    })
+
+    // Status should return to 'idle'
+    expect(result.current.status).toBe('idle')
+  })
+})

--- a/Firmware/webui/frontend/src/hooks/__tests__/useSidecarMetadata.test.jsx
+++ b/Firmware/webui/frontend/src/hooks/__tests__/useSidecarMetadata.test.jsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import useSidecarMetadata, { clearTagsInvalidationTimeout } from '../useSidecarMetadata'
+import useSidecarMetadata from '../useSidecarMetadata'
 import * as api from '../../utils/api'
 
 // Mock the API module
@@ -39,8 +39,8 @@ describe('useSidecarMetadata', () => {
 
   afterEach(() => {
     queryClient.clear()
-    // Clear any pending debounced tags invalidation to prevent test interference
-    clearTagsInvalidationTimeout()
+    // Note: Tags invalidation timeout is now managed by useRef inside the hook,
+    // so cleanup happens automatically when the hook unmounts
   })
 
   /**

--- a/Firmware/webui/frontend/src/hooks/__tests__/useSpecies.test.jsx
+++ b/Firmware/webui/frontend/src/hooks/__tests__/useSpecies.test.jsx
@@ -1,0 +1,420 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import useSpecies from '../useSpecies'
+import * as api from '../../utils/api'
+
+// Mock the API module
+vi.mock('../../utils/api', () => ({
+  getAllSpecies: vi.fn()
+}))
+
+/**
+ * Test suite for useSpecies hook
+ *
+ * Tests the custom hook for fetching all species from sidecar metadata using TanStack Query.
+ * Verifies loading states, success scenarios, error handling, caching, and
+ * query parameter handling.
+ */
+describe('useSpecies', () => {
+  let queryClient
+
+  // Helper function to create a wrapper with QueryClient
+  const createWrapper = () => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false, // Disable retries for faster tests
+        },
+      },
+    })
+
+    return function Wrapper({ children }) {
+      return (
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      )
+    }
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    if (queryClient) {
+      queryClient.clear()
+    }
+  })
+
+  describe('Success scenarios', () => {
+    it('fetches species successfully', async () => {
+      const mockSpeciesData = {
+        species: [
+          { name: 'Actias luna', count: 42 },
+          { name: 'Papilio glaucus', count: 18 },
+          { name: 'Danaus plexippus', count: 7 },
+        ],
+        total: 3,
+      }
+
+      api.getAllSpecies.mockResolvedValueOnce({
+        data: mockSpeciesData,
+      })
+
+      const { result } = renderHook(
+        () => useSpecies(),
+        { wrapper: createWrapper() }
+      )
+
+      // Initially loading
+      expect(result.current.isLoading).toBe(true)
+      expect(result.current.data).toBeUndefined()
+
+      // Wait for successful fetch
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true)
+      })
+
+      expect(result.current.isLoading).toBe(false)
+      expect(result.current.isError).toBe(false)
+      expect(result.current.data).toEqual(mockSpeciesData)
+    })
+
+    it('uses correct API endpoint', async () => {
+      const mockSpeciesData = { species: [], total: 0 }
+      api.getAllSpecies.mockResolvedValueOnce({ data: mockSpeciesData })
+
+      renderHook(
+        () => useSpecies(),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => {
+        expect(api.getAllSpecies).toHaveBeenCalledWith({})
+      })
+    })
+
+    it('passes sort and order params to API', async () => {
+      const mockSpeciesData = { species: [], total: 0 }
+      api.getAllSpecies.mockResolvedValueOnce({ data: mockSpeciesData })
+
+      renderHook(
+        () => useSpecies({ sort: 'count', order: 'desc' }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => {
+        expect(api.getAllSpecies).toHaveBeenCalledWith({ sort: 'count', order: 'desc' })
+      })
+    })
+
+    it('passes limit param to API', async () => {
+      const mockSpeciesData = { species: [], total: 0 }
+      api.getAllSpecies.mockResolvedValueOnce({ data: mockSpeciesData })
+
+      renderHook(
+        () => useSpecies({ limit: 10 }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => {
+        expect(api.getAllSpecies).toHaveBeenCalledWith({ limit: 10 })
+      })
+    })
+
+    it('passes multiple params to API', async () => {
+      const mockSpeciesData = { species: [], total: 0 }
+      api.getAllSpecies.mockResolvedValueOnce({ data: mockSpeciesData })
+
+      renderHook(
+        () => useSpecies({ sort: 'name', order: 'asc', limit: 20 }),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => {
+        expect(api.getAllSpecies).toHaveBeenCalledWith({
+          sort: 'name',
+          order: 'asc',
+          limit: 20
+        })
+      })
+    })
+
+    it('caches species data', async () => {
+      const mockSpeciesData = { species: [], total: 0 }
+      api.getAllSpecies.mockResolvedValue({ data: mockSpeciesData })
+
+      const wrapper = createWrapper()
+
+      // First render - should fetch
+      const { result: result1, unmount: unmount1 } = renderHook(
+        () => useSpecies(),
+        { wrapper }
+      )
+
+      await waitFor(() => {
+        expect(result1.current.isSuccess).toBe(true)
+      })
+
+      expect(api.getAllSpecies).toHaveBeenCalledTimes(1)
+
+      unmount1()
+
+      // Second render - should use cache
+      const { result: result2 } = renderHook(
+        () => useSpecies(),
+        { wrapper }
+      )
+
+      await waitFor(() => {
+        expect(result2.current.isSuccess).toBe(true)
+      })
+
+      // Should still only have 1 fetch call (cached)
+      expect(api.getAllSpecies).toHaveBeenCalledTimes(1)
+    })
+
+    it('uses correct query key for caching', async () => {
+      const mockSpeciesData = { species: [], total: 0 }
+      api.getAllSpecies.mockResolvedValueOnce({ data: mockSpeciesData })
+
+      const wrapper = createWrapper()
+
+      renderHook(
+        () => useSpecies(),
+        { wrapper }
+      )
+
+      await waitFor(() => {
+        const cachedData = queryClient.getQueryData(['species', {}])
+        expect(cachedData).toEqual(mockSpeciesData)
+      })
+    })
+
+    it('uses different cache key with params', async () => {
+      const mockSpeciesData = { species: [], total: 0 }
+      api.getAllSpecies.mockResolvedValueOnce({ data: mockSpeciesData })
+
+      const wrapper = createWrapper()
+      const params = { sort: 'count', order: 'desc' }
+
+      renderHook(
+        () => useSpecies(params),
+        { wrapper }
+      )
+
+      await waitFor(() => {
+        const cachedData = queryClient.getQueryData(['species', params])
+        expect(cachedData).toEqual(mockSpeciesData)
+      })
+    })
+
+    it('refetches when params change', async () => {
+      const mockSpeciesData1 = { species: [{ name: 'Actias luna', count: 10 }], total: 1 }
+      const mockSpeciesData2 = { species: [{ name: 'Papilio glaucus', count: 5 }], total: 1 }
+
+      api.getAllSpecies
+        .mockResolvedValueOnce({ data: mockSpeciesData1 })
+        .mockResolvedValueOnce({ data: mockSpeciesData2 })
+
+      const { result, rerender } = renderHook(
+        ({ params }) => useSpecies(params),
+        {
+          wrapper: createWrapper(),
+          initialProps: { params: { sort: 'name' } },
+        }
+      )
+
+      // Wait for first fetch
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true)
+      })
+
+      expect(result.current.data).toEqual(mockSpeciesData1)
+      expect(api.getAllSpecies).toHaveBeenCalledTimes(1)
+      expect(api.getAllSpecies).toHaveBeenCalledWith({ sort: 'name' })
+
+      // Change params
+      rerender({ params: { sort: 'count' } })
+
+      // Wait for second fetch
+      await waitFor(() => {
+        expect(result.current.data).toEqual(mockSpeciesData2)
+      })
+
+      expect(api.getAllSpecies).toHaveBeenCalledTimes(2)
+      expect(api.getAllSpecies).toHaveBeenLastCalledWith({ sort: 'count' })
+    })
+  })
+
+  describe('Loading state', () => {
+    it('returns loading state initially', () => {
+      api.getAllSpecies.mockImplementation(() => new Promise(() => {})) // Never resolves
+
+      const { result } = renderHook(
+        () => useSpecies(),
+        { wrapper: createWrapper() }
+      )
+
+      expect(result.current.isLoading).toBe(true)
+      expect(result.current.isError).toBe(false)
+      expect(result.current.isSuccess).toBe(false)
+      expect(result.current.data).toBeUndefined()
+    })
+  })
+
+  describe('Error handling', () => {
+    it('handles error state', async () => {
+      const error = new Error('Failed to fetch species')
+      api.getAllSpecies.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(
+        () => useSpecies(),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true)
+      })
+
+      expect(result.current.isLoading).toBe(false)
+      expect(result.current.isSuccess).toBe(false)
+      expect(result.current.data).toBeUndefined()
+      expect(result.current.error).toBeDefined()
+      expect(result.current.error.message).toBe('Failed to fetch species')
+    })
+
+    it('handles 500 server errors gracefully', async () => {
+      const error = new Error('Request failed with status code 500')
+      error.response = {
+        status: 500,
+        statusText: 'Internal Server Error',
+      }
+      api.getAllSpecies.mockRejectedValueOnce(error)
+
+      const { result } = renderHook(
+        () => useSpecies(),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true)
+      })
+
+      expect(result.current.error).toBeDefined()
+      expect(result.current.error.message).toContain('500')
+    })
+
+    it('handles network errors gracefully', async () => {
+      api.getAllSpecies.mockRejectedValueOnce(new Error('Network request failed'))
+
+      const { result } = renderHook(
+        () => useSpecies(),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true)
+      })
+
+      expect(result.current.error).toBeDefined()
+      expect(result.current.error.message).toBe('Network request failed')
+    })
+  })
+
+  describe('Refetch functionality', () => {
+    it('provides refetch function', async () => {
+      const mockSpeciesData = { species: [], total: 0 }
+      api.getAllSpecies.mockResolvedValue({ data: mockSpeciesData })
+
+      const { result } = renderHook(
+        () => useSpecies(),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true)
+      })
+
+      expect(result.current.refetch).toBeDefined()
+      expect(typeof result.current.refetch).toBe('function')
+    })
+
+    it('can refetch data manually', async () => {
+      const mockSpeciesData1 = { species: [{ name: 'Actias luna', count: 10 }], total: 1 }
+      const mockSpeciesData2 = { species: [{ name: 'Actias luna', count: 15 }], total: 1 }
+
+      api.getAllSpecies
+        .mockResolvedValueOnce({ data: mockSpeciesData1 })
+        .mockResolvedValueOnce({ data: mockSpeciesData2 })
+
+      const { result } = renderHook(
+        () => useSpecies(),
+        { wrapper: createWrapper() }
+      )
+
+      // Wait for initial fetch
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true)
+      })
+
+      expect(result.current.data).toEqual(mockSpeciesData1)
+      expect(api.getAllSpecies).toHaveBeenCalledTimes(1)
+
+      // Manually trigger refetch
+      await result.current.refetch()
+
+      // Wait for refetch to complete
+      await waitFor(() => {
+        expect(result.current.data).toEqual(mockSpeciesData2)
+      })
+
+      expect(api.getAllSpecies).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('Cache configuration', () => {
+    it('uses configured staleTime and gcTime', async () => {
+      const mockSpeciesData = { species: [], total: 0 }
+      api.getAllSpecies.mockResolvedValue({ data: mockSpeciesData })
+
+      const wrapper = createWrapper()
+
+      renderHook(
+        () => useSpecies(),
+        { wrapper }
+      )
+
+      await waitFor(() => {
+        const queryState = queryClient.getQueryState(['species', {}])
+        expect(queryState).toBeDefined()
+      })
+
+      const queryState = queryClient.getQueryState(['species', {}])
+      // Verify query state exists (exact staleTime/gcTime values are implementation details)
+      expect(queryState).toBeDefined()
+    })
+  })
+
+  describe('Cleanup', () => {
+    it('cleans up on unmount without errors', async () => {
+      const mockSpeciesData = { species: [], total: 0 }
+      api.getAllSpecies.mockResolvedValueOnce({ data: mockSpeciesData })
+
+      const { unmount } = renderHook(
+        () => useSpecies(),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => {
+        expect(api.getAllSpecies).toHaveBeenCalled()
+      })
+
+      // Should not throw when unmounting
+      expect(() => unmount()).not.toThrow()
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/hooks/useAutoSave.js
+++ b/Firmware/webui/frontend/src/hooks/useAutoSave.js
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
+import deepEqual from '../utils/deepEqual'
 
 /**
  * Auto-save hook with debouncing
@@ -37,7 +38,7 @@ export default function useAutoSave({
     if (!enabled) return
 
     // Don't save if data hasn't changed from initial
-    if (JSON.stringify(dataRef.current) === JSON.stringify(initialDataRef.current)) {
+    if (deepEqual(dataRef.current, initialDataRef.current)) {
       return
     }
 
@@ -72,7 +73,7 @@ export default function useAutoSave({
     }
 
     // Don't set timer if data hasn't changed
-    if (JSON.stringify(data) === JSON.stringify(initialDataRef.current)) {
+    if (deepEqual(data, initialDataRef.current)) {
       return
     }
 

--- a/Firmware/webui/frontend/src/hooks/useAutoSave.js
+++ b/Firmware/webui/frontend/src/hooks/useAutoSave.js
@@ -1,0 +1,111 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+
+/**
+ * Auto-save hook with debouncing
+ *
+ * @param {Object} options
+ * @param {*} options.data - The data to save
+ * @param {Function} options.onSave - Async function that saves the data
+ * @param {number} options.delay - Debounce delay in milliseconds (default: 2000)
+ * @param {boolean} options.enabled - Whether auto-save is active (default: true)
+ *
+ * @returns {Object} { status, saveNow, error }
+ * - status: 'idle' | 'saving' | 'saved' | 'error'
+ * - saveNow: Function to immediately trigger save
+ * - error: Error object if status is 'error', null otherwise
+ */
+export default function useAutoSave({
+  data,
+  onSave,
+  delay = 2000,
+  enabled = true
+}) {
+  const [status, setStatus] = useState('idle')
+  const [error, setError] = useState(null)
+
+  const timerRef = useRef(null)
+  const dataRef = useRef(data)
+  const initialDataRef = useRef(data)
+  const statusResetTimerRef = useRef(null)
+
+  // Keep data ref updated
+  useEffect(() => {
+    dataRef.current = data
+  }, [data])
+
+  const performSave = useCallback(async () => {
+    if (!enabled) return
+
+    // Don't save if data hasn't changed from initial
+    if (JSON.stringify(dataRef.current) === JSON.stringify(initialDataRef.current)) {
+      return
+    }
+
+    setStatus('saving')
+    setError(null)
+
+    try {
+      await onSave(dataRef.current)
+      setStatus('saved')
+      initialDataRef.current = dataRef.current
+
+      // Reset to idle after short delay
+      if (statusResetTimerRef.current) {
+        clearTimeout(statusResetTimerRef.current)
+      }
+      statusResetTimerRef.current = setTimeout(() => {
+        setStatus('idle')
+      }, 1500)
+    } catch (err) {
+      setStatus('error')
+      setError(err)
+    }
+  }, [onSave, enabled])
+
+  // Debounced auto-save on data changes
+  useEffect(() => {
+    if (!enabled) return
+
+    // Clear existing timer
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+    }
+
+    // Don't set timer if data hasn't changed
+    if (JSON.stringify(data) === JSON.stringify(initialDataRef.current)) {
+      return
+    }
+
+    // Set new timer
+    timerRef.current = setTimeout(() => {
+      performSave()
+    }, delay)
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+      }
+    }
+  }, [data, delay, enabled, performSave])
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+      }
+      if (statusResetTimerRef.current) {
+        clearTimeout(statusResetTimerRef.current)
+      }
+    }
+  }, [])
+
+  const saveNow = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+    }
+    performSave()
+  }, [performSave])
+
+  return { status, saveNow, error }
+}

--- a/Firmware/webui/frontend/src/hooks/useSidecarMetadata.js
+++ b/Firmware/webui/frontend/src/hooks/useSidecarMetadata.js
@@ -184,6 +184,18 @@ export default function useSidecarMetadata(filename) {
     updateMutation.mutate({ notes })
   }
 
+  /**
+   * Generic update function for any sidecar metadata fields
+   * Useful for updating multiple fields at once or custom fields
+   * Returns a promise for async/await usage (uses mutateAsync)
+   *
+   * @param {object} updates - Metadata fields to update
+   * @returns {Promise} Resolves on success, rejects on error
+   */
+  const updateMetadata = (updates) => {
+    return updateMutation.mutateAsync(updates)
+  }
+
   return {
     // Query state
     data: query.data,
@@ -198,6 +210,7 @@ export default function useSidecarMetadata(filename) {
     removeTag,
     updateSpecies,
     updateNotes,
+    updateMetadata,
 
     // Mutation state
     isUpdating: updateMutation.isPending,

--- a/Firmware/webui/frontend/src/hooks/useSidecarMetadata.js
+++ b/Firmware/webui/frontend/src/hooks/useSidecarMetadata.js
@@ -1,18 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { getPhotoSidecarMetadata, updatePhotoSidecarMetadata } from '../utils/api'
-
-// Module-level timeout for debouncing tags cache invalidation
-// Batches rapid tag operations into a single refetch after 1 second of inactivity
-let tagsInvalidationTimeout = null
-
-// Export for test cleanup - clears pending debounced invalidation
-export function clearTagsInvalidationTimeout() {
-  if (tagsInvalidationTimeout) {
-    clearTimeout(tagsInvalidationTimeout)
-    tagsInvalidationTimeout = null
-  }
-}
 
 /**
  * Custom hook for fetching and mutating photo sidecar metadata
@@ -61,10 +49,19 @@ export function clearTagsInvalidationTimeout() {
 export default function useSidecarMetadata(filename) {
   const queryClient = useQueryClient()
 
+  // Per-component ref for debouncing tags cache invalidation
+  // Batches rapid tag operations into a single refetch after 1 second of inactivity
+  const tagsInvalidationTimeoutRef = useRef(null)
+
   // Cleanup pending tags invalidation timeout on unmount
   // Prevents memory leaks in fast navigation scenarios
   useEffect(() => {
-    return () => clearTagsInvalidationTimeout()
+    return () => {
+      if (tagsInvalidationTimeoutRef.current) {
+        clearTimeout(tagsInvalidationTimeoutRef.current)
+        tagsInvalidationTimeoutRef.current = null
+      }
+    }
   }, [])
 
   /**
@@ -120,12 +117,12 @@ export default function useSidecarMetadata(filename) {
       // Debounce tags invalidation - wait 1 second after last update
       // This batches rapid tag operations into a single tags refetch,
       // preventing excessive network requests when user rapidly tags photos
-      if (tagsInvalidationTimeout) {
-        clearTimeout(tagsInvalidationTimeout)
+      if (tagsInvalidationTimeoutRef.current) {
+        clearTimeout(tagsInvalidationTimeoutRef.current)
       }
-      tagsInvalidationTimeout = setTimeout(() => {
+      tagsInvalidationTimeoutRef.current = setTimeout(() => {
         queryClient.invalidateQueries({ queryKey: ['tags'] })
-        tagsInvalidationTimeout = null
+        tagsInvalidationTimeoutRef.current = null
       }, 1000)
     },
   })

--- a/Firmware/webui/frontend/src/hooks/useSidecarMetadata.js
+++ b/Firmware/webui/frontend/src/hooks/useSidecarMetadata.js
@@ -1,4 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useEffect } from 'react'
 import { getPhotoSidecarMetadata, updatePhotoSidecarMetadata } from '../utils/api'
 
 // Module-level timeout for debouncing tags cache invalidation
@@ -59,6 +60,12 @@ export function clearTagsInvalidationTimeout() {
  */
 export default function useSidecarMetadata(filename) {
   const queryClient = useQueryClient()
+
+  // Cleanup pending tags invalidation timeout on unmount
+  // Prevents memory leaks in fast navigation scenarios
+  useEffect(() => {
+    return () => clearTagsInvalidationTimeout()
+  }, [])
 
   /**
    * Query for fetching sidecar metadata

--- a/Firmware/webui/frontend/src/hooks/useSpecies.js
+++ b/Firmware/webui/frontend/src/hooks/useSpecies.js
@@ -1,0 +1,76 @@
+import { useQuery } from '@tanstack/react-query'
+import { getAllSpecies } from '../utils/api'
+
+/**
+ * Custom hook for fetching all species from sidecar metadata
+ *
+ * Fetches a list of all species from the sidecar API with optional sorting,
+ * ordering, and limiting. The hook uses TanStack Query for caching,
+ * loading states, and error handling.
+ *
+ * @param {Object} params - Query parameters
+ * @param {string} [params.sort] - Sort field ('name' or 'count')
+ * @param {string} [params.order] - Sort order ('asc' or 'desc')
+ * @param {number} [params.limit] - Maximum species to return
+ * @returns {Object} TanStack Query result object containing:
+ *   - data: Species data object with species array and total count
+ *   - isLoading: Boolean indicating if the query is currently loading
+ *   - isError: Boolean indicating if an error occurred
+ *   - isSuccess: Boolean indicating if the query was successful
+ *   - error: Error object if an error occurred, null otherwise
+ *   - refetch: Function to manually trigger a refetch
+ *
+ * @example
+ * const { data, isLoading, isError, error, refetch } = useSpecies()
+ *
+ * if (isLoading) return <div>Loading species...</div>
+ * if (isError) return <div>Error: {error.message}</div>
+ * if (data) {
+ *   return (
+ *     <ul>
+ *       {data.species.map(species => (
+ *         <li key={species.name}>{species.name} ({species.count})</li>
+ *       ))}
+ *     </ul>
+ *   )
+ * }
+ *
+ * @example
+ * // With sorting
+ * const { data } = useSpecies({ sort: 'count', order: 'desc', limit: 10 })
+ * // Returns top 10 species sorted by count in descending order
+ */
+export default function useSpecies(params = {}) {
+  // Normalize query key to ensure consistent cache keys regardless of
+  // property order in params object (e.g., { sort, order } vs { order, sort })
+  const normalizedParams = {
+    sort: params?.sort,
+    order: params?.order,
+    limit: params?.limit,
+  }
+
+  return useQuery({
+    // Query key: unique identifier for this query in the cache
+    // Format: ['species', normalizedParams] - explicitly ordered for cache consistency
+    queryKey: ['species', normalizedParams],
+
+    // Query function: fetches the species from the API
+    queryFn: async () => {
+      // Fetch species from backend using centralized API client
+      // This automatically includes CSRF tokens, base URL, and error handling
+      const response = await getAllSpecies(params)
+
+      // Return the data from axios response
+      return response.data
+    },
+
+    // Cache configuration
+    // staleTime: How long data is considered fresh (5 minutes)
+    // After this time, data is marked as stale and will be refetched in the background
+    staleTime: 5 * 60 * 1000, // 5 minutes in milliseconds
+
+    // gcTime: How long inactive data stays in cache (10 minutes)
+    // After this time, unused cached data is garbage collected
+    gcTime: 10 * 60 * 1000, // 10 minutes in milliseconds
+  })
+}

--- a/Firmware/webui/frontend/src/utils/__tests__/deepEqual.test.js
+++ b/Firmware/webui/frontend/src/utils/__tests__/deepEqual.test.js
@@ -1,0 +1,254 @@
+import { describe, it, expect } from 'vitest'
+import deepEqual from '../deepEqual'
+
+describe('deepEqual', () => {
+  describe('primitives', () => {
+    it('returns true for identical strings', () => {
+      expect(deepEqual('hello', 'hello')).toBe(true)
+    })
+
+    it('returns false for different strings', () => {
+      expect(deepEqual('hello', 'world')).toBe(false)
+    })
+
+    it('returns true for identical numbers', () => {
+      expect(deepEqual(42, 42)).toBe(true)
+    })
+
+    it('returns false for different numbers', () => {
+      expect(deepEqual(42, 43)).toBe(false)
+    })
+
+    it('returns true for identical booleans', () => {
+      expect(deepEqual(true, true)).toBe(true)
+      expect(deepEqual(false, false)).toBe(true)
+    })
+
+    it('returns false for different booleans', () => {
+      expect(deepEqual(true, false)).toBe(false)
+    })
+
+    it('returns true for both null', () => {
+      expect(deepEqual(null, null)).toBe(true)
+    })
+
+    it('returns true for both undefined', () => {
+      expect(deepEqual(undefined, undefined)).toBe(true)
+    })
+
+    it('returns false for null vs undefined', () => {
+      expect(deepEqual(null, undefined)).toBe(false)
+    })
+  })
+
+  describe('NaN handling', () => {
+    it('returns true for both NaN', () => {
+      expect(deepEqual(NaN, NaN)).toBe(true)
+    })
+
+    it('returns false for NaN vs number', () => {
+      expect(deepEqual(NaN, 42)).toBe(false)
+    })
+  })
+
+  describe('Date handling', () => {
+    it('returns true for same dates', () => {
+      const d1 = new Date('2024-01-01')
+      const d2 = new Date('2024-01-01')
+      expect(deepEqual(d1, d2)).toBe(true)
+    })
+
+    it('returns false for different dates', () => {
+      const d1 = new Date('2024-01-01')
+      const d2 = new Date('2024-01-02')
+      expect(deepEqual(d1, d2)).toBe(false)
+    })
+
+    it('returns false for date vs string', () => {
+      const d = new Date('2024-01-01')
+      expect(deepEqual(d, '2024-01-01')).toBe(false)
+    })
+  })
+
+  describe('arrays', () => {
+    it('returns true for empty arrays', () => {
+      expect(deepEqual([], [])).toBe(true)
+    })
+
+    it('returns true for identical arrays', () => {
+      expect(deepEqual([1, 2, 3], [1, 2, 3])).toBe(true)
+    })
+
+    it('returns false for different length arrays', () => {
+      expect(deepEqual([1, 2], [1, 2, 3])).toBe(false)
+    })
+
+    it('returns false for arrays with different values', () => {
+      expect(deepEqual([1, 2, 3], [1, 2, 4])).toBe(false)
+    })
+
+    it('returns false for arrays with different order', () => {
+      expect(deepEqual([1, 2, 3], [3, 2, 1])).toBe(false)
+    })
+
+    it('handles nested arrays', () => {
+      expect(deepEqual([[1, 2], [3, 4]], [[1, 2], [3, 4]])).toBe(true)
+      expect(deepEqual([[1, 2], [3, 4]], [[1, 2], [3, 5]])).toBe(false)
+    })
+
+    it('returns false for array vs object', () => {
+      expect(deepEqual([1, 2], { 0: 1, 1: 2 })).toBe(false)
+    })
+  })
+
+  describe('objects', () => {
+    it('returns true for empty objects', () => {
+      expect(deepEqual({}, {})).toBe(true)
+    })
+
+    it('returns true for identical objects', () => {
+      expect(deepEqual({ a: 1, b: 2 }, { a: 1, b: 2 })).toBe(true)
+    })
+
+    it('returns true for objects with different key order', () => {
+      // This is the key test that JSON.stringify fails
+      expect(deepEqual({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true)
+    })
+
+    it('returns false for objects with different keys', () => {
+      expect(deepEqual({ a: 1 }, { b: 1 })).toBe(false)
+    })
+
+    it('returns false for objects with different values', () => {
+      expect(deepEqual({ a: 1 }, { a: 2 })).toBe(false)
+    })
+
+    it('returns false for objects with different number of keys', () => {
+      expect(deepEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false)
+    })
+
+    it('handles nested objects', () => {
+      expect(deepEqual(
+        { a: { b: 1, c: 2 } },
+        { a: { b: 1, c: 2 } }
+      )).toBe(true)
+
+      expect(deepEqual(
+        { a: { b: 1, c: 2 } },
+        { a: { b: 1, c: 3 } }
+      )).toBe(false)
+    })
+
+    it('handles deeply nested objects with different key order', () => {
+      expect(deepEqual(
+        { a: { b: 1, c: 2 }, d: 3 },
+        { d: 3, a: { c: 2, b: 1 } }
+      )).toBe(true)
+    })
+  })
+
+  describe('mixed types', () => {
+    it('returns false for number vs string', () => {
+      expect(deepEqual(1, '1')).toBe(false)
+    })
+
+    it('returns false for null vs object', () => {
+      expect(deepEqual(null, {})).toBe(false)
+    })
+
+    it('returns false for undefined vs empty string', () => {
+      expect(deepEqual(undefined, '')).toBe(false)
+    })
+
+    it('handles objects with arrays', () => {
+      expect(deepEqual(
+        { tags: ['a', 'b'], count: 2 },
+        { tags: ['a', 'b'], count: 2 }
+      )).toBe(true)
+
+      expect(deepEqual(
+        { tags: ['a', 'b'], count: 2 },
+        { tags: ['a', 'c'], count: 2 }
+      )).toBe(false)
+    })
+
+    it('handles arrays of objects', () => {
+      expect(deepEqual(
+        [{ a: 1 }, { b: 2 }],
+        [{ a: 1 }, { b: 2 }]
+      )).toBe(true)
+
+      expect(deepEqual(
+        [{ a: 1 }, { b: 2 }],
+        [{ a: 1 }, { b: 3 }]
+      )).toBe(false)
+    })
+  })
+
+  describe('real-world metadata scenarios', () => {
+    it('compares typical sidecar metadata objects', () => {
+      const metadata1 = {
+        tags: ['moth', 'nocturnal'],
+        species: 'Actias luna',
+        species_confidence: 'probable',
+        notes: 'Found near porch light',
+        custom: { location: 'backyard' }
+      }
+
+      const metadata2 = {
+        species: 'Actias luna',
+        tags: ['moth', 'nocturnal'],
+        notes: 'Found near porch light',
+        species_confidence: 'probable',
+        custom: { location: 'backyard' }
+      }
+
+      // Same data, different key order - should be equal
+      expect(deepEqual(metadata1, metadata2)).toBe(true)
+    })
+
+    it('detects changes in nested custom fields', () => {
+      const before = {
+        tags: ['moth'],
+        custom: { field1: 'value1', field2: 'value2' }
+      }
+
+      const after = {
+        tags: ['moth'],
+        custom: { field1: 'value1', field2: 'changed' }
+      }
+
+      expect(deepEqual(before, after)).toBe(false)
+    })
+
+    it('detects tag additions', () => {
+      const before = { tags: ['moth'] }
+      const after = { tags: ['moth', 'new-tag'] }
+
+      expect(deepEqual(before, after)).toBe(false)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles same reference', () => {
+      const obj = { a: 1 }
+      expect(deepEqual(obj, obj)).toBe(true)
+    })
+
+    it('handles empty nested structures', () => {
+      expect(deepEqual({ a: {} }, { a: {} })).toBe(true)
+      expect(deepEqual({ a: [] }, { a: [] })).toBe(true)
+    })
+
+    it('handles 0 vs -0', () => {
+      // In JavaScript, 0 === -0, so they should be equal
+      expect(deepEqual(0, -0)).toBe(true)
+    })
+
+    it('handles Infinity', () => {
+      expect(deepEqual(Infinity, Infinity)).toBe(true)
+      expect(deepEqual(-Infinity, -Infinity)).toBe(true)
+      expect(deepEqual(Infinity, -Infinity)).toBe(false)
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/utils/api.js
+++ b/Firmware/webui/frontend/src/utils/api.js
@@ -137,6 +137,7 @@ export const updateGpsConfig = (config) => api.put('/gps/config', config)
 
 // Sidecar Metadata APIs
 export const getAllTags = (params = {}) => api.get('/sidecar/tags', { params })
+export const getAllSpecies = (params = {}) => api.get('/sidecar/species', { params })
 export const getPhotoSidecarMetadata = (filename) => api.get(`/sidecar/photos/${encodeURIComponent(filename)}`)
 export const updatePhotoSidecarMetadata = (filename, updates) => api.patch(`/sidecar/photos/${encodeURIComponent(filename)}`, updates)
 export const bulkUpdateSidecarMetadata = (filenames, updates) => api.post('/sidecar/bulk', { filenames, updates })

--- a/Firmware/webui/frontend/src/utils/deepEqual.js
+++ b/Firmware/webui/frontend/src/utils/deepEqual.js
@@ -1,0 +1,47 @@
+/**
+ * Deep equality check for plain objects and arrays
+ *
+ * Handles: primitives, objects, arrays, null, undefined, Date, NaN
+ * Does NOT handle: circular references, Maps, Sets, RegExp, functions
+ *
+ * This is a lightweight alternative to lodash.isEqual, suitable for
+ * comparing metadata objects in the useAutoSave hook.
+ *
+ * @param {*} a - First value to compare
+ * @param {*} b - Second value to compare
+ * @returns {boolean} True if values are deeply equal
+ */
+export default function deepEqual(a, b) {
+  // Same reference or both primitive equal
+  if (a === b) return true
+
+  // Handle null/undefined
+  if (a == null || b == null) return a === b
+
+  // Handle NaN (NaN !== NaN in JS)
+  if (Number.isNaN(a) && Number.isNaN(b)) return true
+
+  // Handle Date objects
+  if (a instanceof Date && b instanceof Date) {
+    return a.getTime() === b.getTime()
+  }
+
+  // Must both be objects after this point
+  if (typeof a !== 'object' || typeof b !== 'object') return false
+
+  // Handle arrays
+  if (Array.isArray(a) !== Array.isArray(b)) return false
+  if (Array.isArray(a)) {
+    if (a.length !== b.length) return false
+    return a.every((item, i) => deepEqual(item, b[i]))
+  }
+
+  // Handle plain objects
+  const keysA = Object.keys(a)
+  const keysB = Object.keys(b)
+  if (keysA.length !== keysB.length) return false
+
+  return keysA.every(key =>
+    Object.prototype.hasOwnProperty.call(b, key) && deepEqual(a[key], b[key])
+  )
+}


### PR DESCRIPTION
## Summary

Implements a comprehensive metadata editing panel for the lightbox view (Issue #109). This transforms the read-only metadata display into a full-featured accordion-based editing interface with auto-save functionality.

### Features Implemented

- **Accordion-based UI** with collapsible sections for Tags, Species, Notes, EXIF Data, and Custom Fields
- **Tags editing** with add/remove functionality, autocomplete from existing tags, and duplicate prevention
- **Species identification** with scientific name, common name, confidence level (certain/probable/possible/unknown), and reference URL
- **Notes** textarea with character count and markdown preview support
- **Custom fields** for extensible key-value metadata
- **EXIF display** (read-only) with formatted camera and capture data
- **Auto-save** with 2-second debounce for seamless editing experience
- **Save status indicator** showing idle/saving/saved/error states
- **Keyboard shortcuts**: Ctrl+S (save), Ctrl+Enter (save & close), Escape (close)
- **Mobile drawer** responsive design for touch devices
- **Optimistic updates** for instant UI feedback with rollback on error

### Technical Details

- TanStack Query integration for data fetching and caching
- Real integration tests (API boundary mocking only, testing real hook/component integration)
- 223 frontend tests passing across 14 test files
- 93 backend sidecar metadata tests passing
- Follows sidecar metadata schema v1.1 (species_confidence, species_common_name, species_reference_url)

## Test Plan

- [x] Run frontend tests: `npm test -- --run`
- [x] Run backend tests: `pytest Tests/unit/test_sidecar_metadata*.py`
- [x] Verify integration tests pass with real hook integration
- [ ] Manual testing on Raspberry Pi with real photos
- [ ] Test mobile drawer on touch device
- [ ] Verify keyboard shortcuts work in lightbox view

## Files Changed (27 files, +5500/-709 lines)

### New Components
- `AccordionSection.jsx` - Collapsible section wrapper
- `MetadataTags.jsx` - Tag editing with autocomplete
- `MetadataSpecies.jsx` - Species identification form
- `MetadataNotes.jsx` - Notes textarea with character count
- `MetadataCustomFields.jsx` - Key-value custom fields
- `MetadataEXIF.jsx` - Read-only EXIF display
- `SaveStatusIndicator.jsx` - Auto-save status display

### New Hooks
- `useAutoSave.js` - Debounced auto-save logic
- `useSpecies.js` - Species data fetching with pagination

### Updated Files
- `MetadataPanel.jsx` - Main container with accordion sections
- `useSidecarMetadata.js` - Changed to mutateAsync for error propagation
- `sidecar_metadata.py` - Backend schema v1.1 support

Closes #109