### PR TITLE
feat(search): Index all photos with EXIF dates, not just sidecars

### DIFF
--- a/Firmware/Tests/unit/test_search_service.py
+++ b/Firmware/Tests/unit/test_search_service.py
@@ -13,7 +13,9 @@ import sqlite3
 import threading
 import time
 from pathlib import Path
+from unittest.mock import patch, mock_open
 
+import piexif
 import pytest
 
 from webui.backend.lib.sidecar_metadata import SidecarMetadata
@@ -1071,3 +1073,131 @@ class TestSearchServiceClose:
         service.close()  # Should not raise
 
         assert True
+
+
+# ============================================================================
+# EXIF Extraction Tests
+# ============================================================================
+
+class TestExifExtraction:
+    """Tests for _extract_exif_date method."""
+
+    @pytest.fixture
+    def db_path(self, tmp_path):
+        """Create a temporary database path."""
+        return tmp_path / "test_exif.db"
+
+    @pytest.fixture
+    def photo_without_exif(self, tmp_path):
+        """Create a photo without EXIF data."""
+        photo_path = tmp_path / "photo_no_exif.jpg"
+        # Empty file - will fail to parse EXIF
+        photo_path.touch()
+        return photo_path
+
+    def test_extract_exif_date_success(self, db_path, tmp_path):
+        """Should extract DateTimeOriginal from EXIF and return ISO date."""
+        photo_path = tmp_path / "photo.jpg"
+        photo_path.write_bytes(b"fake jpeg data")
+
+        service = SearchService(SearchServiceConfig(db_path=db_path))
+
+        # Mock piexif.load to return valid EXIF data
+        mock_exif = {
+            'Exif': {
+                piexif.ExifIFD.DateTimeOriginal: b"2024:06:15 14:30:00"
+            }
+        }
+        with patch('piexif.load', return_value=mock_exif):
+            result = service._extract_exif_date(photo_path)
+
+        assert result == "2024-06-15"
+
+        service.close()
+
+    def test_extract_exif_date_no_exif(self, db_path, photo_without_exif):
+        """Should return None when photo has no EXIF data."""
+        service = SearchService(SearchServiceConfig(db_path=db_path))
+
+        result = service._extract_exif_date(photo_without_exif)
+
+        assert result is None
+
+        service.close()
+
+    def test_extract_exif_date_corrupted_file(self, db_path, tmp_path):
+        """Should return None for corrupted files without crashing."""
+        photo_path = tmp_path / "corrupted.jpg"
+        photo_path.write_bytes(b"not a valid jpeg file")
+
+        service = SearchService(SearchServiceConfig(db_path=db_path))
+
+        result = service._extract_exif_date(photo_path)
+
+        assert result is None
+
+        service.close()
+
+    def test_extract_exif_date_missing_datetime_original(self, db_path, tmp_path):
+        """Should return None when EXIF exists but DateTimeOriginal is missing."""
+        photo_path = tmp_path / "no_datetime.jpg"
+        photo_path.write_bytes(b"fake jpeg data")
+
+        service = SearchService(SearchServiceConfig(db_path=db_path))
+
+        # Mock piexif.load to return EXIF without DateTimeOriginal
+        mock_exif = {
+            'Exif': {}  # No DateTimeOriginal
+        }
+        with patch('piexif.load', return_value=mock_exif):
+            result = service._extract_exif_date(photo_path)
+
+        assert result is None
+
+        service.close()
+
+    def test_extract_exif_date_file_not_found(self, db_path, tmp_path):
+        """Should return None for non-existent files."""
+        photo_path = tmp_path / "nonexistent.jpg"
+
+        service = SearchService(SearchServiceConfig(db_path=db_path))
+
+        result = service._extract_exif_date(photo_path)
+
+        assert result is None
+
+        service.close()
+
+    def test_extract_exif_date_handles_piexif_exception(self, db_path, tmp_path):
+        """Should return None when piexif raises exception."""
+        photo_path = tmp_path / "photo.jpg"
+        photo_path.write_bytes(b"fake jpeg data")
+
+        service = SearchService(SearchServiceConfig(db_path=db_path))
+
+        # Mock piexif.load to raise exception
+        with patch('piexif.load', side_effect=Exception("Invalid EXIF")):
+            result = service._extract_exif_date(photo_path)
+
+        assert result is None
+
+        service.close()
+
+    def test_build_index_extracts_exif_date(self, db_path, tmp_path):
+        """Should extract EXIF date during indexing."""
+        photos_dir = tmp_path / "photos"
+        photos_dir.mkdir()
+
+        photo_path = photos_dir / "moth.jpg"
+        photo_path.write_bytes(b"fake jpeg data")
+
+        service = SearchService(SearchServiceConfig(db_path=db_path))
+
+        # Mock _extract_exif_date to return a specific date
+        with patch.object(service, '_extract_exif_date', return_value="2024-11-20"):
+            stats = service.build_index(photos_dir)
+
+        assert stats['indexed'] == 1
+        assert stats['errors'] == 0
+
+        service.close()

--- a/Firmware/Tests/unit/test_search_service.py
+++ b/Firmware/Tests/unit/test_search_service.py
@@ -298,8 +298,8 @@ class TestSearchServiceBuildIndex:
 
         service.close()
 
-    def test_build_index_skips_photos_without_sidecars(self, db_path, tmp_path):
-        """Should skip photos without sidecar files."""
+    def test_build_index_indexes_photos_without_sidecars(self, db_path, tmp_path):
+        """Should index photos even without sidecar files (minimal metadata)."""
         # Create fresh photos directory without using fixture
         photos_dir = tmp_path / "photos_no_sidecars"
         photos_dir.mkdir()
@@ -312,7 +312,9 @@ class TestSearchServiceBuildIndex:
 
         stats = service.build_index(photos_dir)
 
-        assert stats['indexed'] == 0  # No sidecars found
+        # Now indexes all photos, even without sidecars
+        assert stats['indexed'] == 1
+        assert stats['errors'] == 0
 
         service.close()
 

--- a/Firmware/Tests/unit/test_search_service.py
+++ b/Firmware/Tests/unit/test_search_service.py
@@ -1201,3 +1201,29 @@ class TestExifExtraction:
         assert stats['errors'] == 0
 
         service.close()
+
+    def test_extract_exif_date_skips_large_files(self, db_path, tmp_path):
+        """Should skip EXIF extraction for files over 50MB (security)."""
+        photo_path = tmp_path / "large.jpg"
+        photo_path.write_bytes(b"fake jpeg data")
+
+        service = SearchService(SearchServiceConfig(db_path=db_path))
+
+        # Mock stat to return large file size (60MB)
+        # Need to patch Path.stat on the class, not the instance
+        original_stat = Path.stat
+
+        def mock_stat(self):
+            if self == photo_path:
+                from unittest.mock import MagicMock
+                result = MagicMock()
+                result.st_size = 60_000_000  # 60MB
+                return result
+            return original_stat(self)
+
+        with patch.object(Path, 'stat', mock_stat):
+            result = service._extract_exif_date(photo_path)
+
+        assert result is None
+
+        service.close()

--- a/Firmware/webui/backend/lib/search_engine.py
+++ b/Firmware/webui/backend/lib/search_engine.py
@@ -283,8 +283,10 @@ class SearchEngine:
             # Serialize custom fields to JSON string
             custom_fields_str = json.dumps(custom_fields) if custom_fields else ''
 
-            # Extract date from Mothbox filename pattern
-            date_str = self._extract_date_from_filename(filename)
+            # Extract date - prefer EXIF DateTimeOriginal, fall back to filename pattern
+            date_str = metadata.get('exif_date')
+            if not date_str:
+                date_str = self._extract_date_from_filename(filename)
 
             # Delete existing entry for this filepath (if any)
             cursor.execute(

--- a/Firmware/webui/backend/services/search_service.py
+++ b/Firmware/webui/backend/services/search_service.py
@@ -187,9 +187,9 @@ class SearchService:
                     # Convert EXIF format (YYYY:MM:DD HH:MM:SS) to ISO date
                     dt = datetime.strptime(dt_str, '%Y:%m:%d %H:%M:%S')
                     return dt.strftime('%Y-%m-%d')
-        except Exception:
-            # Silently fail - will fall back to filename pattern
-            pass
+        except Exception as e:
+            # Debug logging for troubleshooting EXIF issues
+            logger.debug(f"EXIF extraction failed for {photo_path}: {e}")
         return None
 
     def build_index(self, photos_dir: Path | None = None) -> dict:

--- a/Firmware/webui/backend/services/search_service.py
+++ b/Firmware/webui/backend/services/search_service.py
@@ -38,8 +38,11 @@ import tempfile
 import threading
 import time
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import Any
+
+import piexif
 
 from webui.backend.lib.search_engine import SearchEngine
 from webui.backend.lib.search_query_parser import parse_query
@@ -165,11 +168,36 @@ class SearchService:
 
             self._lazy_index_checked = True
 
-    def build_index(self, photos_dir: Path | None = None) -> dict:
-        """Full rebuild of search index from all photos and their sidecars.
+    def _extract_exif_date(self, photo_path: Path) -> str | None:
+        """Extract DateTimeOriginal from EXIF, return ISO date string or None.
 
-        Scans photos directory recursively for all photos with sidecars,
-        reads metadata, and rebuilds the search index.
+        Args:
+            photo_path: Path to JPEG photo file
+
+        Returns:
+            ISO date string (e.g., "2024-01-15") or None if not available
+        """
+        try:
+            exif_dict = piexif.load(str(photo_path))
+            if 'Exif' in exif_dict:
+                exif_ifd = exif_dict['Exif']
+                if piexif.ExifIFD.DateTimeOriginal in exif_ifd:
+                    dt_bytes = exif_ifd[piexif.ExifIFD.DateTimeOriginal]
+                    dt_str = dt_bytes.decode('utf-8', errors='ignore')
+                    # Convert EXIF format (YYYY:MM:DD HH:MM:SS) to ISO date
+                    dt = datetime.strptime(dt_str, '%Y:%m:%d %H:%M:%S')
+                    return dt.strftime('%Y-%m-%d')
+        except Exception:
+            # Silently fail - will fall back to filename pattern
+            pass
+        return None
+
+    def build_index(self, photos_dir: Path | None = None) -> dict:
+        """Full rebuild of search index from all photos.
+
+        Scans photos directory recursively for all JPEG photos,
+        extracts EXIF metadata (DateTimeOriginal) and merges sidecar
+        metadata (tags, species, notes) when available.
 
         Args:
             photos_dir: Directory to scan for photos (uses PHOTOS_DIR if None)
@@ -228,27 +256,35 @@ class SearchService:
 
             logger.debug(f"Found {len(photos)} photos in {photos_dir}")
 
-            # Index each photo
+            # Index each photo (with or without sidecar)
             for photo_path in photos:
                 try:
-                    # Check if sidecar exists
+                    # Build metadata from multiple sources
+                    metadata = {'filename': photo_path.name, 'tags': []}
+
+                    # 1. Try to get EXIF date (primary source for accurate timestamps)
+                    exif_date = self._extract_exif_date(photo_path)
+                    if exif_date:
+                        metadata['exif_date'] = exif_date
+
+                    # 2. Merge sidecar metadata if available (user-curated tags, species, notes)
                     sidecar_path = photo_path.parent / f"{photo_path.name}.json"
-                    if not sidecar_path.exists():
-                        continue  # Skip photos without sidecars
+                    if sidecar_path.exists():
+                        if self._sidecar_service:
+                            metadata_obj = self._sidecar_service.get_metadata(str(photo_path))
+                        else:
+                            # Read directly from file
+                            from webui.backend.lib.sidecar_metadata import read_metadata
+                            metadata_obj = read_metadata(str(photo_path))
 
-                    # Read metadata
-                    if self._sidecar_service:
-                        metadata_obj = self._sidecar_service.get_metadata(str(photo_path))
-                    else:
-                        # Read directly from file
-                        from webui.backend.lib.sidecar_metadata import read_metadata
-                        metadata_obj = read_metadata(str(photo_path))
-
-                    if not metadata_obj:
-                        continue  # Skip if metadata read failed
-
-                    # Convert to dict for indexing
-                    metadata = metadata_obj.to_dict()
+                        if metadata_obj:
+                            sidecar_data = metadata_obj.to_dict()
+                            # Merge sidecar fields into metadata
+                            metadata['tags'] = sidecar_data.get('tags', [])
+                            metadata['species'] = sidecar_data.get('species')
+                            metadata['species_common_name'] = sidecar_data.get('species_common_name')
+                            metadata['notes'] = sidecar_data.get('notes')
+                            metadata['custom_fields'] = sidecar_data.get('custom_fields', {})
 
                     # Index photo with relative path (for correct URL construction)
                     self._engine.index_photo(str(photo_path.relative_to(photos_dir)), metadata)
@@ -272,12 +308,12 @@ class SearchService:
         """Incremental index sync - only updates changed photos.
 
         Much more efficient than build_index() for large galleries where
-        only a few files have changed. Uses sidecar file mtime to detect
+        only a few files have changed. Uses photo or sidecar mtime to detect
         changes.
 
         Algorithm:
-        1. Scans photos directory for all photos with sidecars
-        2. Compares sidecar mtime with indexed mtime
+        1. Scans photos directory for all photos
+        2. Compares mtime with indexed mtime (sidecar mtime if exists, else photo mtime)
         3. Removes stale entries (photos deleted from filesystem)
         4. Indexes new photos
         5. Re-indexes modified photos
@@ -322,36 +358,50 @@ class SearchService:
 
         for ext in photo_extensions:
             for photo_path in photos_dir.rglob(ext):
-                sidecar_path = photo_path.parent / f"{photo_path.name}.json"
-                if not sidecar_path.exists():
-                    continue  # Skip photos without sidecars
-
                 try:
-                    # Get sidecar mtime for change detection
-                    sidecar_mtime = sidecar_path.stat().st_mtime
+                    sidecar_path = photo_path.parent / f"{photo_path.name}.json"
 
-                    # Read metadata
-                    if self._sidecar_service:
-                        metadata_obj = self._sidecar_service.get_metadata(str(photo_path))
+                    # Build metadata from multiple sources
+                    metadata = {'filename': photo_path.name, 'tags': []}
+
+                    # Get mtime for change detection
+                    # Use sidecar mtime if exists (changes more often), else photo mtime
+                    if sidecar_path.exists():
+                        mtime = sidecar_path.stat().st_mtime
+
+                        # Read sidecar metadata
+                        if self._sidecar_service:
+                            metadata_obj = self._sidecar_service.get_metadata(str(photo_path))
+                        else:
+                            from webui.backend.lib.sidecar_metadata import read_metadata
+                            metadata_obj = read_metadata(str(photo_path))
+
+                        if metadata_obj:
+                            sidecar_data = metadata_obj.to_dict()
+                            metadata['tags'] = sidecar_data.get('tags', [])
+                            metadata['species'] = sidecar_data.get('species')
+                            metadata['species_common_name'] = sidecar_data.get('species_common_name')
+                            metadata['notes'] = sidecar_data.get('notes')
+                            metadata['custom_fields'] = sidecar_data.get('custom_fields', {})
                     else:
-                        from webui.backend.lib.sidecar_metadata import read_metadata
-                        metadata_obj = read_metadata(str(photo_path))
+                        # No sidecar - use photo mtime
+                        mtime = photo_path.stat().st_mtime
 
-                    if not metadata_obj:
-                        continue
-
-                    metadata = metadata_obj.to_dict()
+                    # Extract EXIF date (primary source for accurate timestamps)
+                    exif_date = self._extract_exif_date(photo_path)
+                    if exif_date:
+                        metadata['exif_date'] = exif_date
 
                     photos.append({
                         'filepath': str(photo_path.relative_to(photos_dir)),
-                        'sidecar_mtime': sidecar_mtime,
+                        'sidecar_mtime': mtime,
                         'metadata': metadata
                     })
 
                 except Exception as e:
                     logger.warning(f"Error reading photo {photo_path}: {e}")
 
-        logger.debug(f"Found {len(photos)} photos with sidecars in {photos_dir}")
+        logger.debug(f"Found {len(photos)} photos in {photos_dir}")
 
         # Perform incremental sync
         with self._lock:

--- a/Firmware/webui/backend/services/search_service.py
+++ b/Firmware/webui/backend/services/search_service.py
@@ -184,22 +184,66 @@ class SearchService:
                 logger.debug(f"Skipping EXIF for large file ({file_size} bytes): {photo_path}")
                 return None
 
-            # Use explicit file handle to ensure proper cleanup
-            with open(photo_path, 'rb') as f:
-                exif_bytes = f.read()
-            exif_dict = piexif.load(exif_bytes)
+            # piexif.load(path) only reads EXIF header, not entire file
+            exif_dict = piexif.load(str(photo_path))
             if 'Exif' in exif_dict:
                 exif_ifd = exif_dict['Exif']
                 if piexif.ExifIFD.DateTimeOriginal in exif_ifd:
                     dt_bytes = exif_ifd[piexif.ExifIFD.DateTimeOriginal]
                     dt_str = dt_bytes.decode('utf-8', errors='ignore')
                     # Convert EXIF format (YYYY:MM:DD HH:MM:SS) to ISO date
-                    dt = datetime.strptime(dt_str, '%Y:%m:%d %H:%M:%S')
-                    return dt.strftime('%Y-%m-%d')
+                    try:
+                        dt = datetime.strptime(dt_str, '%Y:%m:%d %H:%M:%S')
+                        return dt.strftime('%Y-%m-%d')
+                    except ValueError:
+                        logger.debug(f"Malformed EXIF date for {photo_path}: {dt_str}")
+                        return None
         except Exception as e:
             # Debug logging for troubleshooting EXIF issues
             logger.debug(f"EXIF extraction failed for {photo_path}: {e}")
         return None
+
+    def _build_photo_metadata(self, photo_path: Path) -> tuple[dict, float]:
+        """Build metadata from EXIF and sidecar sources.
+
+        Args:
+            photo_path: Path to the photo file
+
+        Returns:
+            Tuple of (metadata dict, mtime for change detection)
+        """
+        metadata = {'filename': photo_path.name, 'tags': []}
+
+        # Get sidecar path and check existence
+        sidecar_path = photo_path.parent / f"{photo_path.name}.json"
+
+        if sidecar_path.exists():
+            mtime = sidecar_path.stat().st_mtime
+
+            # Read sidecar metadata
+            if self._sidecar_service:
+                metadata_obj = self._sidecar_service.get_metadata(str(photo_path))
+            else:
+                from webui.backend.lib.sidecar_metadata import read_metadata
+                metadata_obj = read_metadata(str(photo_path))
+
+            if metadata_obj:
+                sidecar_data = metadata_obj.to_dict()
+                metadata['tags'] = sidecar_data.get('tags', [])
+                metadata['species'] = sidecar_data.get('species')
+                metadata['species_common_name'] = sidecar_data.get('species_common_name')
+                metadata['notes'] = sidecar_data.get('notes')
+                metadata['custom_fields'] = sidecar_data.get('custom_fields', {})
+        else:
+            # No sidecar - use photo mtime
+            mtime = photo_path.stat().st_mtime
+
+        # Extract EXIF date
+        exif_date = self._extract_exif_date(photo_path)
+        if exif_date:
+            metadata['exif_date'] = exif_date
+
+        return metadata, mtime
 
     def build_index(self, photos_dir: Path | None = None) -> dict:
         """Full rebuild of search index from all photos.
@@ -268,37 +312,7 @@ class SearchService:
             # Index each photo (with or without sidecar)
             for photo_path in photos:
                 try:
-                    # Build metadata from multiple sources
-                    metadata = {'filename': photo_path.name, 'tags': []}
-
-                    # 1. Try to get EXIF date (primary source for accurate timestamps)
-                    exif_date = self._extract_exif_date(photo_path)
-                    if exif_date:
-                        metadata['exif_date'] = exif_date
-
-                    # 2. Merge sidecar metadata if available (user-curated tags, species, notes)
-                    # Also track mtime for consistency with sync_index()
-                    sidecar_path = photo_path.parent / f"{photo_path.name}.json"
-                    if sidecar_path.exists():
-                        mtime = sidecar_path.stat().st_mtime
-                        if self._sidecar_service:
-                            metadata_obj = self._sidecar_service.get_metadata(str(photo_path))
-                        else:
-                            # Read directly from file
-                            from webui.backend.lib.sidecar_metadata import read_metadata
-                            metadata_obj = read_metadata(str(photo_path))
-
-                        if metadata_obj:
-                            sidecar_data = metadata_obj.to_dict()
-                            # Merge sidecar fields into metadata
-                            metadata['tags'] = sidecar_data.get('tags', [])
-                            metadata['species'] = sidecar_data.get('species')
-                            metadata['species_common_name'] = sidecar_data.get('species_common_name')
-                            metadata['notes'] = sidecar_data.get('notes')
-                            metadata['custom_fields'] = sidecar_data.get('custom_fields', {})
-                    else:
-                        # No sidecar - use photo mtime
-                        mtime = photo_path.stat().st_mtime
+                    metadata, mtime = self._build_photo_metadata(photo_path)
 
                     # Index photo with relative path (for correct URL construction)
                     self._engine.index_photo(
@@ -377,38 +391,7 @@ class SearchService:
         for ext in photo_extensions:
             for photo_path in photos_dir.rglob(ext):
                 try:
-                    sidecar_path = photo_path.parent / f"{photo_path.name}.json"
-
-                    # Build metadata from multiple sources
-                    metadata = {'filename': photo_path.name, 'tags': []}
-
-                    # Get mtime for change detection
-                    # Use sidecar mtime if exists (changes more often), else photo mtime
-                    if sidecar_path.exists():
-                        mtime = sidecar_path.stat().st_mtime
-
-                        # Read sidecar metadata
-                        if self._sidecar_service:
-                            metadata_obj = self._sidecar_service.get_metadata(str(photo_path))
-                        else:
-                            from webui.backend.lib.sidecar_metadata import read_metadata
-                            metadata_obj = read_metadata(str(photo_path))
-
-                        if metadata_obj:
-                            sidecar_data = metadata_obj.to_dict()
-                            metadata['tags'] = sidecar_data.get('tags', [])
-                            metadata['species'] = sidecar_data.get('species')
-                            metadata['species_common_name'] = sidecar_data.get('species_common_name')
-                            metadata['notes'] = sidecar_data.get('notes')
-                            metadata['custom_fields'] = sidecar_data.get('custom_fields', {})
-                    else:
-                        # No sidecar - use photo mtime
-                        mtime = photo_path.stat().st_mtime
-
-                    # Extract EXIF date (primary source for accurate timestamps)
-                    exif_date = self._extract_exif_date(photo_path)
-                    if exif_date:
-                        metadata['exif_date'] = exif_date
+                    metadata, mtime = self._build_photo_metadata(photo_path)
 
                     photos.append({
                         'filepath': str(photo_path.relative_to(photos_dir)),

--- a/Firmware/webui/backend/services/search_service.py
+++ b/Firmware/webui/backend/services/search_service.py
@@ -178,7 +178,10 @@ class SearchService:
             ISO date string (e.g., "2024-01-15") or None if not available
         """
         try:
-            exif_dict = piexif.load(str(photo_path))
+            # Use explicit file handle to ensure proper cleanup
+            with open(photo_path, 'rb') as f:
+                exif_bytes = f.read()
+            exif_dict = piexif.load(exif_bytes)
             if 'Exif' in exif_dict:
                 exif_ifd = exif_dict['Exif']
                 if piexif.ExifIFD.DateTimeOriginal in exif_ifd:
@@ -268,8 +271,10 @@ class SearchService:
                         metadata['exif_date'] = exif_date
 
                     # 2. Merge sidecar metadata if available (user-curated tags, species, notes)
+                    # Also track mtime for consistency with sync_index()
                     sidecar_path = photo_path.parent / f"{photo_path.name}.json"
                     if sidecar_path.exists():
+                        mtime = sidecar_path.stat().st_mtime
                         if self._sidecar_service:
                             metadata_obj = self._sidecar_service.get_metadata(str(photo_path))
                         else:
@@ -285,9 +290,16 @@ class SearchService:
                             metadata['species_common_name'] = sidecar_data.get('species_common_name')
                             metadata['notes'] = sidecar_data.get('notes')
                             metadata['custom_fields'] = sidecar_data.get('custom_fields', {})
+                    else:
+                        # No sidecar - use photo mtime
+                        mtime = photo_path.stat().st_mtime
 
                     # Index photo with relative path (for correct URL construction)
-                    self._engine.index_photo(str(photo_path.relative_to(photos_dir)), metadata)
+                    self._engine.index_photo(
+                        str(photo_path.relative_to(photos_dir)),
+                        metadata,
+                        sidecar_mtime=mtime
+                    )
                     indexed += 1
 
                 except Exception as e:

--- a/Firmware/webui/backend/services/search_service.py
+++ b/Firmware/webui/backend/services/search_service.py
@@ -178,6 +178,12 @@ class SearchService:
             ISO date string (e.g., "2024-01-15") or None if not available
         """
         try:
+            # Check file size before processing (prevent memory exhaustion)
+            file_size = photo_path.stat().st_size
+            if file_size > 50_000_000:  # 50MB limit
+                logger.debug(f"Skipping EXIF for large file ({file_size} bytes): {photo_path}")
+                return None
+
             # Use explicit file handle to ensure proper cleanup
             with open(photo_path, 'rb') as f:
                 exif_bytes = f.read()

--- a/Firmware/webui/frontend/src/components/__tests__/PhotoListItem.test.jsx
+++ b/Firmware/webui/frontend/src/components/__tests__/PhotoListItem.test.jsx
@@ -13,6 +13,23 @@ vi.mock('../../hooks/useProgressiveImage', () => ({
   }))
 }))
 
+// Mock QuickTagButton to avoid useSidecarMetadata hook dependency
+vi.mock('../gallery/QuickTagButton', () => ({
+  default: ({ filename, onDropdownOpenChange, className }) => (
+    <button
+      data-testid="quick-tag-button"
+      data-filename={filename}
+      className={className}
+      onClick={(e) => {
+        e.stopPropagation()
+        onDropdownOpenChange?.(true)
+      }}
+    >
+      Tag
+    </button>
+  )
+}))
+
 /**
  * Test suite for PhotoListItem component
  *
@@ -65,11 +82,11 @@ describe('PhotoListItem', () => {
 
   describe('Layout', () => {
     it('uses horizontal layout (image + metadata side-by-side)', () => {
-      const { container } = render(<PhotoListItem photo={mockPhoto} onClick={() => {}} />)
+      render(<PhotoListItem photo={mockPhoto} onClick={() => {}} />)
 
-      // Container should use flex layout
-      const card = container.firstChild
-      expect(card).toHaveClass('flex')
+      // Main button should use flex layout for horizontal arrangement
+      const button = screen.getByRole('button', { name: /View photo/i })
+      expect(button).toHaveClass('flex')
     })
 
     it('image is appropriately sized for list view', () => {
@@ -98,7 +115,8 @@ describe('PhotoListItem', () => {
 
       render(<PhotoListItem photo={mockPhoto} onClick={onClick} />)
 
-      const card = screen.getByRole('button')
+      // Use the main photo button (with aria-label), not the QuickTagButton
+      const card = screen.getByRole('button', { name: /View photo/i })
       await user.click(card)
 
       expect(onClick).toHaveBeenCalledWith(mockPhoto)
@@ -111,7 +129,8 @@ describe('PhotoListItem', () => {
 
       render(<PhotoListItem photo={mockPhoto} onClick={onClick} />)
 
-      const card = screen.getByRole('button')
+      // Use the main photo button (with aria-label), not the QuickTagButton
+      const card = screen.getByRole('button', { name: /View photo/i })
       card.focus()
       await user.keyboard('{Enter}')
 
@@ -123,8 +142,8 @@ describe('PhotoListItem', () => {
     it('has proper semantic HTML', () => {
       render(<PhotoListItem photo={mockPhoto} onClick={() => {}} />)
 
-      // Should be a button for click interaction
-      const button = screen.getByRole('button')
+      // Should have a main button for click interaction
+      const button = screen.getByRole('button', { name: /View photo/i })
       expect(button).toBeInTheDocument()
 
       // Image should have alt text
@@ -135,14 +154,14 @@ describe('PhotoListItem', () => {
     it('has accessible label describing the photo', () => {
       render(<PhotoListItem photo={mockPhoto} onClick={() => {}} />)
 
-      const button = screen.getByRole('button')
+      const button = screen.getByRole('button', { name: /View photo/i })
       expect(button).toHaveAttribute('aria-label', expect.stringContaining('test-photo.jpg'))
     })
 
     it('provides hover state for better UX', () => {
       render(<PhotoListItem photo={mockPhoto} onClick={() => {}} />)
 
-      const button = screen.getByRole('button')
+      const button = screen.getByRole('button', { name: /View photo/i })
 
       // Should have hover classes
       expect(button).toHaveClass('hover:shadow-md')


### PR DESCRIPTION
## Summary

- Index ALL photos in the gallery (not just those with sidecar JSON files)
- Extract DateTimeOriginal from EXIF metadata for accurate date filtering
- Fall back to Mothbox filename pattern if no EXIF date available
- Merge sidecar metadata (tags, species, notes) when available

## Problem

Previously, the search service only indexed photos that had sidecar JSON files. This meant date filtering in advanced search only found photos with user-added tags (2 of 300 photos), instead of filtering across the entire gallery.

## Solution

Modified `search_service.py` and `search_engine.py` to:
1. Process all JPEG photos during indexing, not just those with sidecars
2. Read EXIF DateTimeOriginal as the primary date source
3. Fall back to Mothbox filename pattern (`name_YYYY_MM_DD__HH_MM_SS.jpg`) if no EXIF
4. Merge sidecar metadata when available for tags/species search

## Test plan

- [x] All 126 search service and engine tests pass
- [x] Linter passes
- [ ] Manual test: Set date range in advanced search, verify all photos in range are returned
- [ ] Manual test: Verify tag/species search still works for photos with sidecars