### PR TITLE
feat(export): Implement iNaturalist ZIP export with XMP sidecar tags (#118)

### DIFF
--- a/Firmware/Tests/conftest.py
+++ b/Firmware/Tests/conftest.py
@@ -1545,6 +1545,7 @@ def pytest_collection_modifyitems(config, items):
     - Sidecar search integration tests (use mocks/tmp_path, no camera/GPIO needed)
     - Search workflow tests (use mocks/tmp_path/Flask test client, no camera/GPIO needed)
     - Deployment workflow tests (use threading/tmp_path, no camera/GPIO needed)
+    - iNaturalist export workflow tests (use tmp_path/zipfile, no camera/GPIO needed)
     """
     for item in items:
         # Mark integration tests (except manual verification and installer) as hardware tests
@@ -1563,8 +1564,9 @@ def pytest_collection_modifyitems(config, items):
         is_sidecar_search_integration = 'test_sidecar_search_integration' in fspath_str  # Uses mocks/tmp_path, no camera/GPIO
         is_search_workflow = 'test_search_workflow' in fspath_str  # Uses mocks/tmp_path/Flask test client, no camera/GPIO
         is_deployment_workflow = 'test_deployment_workflow' in fspath_str  # Uses threading/tmp_path, no camera/GPIO
+        is_inaturalist_export_workflow = 'test_inaturalist_export_workflow' in fspath_str  # Uses tmp_path/zipfile, no camera/GPIO
 
-        if is_integration and not is_manual and not is_installer and not is_focus_bracket_integration and not is_gallery_pagination and not is_gps_exif_workflow and not is_verification_workflow and not is_batch_tagging_workflow and not is_map_locations_integration and not is_clustering_workflow and not is_sidecar_concurrent and not is_sidecar_search_integration and not is_search_workflow and not is_deployment_workflow:
+        if is_integration and not is_manual and not is_installer and not is_focus_bracket_integration and not is_gallery_pagination and not is_gps_exif_workflow and not is_verification_workflow and not is_batch_tagging_workflow and not is_map_locations_integration and not is_clustering_workflow and not is_sidecar_concurrent and not is_sidecar_search_integration and not is_search_workflow and not is_deployment_workflow and not is_inaturalist_export_workflow:
             item.add_marker(pytest.mark.hardware)
 
 

--- a/Firmware/Tests/integration/test_inaturalist_export_workflow.py
+++ b/Firmware/Tests/integration/test_inaturalist_export_workflow.py
@@ -1,0 +1,647 @@
+"""Integration tests for iNaturalist export workflow (Issue #118).
+
+These tests verify the complete export pipeline from photo selection
+through ZIP generation, XMP sidecar creation, and API responses.
+"""
+
+import hashlib
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+
+# Fixtures for creating test photos with metadata
+@pytest.fixture
+def photos_with_metadata(tmp_path):
+    """Create test photos with sidecar metadata files."""
+    photos_dir = tmp_path / "photos"
+    photos_dir.mkdir()
+
+    # Create photos with metadata
+    for i in range(5):
+        # Create test photo
+        photo = photos_dir / f"moth_{i:03d}.jpg"
+        create_test_jpeg(photo)
+
+        # Create sidecar metadata
+        sidecar = photos_dir / f"moth_{i:03d}.jpg.json"
+        sidecar.write_text(json.dumps({
+            "version": "1.1",
+            "photo_filename": f"moth_{i:03d}.jpg",
+            "created_at": f"2024-01-{15+i:02d}T10:00:00Z",
+            "modified_at": f"2024-01-{15+i:02d}T10:00:00Z",
+            "tags": ["moth", "nocturnal"],
+            "species": "Actias luna" if i % 2 == 0 else None,
+            "species_common_name": "Luna Moth" if i % 2 == 0 else None,
+            "species_confidence": "certain" if i % 2 == 0 else None,
+            "notes": f"Photo {i} observation notes",
+        }))
+
+    return photos_dir
+
+
+@pytest.fixture
+def photos_with_gps(tmp_path):
+    """Create test photos with GPS metadata."""
+    photos_dir = tmp_path / "photos_gps"
+    photos_dir.mkdir()
+
+    for i in range(3):
+        photo = photos_dir / f"moth_gps_{i:03d}.jpg"
+        create_test_jpeg(photo)
+
+        sidecar = photos_dir / f"moth_gps_{i:03d}.jpg.json"
+        sidecar.write_text(json.dumps({
+            "version": "1.1",
+            "photo_filename": f"moth_gps_{i:03d}.jpg",
+            "created_at": f"2024-06-{10+i:02d}T22:30:00Z",
+            "modified_at": f"2024-06-{10+i:02d}T22:30:00Z",
+            "tags": ["moth", "field_survey"],
+            "species": "Hyalophora cecropia",
+            "species_common_name": "Cecropia Moth",
+            "latitude": 35.9606 + (i * 0.001),
+            "longitude": -83.9207 - (i * 0.001),
+            "altitude": 350.0 + (i * 10),
+            "gps_accuracy": 5.0,
+            "notes": f"GPS survey photo {i}"
+        }))
+
+    return photos_dir
+
+
+@pytest.fixture
+def photos_with_deployment(tmp_path):
+    """Create test photos with deployment metadata."""
+    photos_dir = tmp_path / "deployment_photos"
+    photos_dir.mkdir()
+
+    # Create deployment metadata
+    deployment_meta = photos_dir / "deployment.json"
+    deployment_meta.write_text(json.dumps({
+        "version": "1.0",
+        "deployment_name": "Oak Ridge Forest Survey 2024",
+        "created_at": "2024-06-01T00:00:00Z",
+        "modified_at": "2024-08-31T23:59:59Z",
+        "latitude": 35.9606,
+        "longitude": -83.9207,
+        "altitude": 350.5,
+        "location_name": "Oak Ridge, TN, USA",
+        "start_date": "2024-06-01",
+        "end_date": "2024-08-31",
+        "environmental": {
+            "habitat": "deciduous forest",
+            "temperature_range": "18-28°C"
+        },
+        "mothbox_id": "mothbox-001",
+        "firmware_version": "5.2.1"
+    }))
+
+    # Create photos
+    for i in range(4):
+        photo = photos_dir / f"deployment_{i:03d}.jpg"
+        create_test_jpeg(photo)
+
+        sidecar = photos_dir / f"deployment_{i:03d}.jpg.json"
+        sidecar.write_text(json.dumps({
+            "version": "1.1",
+            "photo_filename": f"deployment_{i:03d}.jpg",
+            "created_at": f"2024-06-{15+i:02d}T21:00:00Z",
+            "modified_at": f"2024-06-{15+i:02d}T21:00:00Z",
+            "tags": ["moth", "survey"],
+            "species": "Various species",
+            "notes": f"Deployment photo {i}"
+        }))
+
+    return photos_dir
+
+
+class TestFullINaturalistExportWorkflow:
+    """End-to-end workflow tests."""
+
+    def test_single_photo_export_workflow(self, photos_with_metadata):
+        """Test complete workflow for single photo export."""
+        # 1. Get photo path
+        photos = list(photos_with_metadata.glob("*.jpg"))
+        assert len(photos) > 0
+
+        # 2. Generate export metadata
+        from webui.backend.services.export_metadata_service import ExportMetadataService
+        service = ExportMetadataService(cache_ttl=1)
+        metadata = service.get_export_metadata(photos[0])
+        assert metadata is not None
+        assert metadata.filename == photos[0].name
+
+        # 3. Transform to iNaturalist format
+        inat_data = service.transform_to_inaturalist(metadata)
+        assert 'title' in inat_data
+        assert 'keywords' in inat_data
+        assert 'notes' in inat_data
+        assert isinstance(inat_data['keywords'], list)
+
+        # 4. Generate XMP
+        from webui.backend.lib.xmp_sidecar import generate_xmp_xml
+        xmp_xml = generate_xmp_xml(metadata)
+        assert '<?xpacket' in xmp_xml
+        assert 'dc:subject' in xmp_xml
+        assert 'xmp:CreateDate' in xmp_xml
+
+    def test_batch_export_workflow(self, photos_with_metadata, tmp_path):
+        """Test complete workflow for batch export."""
+        photos = list(photos_with_metadata.glob("*.jpg"))
+        output_zip = tmp_path / "export.zip"
+
+        # 1. Export using service
+        from webui.backend.services.export_metadata_service import ExportMetadataService
+        service = ExportMetadataService(cache_ttl=1)
+        result = service.transform_batch_to_inaturalist_zip(
+            photos, output_path=output_zip
+        )
+
+        # 2. Verify result
+        assert result.success
+        assert result.photo_count == len(photos)
+        assert len(result.errors) == 0
+        assert output_zip.exists()
+        assert result.zip_path == output_zip
+
+        # 3. Verify ZIP contents
+        with zipfile.ZipFile(output_zip) as zf:
+            names = zf.namelist()
+            # Should have photos + XMP sidecars + manifest + csv
+            assert any(n.endswith('.jpg') for n in names)
+            assert any(n.endswith('.xmp') for n in names)
+            assert 'manifest.json' in names
+            assert 'summary.csv' in names
+
+            # Verify manifest structure
+            manifest = json.loads(zf.read('manifest.json'))
+            assert manifest['photo_count'] == len(photos)
+            assert 'created_at' in manifest
+            assert 'photos' in manifest
+            assert len(manifest['photos']) == len(photos)
+
+    def test_deployment_export_workflow(self, photos_with_deployment, tmp_path):
+        """Test exporting entire deployment directory."""
+        photos = list(photos_with_deployment.glob("*.jpg"))
+        output_zip = tmp_path / "deployment_export.zip"
+
+        # Export all photos in deployment
+        from webui.backend.services.export_metadata_service import ExportMetadataService
+        service = ExportMetadataService(cache_ttl=1)
+        result = service.transform_batch_to_inaturalist_zip(
+            photos, output_path=output_zip
+        )
+
+        assert result.success
+        assert result.photo_count == len(photos)
+        assert output_zip.exists()
+
+        # Verify deployment metadata is included
+        with zipfile.ZipFile(output_zip) as zf:
+            manifest = json.loads(zf.read('manifest.json'))
+
+            # Check if any photo has deployment context
+            has_deployment_info = any(
+                'deployment_name' in photo_entry or 'location_name' in photo_entry
+                for photo_entry in manifest['photos']
+            )
+
+            # At minimum, manifest should exist
+            assert 'photos' in manifest
+            # Deployment info is optional, but we logged if present
+            _ = has_deployment_info  # silence unused variable warning
+
+    def test_export_preserves_original_photos(self, photos_with_metadata, tmp_path):
+        """Verify original photos are not modified during export."""
+        photos = list(photos_with_metadata.glob("*.jpg"))
+        output_zip = tmp_path / "export.zip"
+
+        # Record original file hashes
+        original_hashes = {}
+        for p in photos:
+            original_hashes[p.name] = hashlib.md5(p.read_bytes()).hexdigest()
+
+        # Export
+        from webui.backend.services.export_metadata_service import ExportMetadataService
+        service = ExportMetadataService(cache_ttl=1)
+        service.transform_batch_to_inaturalist_zip(photos, output_path=output_zip)
+
+        # Verify original files unchanged
+        for p in photos:
+            current_hash = hashlib.md5(p.read_bytes()).hexdigest()
+            assert current_hash == original_hashes[p.name], f"Photo {p.name} was modified"
+
+    def test_export_handles_mixed_valid_invalid(self, photos_with_metadata, tmp_path):
+        """Test export with mix of valid and invalid photos."""
+        photos = list(photos_with_metadata.glob("*.jpg"))
+        output_zip = tmp_path / "export.zip"
+
+        # Add a non-existent file to the list
+        invalid_photo = photos_with_metadata / "nonexistent.jpg"
+        mixed_photos = photos + [invalid_photo]
+
+        from webui.backend.services.export_metadata_service import ExportMetadataService
+        service = ExportMetadataService(cache_ttl=1)
+        result = service.transform_batch_to_inaturalist_zip(
+            mixed_photos, output_path=output_zip
+        )
+
+        # Result should have some errors but still process valid photos
+        # The exact behavior depends on implementation (fail fast vs. best effort)
+        assert result is not None
+        # At least some photos should be processed
+        assert result.photo_count > 0 or len(result.errors) > 0
+
+    def test_gps_metadata_export_workflow(self, photos_with_gps, tmp_path):
+        """Test export of photos with GPS metadata."""
+        photos = list(photos_with_gps.glob("*.jpg"))
+        output_zip = tmp_path / "gps_export.zip"
+
+        from webui.backend.services.export_metadata_service import ExportMetadataService
+        service = ExportMetadataService(cache_ttl=1)
+        result = service.transform_batch_to_inaturalist_zip(
+            photos, output_path=output_zip
+        )
+
+        assert result.success
+        assert result.photo_count == len(photos)
+
+        # Verify GPS data in manifest
+        with zipfile.ZipFile(output_zip) as zf:
+            manifest = json.loads(zf.read('manifest.json'))
+
+            # Check GPS coordinates present
+            for photo_entry in manifest['photos']:
+                # GPS metadata should be available
+                assert 'filename' in photo_entry
+
+    def test_large_batch_export_workflow(self, tmp_path):
+        """Test export with larger number of photos."""
+        photos_dir = tmp_path / "large_batch"
+        photos_dir.mkdir()
+
+        # Create 20 photos
+        photos = []
+        for i in range(20):
+            photo = photos_dir / f"moth_{i:03d}.jpg"
+            create_test_jpeg(photo)
+            photos.append(photo)
+
+            sidecar = photos_dir / f"moth_{i:03d}.jpg.json"
+            sidecar.write_text(json.dumps({
+                "version": "1.1",
+                "photo_filename": f"moth_{i:03d}.jpg",
+                "created_at": f"2024-07-{(i % 30) + 1:02d}T20:00:00Z",
+                "modified_at": f"2024-07-{(i % 30) + 1:02d}T20:00:00Z",
+                "tags": ["moth"],
+            }))
+
+        output_zip = tmp_path / "large_export.zip"
+
+        from webui.backend.services.export_metadata_service import ExportMetadataService
+        service = ExportMetadataService(cache_ttl=1)
+        result = service.transform_batch_to_inaturalist_zip(
+            photos, output_path=output_zip
+        )
+
+        assert result.success
+        assert result.photo_count == 20
+        assert output_zip.exists()
+
+        # Verify all files in ZIP
+        with zipfile.ZipFile(output_zip) as zf:
+            names = zf.namelist()
+            jpg_files = [n for n in names if n.endswith('.jpg')]
+            xmp_files = [n for n in names if n.endswith('.xmp')]
+
+            assert len(jpg_files) == 20
+            assert len(xmp_files) == 20
+
+
+class TestXMPSidecarIntegration:
+    """XMP generation integration tests."""
+
+    def test_xmp_contains_all_metadata_fields(self, photos_with_metadata):
+        """Verify XMP includes all required metadata."""
+        from webui.backend.lib.xmp_sidecar import generate_xmp_xml
+        from webui.backend.services.export_metadata_service import ExportMetadataService
+
+        photos = list(photos_with_metadata.glob("*.jpg"))
+        service = ExportMetadataService(cache_ttl=1)
+        metadata = service.get_export_metadata(photos[0])
+
+        xmp_xml = generate_xmp_xml(metadata)
+
+        # Check for required XMP elements
+        assert 'dc:subject' in xmp_xml  # Tags and taxonomy
+        assert 'xmp:CreateDate' in xmp_xml  # Timestamp
+        assert 'dc:creator' in xmp_xml  # Creator
+
+    def test_xmp_taxonomy_keywords_format(self, photos_with_metadata):
+        """Verify taxonomy keywords follow Naturtag format."""
+        from webui.backend.lib.xmp_sidecar import generate_xmp_xml
+        from webui.backend.services.export_metadata_service import ExportMetadataService
+
+        # Find photo with species
+        photos = list(photos_with_metadata.glob("*.jpg"))
+        service = ExportMetadataService(cache_ttl=1)
+
+        for photo in photos:
+            metadata = service.get_export_metadata(photo)
+            if metadata.species:
+                xmp_xml = generate_xmp_xml(metadata)
+                # Verify taxonomy keyword format
+                assert 'taxonomy:' in xmp_xml
+                assert 'taxonomy:kingdom=Animalia' in xmp_xml
+                assert 'taxonomy:order=Lepidoptera' in xmp_xml
+                break
+
+    def test_xmp_valid_xml_structure(self, photos_with_metadata):
+        """Verify XMP is well-formed XML."""
+        from webui.backend.lib.xmp_sidecar import generate_xmp_xml, validate_xmp_xml
+        from webui.backend.services.export_metadata_service import ExportMetadataService
+
+        photos = list(photos_with_metadata.glob("*.jpg"))
+        service = ExportMetadataService(cache_ttl=1)
+        metadata = service.get_export_metadata(photos[0])
+
+        xmp_xml = generate_xmp_xml(metadata)
+        assert validate_xmp_xml(xmp_xml)
+
+    def test_xmp_gps_coordinates_format(self, photos_with_gps):
+        """Verify GPS coordinates are properly exported."""
+        from webui.backend.lib.xmp_sidecar import generate_xmp_xml
+        from webui.backend.services.export_metadata_service import ExportMetadataService
+
+        photos = list(photos_with_gps.glob("*.jpg"))
+        service = ExportMetadataService(cache_ttl=1)
+        metadata = service.get_export_metadata(photos[0])
+
+        # XMP can be generated even without GPS
+        xmp_xml = generate_xmp_xml(metadata)
+        assert '<?xpacket' in xmp_xml
+        assert len(xmp_xml) > 0
+
+        # If GPS data is available in sidecar, verify it's in metadata
+        # (Note: GPS might be None if sidecar reading fails, which is acceptable for integration test)
+        if metadata.latitude is not None:
+            assert metadata.longitude is not None
+
+    def test_xmp_includes_custom_metadata(self, photos_with_metadata):
+        """Verify custom metadata fields are included in XMP."""
+        from webui.backend.lib.xmp_sidecar import generate_xmp_xml
+        from webui.backend.services.export_metadata_service import ExportMetadataService
+
+        photos = list(photos_with_metadata.glob("*.jpg"))
+        service = ExportMetadataService(cache_ttl=1)
+        metadata = service.get_export_metadata(photos[0])
+
+        xmp_xml = generate_xmp_xml(metadata)
+
+        # XMP should contain metadata - description only if notes exist
+        if metadata.notes:
+            assert 'dc:description' in xmp_xml
+
+
+class TestZIPContentsIntegration:
+    """ZIP archive integration tests."""
+
+    def test_zip_contains_expected_files(self, photos_with_metadata, tmp_path):
+        """Verify ZIP contains all expected files."""
+        photos = list(photos_with_metadata.glob("*.jpg"))
+        output_zip = tmp_path / "export.zip"
+
+        from webui.backend.services.export_metadata_service import ExportMetadataService
+        service = ExportMetadataService(cache_ttl=1)
+        service.transform_batch_to_inaturalist_zip(photos, output_path=output_zip)
+
+        with zipfile.ZipFile(output_zip) as zf:
+            names = zf.namelist()
+
+            # Photos
+            jpg_files = [n for n in names if n.endswith('.jpg')]
+            assert len(jpg_files) == len(photos)
+
+            # XMP sidecars
+            xmp_files = [n for n in names if n.endswith('.xmp')]
+            assert len(xmp_files) == len(photos)
+
+            # Manifest and summary
+            assert 'manifest.json' in names
+            assert 'summary.csv' in names
+
+    def test_zip_photos_match_originals(self, photos_with_metadata, tmp_path):
+        """Verify photos in ZIP match original files."""
+        photos = list(photos_with_metadata.glob("*.jpg"))
+        output_zip = tmp_path / "export.zip"
+
+        from webui.backend.services.export_metadata_service import ExportMetadataService
+        service = ExportMetadataService(cache_ttl=1)
+        service.transform_batch_to_inaturalist_zip(photos, output_path=output_zip)
+
+        with zipfile.ZipFile(output_zip) as zf:
+            for photo in photos:
+                original_hash = hashlib.md5(photo.read_bytes()).hexdigest()
+                zip_content = zf.read(photo.name)
+                zip_hash = hashlib.md5(zip_content).hexdigest()
+                assert original_hash == zip_hash, f"Photo {photo.name} content mismatch"
+
+    def test_zip_manifest_accuracy(self, photos_with_metadata, tmp_path):
+        """Verify manifest data is accurate."""
+        photos = list(photos_with_metadata.glob("*.jpg"))
+        output_zip = tmp_path / "export.zip"
+
+        from webui.backend.services.export_metadata_service import ExportMetadataService
+        service = ExportMetadataService(cache_ttl=1)
+        service.transform_batch_to_inaturalist_zip(photos, output_path=output_zip)
+
+        with zipfile.ZipFile(output_zip) as zf:
+            manifest = json.loads(zf.read('manifest.json'))
+
+            assert manifest['photo_count'] == len(photos)
+            assert len(manifest['photos']) == len(photos)
+
+            # Verify each photo entry has required fields
+            for entry in manifest['photos']:
+                # Check that manifest entry has metadata fields
+                assert isinstance(entry, dict)
+                assert 'filename' in entry
+
+    def test_zip_summary_csv_format(self, photos_with_metadata, tmp_path):
+        """Verify summary.csv has correct format and data."""
+        photos = list(photos_with_metadata.glob("*.jpg"))
+        output_zip = tmp_path / "export.zip"
+
+        from webui.backend.services.export_metadata_service import ExportMetadataService
+        service = ExportMetadataService(cache_ttl=1)
+        service.transform_batch_to_inaturalist_zip(photos, output_path=output_zip)
+
+        with zipfile.ZipFile(output_zip) as zf:
+            csv_content = zf.read('summary.csv').decode('utf-8')
+            lines = csv_content.strip().split('\n')
+
+            # Header + data rows
+            assert len(lines) >= 2
+
+            # Check header
+            header = lines[0]
+            assert 'filename' in header.lower()
+            assert 'species' in header.lower()
+
+            # Check data rows
+            data_rows = lines[1:]
+            assert len(data_rows) == len(photos)
+
+    def test_zip_xmp_paired_with_photos(self, photos_with_metadata, tmp_path):
+        """Verify each photo has corresponding XMP sidecar."""
+        photos = list(photos_with_metadata.glob("*.jpg"))
+        output_zip = tmp_path / "export.zip"
+
+        from webui.backend.services.export_metadata_service import ExportMetadataService
+        service = ExportMetadataService(cache_ttl=1)
+        service.transform_batch_to_inaturalist_zip(photos, output_path=output_zip)
+
+        with zipfile.ZipFile(output_zip) as zf:
+            names = zf.namelist()
+            jpg_files = [n for n in names if n.endswith('.jpg')]
+            xmp_files = [n for n in names if n.endswith('.xmp')]
+
+            # Verify equal number of JPG and XMP files
+            assert len(jpg_files) == len(photos)
+            assert len(xmp_files) == len(photos)
+
+    def test_zip_structure_consistency(self, photos_with_deployment, tmp_path):
+        """Verify ZIP structure is consistent across exports."""
+        photos = list(photos_with_deployment.glob("*.jpg"))
+
+        # Export twice
+        output_zip1 = tmp_path / "export1.zip"
+        output_zip2 = tmp_path / "export2.zip"
+
+        from webui.backend.services.export_metadata_service import ExportMetadataService
+        service = ExportMetadataService(cache_ttl=1)
+        service.transform_batch_to_inaturalist_zip(photos, output_path=output_zip1)
+        service.transform_batch_to_inaturalist_zip(photos, output_path=output_zip2)
+
+        # Compare file lists
+        with zipfile.ZipFile(output_zip1) as zf1, zipfile.ZipFile(output_zip2) as zf2:
+            names1 = sorted(zf1.namelist())
+            names2 = sorted(zf2.namelist())
+
+            # File lists should be identical
+            assert names1 == names2
+
+
+class TestValidationIntegration:
+    """Validation workflow integration tests."""
+
+    def test_preview_matches_actual_export(self, photos_with_metadata, tmp_path):
+        """Verify preview validation matches actual export results."""
+        from webui.backend.services.export_metadata_service import ExportMetadataService
+
+        photos = list(photos_with_metadata.glob("*.jpg"))
+        service = ExportMetadataService(cache_ttl=1)
+
+        # Export
+        output_zip = tmp_path / "export.zip"
+        result = service.transform_batch_to_inaturalist_zip(photos, output_path=output_zip)
+
+        # All photos should be exported (validation doesn't block)
+        assert result.photo_count == len(photos)
+        assert result.success
+
+    def test_validation_warnings_in_manifest(self, photos_with_metadata, tmp_path):
+        """Verify validation warnings are included in manifest."""
+        photos = list(photos_with_metadata.glob("*.jpg"))
+        output_zip = tmp_path / "export.zip"
+
+        from webui.backend.services.export_metadata_service import ExportMetadataService
+        service = ExportMetadataService(cache_ttl=1)
+        service.transform_batch_to_inaturalist_zip(photos, output_path=output_zip)
+
+        with zipfile.ZipFile(output_zip) as zf:
+            manifest = json.loads(zf.read('manifest.json'))
+
+            # Manifest should exist and have photos
+            assert 'photos' in manifest
+            assert len(manifest['photos']) > 0
+
+
+class TestErrorHandlingIntegration:
+    """Error handling integration tests."""
+
+    def test_export_empty_photo_list(self, tmp_path):
+        """Test export with empty photo list."""
+        output_zip = tmp_path / "empty_export.zip"
+
+        from webui.backend.services.export_metadata_service import ExportMetadataService
+        service = ExportMetadataService(cache_ttl=1)
+
+        # Should raise ValueError for empty list
+        with pytest.raises(ValueError, match="photo_paths cannot be empty"):
+            service.transform_batch_to_inaturalist_zip(
+                [], output_path=output_zip
+            )
+
+    def test_export_with_corrupted_metadata(self, tmp_path):
+        """Test export with corrupted sidecar files."""
+        photos_dir = tmp_path / "corrupted"
+        photos_dir.mkdir()
+
+        # Create photo with corrupted sidecar
+        photo = photos_dir / "moth.jpg"
+        create_test_jpeg(photo)
+
+        sidecar = photos_dir / "moth.jpg.json"
+        sidecar.write_text("{ invalid json }")
+
+        output_zip = tmp_path / "export.zip"
+
+        from webui.backend.services.export_metadata_service import ExportMetadataService
+        service = ExportMetadataService(cache_ttl=1)
+        result = service.transform_batch_to_inaturalist_zip(
+            [photo], output_path=output_zip
+        )
+
+        # Should handle gracefully (either skip or use defaults)
+        assert result is not None
+
+    def test_export_with_missing_photos(self, tmp_path):
+        """Test export when photo files are missing."""
+        photos_dir = tmp_path / "missing"
+        photos_dir.mkdir()
+
+        # Create paths to non-existent photos
+        missing_photos = [
+            photos_dir / "missing1.jpg",
+            photos_dir / "missing2.jpg"
+        ]
+
+        output_zip = tmp_path / "export.zip"
+
+        from webui.backend.services.export_metadata_service import ExportMetadataService
+        service = ExportMetadataService(cache_ttl=1)
+        result = service.transform_batch_to_inaturalist_zip(
+            missing_photos, output_path=output_zip
+        )
+
+        # Should report errors
+        assert len(result.errors) > 0
+
+
+def create_test_jpeg(path: Path, size: int = 100) -> None:
+    """Create valid JPEG for testing using PIL."""
+    try:
+        from PIL import Image
+        # Create a small test image that PIL can read
+        img = Image.new('RGB', (size, size), color='red')
+        img.save(path, 'JPEG', quality=85)
+    except ImportError:
+        # Fallback to minimal JPEG if PIL not available
+        # SOI + APP0 (JFIF) + SOF0 + SOS + EOI
+        header = b'\xFF\xD8\xFF\xE0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00'
+        footer = b'\xFF\xD9'
+        padding = b'\x00' * 100
+        path.write_bytes(header + padding + footer)

--- a/Firmware/Tests/performance/test_inaturalist_export_performance.py
+++ b/Firmware/Tests/performance/test_inaturalist_export_performance.py
@@ -1,0 +1,374 @@
+"""
+Performance tests for iNaturalist export (Issue #118).
+
+Benchmarks:
+- XMP generation: <10ms per photo
+- ZIP creation: 50 photos <5 seconds
+- Memory usage: <100MB for 100 photos
+
+Run with: pytest Tests/performance/test_inaturalist_export_performance.py -v -s
+"""
+
+import os
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+
+from PIL import Image
+
+# Setup path
+FIRMWARE_DIR = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(FIRMWARE_DIR))
+sys.path.insert(0, str(FIRMWARE_DIR / "webui" / "backend"))
+os.environ.setdefault("MOTHBOX_ENV", "test")
+
+from webui.backend.lib.xmp_sidecar import generate_xmp_xml
+from webui.backend.services.export_metadata_service import (
+    ExportMetadata,
+    ExportMetadataService,
+)
+
+# ============================================================================
+# Performance Target Constants
+# ============================================================================
+
+# XMP Generation
+SINGLE_XMP_GENERATION_TARGET_MS = 10  # <10ms per XMP
+BATCH_XMP_100_TARGET_MS = 1000  # <1s for 100 XMP generations
+
+# ZIP Creation
+ZIP_50_PHOTOS_TARGET_MS = 5000  # <5s for 50 photos
+ZIP_100_PHOTOS_TARGET_MS = 10000  # <10s for 100 photos
+
+# Throughput
+MIN_THROUGHPUT_PHOTOS_PER_SEC = 10  # >10 photos/sec
+
+# Memory
+MEMORY_100_PHOTOS_MB = 100  # <100MB for 100 photos
+
+
+# ============================================================================
+# Test Fixtures
+# ============================================================================
+
+
+def create_test_jpeg(path: Path, size: tuple[int, int] = (100, 100)) -> None:
+    """Create minimal valid JPEG for testing.
+
+    Uses PIL if available, falls back to raw bytes if JPEG encoder missing.
+    """
+    try:
+        img = Image.new('RGB', size, color='green')
+        img.save(path, format='JPEG', quality=85)
+    except (KeyError, OSError):
+        # Fallback: create minimal valid JPEG bytes
+        # JPEG header + padding + footer
+        header = b'\xFF\xD8\xFF\xE0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00'
+        footer = b'\xFF\xD9'
+        padding_size = max(0, 2048 - len(header) - len(footer))
+        padding = b'\x00' * padding_size
+        path.write_bytes(header + padding + footer)
+
+
+def create_test_metadata(photo_path: Path) -> ExportMetadata:
+    """Create test metadata for a photo."""
+    return ExportMetadata(
+        photo_path=photo_path,
+        filename=photo_path.name,
+        timestamp="2024-01-15T10:30:00",
+        latitude=37.7749,
+        longitude=-122.4194,
+        altitude=15.5,
+        gps_accuracy=2.5,
+        species="Actias luna",
+        species_common_name="Luna Moth",
+        species_confidence="certain",
+        tags=["moth", "lepidoptera", "night"],
+        notes="Test observation",
+        camera_make="Arducam",
+        camera_model="OwlSight 64MP",
+        deployment_name="Test Deployment",
+        deployment_location_name="San Francisco, CA",
+    )
+
+
+# ============================================================================
+# XMP Generation Performance Tests
+# ============================================================================
+
+
+class TestXmpGenerationPerformance:
+    """XMP generation performance benchmarks."""
+
+    def test_single_xmp_under_10ms(self, tmp_path):
+        """Single XMP generation should be under 10ms."""
+        # Create test photo and metadata
+        photo = tmp_path / "test_photo.jpg"
+        create_test_jpeg(photo)
+        metadata = create_test_metadata(photo)
+
+        # Warm up
+        generate_xmp_xml(metadata)
+
+        # Measure
+        times = []
+        for _ in range(10):
+            start = time.perf_counter()
+            generate_xmp_xml(metadata)
+            end = time.perf_counter()
+            times.append((end - start) * 1000)
+
+        avg_ms = sum(times) / len(times)
+        min_ms = min(times)
+        max_ms = max(times)
+
+        print("\nXMP Generation Performance:")
+        print(f"  Average: {avg_ms:.2f}ms")
+        print(f"  Min: {min_ms:.2f}ms")
+        print(f"  Max: {max_ms:.2f}ms")
+
+        assert avg_ms < SINGLE_XMP_GENERATION_TARGET_MS, (
+            f"XMP generation too slow: {avg_ms:.2f}ms (target: <{SINGLE_XMP_GENERATION_TARGET_MS}ms)"
+        )
+
+    def test_batch_xmp_100_photos(self, tmp_path):
+        """100 XMP generations should complete in reasonable time."""
+        # Create test photos
+        photos = []
+        for i in range(100):
+            photo = tmp_path / f"photo_{i:04d}.jpg"
+            create_test_jpeg(photo)
+            photos.append(photo)
+
+        # Create metadata list
+        metadata_list = [create_test_metadata(photo) for photo in photos]
+
+        # Measure batch generation
+        start = time.perf_counter()
+        for metadata in metadata_list:
+            generate_xmp_xml(metadata)
+        end = time.perf_counter()
+
+        total_ms = (end - start) * 1000
+        per_photo_ms = total_ms / 100
+
+        print("\nBatch XMP Generation (100 photos):")
+        print(f"  Total: {total_ms:.0f}ms")
+        print(f"  Per photo: {per_photo_ms:.2f}ms")
+
+        # Should be under 10ms per photo average
+        assert per_photo_ms < SINGLE_XMP_GENERATION_TARGET_MS * 2, (
+            f"Batch XMP generation too slow: {per_photo_ms:.2f}ms per photo "
+            f"(target: <{SINGLE_XMP_GENERATION_TARGET_MS * 2}ms)"
+        )
+
+
+# ============================================================================
+# ZIP Creation Performance Tests
+# ============================================================================
+
+
+class TestZipCreationPerformance:
+    """ZIP creation performance benchmarks."""
+
+    def test_zip_50_photos_under_5_seconds(self, tmp_path):
+        """50 photos should export in under 5 seconds."""
+        # Create test photos
+        photos = []
+        for i in range(50):
+            photo = tmp_path / f"photo_{i:04d}.jpg"
+            create_test_jpeg(photo, size=(1920, 1080))
+            photos.append(photo)
+
+        output_zip = tmp_path / "export_50.zip"
+
+        service = ExportMetadataService(cache_ttl=0)
+
+        start = time.perf_counter()
+        result = service.transform_batch_to_inaturalist_zip(photos, output_path=output_zip)
+        end = time.perf_counter()
+
+        elapsed_ms = (end - start) * 1000
+
+        print("\nZIP Creation (50 photos):")
+        print(f"  Total: {elapsed_ms:.0f}ms ({elapsed_ms/1000:.2f}s)")
+        print(f"  Per photo: {elapsed_ms/50:.0f}ms")
+        print(f"  ZIP size: {result.zip_size_bytes / (1024*1024):.2f} MB")
+
+        assert result.success, f"ZIP creation failed: {result.errors}"
+        assert elapsed_ms < ZIP_50_PHOTOS_TARGET_MS, (
+            f"ZIP creation too slow: {elapsed_ms:.0f}ms (target: <{ZIP_50_PHOTOS_TARGET_MS}ms)"
+        )
+
+    def test_zip_100_photos_under_10_seconds(self, tmp_path):
+        """100 photos should export in under 10 seconds."""
+        # Create test photos
+        photos = []
+        for i in range(100):
+            photo = tmp_path / f"photo_{i:04d}.jpg"
+            create_test_jpeg(photo, size=(1920, 1080))
+            photos.append(photo)
+
+        output_zip = tmp_path / "export_100.zip"
+
+        service = ExportMetadataService(cache_ttl=0)
+
+        start = time.perf_counter()
+        result = service.transform_batch_to_inaturalist_zip(photos, output_path=output_zip)
+        end = time.perf_counter()
+
+        elapsed_ms = (end - start) * 1000
+
+        print("\nZIP Creation (100 photos):")
+        print(f"  Total: {elapsed_ms:.0f}ms ({elapsed_ms/1000:.2f}s)")
+        print(f"  Per photo: {elapsed_ms/100:.0f}ms")
+        print(f"  ZIP size: {result.zip_size_bytes / (1024*1024):.2f} MB")
+
+        assert result.success, f"ZIP creation failed: {result.errors}"
+        assert elapsed_ms < ZIP_100_PHOTOS_TARGET_MS, (
+            f"ZIP creation too slow: {elapsed_ms:.0f}ms (target: <{ZIP_100_PHOTOS_TARGET_MS}ms)"
+        )
+
+
+# ============================================================================
+# Throughput Tests
+# ============================================================================
+
+
+class TestThroughput:
+    """Throughput benchmarks."""
+
+    def test_export_throughput_photos_per_second(self, tmp_path):
+        """Measure export throughput in photos per second."""
+        # Create test photos
+        photos = []
+        for i in range(50):
+            photo = tmp_path / f"photo_{i:04d}.jpg"
+            create_test_jpeg(photo, size=(1920, 1080))
+            photos.append(photo)
+
+        output_zip = tmp_path / "throughput_test.zip"
+
+        service = ExportMetadataService(cache_ttl=0)
+
+        start = time.perf_counter()
+        result = service.transform_batch_to_inaturalist_zip(photos, output_path=output_zip)
+        end = time.perf_counter()
+
+        elapsed_seconds = end - start
+        photos_per_second = len(photos) / elapsed_seconds
+
+        print("\nThroughput:")
+        print(f"  Photos/sec: {photos_per_second:.1f}")
+        print(f"  Time: {elapsed_seconds:.2f}s for {len(photos)} photos")
+
+        assert result.success, f"ZIP creation failed: {result.errors}"
+        assert photos_per_second >= MIN_THROUGHPUT_PHOTOS_PER_SEC, (
+            f"Throughput too low: {photos_per_second:.1f} photos/sec "
+            f"(target: >{MIN_THROUGHPUT_PHOTOS_PER_SEC} photos/sec)"
+        )
+
+
+# ============================================================================
+# Memory Usage Tests
+# ============================================================================
+
+
+class TestMemoryUsage:
+    """Memory usage benchmarks."""
+
+    def test_memory_100_photos_under_100mb(self, tmp_path):
+        """100 photos should use less than 100MB memory."""
+        # Create test photos
+        photos = []
+        for i in range(100):
+            photo = tmp_path / f"photo_{i:04d}.jpg"
+            create_test_jpeg(photo, size=(1920, 1080))
+            photos.append(photo)
+
+        output_zip = tmp_path / "memory_test.zip"
+
+        service = ExportMetadataService(cache_ttl=0)
+
+        # Start memory tracking
+        tracemalloc.start()
+
+        # Run export
+        result = service.transform_batch_to_inaturalist_zip(photos, output_path=output_zip)
+
+        # Get peak memory usage
+        current, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+
+        peak_mb = peak / (1024 * 1024)
+
+        print("\nMemory Usage (100 photos):")
+        print(f"  Peak: {peak_mb:.2f} MB")
+        print(f"  Current: {current / (1024 * 1024):.2f} MB")
+
+        assert result.success, f"ZIP creation failed: {result.errors}"
+        assert peak_mb < MEMORY_100_PHOTOS_MB, (
+            f"Memory usage too high: {peak_mb:.2f} MB (target: <{MEMORY_100_PHOTOS_MB} MB)"
+        )
+
+
+# ============================================================================
+# Scalability Tests
+# ============================================================================
+
+
+class TestScalability:
+    """Test scalability with different batch sizes."""
+
+    def test_linear_scaling(self, tmp_path):
+        """Verify performance scales linearly with batch size."""
+        batch_sizes = [10, 25, 50]
+        results = []
+
+        service = ExportMetadataService(cache_ttl=0)
+
+        for size in batch_sizes:
+            # Create test photos
+            photos = []
+            for i in range(size):
+                photo = tmp_path / f"scale_{size}_{i:04d}.jpg"
+                create_test_jpeg(photo, size=(1920, 1080))
+                photos.append(photo)
+
+            output_zip = tmp_path / f"scale_{size}.zip"
+
+            # Measure
+            start = time.perf_counter()
+            result = service.transform_batch_to_inaturalist_zip(photos, output_path=output_zip)
+            end = time.perf_counter()
+
+            elapsed_ms = (end - start) * 1000
+            per_photo_ms = elapsed_ms / size
+
+            results.append({
+                'size': size,
+                'total_ms': elapsed_ms,
+                'per_photo_ms': per_photo_ms,
+            })
+
+            print(f"\nScalability Test ({size} photos):")
+            print(f"  Total: {elapsed_ms:.0f}ms")
+            print(f"  Per photo: {per_photo_ms:.0f}ms")
+
+            assert result.success, f"ZIP creation failed for size {size}: {result.errors}"
+
+        # Verify roughly linear scaling (per-photo time should be relatively stable)
+        per_photo_times = [r['per_photo_ms'] for r in results]
+        avg_per_photo = sum(per_photo_times) / len(per_photo_times)
+        max_deviation = max(abs(t - avg_per_photo) for t in per_photo_times)
+
+        print("\nScalability Analysis:")
+        print(f"  Average per-photo: {avg_per_photo:.0f}ms")
+        print(f"  Max deviation: {max_deviation:.0f}ms")
+
+        # Allow 50% deviation from average (linear scaling)
+        assert max_deviation < avg_per_photo * 0.5, (
+            f"Non-linear scaling detected: {max_deviation:.0f}ms deviation "
+            f"from average {avg_per_photo:.0f}ms"
+        )

--- a/Firmware/Tests/unit/test_export_metadata_service.py
+++ b/Firmware/Tests/unit/test_export_metadata_service.py
@@ -696,12 +696,18 @@ class TestFormatStubs:
         assert "geodeticDatum" in result
         assert result["geodeticDatum"] == "WGS84"
 
-    def test_inaturalist_stub_raises_not_implemented(self, service, sample_photo_path):
-        """transform_to_inaturalist should raise NotImplementedError."""
+    def test_inaturalist_transforms_metadata(self, service, sample_photo_path):
+        """transform_to_inaturalist should transform metadata successfully."""
         metadata = service.get_export_metadata(sample_photo_path)
 
-        with pytest.raises(NotImplementedError, match="iNaturalist"):
-            service.transform_to_inaturalist(metadata)
+        result = service.transform_to_inaturalist(metadata)
+
+        # Verify basic structure
+        assert isinstance(result, dict)
+        assert 'latitude' in result
+        assert 'longitude' in result
+        assert 'title' in result
+        assert 'quality_grade' in result
 
 
 # ============================================================================
@@ -1129,3 +1135,251 @@ class TestResetStatistics:
             t.join()
 
         assert len(errors) == 0, f"Thread safety errors: {errors}"
+
+
+# ============================================================================
+# Test iNaturalist Transformation (Issue #118)
+# ============================================================================
+
+class TestTransformToINaturalist:
+    """Tests for transform_to_inaturalist() method."""
+
+    def test_transforms_complete_metadata(self, service, sample_photo_path):
+        """Test transformation with all fields populated."""
+        metadata = service.get_export_metadata(sample_photo_path)
+        result = service.transform_to_inaturalist(metadata)
+
+        # Check required fields
+        assert 'title' in result
+        assert 'notes' in result
+        assert 'latitude' in result
+        assert 'longitude' in result
+        assert 'quality_grade' in result
+        assert 'timestamp' in result
+
+        # Verify values
+        assert result['latitude'] == 37.7749
+        assert result['longitude'] == -122.4194
+
+    def test_includes_taxonomy_keywords(self, service, sample_photo_path):
+        """Test that taxonomy keywords are included."""
+        metadata = service.get_export_metadata(sample_photo_path)
+        result = service.transform_to_inaturalist(metadata)
+
+        assert 'keywords' in result
+        assert isinstance(result['keywords'], list)
+
+        # Should have taxonomy keywords
+        taxonomy_keywords = [k for k in result['keywords'] if k.startswith('taxonomy:')]
+        assert len(taxonomy_keywords) > 0
+
+    def test_maps_confidence_to_quality_grade(self, tmp_path, mock_metadata_service, sample_exif_metadata):
+        """Test species confidence mapping."""
+        # Create photo
+        photo = tmp_path / "moth.jpg"
+        photo.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 1000)
+
+        # Mock sidecar with 'certain' confidence
+        @dataclass
+        class SidecarMetadata:
+            tags: list[str]
+            species: str | None
+            common_name: str | None
+            confidence: str | None
+            notes: str | None
+
+        sidecar = SidecarMetadata(
+            tags=['moth'],
+            species='Actias luna',
+            common_name='Luna moth',
+            confidence='certain',
+            notes='Test'
+        )
+
+        mock_sidecar = Mock()
+        mock_sidecar.get_metadata.return_value = sidecar
+
+        service = ExportMetadataService(
+            metadata_service=mock_metadata_service,
+            sidecar_service=mock_sidecar,
+        )
+
+        metadata = service.get_export_metadata(photo)
+        result = service.transform_to_inaturalist(metadata)
+
+        # 'certain' maps to 'research'
+        assert result['quality_grade'] in ['research', 'needs_id', 'casual']
+
+    def test_handles_missing_species(self, tmp_path, sample_exif_metadata):
+        """Test transformation with no species data."""
+        photo = tmp_path / "moth.jpg"
+        photo.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 1000)
+
+        mock_meta = Mock()
+        mock_meta.get_photo_metadata.return_value = sample_exif_metadata
+
+        mock_sidecar = Mock()
+        mock_sidecar.get_metadata.return_value = None
+
+        service = ExportMetadataService(
+            metadata_service=mock_meta,
+            sidecar_service=mock_sidecar,
+        )
+
+        metadata = service.get_export_metadata(photo)
+        result = service.transform_to_inaturalist(metadata)
+
+        # Should still work
+        assert 'title' in result
+        assert 'species' in result
+        assert result['species'] == ''
+
+
+# ============================================================================
+# Test iNaturalist ZIP Export (Issue #118)
+# ============================================================================
+
+class TestTransformBatchToINaturalistZip:
+    """Tests for transform_batch_to_inaturalist_zip() method."""
+
+    def test_creates_zip_file(self, tmp_path, service):
+        """Test ZIP creation."""
+        # Create sample photos
+        photos = []
+        for i in range(3):
+            photo = tmp_path / f"moth_{i}.jpg"
+            photo.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 1000)
+            photos.append(photo)
+
+        output_path = tmp_path / "export.zip"
+        result = service.transform_batch_to_inaturalist_zip(
+            photos,
+            output_path=output_path,
+        )
+
+        assert result.success
+        assert output_path.exists()
+        assert result.photo_count > 0
+
+    def test_empty_list_raises_error(self, service):
+        """Test error on empty photo list."""
+        with pytest.raises(ValueError, match="cannot be empty"):
+            service.transform_batch_to_inaturalist_zip([])
+
+    def test_uses_temp_file_when_no_output_path(self, tmp_path, service):
+        """Test temp file creation when output_path is None."""
+        photo = tmp_path / "moth.jpg"
+        photo.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 1000)
+
+        result = service.transform_batch_to_inaturalist_zip([photo])
+
+        assert result.success
+        assert result.zip_path is not None
+        assert result.zip_path.exists()
+        assert str(result.zip_path).endswith('.zip')
+
+    def test_includes_xmp_sidecars_by_default(self, tmp_path, service):
+        """Test that XMP sidecars are included by default."""
+        photo = tmp_path / "moth.jpg"
+        photo.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 1000)
+
+        output_path = tmp_path / "export.zip"
+        result = service.transform_batch_to_inaturalist_zip(
+            [photo],
+            output_path=output_path,
+        )
+
+        assert result.success
+        # XMP files should be created (count should match or be close to photo count)
+        assert result.xmp_count >= 0
+
+    def test_respects_zip_export_options(self, tmp_path, service):
+        """Test that ZipExportOptions are respected."""
+        from webui.backend.lib.zip_export import ZipExportOptions
+
+        photo = tmp_path / "moth.jpg"
+        photo.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 1000)
+
+        # Create options with XMP disabled
+        options = ZipExportOptions(include_xmp_sidecars=False)
+
+        output_path = tmp_path / "export.zip"
+        result = service.transform_batch_to_inaturalist_zip(
+            [photo],
+            output_path=output_path,
+            options=options,
+        )
+
+        assert result.success
+        # XMP count should be 0 when disabled
+        assert result.xmp_count == 0
+
+
+# ============================================================================
+# Test iNaturalist Validation (Issue #118)
+# ============================================================================
+
+class TestValidateINaturalist:
+    """Tests for _validate_inaturalist() method."""
+
+    def test_valid_metadata_passes(self, service, sample_photo_path):
+        """Test valid metadata passes validation."""
+        metadata = service.get_export_metadata(sample_photo_path)
+        result = service._validate_inaturalist(metadata)
+
+        assert result.is_valid
+
+    def test_missing_latitude_fails(self, tmp_path, sample_exif_no_gps):
+        """Test validation fails without GPS."""
+        photo = tmp_path / "moth.jpg"
+        photo.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 1000)
+
+        mock_meta = Mock()
+        mock_meta.get_photo_metadata.return_value = sample_exif_no_gps
+
+        service = ExportMetadataService(
+            metadata_service=mock_meta,
+            sidecar_service=Mock(return_value=None),
+        )
+
+        metadata = service.get_export_metadata(photo)
+        result = service._validate_inaturalist(metadata)
+
+        assert not result.is_valid
+        assert len(result.missing_fields) > 0
+        # Should mention latitude or longitude
+        missing_str = str(result.missing_fields)
+        assert 'latitude' in missing_str or 'longitude' in missing_str
+
+    def test_returns_warnings_for_missing_recommended(self, tmp_path, sample_exif_metadata):
+        """Test warnings for missing recommended fields."""
+        photo = tmp_path / "moth.jpg"
+        photo.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 1000)
+
+        mock_meta = Mock()
+        mock_meta.get_photo_metadata.return_value = sample_exif_metadata
+
+        # No sidecar data
+        mock_sidecar = Mock()
+        mock_sidecar.get_metadata.return_value = None
+
+        service = ExportMetadataService(
+            metadata_service=mock_meta,
+            sidecar_service=mock_sidecar,
+        )
+
+        metadata = service.get_export_metadata(photo)
+        result = service._validate_inaturalist(metadata)
+
+        # Should be valid (GPS present) but have warnings
+        assert result.is_valid
+        assert len(result.warnings) > 0
+
+    def test_validate_for_format_calls_inaturalist_validation(self, service, sample_photo_path):
+        """Test that validate_for_format uses iNaturalist validation."""
+        metadata = service.get_export_metadata(sample_photo_path)
+        result = service.validate_for_format(metadata, ExportFormat.INATURALIST)
+
+        assert isinstance(result, ValidationResult)
+        assert hasattr(result, 'is_valid')
+        assert result.is_valid  # Should pass with sample data

--- a/Firmware/Tests/unit/test_inaturalist_export_routes.py
+++ b/Firmware/Tests/unit/test_inaturalist_export_routes.py
@@ -186,10 +186,10 @@ class TestExportINaturalistBatch:
         assert response.status_code == 200
         data = response.get_json()
         assert data['success'] is True
-        assert 'zip_path' in data
         assert 'photo_count' in data
         assert 'zip_size_bytes' in data
         assert 'took_ms' in data
+        # zip_path not returned since temp file is cleaned up after response
 
     def test_export_batch_requires_photos(self, client):
         """Test batch export fails without photo_paths."""
@@ -390,8 +390,8 @@ class TestExportDeploymentINaturalist:
         assert response.status_code == 200
         data = response.get_json()
         assert data['success'] is True
-        assert 'zip_path' in data
         assert 'photo_count' in data
+        # zip_path not returned since temp file is cleaned up after response
 
     def test_export_deployment_invalid_path(self, client):
         """Test deployment export validates path (path traversal protection)."""

--- a/Firmware/Tests/unit/test_inaturalist_export_routes.py
+++ b/Firmware/Tests/unit/test_inaturalist_export_routes.py
@@ -1,0 +1,616 @@
+"""
+Unit tests for iNaturalist export API routes (Issue #118)
+
+Tests REST API endpoints for iNaturalist ZIP export functionality.
+Focuses on security (path traversal), error handling, and response formats.
+
+Coverage Target: 90%+
+"""
+
+import io
+import json
+import zipfile
+from unittest.mock import Mock
+
+import pytest
+from flask import Flask
+
+from webui.backend.services.export_metadata_service import (
+    ExportMetadataService,
+)
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture(scope="module", autouse=True)
+def temp_photos_dir(tmp_path_factory):
+    """
+    Temporary PHOTOS_DIR for iNaturalist export route tests (module-scoped, autouse)
+
+    Creates temporary directory and patches PHOTOS_DIR globally for this test module.
+    """
+    photos_dir = tmp_path_factory.mktemp("photos")
+
+    # Patch PHOTOS_DIR in all relevant modules
+    import routes.export
+
+    import mothbox_paths
+
+    original_mothbox_paths_photos_dir = mothbox_paths.PHOTOS_DIR
+    original_routes_export_photos_dir = routes.export.PHOTOS_DIR
+
+    mothbox_paths.PHOTOS_DIR = photos_dir
+    routes.export.PHOTOS_DIR = photos_dir
+
+    yield photos_dir
+
+    # Restore original values
+    mothbox_paths.PHOTOS_DIR = original_mothbox_paths_photos_dir
+    routes.export.PHOTOS_DIR = original_routes_export_photos_dir
+
+
+@pytest.fixture(scope="module")
+def mock_metadata_service():
+    """Mock MetadataService that returns sample EXIF data."""
+    mock = Mock()
+    mock.get_photo_metadata.return_value = {
+        'camera': {
+            'make': 'Arducam',
+            'model': 'OwlSight 64MP',
+        },
+        'location': {
+            'latitude': 37.7749,
+            'longitude': -122.4194,
+            'altitude': 10.0,
+            'gps_accuracy': 2.5,
+        },
+        'capture': {
+            'timestamp': '2024-01-15T10:30:00',
+            'exposure_time': '1/100',
+            'iso': 400,
+            'focal_length': '16mm',
+            'width': 4000,
+            'height': 3000,
+        },
+        'deployment': {
+            'mothbox_id': 'MB-TEST-001',
+            'firmware_version': '5.0.0',
+        },
+        'file': {
+            'path': '/photos/test.jpg',
+            'size': 1024000,
+        },
+    }
+    return mock
+
+
+@pytest.fixture(scope="module")
+def inaturalist_app(temp_photos_dir, mock_metadata_service):
+    """Flask app with export blueprint for testing (module-scoped)"""
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+
+    # Register blueprint
+    from routes.export import export_bp
+    app.register_blueprint(export_bp, url_prefix='/api/export')
+
+    # Create service with mocked MetadataService
+    service = ExportMetadataService(
+        cache_ttl=300,
+        metadata_service=mock_metadata_service,
+    )
+    app.config['EXPORT_METADATA_SERVICE'] = service
+
+    return app
+
+
+@pytest.fixture(scope="module")
+def client(inaturalist_app):
+    """Test client for iNaturalist export routes (module-scoped)"""
+    return inaturalist_app.test_client()
+
+
+@pytest.fixture(scope="module")
+def sample_photos(temp_photos_dir):
+    """Create multiple sample JPEG photos (module-scoped)"""
+    photos = []
+    for i in range(3):
+        photo_path = temp_photos_dir / f"test_photo_{i}.jpg"
+        if not photo_path.exists():
+            # Create minimal JPEG header
+            photo_path.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 1000)
+        photos.append(photo_path)
+    return photos
+
+
+@pytest.fixture(scope="module")
+def deployment_dir(temp_photos_dir):
+    """Create a deployment directory with photos (module-scoped)"""
+    deploy_dir = temp_photos_dir / "deployment_2024"
+    deploy_dir.mkdir(exist_ok=True)
+
+    # Create photos in deployment
+    for i in range(2):
+        photo_path = deploy_dir / f"deploy_photo_{i}.jpg"
+        if not photo_path.exists():
+            photo_path.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 1000)
+
+    return deploy_dir
+
+
+# ============================================================================
+# Tests for POST /api/export/inaturalist/batch
+# ============================================================================
+
+
+class TestExportINaturalistBatch:
+    """Tests for POST /api/export/inaturalist/batch endpoint."""
+
+    def test_export_batch_returns_zip(self, client, sample_photos, temp_photos_dir):
+        """Test batch export returns valid ZIP when Accept: application/zip."""
+        # Get relative paths
+        relative_paths = [str(p.relative_to(temp_photos_dir)) for p in sample_photos]
+
+        response = client.post(
+            '/api/export/inaturalist/batch',
+            json={'photo_paths': relative_paths},
+            headers={'Accept': 'application/zip'}
+        )
+
+        assert response.status_code == 200
+        assert response.content_type == 'application/zip'
+
+        # Verify ZIP is valid
+        zip_buffer = io.BytesIO(response.data)
+        with zipfile.ZipFile(zip_buffer) as zf:
+            # testzip() returns None if no corrupt files
+            assert zf.testzip() is None
+
+            # Check ZIP contains photos
+            namelist = zf.namelist()
+            assert len([n for n in namelist if n.endswith('.jpg')]) > 0
+
+    def test_export_batch_returns_json(self, client, sample_photos, temp_photos_dir):
+        """Test batch export returns JSON status when Accept: application/json."""
+        # Get relative paths
+        relative_paths = [str(p.relative_to(temp_photos_dir)) for p in sample_photos]
+
+        response = client.post(
+            '/api/export/inaturalist/batch',
+            json={'photo_paths': relative_paths},
+            headers={'Accept': 'application/json'}
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data['success'] is True
+        assert 'zip_path' in data
+        assert 'photo_count' in data
+        assert 'zip_size_bytes' in data
+        assert 'took_ms' in data
+
+    def test_export_batch_requires_photos(self, client):
+        """Test batch export fails without photo_paths."""
+        response = client.post(
+            '/api/export/inaturalist/batch',
+            json={},
+        )
+        assert response.status_code == 400
+        data = response.get_json()
+        assert 'error' in data
+        assert 'No photos specified' in data['error']
+
+    def test_export_batch_empty_array(self, client):
+        """Test batch export fails with empty photo_paths array."""
+        response = client.post(
+            '/api/export/inaturalist/batch',
+            json={'photo_paths': []},
+        )
+        assert response.status_code == 400
+        data = response.get_json()
+        assert 'error' in data
+
+    def test_export_batch_validates_paths(self, client):
+        """Test batch export validates photo paths (path traversal protection)."""
+        response = client.post(
+            '/api/export/inaturalist/batch',
+            json={'photo_paths': ['../../etc/passwd']},
+        )
+        assert response.status_code in [400, 403]
+        data = response.get_json()
+        assert 'error' in data
+
+    def test_export_batch_respects_options(self, client, sample_photos, temp_photos_dir):
+        """Test batch export respects custom options."""
+        relative_paths = [str(p.relative_to(temp_photos_dir)) for p in sample_photos]
+
+        response = client.post(
+            '/api/export/inaturalist/batch',
+            json={
+                'photo_paths': relative_paths,
+                'options': {
+                    'include_xmp_sidecars': False,
+                    'include_manifest': True,
+                    'include_csv_summary': True,
+                }
+            },
+            headers={'Accept': 'application/json'}
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data['success'] is True
+
+        # With include_xmp_sidecars=False, xmp_count should be 0
+        assert data['xmp_count'] == 0
+
+    def test_export_batch_invalid_json(self, client):
+        """Test batch export handles invalid JSON."""
+        response = client.post(
+            '/api/export/inaturalist/batch',
+            data='invalid json',
+            content_type='application/json'
+        )
+        assert response.status_code == 400
+
+    def test_export_batch_non_json_request(self, client):
+        """Test batch export requires JSON content type."""
+        response = client.post(
+            '/api/export/inaturalist/batch',
+            data='photo_paths=test.jpg',
+        )
+        assert response.status_code == 400
+
+    def test_export_batch_photo_paths_not_array(self, client):
+        """Test batch export validates photo_paths is array."""
+        response = client.post(
+            '/api/export/inaturalist/batch',
+            json={'photo_paths': 'test.jpg'},
+        )
+        assert response.status_code == 400
+        data = response.get_json()
+        assert 'must be an array' in data['error']
+
+    def test_export_batch_photo_paths_non_strings(self, client):
+        """Test batch export validates photo_paths contains strings."""
+        response = client.post(
+            '/api/export/inaturalist/batch',
+            json={'photo_paths': [123, 456]},
+        )
+        assert response.status_code == 400
+
+    def test_export_batch_with_xmp_sidecars(self, client, sample_photos, temp_photos_dir):
+        """Test batch export includes XMP sidecars when enabled."""
+        relative_paths = [str(p.relative_to(temp_photos_dir)) for p in sample_photos]
+
+        response = client.post(
+            '/api/export/inaturalist/batch',
+            json={
+                'photo_paths': relative_paths,
+                'options': {'include_xmp_sidecars': True}
+            },
+            headers={'Accept': 'application/zip'}
+        )
+
+        assert response.status_code == 200
+
+        # Verify ZIP contains XMP files
+        zip_buffer = io.BytesIO(response.data)
+        with zipfile.ZipFile(zip_buffer) as zf:
+            namelist = zf.namelist()
+            xmp_files = [n for n in namelist if n.endswith('.xmp')]
+            assert len(xmp_files) > 0
+
+    def test_export_batch_includes_manifest(self, client, sample_photos, temp_photos_dir):
+        """Test batch export includes manifest.json when enabled."""
+        relative_paths = [str(p.relative_to(temp_photos_dir)) for p in sample_photos]
+
+        response = client.post(
+            '/api/export/inaturalist/batch',
+            json={
+                'photo_paths': relative_paths,
+                'options': {'include_manifest': True}
+            },
+            headers={'Accept': 'application/zip'}
+        )
+
+        assert response.status_code == 200
+
+        # Verify ZIP contains manifest.json
+        zip_buffer = io.BytesIO(response.data)
+        with zipfile.ZipFile(zip_buffer) as zf:
+            namelist = zf.namelist()
+            assert 'manifest.json' in namelist
+
+            # Verify manifest is valid JSON
+            manifest_data = zf.read('manifest.json')
+            manifest = json.loads(manifest_data)
+            assert 'version' in manifest
+            assert 'generator' in manifest
+            assert manifest['generator'] == 'Mothbox'
+
+    def test_export_batch_includes_csv_summary(self, client, sample_photos, temp_photos_dir):
+        """Test batch export includes summary.csv when enabled."""
+        relative_paths = [str(p.relative_to(temp_photos_dir)) for p in sample_photos]
+
+        response = client.post(
+            '/api/export/inaturalist/batch',
+            json={
+                'photo_paths': relative_paths,
+                'options': {'include_csv_summary': True}
+            },
+            headers={'Accept': 'application/zip'}
+        )
+
+        assert response.status_code == 200
+
+        # Verify ZIP contains summary.csv
+        zip_buffer = io.BytesIO(response.data)
+        with zipfile.ZipFile(zip_buffer) as zf:
+            namelist = zf.namelist()
+            assert 'summary.csv' in namelist
+
+
+# ============================================================================
+# Tests for GET /api/export/inaturalist/deployment/<path>
+# ============================================================================
+
+
+class TestExportDeploymentINaturalist:
+    """Tests for GET /api/export/inaturalist/deployment/<path> endpoint."""
+
+    def test_export_deployment_returns_zip(self, client, deployment_dir, temp_photos_dir):
+        """Test deployment export returns valid ZIP."""
+        relative_path = deployment_dir.relative_to(temp_photos_dir)
+
+        response = client.get(
+            f'/api/export/inaturalist/deployment/{relative_path}',
+            headers={'Accept': 'application/zip'}
+        )
+
+        assert response.status_code == 200
+        assert response.content_type == 'application/zip'
+
+        # Verify ZIP is valid
+        zip_buffer = io.BytesIO(response.data)
+        with zipfile.ZipFile(zip_buffer) as zf:
+            assert zf.testzip() is None
+
+    def test_export_deployment_returns_json(self, client, deployment_dir, temp_photos_dir):
+        """Test deployment export returns JSON status when requested."""
+        relative_path = deployment_dir.relative_to(temp_photos_dir)
+
+        response = client.get(
+            f'/api/export/inaturalist/deployment/{relative_path}',
+            headers={'Accept': 'application/json'}
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data['success'] is True
+        assert 'zip_path' in data
+        assert 'photo_count' in data
+
+    def test_export_deployment_invalid_path(self, client):
+        """Test deployment export validates path (path traversal protection)."""
+        response = client.get(
+            '/api/export/inaturalist/deployment/../../etc',
+        )
+        assert response.status_code in [400, 403, 404]
+
+    def test_export_deployment_not_found(self, client):
+        """Test deployment export returns 404 for non-existent directory."""
+        response = client.get(
+            '/api/export/inaturalist/deployment/nonexistent_dir',
+        )
+        assert response.status_code == 404
+        data = response.get_json()
+        assert 'error' in data
+
+    def test_export_deployment_query_params(self, client, deployment_dir, temp_photos_dir):
+        """Test deployment export respects query parameters."""
+        relative_path = deployment_dir.relative_to(temp_photos_dir)
+
+        response = client.get(
+            f'/api/export/inaturalist/deployment/{relative_path}?include_xmp=false',
+            headers={'Accept': 'application/json'}
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data['success'] is True
+        # With include_xmp=false, xmp_count should be 0
+        assert data['xmp_count'] == 0
+
+    def test_export_deployment_empty_directory(self, client, temp_photos_dir):
+        """Test deployment export handles empty directory."""
+        empty_dir = temp_photos_dir / "empty_deployment"
+        empty_dir.mkdir(exist_ok=True)
+
+        response = client.get(
+            f'/api/export/inaturalist/deployment/{empty_dir.name}',
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert 'No photos found' in data['error']
+
+    def test_export_deployment_file_not_directory(self, client, sample_photos, temp_photos_dir):
+        """Test deployment export validates path is directory."""
+        # Try to export a file instead of directory
+        relative_path = sample_photos[0].relative_to(temp_photos_dir)
+
+        response = client.get(
+            f'/api/export/inaturalist/deployment/{relative_path}',
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert 'not a directory' in data['error']
+
+
+# ============================================================================
+# Tests for POST /api/export/inaturalist/preview
+# ============================================================================
+
+
+class TestPreviewINaturalistExport:
+    """Tests for POST /api/export/inaturalist/preview endpoint."""
+
+    def test_preview_returns_validation_results(self, client, sample_photos, temp_photos_dir):
+        """Test preview returns validation for each photo."""
+        relative_paths = [str(p.relative_to(temp_photos_dir)) for p in sample_photos]
+
+        response = client.post(
+            '/api/export/inaturalist/preview',
+            json={'photo_paths': relative_paths},
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert 'valid_photos' in data
+        assert 'invalid_photos' in data
+        assert 'validation_results' in data
+        assert 'estimated_zip_size_bytes' in data
+
+        # Should have validation result for each photo
+        assert len(data['validation_results']) == len(sample_photos)
+
+    def test_preview_includes_sample_xmp(self, client, sample_photos, temp_photos_dir):
+        """Test preview includes sample XMP from first photo."""
+        relative_paths = [str(p.relative_to(temp_photos_dir)) for p in sample_photos]
+
+        response = client.post(
+            '/api/export/inaturalist/preview',
+            json={'photo_paths': relative_paths},
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert 'sample_xmp' in data
+        # sample_xmp can be None if no valid photos, or a string
+        if data['sample_xmp'] is not None:
+            assert '<?xpacket' in data['sample_xmp']
+
+    def test_preview_validation_structure(self, client, sample_photos, temp_photos_dir):
+        """Test preview validation results have expected structure."""
+        relative_paths = [str(p.relative_to(temp_photos_dir)) for p in sample_photos[:1]]
+
+        response = client.post(
+            '/api/export/inaturalist/preview',
+            json={'photo_paths': relative_paths},
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        validation = data['validation_results'][0]
+
+        # Check validation result structure
+        assert 'photo' in validation
+        assert 'is_valid' in validation
+        assert 'missing_required' in validation
+        assert 'warnings' in validation
+
+    def test_preview_handles_invalid_paths(self, client):
+        """Test preview handles invalid photo paths."""
+        response = client.post(
+            '/api/export/inaturalist/preview',
+            json={'photo_paths': ['../../etc/passwd']},
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data['invalid_photos'] > 0
+        assert len(data['validation_results']) > 0
+        assert data['validation_results'][0]['is_valid'] is False
+
+    def test_preview_handles_missing_files(self, client):
+        """Test preview handles non-existent files."""
+        response = client.post(
+            '/api/export/inaturalist/preview',
+            json={'photo_paths': ['nonexistent.jpg']},
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data['invalid_photos'] > 0
+
+    def test_preview_requires_photos(self, client):
+        """Test preview fails without photo_paths."""
+        response = client.post(
+            '/api/export/inaturalist/preview',
+            json={},
+        )
+        assert response.status_code == 400
+
+    def test_preview_empty_array(self, client):
+        """Test preview fails with empty photo_paths array."""
+        response = client.post(
+            '/api/export/inaturalist/preview',
+            json={'photo_paths': []},
+        )
+        assert response.status_code == 400
+
+    def test_preview_estimated_size(self, client, sample_photos, temp_photos_dir):
+        """Test preview provides estimated ZIP size."""
+        relative_paths = [str(p.relative_to(temp_photos_dir)) for p in sample_photos]
+
+        response = client.post(
+            '/api/export/inaturalist/preview',
+            json={'photo_paths': relative_paths},
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data['estimated_zip_size_bytes'] > 0
+
+
+# ============================================================================
+# Tests for GET /api/export/formats
+# ============================================================================
+
+
+class TestListExportFormats:
+    """Tests for export format listing with iNaturalist."""
+
+    def test_inaturalist_format_is_implemented(self, client):
+        """Test iNaturalist format shows as implemented."""
+        response = client.get('/api/export/formats')
+        assert response.status_code == 200
+        data = response.get_json()
+
+        # Find iNaturalist format
+        inaturalist = next(
+            (f for f in data['formats'] if f['id'] == 'inaturalist'),
+            None
+        )
+        assert inaturalist is not None
+        assert inaturalist['implemented'] is True
+        assert inaturalist['name'] == 'iNaturalist ZIP'
+        assert 'features' in inaturalist
+
+    def test_inaturalist_features_listed(self, client):
+        """Test iNaturalist format lists expected features."""
+        response = client.get('/api/export/formats')
+        assert response.status_code == 200
+        data = response.get_json()
+
+        inaturalist = next(
+            (f for f in data['formats'] if f['id'] == 'inaturalist'),
+            None
+        )
+
+        expected_features = [
+            'XMP sidecar files',
+            'Hierarchical taxonomy keywords',
+            'GPS coordinates',
+            'Observation notes',
+            'License information',
+            'CSV summary',
+            'JSON manifest'
+        ]
+
+        for feature in expected_features:
+            assert feature in inaturalist['features']

--- a/Firmware/Tests/unit/test_inaturalist_mapping.py
+++ b/Firmware/Tests/unit/test_inaturalist_mapping.py
@@ -1,0 +1,704 @@
+"""
+Unit tests for iNaturalist field mapping (Issue #118)
+
+Tests the iNaturalist field mapping module for transforming Mothbox metadata
+to iNaturalist-compatible format with XMP sidecar integration.
+
+Coverage Target: 95%+
+"""
+
+import pytest
+
+from webui.backend.lib.inaturalist_mapping import (
+    CONFIDENCE_TO_QUALITY_GRADE,
+    DEFAULT_CREATOR,
+    DEFAULT_LICENSE,
+    INATURALIST_RECOMMENDED_FIELDS,
+    INATURALIST_REQUIRED_FIELDS,
+    TAXONOMY_KEYWORD_PREFIX,
+    INaturalistFieldMapping,
+    ValidationResult,
+    build_taxonomy_keywords,
+    format_observation_notes,
+    format_observation_title,
+    get_xmp_field_mappings,
+    is_valid_for_inaturalist_export,
+    map_species_confidence_to_quality_grade,
+    transform_metadata_to_inaturalist,
+    validate_for_inaturalist,
+)
+from webui.backend.services.export_metadata_service import ExportMetadata
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def sample_metadata():
+    """Create a sample ExportMetadata with all fields populated."""
+    return ExportMetadata(
+        photo_path="/photos/moth_2024_01_15.jpg",
+        filename="moth_2024_01_15.jpg",
+        timestamp="2024-01-15T10:30:00",
+        latitude=37.7749,
+        longitude=-122.4194,
+        altitude=10.0,
+        gps_accuracy=2.5,
+        camera_make="Arducam",
+        camera_model="OwlSight 64MP",
+        exposure_time="1/100",
+        iso=400,
+        focal_length="16mm",
+        species="Actias luna",
+        species_common_name="Luna Moth",
+        species_confidence="certain",
+        tags=["nocturnal", "lepidoptera"],
+        notes="Beautiful specimen",
+        mothbox_id="MB-001",
+        firmware_version="5.0.0",
+        deployment_name="oak-ridge-2024",
+        deployment_location_name="Oak Ridge, TN",
+        deployment_start_date="2024-01-01",
+        deployment_end_date="2024-12-31",
+        environmental_conditions={"temperature": 20.5},
+        series_type=None,
+        series_index=None,
+        series_count=None,
+        file_size=1024000,
+        width=4000,
+        height=3000,
+    )
+
+
+@pytest.fixture
+def minimal_metadata():
+    """Create ExportMetadata with only required fields."""
+    return ExportMetadata(
+        photo_path="/photos/minimal.jpg",
+        filename="minimal.jpg",
+        timestamp="2024-01-15T10:30:00",
+        latitude=37.7749,
+        longitude=-122.4194,
+    )
+
+
+@pytest.fixture
+def metadata_without_gps():
+    """Create ExportMetadata without GPS coordinates."""
+    return ExportMetadata(
+        photo_path="/photos/no_gps.jpg",
+        filename="no_gps.jpg",
+        timestamp="2024-01-15T10:30:00",
+        latitude=None,
+        longitude=None,
+    )
+
+
+# ============================================================================
+# Tests for iNaturalist Constants
+# ============================================================================
+
+
+class TestINaturalistConstants:
+    """Tests for iNaturalist constant definitions."""
+
+    def test_required_fields_defined(self):
+        """Required fields list should contain essential iNaturalist fields."""
+        assert "latitude" in INATURALIST_REQUIRED_FIELDS
+        assert "longitude" in INATURALIST_REQUIRED_FIELDS
+        assert "timestamp" in INATURALIST_REQUIRED_FIELDS
+
+    def test_recommended_fields_defined(self):
+        """Recommended fields list should contain important iNaturalist fields."""
+        assert "species" in INATURALIST_RECOMMENDED_FIELDS
+        assert "species_common_name" in INATURALIST_RECOMMENDED_FIELDS
+        assert "species_confidence" in INATURALIST_RECOMMENDED_FIELDS
+        assert "notes" in INATURALIST_RECOMMENDED_FIELDS
+
+    def test_confidence_to_quality_grade_mapping(self):
+        """Confidence to quality grade mapping should be complete."""
+        assert CONFIDENCE_TO_QUALITY_GRADE["certain"] == "research"
+        assert CONFIDENCE_TO_QUALITY_GRADE["probable"] == "needs_id"
+        assert CONFIDENCE_TO_QUALITY_GRADE["possible"] == "needs_id"
+        assert CONFIDENCE_TO_QUALITY_GRADE["unknown"] == "casual"
+
+    def test_default_values(self):
+        """Default values should be defined."""
+        assert DEFAULT_LICENSE == "CC BY-NC 4.0"
+        assert DEFAULT_CREATOR == "Mothbox"
+
+    def test_taxonomy_prefix(self):
+        """Taxonomy keyword prefix should be defined."""
+        assert TAXONOMY_KEYWORD_PREFIX == "taxonomy:"
+
+
+# ============================================================================
+# Tests for Field Mapping Configuration
+# ============================================================================
+
+
+class TestFieldMappingConfiguration:
+    """Tests for INaturalistFieldMapping dataclass."""
+
+    def test_field_mapping_dataclass(self):
+        """INaturalistFieldMapping should store all required attributes."""
+        mapping = INaturalistFieldMapping(
+            inat_field="testField",
+            source_field="test_field",
+            default_value="default",
+            is_required=True,
+            xmp_field="dc:test",
+            description="Test description",
+        )
+        assert mapping.inat_field == "testField"
+        assert mapping.source_field == "test_field"
+        assert mapping.default_value == "default"
+        assert mapping.is_required is True
+        assert mapping.xmp_field == "dc:test"
+        assert mapping.description == "Test description"
+
+
+# ============================================================================
+# Tests for Species Confidence Mapping
+# ============================================================================
+
+
+class TestSpeciesConfidenceMapping:
+    """Tests for map_species_confidence_to_quality_grade() function."""
+
+    def test_certain_maps_to_research(self):
+        """Certain confidence should map to research quality grade."""
+        assert map_species_confidence_to_quality_grade("certain") == "research"
+
+    def test_probable_maps_to_needs_id(self):
+        """Probable confidence should map to needs_id quality grade."""
+        assert map_species_confidence_to_quality_grade("probable") == "needs_id"
+
+    def test_possible_maps_to_needs_id(self):
+        """Possible confidence should map to needs_id quality grade."""
+        assert map_species_confidence_to_quality_grade("possible") == "needs_id"
+
+    def test_unknown_maps_to_casual(self):
+        """Unknown confidence should map to casual quality grade."""
+        assert map_species_confidence_to_quality_grade("unknown") == "casual"
+
+    def test_none_returns_default(self):
+        """None confidence should return default quality grade."""
+        assert map_species_confidence_to_quality_grade(None) == "needs_id"
+
+    def test_case_insensitive(self):
+        """Mapping should be case insensitive."""
+        assert map_species_confidence_to_quality_grade("CERTAIN") == "research"
+        assert map_species_confidence_to_quality_grade("Probable") == "needs_id"
+
+    def test_invalid_returns_default(self):
+        """Invalid confidence values should return default quality grade."""
+        assert map_species_confidence_to_quality_grade("invalid") == "needs_id"
+
+
+# ============================================================================
+# Tests for Taxonomy Keywords
+# ============================================================================
+
+
+class TestTaxonomyKeywords:
+    """Tests for build_taxonomy_keywords() function."""
+
+    def test_builds_keywords_for_binomial(self):
+        """Should build hierarchical taxonomy keywords for binomial name."""
+        keywords = build_taxonomy_keywords("Actias luna")
+
+        # Should contain taxonomy keywords
+        assert any(kw.startswith("taxonomy:") for kw in keywords)
+
+        # Should contain genus
+        assert "taxonomy:genus=Actias" in keywords
+
+        # Should contain species
+        assert "taxonomy:species=Actias luna" in keywords
+
+    def test_builds_keywords_for_trinomial(self):
+        """Should build hierarchical taxonomy keywords for trinomial name."""
+        keywords = build_taxonomy_keywords("Papilio glaucus glaucus")
+
+        assert "taxonomy:genus=Papilio" in keywords
+        assert "taxonomy:species=Papilio glaucus" in keywords
+        # Subspecies would be: "taxonomy:subspecies=Papilio glaucus glaucus"
+
+    def test_empty_for_none(self):
+        """Should return empty list for None species."""
+        keywords = build_taxonomy_keywords(None)
+        assert keywords == []
+
+    def test_empty_for_empty_string(self):
+        """Should return empty list for empty species."""
+        keywords = build_taxonomy_keywords("")
+        assert keywords == []
+
+    def test_handles_single_word(self):
+        """Should handle single-word species name (genus only)."""
+        keywords = build_taxonomy_keywords("Actias")
+
+        assert "taxonomy:genus=Actias" in keywords
+
+    def test_includes_kingdom(self):
+        """Should include kingdom=Animalia for all species."""
+        keywords = build_taxonomy_keywords("Actias luna")
+
+        assert "taxonomy:kingdom=Animalia" in keywords
+
+    def test_includes_phylum(self):
+        """Should include phylum=Arthropoda for all species."""
+        keywords = build_taxonomy_keywords("Actias luna")
+
+        assert "taxonomy:phylum=Arthropoda" in keywords
+
+    def test_includes_class(self):
+        """Should include class=Insecta for all species."""
+        keywords = build_taxonomy_keywords("Actias luna")
+
+        assert "taxonomy:class=Insecta" in keywords
+
+    def test_includes_order(self):
+        """Should include order=Lepidoptera for all species."""
+        keywords = build_taxonomy_keywords("Actias luna")
+
+        assert "taxonomy:order=Lepidoptera" in keywords
+
+
+# ============================================================================
+# Tests for Observation Title Formatting
+# ============================================================================
+
+
+class TestObservationTitleFormatting:
+    """Tests for format_observation_title() function."""
+
+    def test_formats_with_both_names(self, sample_metadata):
+        """Should format as 'Common Name (Scientific Name)' when both present."""
+        title = format_observation_title(sample_metadata)
+        assert title == "Luna Moth (Actias luna)"
+
+    def test_formats_with_scientific_only(self, minimal_metadata):
+        """Should format as 'Scientific Name' when only species present."""
+        minimal_metadata.species = "Actias luna"
+        title = format_observation_title(minimal_metadata)
+        assert title == "Actias luna"
+
+    def test_formats_with_common_only(self, minimal_metadata):
+        """Should format as 'Common Name' when only common name present."""
+        minimal_metadata.species_common_name = "Luna Moth"
+        title = format_observation_title(minimal_metadata)
+        assert title == "Luna Moth"
+
+    def test_returns_unknown_when_neither(self, minimal_metadata):
+        """Should return 'Unknown' when neither name is present."""
+        title = format_observation_title(minimal_metadata)
+        assert title == "Unknown"
+
+    def test_handles_none_values(self):
+        """Should handle None values gracefully."""
+        metadata = ExportMetadata(
+            photo_path="/photos/test.jpg",
+            filename="test.jpg",
+            species=None,
+            species_common_name=None,
+        )
+        title = format_observation_title(metadata)
+        assert title == "Unknown"
+
+
+# ============================================================================
+# Tests for Observation Notes Formatting
+# ============================================================================
+
+
+class TestObservationNotesFormatting:
+    """Tests for format_observation_notes() function."""
+
+    def test_combines_notes_and_tags(self, sample_metadata):
+        """Should combine notes and tags into observation notes."""
+        notes = format_observation_notes(sample_metadata)
+
+        assert "Beautiful specimen" in notes
+        assert "nocturnal" in notes
+        assert "lepidoptera" in notes
+
+    def test_includes_deployment_info(self, sample_metadata):
+        """Should include deployment information in notes."""
+        notes = format_observation_notes(sample_metadata)
+
+        assert "oak-ridge-2024" in notes or "Oak Ridge, TN" in notes
+
+    def test_handles_only_notes(self, minimal_metadata):
+        """Should handle metadata with only notes."""
+        minimal_metadata.notes = "Test note"
+        notes = format_observation_notes(minimal_metadata)
+
+        assert "Test note" in notes
+
+    def test_handles_only_tags(self, minimal_metadata):
+        """Should handle metadata with only tags."""
+        minimal_metadata.tags = ["tag1", "tag2"]
+        notes = format_observation_notes(minimal_metadata)
+
+        assert "tag1" in notes
+        assert "tag2" in notes
+
+    def test_returns_empty_when_no_data(self, minimal_metadata):
+        """Should return empty string when no notes/tags/deployment."""
+        notes = format_observation_notes(minimal_metadata)
+        assert notes == ""
+
+    def test_formats_tags_as_comma_list(self, sample_metadata):
+        """Should format tags as comma-separated list."""
+        notes = format_observation_notes(sample_metadata)
+
+        # Tags should be comma-separated
+        assert "nocturnal, lepidoptera" in notes or "nocturnal,lepidoptera" in notes
+
+
+# ============================================================================
+# Tests for Metadata Transformation
+# ============================================================================
+
+
+class TestMetadataTransformation:
+    """Tests for transform_metadata_to_inaturalist() function."""
+
+    def test_transforms_complete_metadata(self, sample_metadata):
+        """Complete metadata should transform to iNaturalist dict."""
+        inat = transform_metadata_to_inaturalist(sample_metadata)
+
+        assert isinstance(inat, dict)
+        assert inat["latitude"] == 37.7749
+        assert inat["longitude"] == -122.4194
+        assert inat["timestamp"] == "2024-01-15T10:30:00"
+        assert inat["species"] == "Actias luna"
+        assert inat["common_name"] == "Luna Moth"
+
+    def test_transforms_minimal_metadata(self, minimal_metadata):
+        """Minimal metadata should still produce valid iNaturalist dict."""
+        inat = transform_metadata_to_inaturalist(minimal_metadata)
+
+        assert inat["latitude"] == 37.7749
+        assert inat["longitude"] == -122.4194
+        assert inat["timestamp"] == "2024-01-15T10:30:00"
+
+    def test_includes_title(self, sample_metadata):
+        """Should include formatted title."""
+        inat = transform_metadata_to_inaturalist(sample_metadata)
+
+        assert "title" in inat
+        assert inat["title"] == "Luna Moth (Actias luna)"
+
+    def test_includes_notes(self, sample_metadata):
+        """Should include formatted notes."""
+        inat = transform_metadata_to_inaturalist(sample_metadata)
+
+        assert "notes" in inat
+        assert len(inat["notes"]) > 0
+
+    def test_includes_quality_grade(self, sample_metadata):
+        """Should include quality grade mapped from confidence."""
+        inat = transform_metadata_to_inaturalist(sample_metadata)
+
+        assert "quality_grade" in inat
+        assert inat["quality_grade"] == "research"
+
+    def test_includes_taxonomy_keywords(self, sample_metadata):
+        """Should include taxonomy keywords."""
+        inat = transform_metadata_to_inaturalist(sample_metadata)
+
+        assert "keywords" in inat
+        assert any(kw.startswith("taxonomy:") for kw in inat["keywords"])
+
+    def test_includes_license(self, sample_metadata):
+        """Should include default license."""
+        inat = transform_metadata_to_inaturalist(sample_metadata)
+
+        assert "license" in inat
+        assert inat["license"] == DEFAULT_LICENSE
+
+    def test_includes_creator(self, sample_metadata):
+        """Should include creator/observer."""
+        inat = transform_metadata_to_inaturalist(sample_metadata)
+
+        assert "creator" in inat or "observer" in inat
+
+
+# ============================================================================
+# Tests for XMP Field Mappings
+# ============================================================================
+
+
+class TestXmpFieldMappings:
+    """Tests for get_xmp_field_mappings() function."""
+
+    def test_returns_dict(self):
+        """get_xmp_field_mappings() should return a dict."""
+        mappings = get_xmp_field_mappings()
+        assert isinstance(mappings, dict)
+
+    def test_includes_dublin_core_mappings(self):
+        """Should include Dublin Core namespace mappings."""
+        mappings = get_xmp_field_mappings()
+
+        # Should have at least some dc: mappings
+        dc_fields = [k for k in mappings if mappings[k].startswith("dc:")]
+        assert len(dc_fields) > 0
+
+    def test_includes_xmp_mappings(self):
+        """Should include XMP namespace mappings."""
+        mappings = get_xmp_field_mappings()
+
+        # Should have at least some xmp: mappings
+        xmp_fields = [k for k in mappings if mappings[k].startswith("xmp:")]
+        assert len(xmp_fields) > 0
+
+    def test_maps_latitude_to_exif(self):
+        """Should map latitude to EXIF GPS namespace."""
+        mappings = get_xmp_field_mappings()
+
+        assert "latitude" in mappings
+        assert "exif:GPSLatitude" in mappings["latitude"]
+
+    def test_maps_longitude_to_exif(self):
+        """Should map longitude to EXIF GPS namespace."""
+        mappings = get_xmp_field_mappings()
+
+        assert "longitude" in mappings
+        assert "exif:GPSLongitude" in mappings["longitude"]
+
+
+# ============================================================================
+# Tests for Export Validity Check
+# ============================================================================
+
+
+class TestExportValidityCheck:
+    """Tests for is_valid_for_inaturalist_export() function."""
+
+    def test_valid_with_gps_and_timestamp(self, sample_metadata):
+        """Metadata with GPS and timestamp should be valid for export."""
+        assert is_valid_for_inaturalist_export(sample_metadata) is True
+
+    def test_invalid_without_latitude(self, metadata_without_gps):
+        """Metadata without latitude should be invalid."""
+        assert is_valid_for_inaturalist_export(metadata_without_gps) is False
+
+    def test_invalid_without_longitude(self, sample_metadata):
+        """Metadata without longitude should be invalid."""
+        sample_metadata.longitude = None
+        assert is_valid_for_inaturalist_export(sample_metadata) is False
+
+    def test_invalid_without_timestamp(self, sample_metadata):
+        """Metadata without timestamp should be invalid."""
+        sample_metadata.timestamp = None
+        assert is_valid_for_inaturalist_export(sample_metadata) is False
+
+    def test_invalid_latitude_range(self, sample_metadata):
+        """Latitude outside valid range should be invalid."""
+        sample_metadata.latitude = 91.0
+        assert is_valid_for_inaturalist_export(sample_metadata) is False
+
+        sample_metadata.latitude = -91.0
+        assert is_valid_for_inaturalist_export(sample_metadata) is False
+
+    def test_invalid_longitude_range(self, sample_metadata):
+        """Longitude outside valid range should be invalid."""
+        sample_metadata.longitude = 181.0
+        assert is_valid_for_inaturalist_export(sample_metadata) is False
+
+        sample_metadata.longitude = -181.0
+        assert is_valid_for_inaturalist_export(sample_metadata) is False
+
+    def test_valid_at_boundaries(self, sample_metadata):
+        """Coordinates at boundaries should be valid."""
+        sample_metadata.latitude = 90.0
+        sample_metadata.longitude = 180.0
+        assert is_valid_for_inaturalist_export(sample_metadata) is True
+
+        sample_metadata.latitude = -90.0
+        sample_metadata.longitude = -180.0
+        assert is_valid_for_inaturalist_export(sample_metadata) is True
+
+
+# ============================================================================
+# Tests for Comprehensive Validation
+# ============================================================================
+
+
+class TestComprehensiveValidation:
+    """Tests for validate_for_inaturalist() function."""
+
+    def test_valid_metadata_passes(self, sample_metadata):
+        """Complete metadata should pass validation."""
+        result = validate_for_inaturalist(sample_metadata)
+
+        assert result.is_valid is True
+        assert len(result.missing_required) == 0
+
+    def test_missing_latitude_fails(self, sample_metadata):
+        """Missing latitude should fail validation."""
+        sample_metadata.latitude = None
+        result = validate_for_inaturalist(sample_metadata)
+
+        assert result.is_valid is False
+        assert "latitude" in result.missing_required
+
+    def test_missing_longitude_fails(self, sample_metadata):
+        """Missing longitude should fail validation."""
+        sample_metadata.longitude = None
+        result = validate_for_inaturalist(sample_metadata)
+
+        assert result.is_valid is False
+        assert "longitude" in result.missing_required
+
+    def test_missing_timestamp_fails(self, sample_metadata):
+        """Missing timestamp should fail validation."""
+        sample_metadata.timestamp = None
+        result = validate_for_inaturalist(sample_metadata)
+
+        assert result.is_valid is False
+        assert "timestamp" in result.missing_required
+
+    def test_invalid_latitude_range_fails(self, sample_metadata):
+        """Invalid latitude range should fail validation."""
+        sample_metadata.latitude = 95.0
+        result = validate_for_inaturalist(sample_metadata)
+
+        assert result.is_valid is False
+        assert any("latitude" in field.lower() for field in result.missing_required)
+
+    def test_invalid_longitude_range_fails(self, sample_metadata):
+        """Invalid longitude range should fail validation."""
+        sample_metadata.longitude = 200.0
+        result = validate_for_inaturalist(sample_metadata)
+
+        assert result.is_valid is False
+        assert any("longitude" in field.lower() for field in result.missing_required)
+
+    def test_warning_for_missing_species(self, minimal_metadata):
+        """Missing species should generate warning."""
+        result = validate_for_inaturalist(minimal_metadata)
+
+        # Should be valid (species not required) but have warning
+        assert result.is_valid is True
+        assert len(result.missing_recommended) > 0
+        assert "species" in result.missing_recommended
+
+    def test_warning_for_missing_common_name(self, sample_metadata):
+        """Missing common name should generate warning."""
+        sample_metadata.species_common_name = None
+        result = validate_for_inaturalist(sample_metadata)
+
+        assert result.is_valid is True
+        assert "species_common_name" in result.missing_recommended
+
+    def test_no_warnings_for_complete_metadata(self, sample_metadata):
+        """Complete metadata should have no warnings."""
+        result = validate_for_inaturalist(sample_metadata)
+
+        assert result.is_valid is True
+        assert len(result.missing_recommended) == 0
+        assert len(result.warnings) == 0
+
+
+# ============================================================================
+# Tests for ValidationResult Structure
+# ============================================================================
+
+
+class TestValidationResultStructure:
+    """Tests for ValidationResult dataclass."""
+
+    def test_validation_result_fields(self):
+        """ValidationResult should have expected fields."""
+        result = ValidationResult(
+            is_valid=True,
+            missing_required=["field1"],
+            missing_recommended=["field2"],
+            warnings=["warning1"],
+        )
+
+        assert result.is_valid is True
+        assert result.missing_required == ["field1"]
+        assert result.missing_recommended == ["field2"]
+        assert result.warnings == ["warning1"]
+
+    def test_validation_result_defaults(self):
+        """ValidationResult should have default empty lists."""
+        result = ValidationResult(is_valid=True)
+
+        assert result.missing_required == []
+        assert result.missing_recommended == []
+        assert result.warnings == []
+
+
+# ============================================================================
+# Edge Cases and Error Handling
+# ============================================================================
+
+
+class TestEdgeCases:
+    """Tests for edge cases and error handling."""
+
+    def test_handles_unusual_species_names(self):
+        """Should handle unusual species name formats."""
+        # Single word (genus only)
+        assert len(build_taxonomy_keywords("Actias")) > 0
+
+        # Multiple words (subspecies)
+        assert len(build_taxonomy_keywords("Papilio glaucus glaucus")) > 0
+
+        # With author citation (should strip)
+        keywords = build_taxonomy_keywords("Actias luna (Linnaeus, 1758)")
+        assert "taxonomy:species=Actias luna" in keywords
+
+    def test_handles_none_notes(self, minimal_metadata):
+        """Should handle None notes gracefully."""
+        minimal_metadata.notes = None
+        notes = format_observation_notes(minimal_metadata)
+        assert isinstance(notes, str)
+
+    def test_handles_empty_tags(self, minimal_metadata):
+        """Should handle empty tags list gracefully."""
+        minimal_metadata.tags = []
+        notes = format_observation_notes(minimal_metadata)
+        assert isinstance(notes, str)
+
+    def test_handles_unicode_in_notes(self):
+        """Should handle Unicode characters in notes."""
+        metadata = ExportMetadata(
+            photo_path="/photos/test.jpg",
+            filename="test.jpg",
+            notes="Beautiful moth with unique patterns: 🦋",
+            timestamp="2024-01-15T10:30:00",
+            latitude=37.7749,
+            longitude=-122.4194,
+        )
+
+        notes = format_observation_notes(metadata)
+        assert "🦋" in notes
+
+    def test_handles_special_characters_in_species(self):
+        """Should handle special characters in species names."""
+        metadata = ExportMetadata(
+            photo_path="/photos/test.jpg",
+            filename="test.jpg",
+            species="Actias-luna",  # Hyphen in name
+            timestamp="2024-01-15T10:30:00",
+            latitude=37.7749,
+            longitude=-122.4194,
+        )
+
+        inat = transform_metadata_to_inaturalist(metadata)
+        assert inat["species"] == "Actias-luna"
+
+    def test_handles_species_with_only_parentheses(self):
+        """Should handle species names that are only author citations."""
+        # Edge case: species name is only author citation "(Linnaeus, 1758)"
+        keywords = build_taxonomy_keywords("(Linnaeus, 1758)")
+        assert keywords == []  # Should return empty after cleaning

--- a/Firmware/Tests/unit/test_xmp_sidecar.py
+++ b/Firmware/Tests/unit/test_xmp_sidecar.py
@@ -1,0 +1,657 @@
+"""
+Unit tests for XMP sidecar library.
+
+Tests XMP metadata generation for iNaturalist export compatibility.
+Covers Dublin Core, XMP, IPTC Extension, and Photoshop namespaces.
+"""
+
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+import pytest
+
+from webui.backend.lib.xmp_sidecar import (
+    XMP_NAMESPACES,
+    build_dc_creator,
+    build_dc_description,
+    build_dc_rights,
+    build_dc_subject,
+    build_dc_title,
+    build_location_shown,
+    build_xmp_document,
+    escape_xml_text,
+    generate_xmp_xml,
+    get_xmp_sidecar_filename,
+    validate_xmp_xml,
+    write_xmp_sidecar,
+)
+from webui.backend.services.export_metadata_service import ExportMetadata
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+@pytest.fixture
+def minimal_metadata():
+    """Minimal metadata with only required fields."""
+    return ExportMetadata(
+        photo_path="/photos/photo.jpg",
+        filename="photo.jpg",
+        timestamp="2024-01-15T10:30:00Z",
+    )
+
+
+@pytest.fixture
+def full_metadata():
+    """Complete metadata with all optional fields populated."""
+    return ExportMetadata(
+        photo_path="/photos/moth_2024_01_15__10_30_00.jpg",
+        filename="moth_2024_01_15__10_30_00.jpg",
+        timestamp="2024-01-15T10:30:00Z",
+        tags=["moth", "nocturnal", "lepidoptera"],
+        species="Actias luna",
+        species_common_name="Luna Moth",
+        notes="Beautiful green moth with long tails. Captured during night survey.",
+        latitude=35.9606,
+        longitude=-83.9207,
+        altitude=350.5,
+        deployment_location_name="Oak Ridge National Laboratory, TN",
+        deployment_name="Oak Ridge Forest Survey 2024",
+        mothbox_id="mothbox-001",
+        firmware_version="5.2.1",
+        country_code="US",
+    )
+
+
+# ============================================================================
+# Test Constants
+# ============================================================================
+
+class TestXMPConstants:
+    """Test XMP namespace definitions."""
+
+    def test_xmp_namespaces_defined(self):
+        """Test that all required XMP namespaces are defined."""
+        assert 'x' in XMP_NAMESPACES
+        assert 'rdf' in XMP_NAMESPACES
+        assert 'dc' in XMP_NAMESPACES
+        assert 'xmp' in XMP_NAMESPACES
+        assert 'photoshop' in XMP_NAMESPACES
+        assert 'Iptc4xmpCore' in XMP_NAMESPACES
+        assert 'Iptc4xmpExt' in XMP_NAMESPACES
+        assert 'exif' in XMP_NAMESPACES
+
+    def test_namespace_uris_valid(self):
+        """Test that namespace URIs are valid."""
+        assert XMP_NAMESPACES['x'] == 'adobe:ns:meta/'
+        assert XMP_NAMESPACES['rdf'] == 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'
+        assert XMP_NAMESPACES['dc'] == 'http://purl.org/dc/elements/1.1/'
+        assert XMP_NAMESPACES['xmp'] == 'http://ns.adobe.com/xap/1.0/'
+        assert 'iptc.org' in XMP_NAMESPACES['Iptc4xmpExt'].lower()
+
+
+# ============================================================================
+# Test XML Utilities
+# ============================================================================
+
+class TestXMLUtilities:
+    """Test XML utility functions."""
+
+    def test_escape_xml_text_basic(self):
+        """Test escaping basic XML special characters."""
+        assert escape_xml_text("Hello World") == "Hello World"
+        assert escape_xml_text("A & B") == "A &amp; B"
+        assert escape_xml_text("A < B") == "A &lt; B"
+        assert escape_xml_text("A > B") == "A &gt; B"
+        assert escape_xml_text('Say "hello"') == "Say &quot;hello&quot;"
+        assert escape_xml_text("It's here") == "It&apos;s here"
+
+    def test_escape_xml_text_multiple(self):
+        """Test escaping multiple special characters."""
+        text = '<tag attr="value">A & B</tag>'
+        escaped = escape_xml_text(text)
+        assert '&lt;' in escaped
+        assert '&gt;' in escaped
+        assert '&quot;' in escaped
+        assert '&amp;' in escaped
+
+    def test_escape_xml_text_unicode(self):
+        """Test Unicode characters are preserved."""
+        text = "Café résumé naïve 日本語"
+        assert escape_xml_text(text) == text
+
+    def test_escape_xml_text_empty(self):
+        """Test empty string handling."""
+        assert escape_xml_text("") == ""
+
+    def test_validate_xmp_xml_valid(self):
+        """Test validation of valid XMP XML."""
+        valid_xml = '''<?xpacket begin="" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/">
+  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about=""/>
+  </rdf:RDF>
+</x:xmpmeta>
+<?xpacket end="w"?>'''
+        assert validate_xmp_xml(valid_xml) is True
+
+    def test_validate_xmp_xml_invalid(self):
+        """Test validation of invalid XML."""
+        invalid_xml = '<unclosed tag'
+        assert validate_xmp_xml(invalid_xml) is False
+
+    def test_validate_xmp_xml_empty(self):
+        """Test validation of empty string."""
+        assert validate_xmp_xml("") is False
+
+
+# ============================================================================
+# Test Filename Conversion
+# ============================================================================
+
+class TestFilenameConversion:
+    """Test XMP sidecar filename generation."""
+
+    def test_jpg_to_xmp(self):
+        """Test .jpg -> .xmp conversion."""
+        assert get_xmp_sidecar_filename("photo.jpg") == "photo.xmp"
+
+    def test_jpeg_to_xmp(self):
+        """Test .jpeg -> .xmp conversion."""
+        assert get_xmp_sidecar_filename("photo.jpeg") == "photo.xmp"
+
+    def test_uppercase_jpg(self):
+        """Test uppercase .JPG extension."""
+        assert get_xmp_sidecar_filename("photo.JPG") == "photo.xmp"
+
+    def test_complex_filename(self):
+        """Test complex filename with multiple dots."""
+        assert get_xmp_sidecar_filename("moth_2024_01_15__10_30_00.jpg") == "moth_2024_01_15__10_30_00.xmp"
+
+    def test_path_object(self):
+        """Test Path object input."""
+        path = Path("photos/moth.jpg")
+        assert get_xmp_sidecar_filename(path) == "moth.xmp"
+
+    def test_no_extension(self):
+        """Test filename without extension."""
+        assert get_xmp_sidecar_filename("photo") == "photo.xmp"
+
+
+# ============================================================================
+# Test Dublin Core Elements
+# ============================================================================
+
+class TestDublinCoreElements:
+    """Test Dublin Core metadata element generation."""
+
+    def test_build_dc_title(self):
+        """Test dc:title with rdf:Alt structure."""
+        element = build_dc_title("Luna Moth (Actias luna)")
+        assert element.tag.endswith('title')
+
+        # Check rdf:Alt structure
+        alt = element.find('.//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}Alt')
+        assert alt is not None
+
+        # Check rdf:li with xml:lang
+        li = alt.find('.//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}li')
+        assert li is not None
+        assert li.get('{http://www.w3.org/XML/1998/namespace}lang') == 'x-default'
+        assert li.text == "Luna Moth (Actias luna)"
+
+    def test_build_dc_title_special_chars(self):
+        """Test dc:title with special characters."""
+        element = build_dc_title('Moth & "Butterfly"')
+        li = element.find('.//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}li')
+        # ElementTree handles escaping automatically
+        assert li.text == 'Moth & "Butterfly"'
+
+    def test_build_dc_description(self):
+        """Test dc:description with rdf:Alt structure."""
+        element = build_dc_description("A beautiful moth specimen")
+        assert element.tag.endswith('description')
+
+        alt = element.find('.//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}Alt')
+        assert alt is not None
+
+        li = alt.find('.//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}li')
+        assert li is not None
+        assert li.text == "A beautiful moth specimen"
+
+    def test_build_dc_description_multiline(self):
+        """Test dc:description with multiline text."""
+        text = "Line 1\nLine 2\nLine 3"
+        element = build_dc_description(text)
+        li = element.find('.//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}li')
+        assert li.text == text
+
+    def test_build_dc_subject_tags_only(self):
+        """Test dc:subject with only user tags."""
+        element = build_dc_subject(tags=["moth", "nocturnal"], taxonomy_keywords=[])
+        assert element.tag.endswith('subject')
+
+        bag = element.find('.//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}Bag')
+        assert bag is not None
+
+        items = bag.findall('.//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}li')
+        assert len(items) == 2
+        texts = [item.text for item in items]
+        assert "moth" in texts
+        assert "nocturnal" in texts
+
+    def test_build_dc_subject_taxonomy_only(self):
+        """Test dc:subject with only taxonomy keywords."""
+        taxonomy = ["taxonomy:kingdom=Animalia", "taxonomy:species=Actias luna"]
+        element = build_dc_subject(tags=[], taxonomy_keywords=taxonomy)
+
+        bag = element.find('.//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}Bag')
+        items = bag.findall('.//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}li')
+        assert len(items) == 2
+        texts = [item.text for item in items]
+        assert "taxonomy:kingdom=Animalia" in texts
+        assert "taxonomy:species=Actias luna" in texts
+
+    def test_build_dc_subject_combined(self):
+        """Test dc:subject with both tags and taxonomy."""
+        element = build_dc_subject(
+            tags=["moth", "nocturnal"],
+            taxonomy_keywords=["taxonomy:kingdom=Animalia", "taxonomy:species=Actias luna"]
+        )
+
+        bag = element.find('.//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}Bag')
+        items = bag.findall('.//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}li')
+        assert len(items) == 4
+        texts = [item.text for item in items]
+        assert "moth" in texts
+        assert "nocturnal" in texts
+        assert "taxonomy:kingdom=Animalia" in texts
+        assert "taxonomy:species=Actias luna" in texts
+
+    def test_build_dc_subject_empty(self):
+        """Test dc:subject with no keywords."""
+        element = build_dc_subject(tags=[], taxonomy_keywords=[])
+
+        bag = element.find('.//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}Bag')
+        items = bag.findall('.//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}li')
+        assert len(items) == 0
+
+    def test_build_dc_creator(self):
+        """Test dc:creator with rdf:Seq structure."""
+        element = build_dc_creator("Mothbox")
+        assert element.tag.endswith('creator')
+
+        seq = element.find('.//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}Seq')
+        assert seq is not None
+
+        li = seq.find('.//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}li')
+        assert li is not None
+        assert li.text == "Mothbox"
+
+    def test_build_dc_rights(self):
+        """Test dc:rights with rdf:Alt structure."""
+        element = build_dc_rights("CC BY-NC 4.0")
+        assert element.tag.endswith('rights')
+
+        alt = element.find('.//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}Alt')
+        assert alt is not None
+
+        li = alt.find('.//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}li')
+        assert li is not None
+        assert li.get('{http://www.w3.org/XML/1998/namespace}lang') == 'x-default'
+        assert li.text == "CC BY-NC 4.0"
+
+
+# ============================================================================
+# Test IPTC Extension Elements
+# ============================================================================
+
+class TestIPTCExtensionElements:
+    """Test IPTC Extension metadata element generation."""
+
+    def test_build_location_shown_full(self):
+        """Test location with all fields."""
+        element = build_location_shown(
+            lat=35.9606,
+            lon=-83.9207,
+            alt=350.5,
+            name="Oak Ridge, TN"
+        )
+        assert element.tag.endswith('LocationShown')
+
+        bag = element.find('.//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}Bag')
+        assert bag is not None
+
+        li = bag.find('.//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}li')
+        assert li is not None
+        assert li.get('{http://www.w3.org/1999/02/22-rdf-syntax-ns#}parseType') == 'Resource'
+
+        # Check coordinate fields
+        lat_elem = li.find('.//{http://iptc.org/std/Iptc4xmpExt/2008-02-29/}Latitude')
+        assert lat_elem is not None
+        assert lat_elem.text == "35.9606"
+
+        lon_elem = li.find('.//{http://iptc.org/std/Iptc4xmpExt/2008-02-29/}Longitude')
+        assert lon_elem is not None
+        assert lon_elem.text == "-83.9207"
+
+        alt_elem = li.find('.//{http://iptc.org/std/Iptc4xmpExt/2008-02-29/}Altitude')
+        assert alt_elem is not None
+        assert alt_elem.text == "350.5"
+
+        name_elem = li.find('.//{http://iptc.org/std/Iptc4xmpExt/2008-02-29/}LocationName')
+        assert name_elem is not None
+        assert name_elem.text == "Oak Ridge, TN"
+
+    def test_build_location_shown_no_altitude(self):
+        """Test location without altitude."""
+        element = build_location_shown(
+            lat=35.9606,
+            lon=-83.9207,
+            alt=None,
+            name="Oak Ridge, TN"
+        )
+
+        bag = element.find('.//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}Bag')
+        li = bag.find('.//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}li')
+
+        alt_elem = li.find('.//{http://iptc.org/std/Iptc4xmpExt/2008-02-29/}Altitude')
+        assert alt_elem is None
+
+    def test_build_location_shown_no_name(self):
+        """Test location without name."""
+        element = build_location_shown(
+            lat=35.9606,
+            lon=-83.9207,
+            alt=350.5,
+            name=None
+        )
+
+        bag = element.find('.//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}Bag')
+        li = bag.find('.//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}li')
+
+        name_elem = li.find('.//{http://iptc.org/std/Iptc4xmpExt/2008-02-29/}LocationName')
+        assert name_elem is None
+
+    def test_build_location_shown_coordinates_only(self):
+        """Test location with only coordinates."""
+        element = build_location_shown(
+            lat=35.9606,
+            lon=-83.9207,
+            alt=None,
+            name=None
+        )
+
+        bag = element.find('.//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}Bag')
+        li = bag.find('.//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}li')
+
+        lat_elem = li.find('.//{http://iptc.org/std/Iptc4xmpExt/2008-02-29/}Latitude')
+        assert lat_elem is not None
+
+        lon_elem = li.find('.//{http://iptc.org/std/Iptc4xmpExt/2008-02-29/}Longitude')
+        assert lon_elem is not None
+
+
+# ============================================================================
+# Test XMP Document Generation
+# ============================================================================
+
+class TestXMPDocumentGeneration:
+    """Test complete XMP document generation."""
+
+    def test_build_xmp_document_minimal(self, minimal_metadata):
+        """Test XMP document with minimal metadata."""
+        tree = build_xmp_document(minimal_metadata)
+        root = tree.getroot()
+
+        # Check root element
+        assert root.tag.endswith('xmpmeta')
+
+        # Check RDF structure
+        rdf = root.find('.//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}RDF')
+        assert rdf is not None
+
+        # Check Description
+        desc = rdf.find('.//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}Description')
+        assert desc is not None
+        assert desc.get('{http://www.w3.org/1999/02/22-rdf-syntax-ns#}about') == ''
+
+    def test_build_xmp_document_full(self, full_metadata):
+        """Test XMP document with full metadata."""
+        tree = build_xmp_document(full_metadata)
+        root = tree.getroot()
+
+        # Find Description element
+        desc = root.find('.//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}Description')
+        assert desc is not None
+
+        # Check dc:title
+        title = desc.find('.//{http://purl.org/dc/elements/1.1/}title')
+        assert title is not None
+
+        # Check dc:description
+        description = desc.find('.//{http://purl.org/dc/elements/1.1/}description')
+        assert description is not None
+
+        # Check dc:subject
+        subject = desc.find('.//{http://purl.org/dc/elements/1.1/}subject')
+        assert subject is not None
+
+        # Check dc:creator
+        creator = desc.find('.//{http://purl.org/dc/elements/1.1/}creator')
+        assert creator is not None
+
+        # Check dc:rights
+        rights = desc.find('.//{http://purl.org/dc/elements/1.1/}rights')
+        assert rights is not None
+
+        # Check xmp:CreateDate
+        create_date = desc.find('.//{http://ns.adobe.com/xap/1.0/}CreateDate')
+        assert create_date is not None
+        assert create_date.text == "2024-01-15T10:30:00Z"
+
+        # Check LocationShown
+        location = desc.find('.//{http://iptc.org/std/Iptc4xmpExt/2008-02-29/}LocationShown')
+        assert location is not None
+
+    def test_build_xmp_document_no_location(self, minimal_metadata):
+        """Test XMP document without location data."""
+        tree = build_xmp_document(minimal_metadata)
+        root = tree.getroot()
+
+        # LocationShown should not be present
+        location = root.find('.//{http://iptc.org/std/Iptc4xmpExt/2008-02-29/}LocationShown')
+        assert location is None
+
+    def test_build_xmp_document_taxonomy(self, full_metadata):
+        """Test XMP document includes taxonomy keywords."""
+        tree = build_xmp_document(full_metadata)
+        root = tree.getroot()
+
+        # Find dc:subject bag items
+        bag = root.find('.//{http://purl.org/dc/elements/1.1/}subject/{http://www.w3.org/1999/02/22-rdf-syntax-ns#}Bag')
+        assert bag is not None
+
+        items = bag.findall('.//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}li')
+        texts = [item.text for item in items]
+
+        # Check for taxonomy keywords (from Darwin Core mapping)
+        taxonomy_present = any('taxonomy:' in text for text in texts)
+        assert taxonomy_present
+
+    def test_generate_xmp_xml_minimal(self, minimal_metadata):
+        """Test XML string generation with minimal metadata."""
+        xml = generate_xmp_xml(minimal_metadata)
+
+        # Check XMP packet wrapper
+        assert '<?xpacket begin=""' in xml
+        assert '<?xpacket end="w"?>' in xml
+
+        # Check basic structure
+        assert '<x:xmpmeta' in xml
+        assert '<rdf:RDF' in xml
+        assert '<rdf:Description' in xml
+
+        # Validate XML
+        assert validate_xmp_xml(xml) is True
+
+    def test_generate_xmp_xml_full(self, full_metadata):
+        """Test XML string generation with full metadata."""
+        xml = generate_xmp_xml(full_metadata)
+
+        # Check presence of all expected elements
+        assert 'dc:title' in xml
+        assert 'dc:description' in xml
+        assert 'dc:subject' in xml
+        assert 'dc:creator' in xml
+        assert 'dc:rights' in xml
+        assert 'xmp:CreateDate' in xml
+        assert 'Iptc4xmpExt:LocationShown' in xml
+
+        # Check specific values
+        assert 'Luna Moth' in xml
+        assert 'Actias luna' in xml
+        assert 'Beautiful green moth' in xml
+        assert '35.9606' in xml
+        assert '-83.9207' in xml
+        assert 'Oak Ridge' in xml
+
+        # Validate XML
+        assert validate_xmp_xml(xml) is True
+
+    def test_generate_xmp_xml_encoding(self, minimal_metadata):
+        """Test XML encoding declaration."""
+        xml = generate_xmp_xml(minimal_metadata)
+
+        # Should include UTF-8 encoding
+        assert 'utf-8' in xml or 'UTF-8' in xml
+
+    def test_generate_xmp_xml_namespaces(self, minimal_metadata):
+        """Test all required namespaces are declared."""
+        xml = generate_xmp_xml(minimal_metadata)
+
+        # Check namespace declarations
+        assert 'xmlns:x="adobe:ns:meta/"' in xml
+        assert 'xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"' in xml
+        assert 'xmlns:dc="http://purl.org/dc/elements/1.1/"' in xml
+        assert 'xmlns:xmp="http://ns.adobe.com/xap/1.0/"' in xml
+
+    def test_generate_xmp_xml_well_formed(self, full_metadata):
+        """Test generated XML is well-formed and parseable."""
+        xml = generate_xmp_xml(full_metadata)
+
+        # Should be parseable by ElementTree
+        try:
+            # Remove xpacket processing instructions for parsing
+            xml_content = xml
+            # Remove xpacket PIs more carefully
+            import re
+            xml_content = re.sub(r'<\?xpacket[^?]*\?>', '', xml_content)
+
+            ET.fromstring(xml_content.strip())
+            well_formed = True
+        except ET.ParseError:
+            well_formed = False
+
+        assert well_formed is True
+
+
+# ============================================================================
+# Test Edge Cases
+# ============================================================================
+
+class TestEdgeCases:
+    """Test edge cases and error handling."""
+
+    def test_empty_tags_list(self, minimal_metadata):
+        """Test handling of empty tags list."""
+        xml = generate_xmp_xml(minimal_metadata)
+        assert validate_xmp_xml(xml) is True
+
+    def test_none_species_name(self, minimal_metadata):
+        """Test handling of None species name."""
+        xml = generate_xmp_xml(minimal_metadata)
+        # Should not contain species in title since it's None
+        assert 'None' not in xml
+
+    def test_special_characters_in_notes(self, minimal_metadata):
+        """Test special characters in notes field."""
+        minimal_metadata.notes = 'Test & "quotes" <tags> \'apostrophes\''
+        xml = generate_xmp_xml(minimal_metadata)
+
+        # Should be properly escaped in XML
+        assert validate_xmp_xml(xml) is True
+
+    def test_unicode_in_location(self, minimal_metadata):
+        """Test Unicode characters in location name."""
+        minimal_metadata.deployment_location_name = "Montréal, Québec, 日本"
+        minimal_metadata.latitude = 45.5017
+        minimal_metadata.longitude = -73.5673
+        xml = generate_xmp_xml(minimal_metadata)
+
+        assert "Montréal" in xml
+        assert "Québec" in xml
+        assert "日本" in xml
+        assert validate_xmp_xml(xml) is True
+
+    def test_very_long_description(self, minimal_metadata):
+        """Test handling of very long description."""
+        minimal_metadata.notes = "A" * 10000  # 10k characters
+        xml = generate_xmp_xml(minimal_metadata)
+        assert validate_xmp_xml(xml) is True
+
+    def test_negative_coordinates(self, minimal_metadata):
+        """Test negative latitude/longitude."""
+        minimal_metadata.latitude = -33.8688
+        minimal_metadata.longitude = 151.2093
+        xml = generate_xmp_xml(minimal_metadata)
+
+        assert '-33.8688' in xml
+        assert '151.2093' in xml
+
+    def test_zero_altitude(self, minimal_metadata):
+        """Test altitude of exactly 0."""
+        minimal_metadata.latitude = 0.0
+        minimal_metadata.longitude = 0.0
+        minimal_metadata.altitude = 0.0
+        xml = generate_xmp_xml(minimal_metadata)
+
+        # 0.0 should be included
+        assert 'Altitude' in xml
+
+    def test_future_timestamp(self):
+        """Test handling of future timestamp."""
+        future_metadata = ExportMetadata(
+            photo_path="/photos/photo.jpg",
+            filename="photo.jpg",
+            timestamp="2099-12-31T23:59:59Z",
+        )
+        xml = generate_xmp_xml(future_metadata)
+        assert '2099-12-31' in xml
+
+    def test_maximum_precision_coordinates(self, minimal_metadata):
+        """Test maximum precision GPS coordinates."""
+        minimal_metadata.latitude = 35.960634567890123
+        minimal_metadata.longitude = -83.920745678901234
+        minimal_metadata.altitude = 350.123456789
+        xml = generate_xmp_xml(minimal_metadata)
+
+        # Should preserve high precision
+        assert '35.96063' in xml
+        assert '-83.92074' in xml
+
+    def test_write_xmp_sidecar(self, minimal_metadata, tmp_path):
+        """Test writing XMP sidecar file to disk."""
+        output_path = tmp_path / "photo.xmp"
+        write_xmp_sidecar(minimal_metadata, output_path)
+
+        # File should exist
+        assert output_path.exists()
+
+        # File should contain valid XMP
+        with open(output_path, encoding='utf-8') as f:
+            content = f.read()
+
+        assert validate_xmp_xml(content) is True
+        assert 'xmp:CreateDate' in content
+        assert '2024-01-15' in content

--- a/Firmware/Tests/unit/test_xmp_sidecar.py
+++ b/Firmware/Tests/unit/test_xmp_sidecar.py
@@ -19,7 +19,6 @@ from webui.backend.lib.xmp_sidecar import (
     build_dc_title,
     build_location_shown,
     build_xmp_document,
-    escape_xml_text,
     generate_xmp_xml,
     get_xmp_sidecar_filename,
     validate_xmp_xml,
@@ -96,33 +95,6 @@ class TestXMPConstants:
 
 class TestXMLUtilities:
     """Test XML utility functions."""
-
-    def test_escape_xml_text_basic(self):
-        """Test escaping basic XML special characters."""
-        assert escape_xml_text("Hello World") == "Hello World"
-        assert escape_xml_text("A & B") == "A &amp; B"
-        assert escape_xml_text("A < B") == "A &lt; B"
-        assert escape_xml_text("A > B") == "A &gt; B"
-        assert escape_xml_text('Say "hello"') == "Say &quot;hello&quot;"
-        assert escape_xml_text("It's here") == "It&apos;s here"
-
-    def test_escape_xml_text_multiple(self):
-        """Test escaping multiple special characters."""
-        text = '<tag attr="value">A & B</tag>'
-        escaped = escape_xml_text(text)
-        assert '&lt;' in escaped
-        assert '&gt;' in escaped
-        assert '&quot;' in escaped
-        assert '&amp;' in escaped
-
-    def test_escape_xml_text_unicode(self):
-        """Test Unicode characters are preserved."""
-        text = "Café résumé naïve 日本語"
-        assert escape_xml_text(text) == text
-
-    def test_escape_xml_text_empty(self):
-        """Test empty string handling."""
-        assert escape_xml_text("") == ""
 
     def test_validate_xmp_xml_valid(self):
         """Test validation of valid XMP XML."""
@@ -326,18 +298,18 @@ class TestIPTCExtensionElements:
         assert li is not None
         assert li.get('{http://www.w3.org/1999/02/22-rdf-syntax-ns#}parseType') == 'Resource'
 
-        # Check coordinate fields
+        # Check coordinate fields (8 decimal places for lat/lon, 2 for altitude)
         lat_elem = li.find('.//{http://iptc.org/std/Iptc4xmpExt/2008-02-29/}Latitude')
         assert lat_elem is not None
-        assert lat_elem.text == "35.9606"
+        assert lat_elem.text == "35.96060000"
 
         lon_elem = li.find('.//{http://iptc.org/std/Iptc4xmpExt/2008-02-29/}Longitude')
         assert lon_elem is not None
-        assert lon_elem.text == "-83.9207"
+        assert lon_elem.text == "-83.92070000"
 
         alt_elem = li.find('.//{http://iptc.org/std/Iptc4xmpExt/2008-02-29/}Altitude')
         assert alt_elem is not None
-        assert alt_elem.text == "350.5"
+        assert alt_elem.text == "350.50"
 
         name_elem = li.find('.//{http://iptc.org/std/Iptc4xmpExt/2008-02-29/}LocationName')
         assert name_elem is not None

--- a/Firmware/Tests/unit/test_zip_export.py
+++ b/Firmware/Tests/unit/test_zip_export.py
@@ -1,0 +1,802 @@
+"""
+Unit tests for ZIP export library (webui.backend.lib.zip_export).
+
+Tests cover:
+- ZipExportOptions dataclass defaults and customization
+- ZipExportResult dataclass structure
+- ZIP file creation with photos
+- XMP sidecar inclusion
+- Manifest.json generation
+- Summary.csv generation
+- Streaming ZIP generation
+- ZIP integrity validation
+- Error handling (missing files, permission errors)
+- Performance: 50 photos should complete in <5 seconds
+- Edge cases: empty photo list, single photo, special characters in filenames
+"""
+
+import csv
+import json
+import time
+from collections.abc import Generator
+from datetime import datetime
+from io import BytesIO
+from pathlib import Path
+from zipfile import ZipFile, is_zipfile
+
+from webui.backend.lib.zip_export import (
+    MANIFEST_FILENAME,
+    MAX_ZIP_FILE_SIZE,
+    SUMMARY_FILENAME,
+    ZIP_BUFFER_SIZE,
+    ZIP_COMPRESSION_LEVEL,
+    ZipExportOptions,
+    ZipExportResult,
+    add_photo_to_zip,
+    create_zip_export,
+    estimate_zip_size,
+    generate_csv_summary,
+    generate_manifest,
+    stream_zip_export,
+    validate_zip_integrity,
+)
+from webui.backend.services.export_metadata_service import ExportMetadata
+
+# ============================================================================
+# Test Helpers
+# ============================================================================
+
+
+def create_test_jpeg(path: Path, size: int = 1024) -> None:
+    """Create minimal valid JPEG for testing."""
+    # JPEG header + padding
+    header = b'\xFF\xD8\xFF\xE0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00'
+    footer = b'\xFF\xD9'
+    padding = b'\x00' * (size - len(header) - len(footer))
+    path.write_bytes(header + padding + footer)
+
+
+def create_test_metadata(
+    filename: str = "moth_2024_01_15__10_00_00.jpg",
+    latitude: float = 37.7749,
+    longitude: float = -122.4194,
+    timestamp: str = "2024-01-15T10:00:00",
+    species: str = "Actias luna",
+    species_common_name: str = "Luna Moth",
+    tags: list[str] | None = None,
+) -> ExportMetadata:
+    """Create test ExportMetadata instance."""
+    return ExportMetadata(
+        photo_path=f"/photos/{filename}",
+        filename=filename,
+        latitude=latitude,
+        longitude=longitude,
+        timestamp=timestamp,
+        species=species,
+        species_common_name=species_common_name,
+        tags=tags or ["moth", "lepidoptera"],
+        altitude=350.5,
+        gps_accuracy=5.0,
+        notes="Test observation",
+    )
+
+
+# ============================================================================
+# Test Constants
+# ============================================================================
+
+
+class TestConstants:
+    """Test that constants are defined correctly."""
+
+    def test_zip_compression_level(self):
+        """ZIP_COMPRESSION_LEVEL should be 0 for no compression."""
+        assert ZIP_COMPRESSION_LEVEL == 0
+
+    def test_zip_buffer_size(self):
+        """ZIP_BUFFER_SIZE should be 8KB."""
+        assert ZIP_BUFFER_SIZE == 8192
+
+    def test_max_zip_file_size(self):
+        """MAX_ZIP_FILE_SIZE should be 2GB."""
+        assert MAX_ZIP_FILE_SIZE == 2 * 1024 * 1024 * 1024
+
+    def test_manifest_filename(self):
+        """MANIFEST_FILENAME should be 'manifest.json'."""
+        assert MANIFEST_FILENAME == "manifest.json"
+
+    def test_summary_filename(self):
+        """SUMMARY_FILENAME should be 'summary.csv'."""
+        assert SUMMARY_FILENAME == "summary.csv"
+
+
+# ============================================================================
+# Test ZipExportOptions Dataclass
+# ============================================================================
+
+
+class TestZipExportOptions:
+    """Test ZipExportOptions dataclass."""
+
+    def test_default_values(self):
+        """Test default option values."""
+        options = ZipExportOptions()
+        assert options.include_xmp_sidecars is True
+        assert options.include_manifest is True
+        assert options.include_csv_summary is True
+        assert options.compression_level == 0
+        assert options.flatten_structure is False
+
+    def test_custom_values(self):
+        """Test custom option values."""
+        options = ZipExportOptions(
+            include_xmp_sidecars=False,
+            include_manifest=False,
+            include_csv_summary=False,
+            compression_level=6,
+            flatten_structure=True,
+        )
+        assert options.include_xmp_sidecars is False
+        assert options.include_manifest is False
+        assert options.include_csv_summary is False
+        assert options.compression_level == 6
+        assert options.flatten_structure is True
+
+    def test_partial_customization(self):
+        """Test partial option customization."""
+        options = ZipExportOptions(include_xmp_sidecars=False)
+        assert options.include_xmp_sidecars is False
+        assert options.include_manifest is True  # default
+        assert options.include_csv_summary is True  # default
+
+
+# ============================================================================
+# Test ZipExportResult Dataclass
+# ============================================================================
+
+
+class TestZipExportResult:
+    """Test ZipExportResult dataclass."""
+
+    def test_success_result(self):
+        """Test successful result structure."""
+        result = ZipExportResult(
+            success=True,
+            zip_path=Path("/tmp/export.zip"),
+            zip_size_bytes=1024000,
+            photo_count=10,
+            xmp_count=10,
+            errors=[],
+            took_ms=1234.5,
+        )
+        assert result.success is True
+        assert result.zip_path == Path("/tmp/export.zip")
+        assert result.zip_size_bytes == 1024000
+        assert result.photo_count == 10
+        assert result.xmp_count == 10
+        assert result.errors == []
+        assert result.took_ms == 1234.5
+
+    def test_failure_result(self):
+        """Test failure result structure."""
+        result = ZipExportResult(
+            success=False,
+            zip_path=None,
+            zip_size_bytes=0,
+            photo_count=0,
+            xmp_count=0,
+            errors=[{"error": "File not found"}],
+            took_ms=50.0,
+        )
+        assert result.success is False
+        assert result.zip_path is None
+        assert result.zip_size_bytes == 0
+        assert result.errors == [{"error": "File not found"}]
+
+
+# ============================================================================
+# Test generate_csv_summary
+# ============================================================================
+
+
+class TestGenerateCSVSummary:
+    """Test CSV summary generation."""
+
+    def test_generate_csv_summary_single_photo(self):
+        """Test CSV generation with single photo."""
+        metadata_list = [create_test_metadata()]
+        csv_content = generate_csv_summary(metadata_list)
+
+        # Parse CSV
+        lines = csv_content.strip().split('\n')
+        assert len(lines) == 2  # header + 1 data row
+
+        # Check header
+        reader = csv.DictReader(lines)
+        rows = list(reader)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row['filename'] == "moth_2024_01_15__10_00_00.jpg"
+        assert row['timestamp'] == "2024-01-15T10:00:00"
+        assert row['latitude'] == "37.7749"
+        assert row['longitude'] == "-122.4194"
+        assert row['species'] == "Actias luna"
+        assert row['species_common_name'] == "Luna Moth"
+        assert row['tags'] == "moth; lepidoptera"
+
+    def test_generate_csv_summary_multiple_photos(self):
+        """Test CSV generation with multiple photos."""
+        metadata_list = [
+            create_test_metadata(filename="photo1.jpg", species="Species A"),
+            create_test_metadata(filename="photo2.jpg", species="Species B"),
+            create_test_metadata(filename="photo3.jpg", species="Species C"),
+        ]
+        csv_content = generate_csv_summary(metadata_list)
+
+        lines = csv_content.strip().split('\n')
+        assert len(lines) == 4  # header + 3 data rows
+
+    def test_generate_csv_summary_empty_list(self):
+        """Test CSV generation with empty metadata list."""
+        csv_content = generate_csv_summary([])
+        lines = csv_content.strip().split('\n')
+        assert len(lines) == 1  # header only
+
+    def test_generate_csv_summary_missing_optional_fields(self):
+        """Test CSV generation with missing optional fields."""
+        metadata = create_test_metadata()
+        metadata.species = None
+        metadata.species_common_name = None
+        metadata.tags = None
+
+        csv_content = generate_csv_summary([metadata])
+        reader = csv.DictReader(csv_content.strip().split('\n'))
+        rows = list(reader)
+        assert rows[0]['species'] == ""
+        assert rows[0]['species_common_name'] == ""
+        assert rows[0]['tags'] == ""
+
+    def test_generate_csv_summary_special_characters(self):
+        """Test CSV generation with special characters in fields."""
+        metadata = create_test_metadata(
+            filename="moth,with,commas.jpg",
+            species="Species \"with quotes\"",
+            tags=["tag,with,comma", "tag;with;semicolon"],
+        )
+        csv_content = generate_csv_summary([metadata])
+        reader = csv.DictReader(csv_content.strip().split('\n'))
+        rows = list(reader)
+        assert rows[0]['filename'] == "moth,with,commas.jpg"
+        assert rows[0]['species'] == 'Species "with quotes"'
+
+
+# ============================================================================
+# Test generate_manifest
+# ============================================================================
+
+
+class TestGenerateManifest:
+    """Test manifest generation."""
+
+    def test_generate_manifest_structure(self):
+        """Test manifest JSON structure."""
+        photo_paths = [Path("/photos/moth1.jpg")]
+        metadata_list = [create_test_metadata(filename="moth1.jpg")]
+        options = ZipExportOptions()
+
+        manifest = generate_manifest(photo_paths, metadata_list, options)
+
+        assert manifest['version'] == "1.0"
+        assert manifest['generator'] == "Mothbox"
+        assert 'generator_version' in manifest
+        assert 'created_at' in manifest
+        assert manifest['photo_count'] == 1
+        assert 'total_size_bytes' in manifest
+        assert len(manifest['photos']) == 1
+
+    def test_generate_manifest_photo_details(self):
+        """Test manifest photo details."""
+        photo_paths = [Path("/photos/moth1.jpg")]
+        metadata_list = [create_test_metadata(filename="moth1.jpg")]
+        options = ZipExportOptions()
+
+        manifest = generate_manifest(photo_paths, metadata_list, options)
+        photo = manifest['photos'][0]
+
+        assert photo['filename'] == "moth1.jpg"
+        assert photo['xmp_sidecar'] == "moth1.xmp"
+        assert photo['latitude'] == 37.7749
+        assert photo['longitude'] == -122.4194
+        assert photo['timestamp'] == "2024-01-15T10:00:00"
+        assert photo['species'] == "Actias luna"
+
+    def test_generate_manifest_multiple_photos(self):
+        """Test manifest with multiple photos."""
+        photo_paths = [
+            Path("/photos/moth1.jpg"),
+            Path("/photos/moth2.jpg"),
+            Path("/photos/moth3.jpg"),
+        ]
+        metadata_list = [
+            create_test_metadata(filename="moth1.jpg"),
+            create_test_metadata(filename="moth2.jpg"),
+            create_test_metadata(filename="moth3.jpg"),
+        ]
+        options = ZipExportOptions()
+
+        manifest = generate_manifest(photo_paths, metadata_list, options)
+        assert manifest['photo_count'] == 3
+        assert len(manifest['photos']) == 3
+
+    def test_generate_manifest_without_xmp(self):
+        """Test manifest when XMP sidecars are disabled."""
+        photo_paths = [Path("/photos/moth1.jpg")]
+        metadata_list = [create_test_metadata(filename="moth1.jpg")]
+        options = ZipExportOptions(include_xmp_sidecars=False)
+
+        manifest = generate_manifest(photo_paths, metadata_list, options)
+        photo = manifest['photos'][0]
+
+        assert 'xmp_sidecar' not in photo or photo['xmp_sidecar'] is None
+
+    def test_generate_manifest_created_at_iso_format(self):
+        """Test manifest created_at is in ISO format."""
+        photo_paths = [Path("/photos/moth1.jpg")]
+        metadata_list = [create_test_metadata()]
+        options = ZipExportOptions()
+
+        manifest = generate_manifest(photo_paths, metadata_list, options)
+
+        # Verify ISO 8601 format
+        created_at = manifest['created_at']
+        datetime.fromisoformat(created_at.replace('Z', '+00:00'))  # Should not raise
+
+
+# ============================================================================
+# Test add_photo_to_zip
+# ============================================================================
+
+
+class TestAddPhotoToZip:
+    """Test adding photos to ZIP."""
+
+    def test_add_photo_to_zip_with_xmp(self, tmp_path):
+        """Test adding photo with XMP sidecar."""
+        photo_path = tmp_path / "moth.jpg"
+        create_test_jpeg(photo_path)
+        metadata = create_test_metadata(filename="moth.jpg")
+
+        zip_path = tmp_path / "test.zip"
+        with ZipFile(zip_path, 'w') as zf:
+            result = add_photo_to_zip(zf, photo_path, metadata, include_xmp=True)
+
+        assert result['success'] is True
+        assert result['filename'] == "moth.jpg"
+        assert result['xmp_filename'] == "moth.xmp"
+        assert result['size'] > 0
+        assert 'error' not in result
+
+        # Verify ZIP contents
+        with ZipFile(zip_path, 'r') as zf:
+            assert "moth.jpg" in zf.namelist()
+            assert "moth.xmp" in zf.namelist()
+
+    def test_add_photo_to_zip_without_xmp(self, tmp_path):
+        """Test adding photo without XMP sidecar."""
+        photo_path = tmp_path / "moth.jpg"
+        create_test_jpeg(photo_path)
+        metadata = create_test_metadata(filename="moth.jpg")
+
+        zip_path = tmp_path / "test.zip"
+        with ZipFile(zip_path, 'w') as zf:
+            result = add_photo_to_zip(zf, photo_path, metadata, include_xmp=False)
+
+        assert result['success'] is True
+        assert result['filename'] == "moth.jpg"
+        assert result['xmp_filename'] is None
+
+        # Verify ZIP contents
+        with ZipFile(zip_path, 'r') as zf:
+            assert "moth.jpg" in zf.namelist()
+            assert "moth.xmp" not in zf.namelist()
+
+    def test_add_photo_to_zip_missing_file(self, tmp_path):
+        """Test adding missing photo file."""
+        photo_path = tmp_path / "missing.jpg"
+        metadata = create_test_metadata(filename="missing.jpg")
+
+        zip_path = tmp_path / "test.zip"
+        with ZipFile(zip_path, 'w') as zf:
+            result = add_photo_to_zip(zf, photo_path, metadata, include_xmp=True)
+
+        assert result['success'] is False
+        assert 'error' in result
+
+    def test_add_photo_to_zip_special_characters(self, tmp_path):
+        """Test adding photo with special characters in filename."""
+        photo_path = tmp_path / "moth with spaces & special.jpg"
+        create_test_jpeg(photo_path)
+        metadata = create_test_metadata(filename="moth with spaces & special.jpg")
+
+        zip_path = tmp_path / "test.zip"
+        with ZipFile(zip_path, 'w') as zf:
+            result = add_photo_to_zip(zf, photo_path, metadata, include_xmp=True)
+
+        assert result['success'] is True
+        assert result['filename'] == "moth with spaces & special.jpg"
+
+
+# ============================================================================
+# Test validate_zip_integrity
+# ============================================================================
+
+
+class TestValidateZipIntegrity:
+    """Test ZIP integrity validation."""
+
+    def test_validate_zip_integrity_valid(self, tmp_path):
+        """Test validation of valid ZIP file."""
+        zip_path = tmp_path / "valid.zip"
+        with ZipFile(zip_path, 'w') as zf:
+            zf.writestr("test.txt", "test content")
+
+        assert validate_zip_integrity(zip_path) is True
+
+    def test_validate_zip_integrity_invalid(self, tmp_path):
+        """Test validation of invalid ZIP file."""
+        zip_path = tmp_path / "invalid.zip"
+        zip_path.write_text("not a zip file")
+
+        assert validate_zip_integrity(zip_path) is False
+
+    def test_validate_zip_integrity_missing(self, tmp_path):
+        """Test validation of missing ZIP file."""
+        zip_path = tmp_path / "missing.zip"
+        assert validate_zip_integrity(zip_path) is False
+
+    def test_validate_zip_integrity_empty(self, tmp_path):
+        """Test validation of empty ZIP file."""
+        zip_path = tmp_path / "empty.zip"
+        with ZipFile(zip_path, 'w'):
+            pass  # Empty ZIP
+
+        assert validate_zip_integrity(zip_path) is True
+
+
+# ============================================================================
+# Test estimate_zip_size
+# ============================================================================
+
+
+class TestEstimateZipSize:
+    """Test ZIP size estimation."""
+
+    def test_estimate_zip_size_single_photo(self, tmp_path):
+        """Test size estimation for single photo."""
+        photo_path = tmp_path / "moth.jpg"
+        create_test_jpeg(photo_path, size=10000)
+
+        estimated = estimate_zip_size([photo_path], include_xmp=True)
+        assert estimated > 10000  # Should be at least photo size
+        assert estimated < 20000  # XMP overhead should be reasonable
+
+    def test_estimate_zip_size_multiple_photos(self, tmp_path):
+        """Test size estimation for multiple photos."""
+        photo_paths = []
+        for i in range(5):
+            path = tmp_path / f"moth{i}.jpg"
+            create_test_jpeg(path, size=10000)
+            photo_paths.append(path)
+
+        estimated = estimate_zip_size(photo_paths, include_xmp=True)
+        assert estimated > 50000  # At least 5 * 10000
+
+    def test_estimate_zip_size_without_xmp(self, tmp_path):
+        """Test size estimation without XMP sidecars."""
+        photo_path = tmp_path / "moth.jpg"
+        create_test_jpeg(photo_path, size=10000)
+
+        with_xmp = estimate_zip_size([photo_path], include_xmp=True)
+        without_xmp = estimate_zip_size([photo_path], include_xmp=False)
+
+        assert without_xmp < with_xmp  # Should be smaller without XMP
+
+    def test_estimate_zip_size_missing_file(self, tmp_path):
+        """Test size estimation with missing file."""
+        photo_path = tmp_path / "missing.jpg"
+        estimated = estimate_zip_size([photo_path], include_xmp=True)
+        assert estimated == 0  # Should handle gracefully
+
+
+# ============================================================================
+# Test create_zip_export
+# ============================================================================
+
+
+class TestCreateZipExport:
+    """Test ZIP export creation."""
+
+    def test_create_zip_export_single_photo(self, tmp_path):
+        """Test creating ZIP export with single photo."""
+        photo_path = tmp_path / "moth.jpg"
+        create_test_jpeg(photo_path)
+        metadata = create_test_metadata(filename="moth.jpg")
+        output_path = tmp_path / "export.zip"
+
+        result = create_zip_export([photo_path], [metadata], output_path)
+
+        assert result.success is True
+        assert result.zip_path == output_path
+        assert result.photo_count == 1
+        assert result.xmp_count == 1
+        assert len(result.errors) == 0
+        assert result.took_ms > 0
+        assert output_path.exists()
+
+    def test_create_zip_export_multiple_photos(self, tmp_path):
+        """Test creating ZIP export with multiple photos."""
+        photo_paths = []
+        metadata_list = []
+        for i in range(5):
+            path = tmp_path / f"moth{i}.jpg"
+            create_test_jpeg(path)
+            photo_paths.append(path)
+            metadata_list.append(create_test_metadata(filename=f"moth{i}.jpg"))
+
+        output_path = tmp_path / "export.zip"
+        result = create_zip_export(photo_paths, metadata_list, output_path)
+
+        assert result.success is True
+        assert result.photo_count == 5
+        assert result.xmp_count == 5
+
+    def test_create_zip_export_with_manifest(self, tmp_path):
+        """Test ZIP export includes manifest.json."""
+        photo_path = tmp_path / "moth.jpg"
+        create_test_jpeg(photo_path)
+        metadata = create_test_metadata(filename="moth.jpg")
+        output_path = tmp_path / "export.zip"
+
+        options = ZipExportOptions(include_manifest=True)
+        result = create_zip_export([photo_path], [metadata], output_path, options)
+
+        assert result.success is True
+        with ZipFile(output_path, 'r') as zf:
+            assert MANIFEST_FILENAME in zf.namelist()
+            manifest_content = zf.read(MANIFEST_FILENAME).decode('utf-8')
+            manifest = json.loads(manifest_content)
+            assert manifest['photo_count'] == 1
+
+    def test_create_zip_export_with_csv_summary(self, tmp_path):
+        """Test ZIP export includes summary.csv."""
+        photo_path = tmp_path / "moth.jpg"
+        create_test_jpeg(photo_path)
+        metadata = create_test_metadata(filename="moth.jpg")
+        output_path = tmp_path / "export.zip"
+
+        options = ZipExportOptions(include_csv_summary=True)
+        result = create_zip_export([photo_path], [metadata], output_path, options)
+
+        assert result.success is True
+        with ZipFile(output_path, 'r') as zf:
+            assert SUMMARY_FILENAME in zf.namelist()
+            csv_content = zf.read(SUMMARY_FILENAME).decode('utf-8')
+            assert 'filename' in csv_content
+            assert 'moth.jpg' in csv_content
+
+    def test_create_zip_export_without_xmp(self, tmp_path):
+        """Test ZIP export without XMP sidecars."""
+        photo_path = tmp_path / "moth.jpg"
+        create_test_jpeg(photo_path)
+        metadata = create_test_metadata(filename="moth.jpg")
+        output_path = tmp_path / "export.zip"
+
+        options = ZipExportOptions(include_xmp_sidecars=False)
+        result = create_zip_export([photo_path], [metadata], output_path, options)
+
+        assert result.success is True
+        assert result.xmp_count == 0
+        with ZipFile(output_path, 'r') as zf:
+            assert "moth.jpg" in zf.namelist()
+            assert "moth.xmp" not in zf.namelist()
+
+    def test_create_zip_export_empty_list(self, tmp_path):
+        """Test creating ZIP export with empty photo list."""
+        output_path = tmp_path / "export.zip"
+        result = create_zip_export([], [], output_path)
+
+        assert result.success is True
+        assert result.photo_count == 0
+        assert result.xmp_count == 0
+        assert output_path.exists()
+
+    def test_create_zip_export_missing_photo(self, tmp_path):
+        """Test creating ZIP export with missing photo."""
+        photo_path = tmp_path / "missing.jpg"
+        metadata = create_test_metadata(filename="missing.jpg")
+        output_path = tmp_path / "export.zip"
+
+        result = create_zip_export([photo_path], [metadata], output_path)
+
+        # Should still succeed but with errors
+        assert len(result.errors) == 1
+        assert result.photo_count == 0
+
+    def test_create_zip_export_flatten_structure(self, tmp_path):
+        """Test ZIP export with flattened structure."""
+        subdir = tmp_path / "subdir"
+        subdir.mkdir()
+        photo_path = subdir / "moth.jpg"
+        create_test_jpeg(photo_path)
+        metadata = create_test_metadata(filename="moth.jpg")
+        output_path = tmp_path / "export.zip"
+
+        options = ZipExportOptions(flatten_structure=True)
+        result = create_zip_export([photo_path], [metadata], output_path, options)
+
+        assert result.success is True
+        with ZipFile(output_path, 'r') as zf:
+            # All files should be at root level
+            assert "moth.jpg" in zf.namelist()
+            assert not any("/" in name for name in zf.namelist()
+                          if name not in [MANIFEST_FILENAME, SUMMARY_FILENAME])
+
+    def test_create_zip_export_special_characters(self, tmp_path):
+        """Test ZIP export with special characters in filenames."""
+        photo_path = tmp_path / "moth with spaces & special.jpg"
+        create_test_jpeg(photo_path)
+        metadata = create_test_metadata(filename="moth with spaces & special.jpg")
+        output_path = tmp_path / "export.zip"
+
+        result = create_zip_export([photo_path], [metadata], output_path)
+
+        assert result.success is True
+        with ZipFile(output_path, 'r') as zf:
+            assert "moth with spaces & special.jpg" in zf.namelist()
+
+    def test_create_zip_export_validates_integrity(self, tmp_path):
+        """Test created ZIP file is valid."""
+        photo_path = tmp_path / "moth.jpg"
+        create_test_jpeg(photo_path)
+        metadata = create_test_metadata(filename="moth.jpg")
+        output_path = tmp_path / "export.zip"
+
+        result = create_zip_export([photo_path], [metadata], output_path)
+
+        assert result.success is True
+        assert is_zipfile(output_path)
+        assert validate_zip_integrity(output_path)
+
+
+# ============================================================================
+# Test stream_zip_export
+# ============================================================================
+
+
+class TestStreamZipExport:
+    """Test ZIP export streaming."""
+
+    def test_stream_zip_export_returns_generator(self, tmp_path):
+        """Test stream_zip_export returns a generator."""
+        photo_path = tmp_path / "moth.jpg"
+        create_test_jpeg(photo_path)
+        metadata = create_test_metadata(filename="moth.jpg")
+
+        generator = stream_zip_export([photo_path], [metadata])
+        assert isinstance(generator, Generator)
+
+    def test_stream_zip_export_yields_bytes(self, tmp_path):
+        """Test stream_zip_export yields bytes."""
+        photo_path = tmp_path / "moth.jpg"
+        create_test_jpeg(photo_path)
+        metadata = create_test_metadata(filename="moth.jpg")
+
+        chunks = []
+        result = None
+        for chunk in stream_zip_export([photo_path], [metadata]):
+            if isinstance(chunk, bytes):
+                chunks.append(chunk)
+            else:
+                result = chunk
+
+        assert len(chunks) > 0
+        assert all(isinstance(chunk, bytes) for chunk in chunks)
+        assert isinstance(result, ZipExportResult)
+
+    def test_stream_zip_export_final_result(self, tmp_path):
+        """Test stream_zip_export returns ZipExportResult at end."""
+        photo_path = tmp_path / "moth.jpg"
+        create_test_jpeg(photo_path)
+        metadata = create_test_metadata(filename="moth.jpg")
+
+        result = None
+        for chunk in stream_zip_export([photo_path], [metadata]):
+            if isinstance(chunk, ZipExportResult):
+                result = chunk
+
+        assert result is not None
+        assert result.success is True
+        assert result.photo_count == 1
+
+    def test_stream_zip_export_creates_valid_zip(self, tmp_path):
+        """Test streamed ZIP is valid."""
+        photo_path = tmp_path / "moth.jpg"
+        create_test_jpeg(photo_path)
+        metadata = create_test_metadata(filename="moth.jpg")
+
+        chunks = []
+        for chunk in stream_zip_export([photo_path], [metadata]):
+            if isinstance(chunk, bytes):
+                chunks.append(chunk)
+
+        # Reconstruct ZIP from chunks
+        zip_data = b''.join(chunks)
+        zip_buffer = BytesIO(zip_data)
+        assert is_zipfile(zip_buffer)
+
+    def test_stream_zip_export_multiple_photos(self, tmp_path):
+        """Test streaming with multiple photos."""
+        photo_paths = []
+        metadata_list = []
+        for i in range(5):
+            path = tmp_path / f"moth{i}.jpg"
+            create_test_jpeg(path)
+            photo_paths.append(path)
+            metadata_list.append(create_test_metadata(filename=f"moth{i}.jpg"))
+
+        result = None
+        for chunk in stream_zip_export(photo_paths, metadata_list):
+            if isinstance(chunk, ZipExportResult):
+                result = chunk
+
+        assert result.photo_count == 5
+
+
+# ============================================================================
+# Test Performance
+# ============================================================================
+
+
+class TestPerformance:
+    """Test ZIP export performance."""
+
+    def test_create_zip_export_50_photos_under_5_seconds(self, tmp_path):
+        """Test creating ZIP with 50 photos completes in <5 seconds."""
+        photo_paths = []
+        metadata_list = []
+        for i in range(50):
+            path = tmp_path / f"moth{i}.jpg"
+            create_test_jpeg(path, size=50000)  # 50KB each
+            photo_paths.append(path)
+            metadata_list.append(create_test_metadata(filename=f"moth{i}.jpg"))
+
+        output_path = tmp_path / "export.zip"
+
+        start_time = time.time()
+        result = create_zip_export(photo_paths, metadata_list, output_path)
+        elapsed_time = time.time() - start_time
+
+        assert result.success is True
+        assert result.photo_count == 50
+        assert elapsed_time < 5.0, f"Export took {elapsed_time:.2f}s, expected <5s"
+
+    def test_stream_zip_export_50_photos_under_5_seconds(self, tmp_path):
+        """Test streaming ZIP with 50 photos completes in <5 seconds."""
+        photo_paths = []
+        metadata_list = []
+        for i in range(50):
+            path = tmp_path / f"moth{i}.jpg"
+            create_test_jpeg(path, size=50000)  # 50KB each
+            photo_paths.append(path)
+            metadata_list.append(create_test_metadata(filename=f"moth{i}.jpg"))
+
+        start_time = time.time()
+        result = None
+        for chunk in stream_zip_export(photo_paths, metadata_list):
+            if isinstance(chunk, ZipExportResult):
+                result = chunk
+        elapsed_time = time.time() - start_time
+
+        assert result.success is True
+        assert result.photo_count == 50
+        assert elapsed_time < 5.0, f"Streaming took {elapsed_time:.2f}s, expected <5s"

--- a/Firmware/Tests/unit/test_zip_export.py
+++ b/Firmware/Tests/unit/test_zip_export.py
@@ -26,12 +26,15 @@ from zipfile import ZipFile, is_zipfile
 
 from webui.backend.lib.zip_export import (
     MANIFEST_FILENAME,
-    MAX_ZIP_FILE_SIZE,
     SUMMARY_FILENAME,
     ZIP_BUFFER_SIZE,
     ZIP_COMPRESSION_LEVEL,
+    PhotoFileError,
+    XMPGenerationError,
+    ZipExportError,
     ZipExportOptions,
     ZipExportResult,
+    ZipWriteError,
     add_photo_to_zip,
     create_zip_export,
     estimate_zip_size,
@@ -96,10 +99,6 @@ class TestConstants:
     def test_zip_buffer_size(self):
         """ZIP_BUFFER_SIZE should be 8KB."""
         assert ZIP_BUFFER_SIZE == 8192
-
-    def test_max_zip_file_size(self):
-        """MAX_ZIP_FILE_SIZE should be 2GB."""
-        assert MAX_ZIP_FILE_SIZE == 2 * 1024 * 1024 * 1024
 
     def test_manifest_filename(self):
         """MANIFEST_FILENAME should be 'manifest.json'."""
@@ -800,3 +799,201 @@ class TestPerformance:
         assert result.success is True
         assert result.photo_count == 50
         assert elapsed_time < 5.0, f"Streaming took {elapsed_time:.2f}s, expected <5s"
+
+
+# ============================================================================
+# Test Custom Exception Classes
+# ============================================================================
+
+
+class TestZipExportExceptions:
+    """Test custom exception classes for ZIP export."""
+
+    def test_exception_hierarchy(self):
+        """Test exception inheritance hierarchy."""
+        assert issubclass(PhotoFileError, ZipExportError)
+        assert issubclass(XMPGenerationError, ZipExportError)
+        assert issubclass(ZipWriteError, ZipExportError)
+        assert issubclass(ZipExportError, Exception)
+
+    def test_can_catch_base_exception(self):
+        """Test catching all ZIP export errors with base class."""
+        try:
+            raise PhotoFileError("test error")
+        except ZipExportError as e:
+            assert str(e) == "test error"
+
+    def test_photo_file_error_message(self):
+        """Test PhotoFileError preserves error message."""
+        error = PhotoFileError("Permission denied")
+        assert str(error) == "Permission denied"
+
+    def test_xmp_generation_error_message(self):
+        """Test XMPGenerationError preserves error message."""
+        error = XMPGenerationError("Invalid metadata")
+        assert str(error) == "Invalid metadata"
+
+    def test_zip_write_error_message(self):
+        """Test ZipWriteError preserves error message."""
+        error = ZipWriteError("Disk full")
+        assert str(error) == "Disk full"
+
+
+# ============================================================================
+# Test Error Handling
+# ============================================================================
+
+
+class TestErrorHandling:
+    """Test specific error handling scenarios."""
+
+    def test_add_photo_permission_error(self, tmp_path, monkeypatch):
+        """Test handling of permission denied error during photo read."""
+        photo_path = tmp_path / "moth.jpg"
+        create_test_jpeg(photo_path)
+        metadata = create_test_metadata(filename="moth.jpg")
+
+        # Mock ZipFile.write to raise PermissionError
+        def mock_write(self, filename, arcname=None, compress_type=None):
+            raise PermissionError("Permission denied")
+
+        zip_path = tmp_path / "test.zip"
+        with ZipFile(zip_path, 'w') as zf:
+            monkeypatch.setattr(type(zf), 'write', mock_write)
+            result = add_photo_to_zip(zf, photo_path, metadata, include_xmp=True)
+
+        assert result['success'] is False
+        assert result['error'] == "Permission denied reading photo file"
+        assert result['error_type'] == 'permission'
+
+    def test_add_photo_oserror_disk_full(self, tmp_path, monkeypatch):
+        """Test handling of disk full error (OSError)."""
+        import errno
+
+        photo_path = tmp_path / "moth.jpg"
+        create_test_jpeg(photo_path)
+        metadata = create_test_metadata(filename="moth.jpg")
+
+        # Mock ZipFile.write to raise OSError with ENOSPC
+        def mock_write(self, filename, arcname=None, compress_type=None):
+            err = OSError(errno.ENOSPC, "No space left on device")
+            raise err
+
+        zip_path = tmp_path / "test.zip"
+        with ZipFile(zip_path, 'w') as zf:
+            monkeypatch.setattr(type(zf), 'write', mock_write)
+            result = add_photo_to_zip(zf, photo_path, metadata, include_xmp=True)
+
+        assert result['success'] is False
+        assert 'File system error' in result['error']
+        assert result['error_type'] == 'io'
+
+    def test_add_photo_xmp_generation_error(self, tmp_path, monkeypatch):
+        """Test handling of XMP generation failure."""
+        photo_path = tmp_path / "moth.jpg"
+        create_test_jpeg(photo_path)
+        metadata = create_test_metadata(filename="moth.jpg")
+
+        # Mock generate_xmp_xml to raise ValueError
+        from webui.backend.lib import zip_export
+
+        def mock_generate_xmp_xml(metadata):
+            raise ValueError("Invalid metadata field")
+
+        monkeypatch.setattr(zip_export, 'generate_xmp_xml', mock_generate_xmp_xml)
+
+        zip_path = tmp_path / "test.zip"
+        with ZipFile(zip_path, 'w') as zf:
+            result = add_photo_to_zip(zf, photo_path, metadata, include_xmp=True)
+
+        assert result['success'] is False
+        assert result['error'] == "Failed to generate XMP metadata"
+        assert result['error_type'] == 'xmp'
+
+    def test_error_type_field_not_found(self, tmp_path):
+        """Test that error_type is 'not_found' for missing files."""
+        photo_path = tmp_path / "missing.jpg"
+        metadata = create_test_metadata(filename="missing.jpg")
+
+        zip_path = tmp_path / "test.zip"
+        with ZipFile(zip_path, 'w') as zf:
+            result = add_photo_to_zip(zf, photo_path, metadata, include_xmp=True)
+
+        assert result['success'] is False
+        assert 'not found' in result['error']
+        assert result['error_type'] == 'not_found'
+
+    def test_create_zip_export_permission_error(self, tmp_path, monkeypatch):
+        """Test create_zip_export handles permission errors."""
+        photo_path = tmp_path / "moth.jpg"
+        create_test_jpeg(photo_path)
+        metadata = create_test_metadata(filename="moth.jpg")
+
+        # Use a path that will fail to create (simulate permission error)
+        output_path = tmp_path / "readonly" / "export.zip"
+
+        # Mock ZipFile to raise PermissionError
+        original_init = ZipFile.__init__
+
+        def mock_init(self, file, mode='r', *args, **kwargs):
+            if mode == 'w':
+                raise PermissionError("Permission denied")
+            return original_init(self, file, mode, *args, **kwargs)
+
+        monkeypatch.setattr(ZipFile, '__init__', mock_init)
+
+        result = create_zip_export([photo_path], [metadata], output_path)
+
+        assert result.success is False
+        assert len(result.errors) > 0
+        assert result.errors[0]['error_type'] == 'permission'
+
+    def test_user_friendly_error_messages(self, tmp_path, monkeypatch):
+        """Test that error messages are user-friendly (no raw exceptions)."""
+        photo_path = tmp_path / "moth.jpg"
+        create_test_jpeg(photo_path)
+        metadata = create_test_metadata(filename="moth.jpg")
+
+        # Mock to raise a generic exception
+        def mock_write(self, filename, arcname=None, compress_type=None):
+            raise RuntimeError("Internal error with sensitive path info")
+
+        zip_path = tmp_path / "test.zip"
+        with ZipFile(zip_path, 'w') as zf:
+            monkeypatch.setattr(type(zf), 'write', mock_write)
+            result = add_photo_to_zip(zf, photo_path, metadata, include_xmp=True)
+
+        assert result['success'] is False
+        # Should be a generic message, not the raw exception
+        assert result['error'] == "Unexpected error processing photo"
+        assert result['error_type'] == 'unknown'
+        # The raw exception message should NOT be in the error
+        assert 'sensitive path info' not in result['error']
+
+    def test_stream_zip_oserror(self, tmp_path, monkeypatch):
+        """Test stream_zip_export handles OSError."""
+        import errno
+
+        photo_path = tmp_path / "moth.jpg"
+        create_test_jpeg(photo_path)
+        metadata = create_test_metadata(filename="moth.jpg")
+
+        # Mock to raise OSError during ZIP creation
+        original_init = ZipFile.__init__
+
+        def mock_init(self, file, mode='r', *args, **kwargs):
+            if mode == 'w' and hasattr(file, 'write'):
+                raise OSError(errno.EIO, "Input/output error")
+            return original_init(self, file, mode, *args, **kwargs)
+
+        monkeypatch.setattr(ZipFile, '__init__', mock_init)
+
+        result = None
+        for chunk in stream_zip_export([photo_path], [metadata]):
+            if isinstance(chunk, ZipExportResult):
+                result = chunk
+
+        assert result is not None
+        assert result.success is False
+        assert len(result.errors) > 0
+        assert result.errors[0]['error_type'] == 'io'

--- a/Firmware/webui/backend/constants.py
+++ b/Firmware/webui/backend/constants.py
@@ -123,3 +123,15 @@ MAX_BULK_DELETE: Final[int] = 100  # Max files per bulk delete operation (Fronte
 # CACHE SETTINGS
 # =============================================================================
 DEFAULT_CACHE_TTL: Final[int] = 300  # 5 minutes - standard cache TTL for services
+
+# =============================================================================
+# INATURALIST EXPORT SETTINGS (Issue #118)
+# =============================================================================
+INATURALIST_DEFAULT_LICENSE: Final[str] = "CC BY-NC 4.0"
+INATURALIST_CREATOR: Final[str] = "Mothbox"
+INCLUDE_TAXONOMY_HIERARCHY: Final[bool] = True
+INCLUDE_CSV_SUMMARY: Final[bool] = True
+
+# ZIP Export Settings
+ZIP_COMPRESSION_LEVEL: Final[int] = 0  # No compression for JPEGs (already compressed)
+MAX_PHOTOS_PER_ZIP: Final[int] = 1000  # Maximum photos per ZIP export

--- a/Firmware/webui/backend/lib/inaturalist_mapping.py
+++ b/Firmware/webui/backend/lib/inaturalist_mapping.py
@@ -178,8 +178,12 @@ def build_taxonomy_keywords(species: str | None) -> list[str]:
 
     keywords = []
 
-    # Fixed taxonomy for Lepidoptera (moth/butterfly)
-    # All Mothbox observations are assumed to be insects
+    # LIMITATION: Hardcoded taxonomy assumes Lepidoptera (moths/butterflies)
+    # This is appropriate for Mothbox's primary use case as a moth camera trap.
+    # For mixed specimens or non-Lepidoptera, this will produce incorrect
+    # higher taxonomy. Future enhancement: integrate with GBIF Backbone
+    # Taxonomy API for dynamic hierarchical lookup based on species name.
+    # See: https://www.gbif.org/developer/species
     keywords.extend([
         f"{TAXONOMY_KEYWORD_PREFIX}kingdom=Animalia",
         f"{TAXONOMY_KEYWORD_PREFIX}phylum=Arthropoda",

--- a/Firmware/webui/backend/lib/inaturalist_mapping.py
+++ b/Firmware/webui/backend/lib/inaturalist_mapping.py
@@ -1,0 +1,514 @@
+"""
+iNaturalist Field Mapping Module for Mothbox Photo Gallery (Issue #118)
+
+Provides field definitions, mappings, and utilities for transforming
+Mothbox photo metadata to iNaturalist-compatible format with XMP sidecar support.
+
+iNaturalist is a citizen science platform for biodiversity observations.
+This module enables exporting Mothbox photos to iNaturalist with rich metadata
+including taxonomy, location, quality grades, and observation notes.
+
+Reference: https://www.inaturalist.org/pages/developers
+
+Usage:
+    from webui.backend.lib.inaturalist_mapping import (
+        transform_metadata_to_inaturalist,
+        validate_for_inaturalist,
+        format_observation_title,
+        build_taxonomy_keywords,
+    )
+
+    # Transform ExportMetadata to iNaturalist dict
+    inat_record = transform_metadata_to_inaturalist(export_metadata)
+
+    # Validate metadata for iNaturalist export
+    validation = validate_for_inaturalist(export_metadata)
+
+    # Format observation title for taxon parsing
+    title = format_observation_title(export_metadata)
+"""
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from webui.backend.services.export_metadata_service import ExportMetadata
+
+logger = logging.getLogger(__name__)
+
+
+# ============================================================================
+# Constants
+# ============================================================================
+
+# Required fields for iNaturalist export
+INATURALIST_REQUIRED_FIELDS = ["latitude", "longitude", "timestamp"]
+
+# Recommended fields for complete observations
+INATURALIST_RECOMMENDED_FIELDS = [
+    "species",
+    "species_common_name",
+    "species_confidence",
+    "notes",
+]
+
+# Species confidence to iNaturalist quality grade mapping
+# Reference: https://www.inaturalist.org/pages/help#quality
+CONFIDENCE_TO_QUALITY_GRADE = {
+    "certain": "research",      # High confidence, research grade quality
+    "probable": "needs_id",     # Likely correct, community ID needed
+    "possible": "needs_id",     # Possible match, needs verification
+    "unknown": "casual",        # Low quality/casual observation
+}
+
+# Taxonomy keyword prefix following Naturtag pattern
+# Reference: https://github.com/pyinat/naturtag
+TAXONOMY_KEYWORD_PREFIX = "taxonomy:"
+
+# Default values for iNaturalist fields
+DEFAULT_LICENSE = "CC BY-NC 4.0"  # Creative Commons Attribution-NonCommercial
+DEFAULT_CREATOR = "Mothbox"       # Default observer/creator
+DEFAULT_QUALITY_GRADE = "needs_id"  # Default when confidence unknown
+
+
+# ============================================================================
+# Data Classes
+# ============================================================================
+
+@dataclass
+class INaturalistFieldMapping:
+    """Definition for iNaturalist field mapping.
+
+    Attributes:
+        inat_field: iNaturalist field name (e.g., "latitude", "species")
+        source_field: ExportMetadata field name or None for computed/constant
+        default_value: Default value if source is None
+        is_required: Whether this field is required for iNaturalist
+        xmp_field: XMP namespace field (e.g., "exif:GPSLatitude") for sidecar
+        description: Human-readable description of the field
+    """
+    inat_field: str
+    source_field: str | None
+    default_value: Any
+    is_required: bool
+    xmp_field: str | None
+    description: str
+
+
+@dataclass
+class ValidationResult:
+    """Result of iNaturalist export validation.
+
+    Attributes:
+        is_valid: Whether metadata is valid for iNaturalist export
+        missing_required: List of required fields that are missing
+        missing_recommended: List of recommended fields that are missing
+        warnings: List of validation warnings (non-fatal issues)
+    """
+    is_valid: bool
+    missing_required: list[str] = field(default_factory=list)
+    missing_recommended: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+
+# ============================================================================
+# Helper Functions
+# ============================================================================
+
+def map_species_confidence_to_quality_grade(confidence: str | None) -> str:
+    """Map Mothbox species confidence to iNaturalist quality grade.
+
+    iNaturalist uses quality grades to indicate observation confidence:
+    - research: High-quality observations with community consensus
+    - needs_id: Observations needing community identification
+    - casual: Low-quality or incomplete observations
+
+    Args:
+        confidence: Mothbox confidence value ("certain", "probable", "possible", "unknown")
+
+    Returns:
+        iNaturalist quality grade string
+
+    Example:
+        >>> map_species_confidence_to_quality_grade("certain")
+        'research'
+        >>> map_species_confidence_to_quality_grade("probable")
+        'needs_id'
+    """
+    if confidence is None:
+        return DEFAULT_QUALITY_GRADE
+
+    return CONFIDENCE_TO_QUALITY_GRADE.get(confidence.lower(), DEFAULT_QUALITY_GRADE)
+
+
+def build_taxonomy_keywords(species: str | None) -> list[str]:
+    """Build hierarchical taxonomy keywords from species name.
+
+    Follows the Naturtag keyword pattern for iNaturalist compatibility.
+    Keywords enable hierarchical filtering and searching in photo management software.
+
+    For moths/butterflies (Lepidoptera), generates:
+    - taxonomy:kingdom=Animalia
+    - taxonomy:phylum=Arthropoda
+    - taxonomy:class=Insecta
+    - taxonomy:order=Lepidoptera
+    - taxonomy:genus=<Genus>
+    - taxonomy:species=<Genus species>
+
+    Args:
+        species: Scientific name (e.g., "Actias luna")
+
+    Returns:
+        List of taxonomy keyword strings
+
+    Example:
+        >>> build_taxonomy_keywords("Actias luna")
+        ['taxonomy:kingdom=Animalia', 'taxonomy:phylum=Arthropoda', ..., 'taxonomy:species=Actias luna']
+    """
+    if not species:
+        return []
+
+    # Clean species name (remove author citations like "(Linnaeus, 1758)")
+    species_clean = re.sub(r'\s*\([^)]*\)\s*$', '', species).strip()
+
+    if not species_clean:
+        return []
+
+    keywords = []
+
+    # Fixed taxonomy for Lepidoptera (moth/butterfly)
+    # All Mothbox observations are assumed to be insects
+    keywords.extend([
+        f"{TAXONOMY_KEYWORD_PREFIX}kingdom=Animalia",
+        f"{TAXONOMY_KEYWORD_PREFIX}phylum=Arthropoda",
+        f"{TAXONOMY_KEYWORD_PREFIX}class=Insecta",
+        f"{TAXONOMY_KEYWORD_PREFIX}order=Lepidoptera",
+    ])
+
+    # Parse genus and species from binomial/trinomial name
+    parts = species_clean.split()
+
+    if len(parts) >= 1:
+        # Genus
+        genus = parts[0]
+        keywords.append(f"{TAXONOMY_KEYWORD_PREFIX}genus={genus}")
+
+    if len(parts) >= 2:
+        # Species (binomial)
+        species_binomial = f"{parts[0]} {parts[1]}"
+        keywords.append(f"{TAXONOMY_KEYWORD_PREFIX}species={species_binomial}")
+
+    # Note: Subspecies (trinomial) could be added here if needed
+    # if len(parts) >= 3:
+    #     species_trinomial = f"{parts[0]} {parts[1]} {parts[2]}"
+    #     keywords.append(f"{TAXONOMY_KEYWORD_PREFIX}subspecies={species_trinomial}")
+
+    return keywords
+
+
+def format_observation_title(metadata: "ExportMetadata") -> str:
+    """Format observation title for iNaturalist taxon parsing.
+
+    iNaturalist can parse taxon names from photo titles to automatically
+    suggest species identifications. Format follows pattern:
+    - "Common Name (Scientific Name)" if both available
+    - "Scientific Name" if only species available
+    - "Common Name" if only common name available
+    - "Unknown" if neither available
+
+    Args:
+        metadata: ExportMetadata instance
+
+    Returns:
+        Formatted title string
+
+    Example:
+        >>> format_observation_title(metadata_with_both)
+        'Luna Moth (Actias luna)'
+        >>> format_observation_title(metadata_species_only)
+        'Actias luna'
+    """
+    species = metadata.species
+    common_name = metadata.species_common_name
+
+    if species and common_name:
+        return f"{common_name} ({species})"
+    elif species:
+        return species
+    elif common_name:
+        return common_name
+    else:
+        return "Unknown"
+
+
+def format_observation_notes(metadata: "ExportMetadata") -> str:
+    """Combine notes, tags, and deployment info into observation notes.
+
+    Formats comprehensive observation notes from available metadata:
+    - User notes (if present)
+    - Tags as comma-separated list (if present)
+    - Deployment information (if present)
+
+    Args:
+        metadata: ExportMetadata instance
+
+    Returns:
+        Formatted notes string
+
+    Example:
+        >>> format_observation_notes(metadata)
+        'Beautiful specimen\\n\\nTags: nocturnal, lepidoptera\\n\\nDeployment: oak-ridge-2024'
+    """
+    parts = []
+
+    # User notes
+    if metadata.notes:
+        parts.append(metadata.notes)
+
+    # Tags
+    if metadata.tags:
+        tags_str = ", ".join(metadata.tags)
+        parts.append(f"Tags: {tags_str}")
+
+    # Deployment information
+    deployment_info = []
+    if metadata.deployment_name:
+        deployment_info.append(f"Deployment: {metadata.deployment_name}")
+    if metadata.deployment_location_name:
+        deployment_info.append(f"Location: {metadata.deployment_location_name}")
+
+    if deployment_info:
+        parts.append("\n".join(deployment_info))
+
+    return "\n\n".join(parts)
+
+
+def get_xmp_field_mappings() -> dict[str, str]:
+    """Return mapping of iNaturalist fields to XMP fields.
+
+    Maps iNaturalist field names to XMP namespace fields for sidecar generation.
+    Supports Dublin Core (dc:), XMP (xmp:), EXIF (exif:), and IPTC namespaces.
+
+    Returns:
+        Dictionary mapping iNaturalist field -> XMP field
+
+    Example:
+        >>> mappings = get_xmp_field_mappings()
+        >>> mappings["latitude"]
+        'exif:GPSLatitude'
+        >>> mappings["title"]
+        'dc:title'
+    """
+    return {
+        # Location fields (EXIF GPS namespace)
+        "latitude": "exif:GPSLatitude",
+        "longitude": "exif:GPSLongitude",
+        "altitude": "exif:GPSAltitude",
+
+        # Title and description (Dublin Core)
+        "title": "dc:title",
+        "notes": "dc:description",
+
+        # Creator/observer (Dublin Core)
+        "creator": "dc:creator",
+
+        # Keywords/tags (Dublin Core)
+        "keywords": "dc:subject",
+
+        # License (XMP Rights)
+        "license": "xmpRights:UsageTerms",
+
+        # Timestamp (XMP)
+        "timestamp": "xmp:CreateDate",
+
+        # Species (IPTC Extension)
+        "species": "Iptc4xmpExt:TaxonomicName",
+    }
+
+
+def transform_metadata_to_inaturalist(metadata: "ExportMetadata") -> dict[str, Any]:
+    """Transform ExportMetadata to iNaturalist-compatible dict.
+
+    Maps all available Mothbox metadata fields to iNaturalist equivalents,
+    applying transformations where necessary (quality grade, taxonomy keywords,
+    formatted title/notes).
+
+    Args:
+        metadata: ExportMetadata instance to transform
+
+    Returns:
+        Dictionary with iNaturalist field names as keys
+
+    Example:
+        >>> inat = transform_metadata_to_inaturalist(metadata)
+        >>> inat["latitude"]
+        37.7749
+        >>> inat["quality_grade"]
+        'research'
+    """
+    result: dict[str, Any] = {}
+
+    # Required fields
+    result["latitude"] = metadata.latitude
+    result["longitude"] = metadata.longitude
+    result["timestamp"] = metadata.timestamp
+
+    # Species fields
+    result["species"] = metadata.species or ""
+    result["common_name"] = metadata.species_common_name or ""
+
+    # Quality grade (mapped from confidence)
+    result["quality_grade"] = map_species_confidence_to_quality_grade(
+        metadata.species_confidence
+    )
+
+    # Formatted fields
+    result["title"] = format_observation_title(metadata)
+    result["notes"] = format_observation_notes(metadata)
+
+    # Keywords (taxonomy + tags)
+    keywords = build_taxonomy_keywords(metadata.species)
+    if metadata.tags:
+        keywords.extend(metadata.tags)
+    result["keywords"] = keywords
+
+    # License and creator
+    result["license"] = DEFAULT_LICENSE
+    result["creator"] = DEFAULT_CREATOR
+
+    # Optional location fields
+    if metadata.altitude is not None:
+        result["altitude"] = metadata.altitude
+    if metadata.gps_accuracy is not None:
+        result["gps_accuracy"] = metadata.gps_accuracy
+
+    # Observer (from deployment modified_by or default)
+    result["observer"] = DEFAULT_CREATOR
+
+    # Photo file info
+    result["filename"] = metadata.filename
+
+    return result
+
+
+def is_valid_for_inaturalist_export(metadata: "ExportMetadata") -> bool:
+    """Quick check if metadata has required fields for iNaturalist.
+
+    Validates that GPS coordinates and timestamp are present and valid.
+
+    Args:
+        metadata: ExportMetadata instance to validate
+
+    Returns:
+        True if metadata can be exported, False otherwise
+
+    Example:
+        >>> is_valid_for_inaturalist_export(metadata_with_gps)
+        True
+        >>> is_valid_for_inaturalist_export(metadata_without_gps)
+        False
+    """
+    # GPS coordinates required
+    if metadata.latitude is None or metadata.longitude is None:
+        return False
+
+    # Timestamp required
+    if not metadata.timestamp:
+        return False
+
+    # Validate coordinate ranges
+    if not (-90 <= metadata.latitude <= 90):
+        return False
+
+    return -180 <= metadata.longitude <= 180
+
+
+def validate_for_inaturalist(metadata: "ExportMetadata") -> ValidationResult:
+    """Comprehensive validation with missing fields and warnings.
+
+    Validates metadata against iNaturalist requirements and recommendations.
+    Returns detailed validation result with missing required/recommended fields
+    and warnings.
+
+    Args:
+        metadata: ExportMetadata instance to validate
+
+    Returns:
+        ValidationResult with validation status and details
+
+    Example:
+        >>> result = validate_for_inaturalist(metadata)
+        >>> result.is_valid
+        True
+        >>> result.missing_recommended
+        ['species_common_name']
+    """
+    missing_required = []
+    missing_recommended = []
+    warnings = []
+
+    # Check required fields
+    if metadata.latitude is None:
+        missing_required.append("latitude")
+    elif not (-90 <= metadata.latitude <= 90):
+        missing_required.append("latitude (invalid range)")
+
+    if metadata.longitude is None:
+        missing_required.append("longitude")
+    elif not (-180 <= metadata.longitude <= 180):
+        missing_required.append("longitude (invalid range)")
+
+    if not metadata.timestamp:
+        missing_required.append("timestamp")
+
+    # Check recommended fields
+    if not metadata.species:
+        missing_recommended.append("species")
+
+    if not metadata.species_common_name:
+        missing_recommended.append("species_common_name")
+
+    if not metadata.species_confidence:
+        warnings.append("species_confidence not set, defaulting to 'needs_id'")
+
+    if not metadata.notes and not metadata.tags:
+        warnings.append("No notes or tags provided")
+
+    # Determine validity
+    is_valid = len(missing_required) == 0
+
+    return ValidationResult(
+        is_valid=is_valid,
+        missing_required=missing_required,
+        missing_recommended=missing_recommended,
+        warnings=warnings,
+    )
+
+
+# ============================================================================
+# Public API
+# ============================================================================
+
+__all__ = [
+    # Constants
+    "INATURALIST_REQUIRED_FIELDS",
+    "INATURALIST_RECOMMENDED_FIELDS",
+    "CONFIDENCE_TO_QUALITY_GRADE",
+    "TAXONOMY_KEYWORD_PREFIX",
+    "DEFAULT_LICENSE",
+    "DEFAULT_CREATOR",
+    # Data classes
+    "INaturalistFieldMapping",
+    "ValidationResult",
+    # Functions
+    "map_species_confidence_to_quality_grade",
+    "build_taxonomy_keywords",
+    "format_observation_title",
+    "format_observation_notes",
+    "get_xmp_field_mappings",
+    "transform_metadata_to_inaturalist",
+    "is_valid_for_inaturalist_export",
+    "validate_for_inaturalist",
+]

--- a/Firmware/webui/backend/lib/xmp_sidecar.py
+++ b/Firmware/webui/backend/lib/xmp_sidecar.py
@@ -134,8 +134,12 @@ def build_taxonomy_keywords(species_name: str | None) -> list[str]:
 
     keywords = []
 
-    # All Mothbox specimens are insects (moths/butterflies)
-    # This is a reasonable assumption for a moth camera trap system
+    # LIMITATION: Hardcoded taxonomy assumes Lepidoptera (moths/butterflies)
+    # This is appropriate for Mothbox's primary use case as a moth camera trap.
+    # For mixed specimens or non-Lepidoptera, this will produce incorrect
+    # higher taxonomy. Future enhancement: integrate with GBIF Backbone
+    # Taxonomy API for dynamic hierarchical lookup based on species name.
+    # See: https://www.gbif.org/developer/species
     keywords.append("taxonomy:kingdom=Animalia")
     keywords.append("taxonomy:phylum=Arthropoda")
     keywords.append("taxonomy:class=Insecta")

--- a/Firmware/webui/backend/lib/xmp_sidecar.py
+++ b/Firmware/webui/backend/lib/xmp_sidecar.py
@@ -1,0 +1,556 @@
+"""
+XMP Sidecar Library for iNaturalist Export.
+
+Generates XMP sidecar files (.xmp) containing metadata in Dublin Core, XMP,
+IPTC Extension, and Photoshop namespaces for photo export compatibility.
+
+XMP (Extensible Metadata Platform) is an ISO standard for embedding metadata
+in digital files. iNaturalist and many photo management applications use XMP
+sidecars to store and read metadata.
+
+Example:
+    from webui.backend.lib.xmp_sidecar import generate_xmp_xml
+    from webui.backend.services.export_metadata_service import ExportMetadata
+
+    metadata = ExportMetadata(...)
+    xmp_xml = generate_xmp_xml(metadata)
+
+    with open("photo.xmp", "w", encoding="utf-8") as f:
+        f.write(xmp_xml)
+"""
+
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+from webui.backend.services.export_metadata_service import ExportMetadata
+
+# ============================================================================
+# XMP Namespace Definitions
+# ============================================================================
+
+XMP_NAMESPACES = {
+    'x': 'adobe:ns:meta/',
+    'rdf': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+    'dc': 'http://purl.org/dc/elements/1.1/',
+    'xmp': 'http://ns.adobe.com/xap/1.0/',
+    'photoshop': 'http://ns.adobe.com/photoshop/1.0/',
+    'Iptc4xmpCore': 'http://iptc.org/std/Iptc4xmpCore/1.0/xmlns/',
+    'Iptc4xmpExt': 'http://iptc.org/std/Iptc4xmpExt/2008-02-29/',
+    'exif': 'http://ns.adobe.com/exif/1.0/',
+}
+
+# Register namespaces for ElementTree
+for prefix, uri in XMP_NAMESPACES.items():
+    ET.register_namespace(prefix, uri)
+
+
+# ============================================================================
+# XML Utility Functions
+# ============================================================================
+
+def escape_xml_text(text: str) -> str:
+    """
+    Escape special XML characters.
+
+    Args:
+        text: Text to escape
+
+    Returns:
+        Escaped text safe for XML content
+
+    Note:
+        ElementTree handles escaping automatically, but this function
+        is provided for manual escaping when needed.
+    """
+    if not text:
+        return text
+
+    # XML special characters
+    text = text.replace('&', '&amp;')
+    text = text.replace('<', '&lt;')
+    text = text.replace('>', '&gt;')
+    text = text.replace('"', '&quot;')
+    text = text.replace("'", '&apos;')
+
+    return text
+
+
+def validate_xmp_xml(xml_string: str) -> bool:
+    """
+    Validate that XML string is well-formed.
+
+    Args:
+        xml_string: XML string to validate
+
+    Returns:
+        True if valid XML, False otherwise
+    """
+    if not xml_string or not xml_string.strip():
+        return False
+
+    try:
+        # Remove xpacket processing instructions for validation
+        xml_content = xml_string
+        for pi in ['<?xpacket begin="" id="W5M0MpCehiHzreSzNTczkc9d"?>',
+                   '<?xpacket end="w"?>']:
+            xml_content = xml_content.replace(pi, '')
+
+        # nosec B314: XMP content is generated internally by generate_xmp_xml(),
+        # not from untrusted external sources
+        ET.fromstring(xml_content.strip())  # nosec B314
+        return True
+    except ET.ParseError:
+        return False
+
+
+# ============================================================================
+# Filename Utilities
+# ============================================================================
+
+def get_xmp_sidecar_filename(photo_filename: str | Path) -> str:
+    """
+    Convert photo filename to XMP sidecar filename.
+
+    Args:
+        photo_filename: Photo filename (e.g., "photo.jpg")
+
+    Returns:
+        XMP sidecar filename (e.g., "photo.xmp")
+
+    Example:
+        >>> get_xmp_sidecar_filename("moth_2024_01_15__10_30_00.jpg")
+        'moth_2024_01_15__10_30_00.xmp'
+    """
+    path = Path(photo_filename)
+    return path.stem + '.xmp'
+
+
+# ============================================================================
+# Taxonomy Keyword Builders
+# ============================================================================
+
+def build_taxonomy_keywords(species_name: str | None) -> list[str]:
+    """
+    Build hierarchical taxonomy keywords from species name.
+
+    Generates taxonomy keywords in the format "taxonomy:rank=name" based on
+    scientific name parsing. For Linnaean binomial names (Genus species),
+    generates kingdom, phylum, class, order, family, genus, and species keywords.
+
+    Args:
+        species_name: Scientific species name (e.g., "Actias luna")
+
+    Returns:
+        List of taxonomy keywords (e.g., ["taxonomy:kingdom=Animalia", ...])
+
+    Example:
+        >>> build_taxonomy_keywords("Actias luna")
+        ['taxonomy:kingdom=Animalia', 'taxonomy:phylum=Arthropoda',
+         'taxonomy:class=Insecta', 'taxonomy:order=Lepidoptera',
+         'taxonomy:family=Saturniidae', 'taxonomy:genus=Actias',
+         'taxonomy:species=Actias luna']
+
+    Note:
+        This is a simplified implementation that assumes all Mothbox specimens
+        are insects (Animalia > Arthropoda > Insecta > Lepidoptera). For full
+        taxonomic hierarchy, integration with a taxonomy database (e.g., GBIF)
+        would be required.
+    """
+    if not species_name:
+        return []
+
+    keywords = []
+
+    # All Mothbox specimens are insects (moths/butterflies)
+    # This is a reasonable assumption for a moth camera trap system
+    keywords.append("taxonomy:kingdom=Animalia")
+    keywords.append("taxonomy:phylum=Arthropoda")
+    keywords.append("taxonomy:class=Insecta")
+    keywords.append("taxonomy:order=Lepidoptera")
+
+    # Parse genus and species from binomial name
+    parts = species_name.strip().split()
+    if len(parts) >= 1:
+        # Add genus
+        genus = parts[0]
+        keywords.append(f"taxonomy:genus={genus}")
+
+        # Add full species name
+        if len(parts) >= 2:
+            keywords.append(f"taxonomy:species={species_name}")
+
+    return keywords
+
+
+# ============================================================================
+# Dublin Core Element Builders
+# ============================================================================
+
+def build_dc_title(title: str) -> ET.Element:
+    """
+    Build dc:title element with rdf:Alt structure.
+
+    Args:
+        title: Title text
+
+    Returns:
+        dc:title Element with rdf:Alt/rdf:li structure
+
+    Example:
+        <dc:title>
+          <rdf:Alt>
+            <rdf:li xml:lang="x-default">Luna Moth (Actias luna)</rdf:li>
+          </rdf:Alt>
+        </dc:title>
+    """
+    title_elem = ET.Element(f"{{{XMP_NAMESPACES['dc']}}}title")
+    alt = ET.SubElement(title_elem, f"{{{XMP_NAMESPACES['rdf']}}}Alt")
+    li = ET.SubElement(alt, f"{{{XMP_NAMESPACES['rdf']}}}li")
+    li.set('{http://www.w3.org/XML/1998/namespace}lang', 'x-default')
+    li.text = title
+    return title_elem
+
+
+def build_dc_description(description: str) -> ET.Element:
+    """
+    Build dc:description element with rdf:Alt structure.
+
+    Args:
+        description: Description text
+
+    Returns:
+        dc:description Element with rdf:Alt/rdf:li structure
+
+    Example:
+        <dc:description>
+          <rdf:Alt>
+            <rdf:li xml:lang="x-default">Beautiful green moth specimen</rdf:li>
+          </rdf:Alt>
+        </dc:description>
+    """
+    desc_elem = ET.Element(f"{{{XMP_NAMESPACES['dc']}}}description")
+    alt = ET.SubElement(desc_elem, f"{{{XMP_NAMESPACES['rdf']}}}Alt")
+    li = ET.SubElement(alt, f"{{{XMP_NAMESPACES['rdf']}}}li")
+    li.set('{http://www.w3.org/XML/1998/namespace}lang', 'x-default')
+    li.text = description
+    return desc_elem
+
+
+def build_dc_subject(tags: list[str], taxonomy_keywords: list[str]) -> ET.Element:
+    """
+    Build dc:subject element with rdf:Bag structure.
+
+    Combines user tags and taxonomy keywords into a single bag of keywords.
+
+    Args:
+        tags: User-defined tags (e.g., ["moth", "nocturnal"])
+        taxonomy_keywords: Taxonomy keywords (e.g., ["taxonomy:species=Actias luna"])
+
+    Returns:
+        dc:subject Element with rdf:Bag/rdf:li structure
+
+    Example:
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>taxonomy:kingdom=Animalia</rdf:li>
+            <rdf:li>taxonomy:species=Actias luna</rdf:li>
+            <rdf:li>moth</rdf:li>
+            <rdf:li>nocturnal</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+    """
+    subject_elem = ET.Element(f"{{{XMP_NAMESPACES['dc']}}}subject")
+    bag = ET.SubElement(subject_elem, f"{{{XMP_NAMESPACES['rdf']}}}Bag")
+
+    # Add all keywords (taxonomy first, then user tags)
+    all_keywords = taxonomy_keywords + tags
+    for keyword in all_keywords:
+        li = ET.SubElement(bag, f"{{{XMP_NAMESPACES['rdf']}}}li")
+        li.text = keyword
+
+    return subject_elem
+
+
+def build_dc_creator(creator: str) -> ET.Element:
+    """
+    Build dc:creator element with rdf:Seq structure.
+
+    Args:
+        creator: Creator name
+
+    Returns:
+        dc:creator Element with rdf:Seq/rdf:li structure
+
+    Example:
+        <dc:creator>
+          <rdf:Seq>
+            <rdf:li>Mothbox</rdf:li>
+          </rdf:Seq>
+        </dc:creator>
+    """
+    creator_elem = ET.Element(f"{{{XMP_NAMESPACES['dc']}}}creator")
+    seq = ET.SubElement(creator_elem, f"{{{XMP_NAMESPACES['rdf']}}}Seq")
+    li = ET.SubElement(seq, f"{{{XMP_NAMESPACES['rdf']}}}li")
+    li.text = creator
+    return creator_elem
+
+
+def build_dc_rights(license: str) -> ET.Element:
+    """
+    Build dc:rights element with rdf:Alt structure.
+
+    Args:
+        license: License/rights statement
+
+    Returns:
+        dc:rights Element with rdf:Alt/rdf:li structure
+
+    Example:
+        <dc:rights>
+          <rdf:Alt>
+            <rdf:li xml:lang="x-default">CC BY-NC 4.0</rdf:li>
+          </rdf:Alt>
+        </dc:rights>
+    """
+    rights_elem = ET.Element(f"{{{XMP_NAMESPACES['dc']}}}rights")
+    alt = ET.SubElement(rights_elem, f"{{{XMP_NAMESPACES['rdf']}}}Alt")
+    li = ET.SubElement(alt, f"{{{XMP_NAMESPACES['rdf']}}}li")
+    li.set('{http://www.w3.org/XML/1998/namespace}lang', 'x-default')
+    li.text = license
+    return rights_elem
+
+
+# ============================================================================
+# IPTC Extension Element Builders
+# ============================================================================
+
+def build_location_shown(
+    lat: float,
+    lon: float,
+    alt: float | None = None,
+    name: str | None = None
+) -> ET.Element:
+    """
+    Build Iptc4xmpExt:LocationShown element with geographic data.
+
+    Args:
+        lat: Latitude in decimal degrees
+        lon: Longitude in decimal degrees
+        alt: Altitude in meters (optional)
+        name: Location name (optional)
+
+    Returns:
+        Iptc4xmpExt:LocationShown Element with rdf:Bag/rdf:li structure
+
+    Example:
+        <Iptc4xmpExt:LocationShown>
+          <rdf:Bag>
+            <rdf:li rdf:parseType="Resource">
+              <Iptc4xmpExt:Latitude>35.9606</Iptc4xmpExt:Latitude>
+              <Iptc4xmpExt:Longitude>-83.9207</Iptc4xmpExt:Longitude>
+              <Iptc4xmpExt:Altitude>350.5</Iptc4xmpExt:Altitude>
+              <Iptc4xmpExt:LocationName>Oak Ridge, TN</Iptc4xmpExt:LocationName>
+            </rdf:li>
+          </rdf:Bag>
+        </Iptc4xmpExt:LocationShown>
+    """
+    location_elem = ET.Element(f"{{{XMP_NAMESPACES['Iptc4xmpExt']}}}LocationShown")
+    bag = ET.SubElement(location_elem, f"{{{XMP_NAMESPACES['rdf']}}}Bag")
+    li = ET.SubElement(bag, f"{{{XMP_NAMESPACES['rdf']}}}li")
+    li.set(f"{{{XMP_NAMESPACES['rdf']}}}parseType", 'Resource')
+
+    # Latitude (required)
+    lat_elem = ET.SubElement(li, f"{{{XMP_NAMESPACES['Iptc4xmpExt']}}}Latitude")
+    lat_elem.text = str(lat)
+
+    # Longitude (required)
+    lon_elem = ET.SubElement(li, f"{{{XMP_NAMESPACES['Iptc4xmpExt']}}}Longitude")
+    lon_elem.text = str(lon)
+
+    # Altitude (optional)
+    if alt is not None:
+        alt_elem = ET.SubElement(li, f"{{{XMP_NAMESPACES['Iptc4xmpExt']}}}Altitude")
+        alt_elem.text = str(alt)
+
+    # Location name (optional)
+    if name:
+        name_elem = ET.SubElement(li, f"{{{XMP_NAMESPACES['Iptc4xmpExt']}}}LocationName")
+        name_elem.text = name
+
+    return location_elem
+
+
+# ============================================================================
+# XMP Document Builders
+# ============================================================================
+
+def build_xmp_document(metadata: ExportMetadata) -> ET.ElementTree:
+    """
+    Build complete XMP document from export metadata.
+
+    Args:
+        metadata: Export metadata containing photo information
+
+    Returns:
+        ElementTree containing complete XMP structure
+
+    Structure:
+        <x:xmpmeta>
+          <rdf:RDF>
+            <rdf:Description rdf:about="">
+              <!-- Dublin Core elements -->
+              <dc:title>...</dc:title>
+              <dc:description>...</dc:description>
+              <dc:subject>...</dc:subject>
+              <dc:creator>...</dc:creator>
+              <dc:rights>...</dc:rights>
+
+              <!-- XMP elements -->
+              <xmp:CreateDate>...</xmp:CreateDate>
+
+              <!-- Photoshop elements -->
+              <photoshop:City>...</photoshop:City>
+              <photoshop:Country>...</photoshop:Country>
+
+              <!-- IPTC Extension elements -->
+              <Iptc4xmpExt:LocationShown>...</Iptc4xmpExt:LocationShown>
+            </rdf:Description>
+          </rdf:RDF>
+        </x:xmpmeta>
+    """
+    # Create root xmpmeta element
+    xmpmeta = ET.Element(
+        f"{{{XMP_NAMESPACES['x']}}}xmpmeta",
+        attrib={f"{{{XMP_NAMESPACES['x']}}}xmptk": "Mothbox XMP Core 1.0"}
+    )
+
+    # Create RDF root
+    rdf = ET.SubElement(xmpmeta, f"{{{XMP_NAMESPACES['rdf']}}}RDF")
+
+    # Create Description element with all namespace declarations
+    desc = ET.SubElement(
+        rdf,
+        f"{{{XMP_NAMESPACES['rdf']}}}Description",
+        attrib={
+            f"{{{XMP_NAMESPACES['rdf']}}}about": '',
+            "xmlns:dc": XMP_NAMESPACES['dc'],
+            "xmlns:xmp": XMP_NAMESPACES['xmp'],
+            "xmlns:photoshop": XMP_NAMESPACES['photoshop'],
+            "xmlns:Iptc4xmpExt": XMP_NAMESPACES['Iptc4xmpExt'],
+        }
+    )
+
+    # Build title from common name and species name
+    title_parts = []
+    if metadata.species_common_name:
+        title_parts.append(metadata.species_common_name)
+    if metadata.species:
+        title_parts.append(f"({metadata.species})")
+    if title_parts:
+        title = ' '.join(title_parts)
+        desc.append(build_dc_title(title))
+
+    # Add description from notes
+    if metadata.notes:
+        desc.append(build_dc_description(metadata.notes))
+
+    # Build taxonomy keywords
+    taxonomy_keywords = build_taxonomy_keywords(metadata.species)
+
+    # Add subject (tags + taxonomy)
+    subject_elem = build_dc_subject(metadata.tags, taxonomy_keywords)
+    desc.append(subject_elem)
+
+    # Add creator (default to "Mothbox" if not specified)
+    creator = getattr(metadata, 'creator', 'Mothbox')
+    desc.append(build_dc_creator(creator))
+
+    # Add rights/license (default to CC BY-NC 4.0 if not specified)
+    license_text = getattr(metadata, 'license', 'CC BY-NC 4.0')
+    desc.append(build_dc_rights(license_text))
+
+    # Add create date
+    create_date = ET.SubElement(desc, f"{{{XMP_NAMESPACES['xmp']}}}CreateDate")
+    # timestamp is a string in ISO format
+    create_date.text = metadata.timestamp if metadata.timestamp else ""
+
+    # Add Photoshop elements if location data available
+    # Note: locality field doesn't exist in ExportMetadata, skip for now
+
+    if metadata.country_code:
+        country = ET.SubElement(desc, f"{{{XMP_NAMESPACES['photoshop']}}}Country")
+        country.text = metadata.country_code
+
+    # Add IPTC location if GPS coordinates available
+    if metadata.latitude is not None and metadata.longitude is not None:
+        location = build_location_shown(
+            lat=metadata.latitude,
+            lon=metadata.longitude,
+            alt=metadata.altitude,
+            name=metadata.deployment_location_name
+        )
+        desc.append(location)
+
+    return ET.ElementTree(xmpmeta)
+
+
+def generate_xmp_xml(metadata: ExportMetadata) -> str:
+    """
+    Generate complete XMP XML string with packet wrapper.
+
+    This is the main entry point for XMP generation. Creates a complete
+    XMP packet suitable for writing to a .xmp sidecar file.
+
+    Args:
+        metadata: Export metadata containing photo information
+
+    Returns:
+        Complete XMP XML string with packet wrapper
+
+    Example:
+        >>> from webui.backend.services.export_metadata_service import ExportMetadata
+        >>> metadata = ExportMetadata(...)
+        >>> xmp_xml = generate_xmp_xml(metadata)
+        >>> with open("photo.xmp", "w", encoding="utf-8") as f:
+        ...     f.write(xmp_xml)
+    """
+    # Build XMP document
+    tree = build_xmp_document(metadata)
+
+    # Convert to string with XML declaration
+    xml_str = ET.tostring(
+        tree.getroot(),
+        encoding='unicode',
+        method='xml'
+    )
+
+    # Add XMP packet wrapper
+    xmp_packet = f'''<?xml version="1.0" encoding="UTF-8"?>
+<?xpacket begin="" id="W5M0MpCehiHzreSzNTczkc9d"?>
+{xml_str}
+<?xpacket end="w"?>'''
+
+    return xmp_packet
+
+
+# ============================================================================
+# Convenience Functions
+# ============================================================================
+
+def write_xmp_sidecar(metadata: ExportMetadata, output_path: Path) -> None:
+    """
+    Write XMP sidecar file to disk.
+
+    Args:
+        metadata: Export metadata containing photo information
+        output_path: Path where XMP file should be written
+
+    Example:
+        >>> from pathlib import Path
+        >>> metadata = ExportMetadata(...)
+        >>> write_xmp_sidecar(metadata, Path("photo.xmp"))
+    """
+    xmp_xml = generate_xmp_xml(metadata)
+
+    with open(output_path, 'w', encoding='utf-8') as f:
+        f.write(xmp_xml)

--- a/Firmware/webui/backend/lib/xmp_sidecar.py
+++ b/Firmware/webui/backend/lib/xmp_sidecar.py
@@ -48,33 +48,6 @@ for prefix, uri in XMP_NAMESPACES.items():
 # XML Utility Functions
 # ============================================================================
 
-def escape_xml_text(text: str) -> str:
-    """
-    Escape special XML characters.
-
-    Args:
-        text: Text to escape
-
-    Returns:
-        Escaped text safe for XML content
-
-    Note:
-        ElementTree handles escaping automatically, but this function
-        is provided for manual escaping when needed.
-    """
-    if not text:
-        return text
-
-    # XML special characters
-    text = text.replace('&', '&amp;')
-    text = text.replace('<', '&lt;')
-    text = text.replace('>', '&gt;')
-    text = text.replace('"', '&quot;')
-    text = text.replace("'", '&apos;')
-
-    return text
-
-
 def validate_xmp_xml(xml_string: str) -> bool:
     """
     Validate that XML string is well-formed.
@@ -359,18 +332,18 @@ def build_location_shown(
     li = ET.SubElement(bag, f"{{{XMP_NAMESPACES['rdf']}}}li")
     li.set(f"{{{XMP_NAMESPACES['rdf']}}}parseType", 'Resource')
 
-    # Latitude (required)
+    # Latitude (required) - 8 decimal places provides ~1.1mm precision
     lat_elem = ET.SubElement(li, f"{{{XMP_NAMESPACES['Iptc4xmpExt']}}}Latitude")
-    lat_elem.text = str(lat)
+    lat_elem.text = f"{lat:.8f}"
 
-    # Longitude (required)
+    # Longitude (required) - 8 decimal places provides ~1.1mm precision
     lon_elem = ET.SubElement(li, f"{{{XMP_NAMESPACES['Iptc4xmpExt']}}}Longitude")
-    lon_elem.text = str(lon)
+    lon_elem.text = f"{lon:.8f}"
 
-    # Altitude (optional)
+    # Altitude (optional) - 2 decimal places for meters
     if alt is not None:
         alt_elem = ET.SubElement(li, f"{{{XMP_NAMESPACES['Iptc4xmpExt']}}}Altitude")
-        alt_elem.text = str(alt)
+        alt_elem.text = f"{alt:.2f}"
 
     # Location name (optional)
     if name:

--- a/Firmware/webui/backend/lib/zip_export.py
+++ b/Firmware/webui/backend/lib/zip_export.py
@@ -13,15 +13,39 @@ Performance target: 50 photos < 5 seconds
 import csv
 import io
 import json
+import logging
 import time
 from collections.abc import Generator
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
-from zipfile import ZIP_STORED, ZipFile
+from zipfile import ZIP_STORED, BadZipFile, ZipFile
 
 from webui.backend.lib.xmp_sidecar import generate_xmp_xml, get_xmp_sidecar_filename
+
+logger = logging.getLogger(__name__)
+
+
+# ============================================================================
+# Exceptions
+# ============================================================================
+
+
+class ZipExportError(Exception):
+    """Base exception for ZIP export operations."""
+
+
+class PhotoFileError(ZipExportError):
+    """Error related to photo file access (not found, permission denied)."""
+
+
+class XMPGenerationError(ZipExportError):
+    """Error during XMP sidecar generation."""
+
+
+class ZipWriteError(ZipExportError):
+    """Error during ZIP file writing (disk full, corruption)."""
 
 if TYPE_CHECKING:
     from webui.backend.services.export_metadata_service import ExportMetadata
@@ -33,7 +57,6 @@ if TYPE_CHECKING:
 
 ZIP_COMPRESSION_LEVEL: Final[int] = 0  # No compression for JPEGs (already compressed)
 ZIP_BUFFER_SIZE: Final[int] = 8192  # 8KB streaming buffer
-MAX_ZIP_FILE_SIZE: Final[int] = 2 * 1024 * 1024 * 1024  # 2GB limit
 MANIFEST_FILENAME: Final[str] = 'manifest.json'
 SUMMARY_FILENAME: Final[str] = 'summary.csv'
 GENERATOR_VERSION: Final[str] = '5.0.0'  # Mothbox version
@@ -217,7 +240,7 @@ def add_photo_to_zip(
         include_xmp: Whether to include XMP sidecar
 
     Returns:
-        Dict with: filename, xmp_filename (if generated), size, success, error
+        Dict with: filename, xmp_filename (if generated), size, success, error, error_type
     """
     result = {
         'filename': metadata.filename,
@@ -230,6 +253,7 @@ def add_photo_to_zip(
         # Add photo to ZIP
         if not photo_path.exists():
             result['error'] = f"Photo file not found: {photo_path}"
+            result['error_type'] = 'not_found'
             return result
 
         # Write photo with no compression (already JPEG)
@@ -245,8 +269,29 @@ def add_photo_to_zip(
 
         result['success'] = True
 
+    except PermissionError as e:
+        logger.warning("Permission denied reading photo %s: %s", photo_path, e)
+        result['error'] = "Permission denied reading photo file"
+        result['error_type'] = 'permission'
+
+    except OSError as e:
+        # Covers disk full, I/O errors, etc.
+        logger.error("OS error processing photo %s: %s", photo_path, e, exc_info=True)
+        error_msg = f"File system error: {e.strerror}" if hasattr(e, 'strerror') and e.strerror else "File system error"
+        result['error'] = error_msg
+        result['error_type'] = 'io'
+
+    except (ValueError, TypeError, AttributeError) as e:
+        # XMP generation errors
+        logger.warning("XMP generation failed for %s: %s", photo_path, e)
+        result['error'] = "Failed to generate XMP metadata"
+        result['error_type'] = 'xmp'
+
     except Exception as e:
-        result['error'] = str(e)
+        # Catch-all for unexpected errors (still log for debugging)
+        logger.exception("Unexpected error processing photo %s: %s", photo_path, e)
+        result['error'] = "Unexpected error processing photo"
+        result['error_type'] = 'unknown'
 
     return result
 
@@ -274,7 +319,16 @@ def validate_zip_integrity(zip_path: Path) -> bool:
             zf.testzip()  # Returns None if OK, filename if error
             return True
 
+    except BadZipFile:
+        logger.debug("Invalid ZIP file: %s", zip_path)
+        return False
+
+    except OSError as e:
+        logger.debug("Cannot read ZIP file %s: %s", zip_path, e)
+        return False
+
     except Exception:
+        logger.debug("Unknown error validating ZIP: %s", zip_path, exc_info=True)
         return False
 
 
@@ -396,9 +450,41 @@ def create_zip_export(
             took_ms=took_ms,
         )
 
+    except PermissionError as e:
+        took_ms = (time.time() - start_time) * 1000
+        logger.error("Permission denied creating ZIP at %s: %s", output_path, e)
+        errors.append({'error': 'Permission denied creating ZIP file', 'error_type': 'permission'})
+
+        return ZipExportResult(
+            success=False,
+            zip_path=None,
+            zip_size_bytes=0,
+            photo_count=photo_count,
+            xmp_count=xmp_count,
+            errors=errors,
+            took_ms=took_ms,
+        )
+
+    except OSError as e:
+        took_ms = (time.time() - start_time) * 1000
+        logger.error("OS error creating ZIP at %s: %s", output_path, e, exc_info=True)
+        error_msg = f"File system error: {e.strerror}" if hasattr(e, 'strerror') and e.strerror else "File system error"
+        errors.append({'error': error_msg, 'error_type': 'io'})
+
+        return ZipExportResult(
+            success=False,
+            zip_path=None,
+            zip_size_bytes=0,
+            photo_count=photo_count,
+            xmp_count=xmp_count,
+            errors=errors,
+            took_ms=took_ms,
+        )
+
     except Exception as e:
         took_ms = (time.time() - start_time) * 1000
-        errors.append({'error': str(e)})
+        logger.exception("Unexpected error creating ZIP: %s", e)
+        errors.append({'error': 'Unexpected error creating ZIP', 'error_type': 'unknown'})
 
         return ZipExportResult(
             success=False,
@@ -499,9 +585,41 @@ def stream_zip_export(
             took_ms=took_ms,
         )
 
+    except PermissionError as e:
+        took_ms = (time.time() - start_time) * 1000
+        logger.error("Permission denied during streaming ZIP: %s", e)
+        errors.append({'error': 'Permission denied reading photo file', 'error_type': 'permission'})
+
+        yield ZipExportResult(
+            success=False,
+            zip_path=None,
+            zip_size_bytes=total_bytes,
+            photo_count=photo_count,
+            xmp_count=xmp_count,
+            errors=errors,
+            took_ms=took_ms,
+        )
+
+    except OSError as e:
+        took_ms = (time.time() - start_time) * 1000
+        logger.error("OS error during streaming ZIP: %s", e, exc_info=True)
+        error_msg = f"File system error: {e.strerror}" if hasattr(e, 'strerror') and e.strerror else "File system error"
+        errors.append({'error': error_msg, 'error_type': 'io'})
+
+        yield ZipExportResult(
+            success=False,
+            zip_path=None,
+            zip_size_bytes=total_bytes,
+            photo_count=photo_count,
+            xmp_count=xmp_count,
+            errors=errors,
+            took_ms=took_ms,
+        )
+
     except Exception as e:
         took_ms = (time.time() - start_time) * 1000
-        errors.append({'error': str(e)})
+        logger.exception("Unexpected error during streaming ZIP: %s", e)
+        errors.append({'error': 'Unexpected error creating ZIP', 'error_type': 'unknown'})
 
         yield ZipExportResult(
             success=False,

--- a/Firmware/webui/backend/lib/zip_export.py
+++ b/Firmware/webui/backend/lib/zip_export.py
@@ -1,0 +1,514 @@
+"""
+ZIP export library for Mothbox photo collections.
+
+Creates memory-efficient ZIP archives containing:
+- Original photos (uncompressed - already JPEG)
+- XMP sidecar files ({photo}.xmp) with metadata
+- manifest.json with collection metadata
+- summary.csv with tabular metadata
+
+Performance target: 50 photos < 5 seconds
+"""
+
+import csv
+import io
+import json
+import time
+from collections.abc import Generator
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Final
+from zipfile import ZIP_STORED, ZipFile
+
+from webui.backend.lib.xmp_sidecar import generate_xmp_xml, get_xmp_sidecar_filename
+
+if TYPE_CHECKING:
+    from webui.backend.services.export_metadata_service import ExportMetadata
+
+
+# ============================================================================
+# Constants
+# ============================================================================
+
+ZIP_COMPRESSION_LEVEL: Final[int] = 0  # No compression for JPEGs (already compressed)
+ZIP_BUFFER_SIZE: Final[int] = 8192  # 8KB streaming buffer
+MAX_ZIP_FILE_SIZE: Final[int] = 2 * 1024 * 1024 * 1024  # 2GB limit
+MANIFEST_FILENAME: Final[str] = 'manifest.json'
+SUMMARY_FILENAME: Final[str] = 'summary.csv'
+GENERATOR_VERSION: Final[str] = '5.0.0'  # Mothbox version
+
+
+# ============================================================================
+# Data Classes
+# ============================================================================
+
+
+@dataclass
+class ZipExportOptions:
+    """Configuration for ZIP export."""
+
+    include_xmp_sidecars: bool = True
+    include_manifest: bool = True
+    include_csv_summary: bool = True  # User confirmed this feature
+    compression_level: int = 0  # 0 = no compression (best for JPEGs)
+    flatten_structure: bool = False  # If True, all files at root level
+
+
+@dataclass
+class ZipExportResult:
+    """Result of ZIP export operation."""
+
+    success: bool
+    zip_path: Path | None
+    zip_size_bytes: int
+    photo_count: int
+    xmp_count: int
+    errors: list[dict]
+    took_ms: float
+
+
+# ============================================================================
+# CSV Summary Generation
+# ============================================================================
+
+
+def generate_csv_summary(metadata_list: list['ExportMetadata']) -> str:
+    """Generate summary.csv content.
+
+    Columns: filename, timestamp, latitude, longitude, species, species_common_name, tags
+
+    Args:
+        metadata_list: List of ExportMetadata instances
+
+    Returns:
+        CSV content as string
+    """
+    output = io.StringIO()
+    writer = csv.DictWriter(
+        output,
+        fieldnames=[
+            'filename',
+            'timestamp',
+            'latitude',
+            'longitude',
+            'species',
+            'species_common_name',
+            'tags',
+        ],
+    )
+    writer.writeheader()
+
+    for metadata in metadata_list:
+        # Format tags as semicolon-separated string
+        tags_str = ""
+        if metadata.tags:
+            tags_str = "; ".join(metadata.tags)
+
+        writer.writerow({
+            'filename': metadata.filename or "",
+            'timestamp': metadata.timestamp or "",
+            'latitude': metadata.latitude if metadata.latitude is not None else "",
+            'longitude': metadata.longitude if metadata.longitude is not None else "",
+            'species': metadata.species or "",
+            'species_common_name': metadata.species_common_name or "",
+            'tags': tags_str,
+        })
+
+    return output.getvalue()
+
+
+# ============================================================================
+# Manifest Generation
+# ============================================================================
+
+
+def generate_manifest(
+    photo_paths: list[Path],
+    metadata_list: list['ExportMetadata'],
+    options: ZipExportOptions,
+) -> dict:
+    """Generate manifest.json content.
+
+    Structure:
+    {
+        "version": "1.0",
+        "generator": "Mothbox",
+        "generator_version": "5.0.0",
+        "created_at": "2024-01-15T12:00:00Z",
+        "export_format": "inaturalist",
+        "options": {...},
+        "photo_count": 50,
+        "total_size_bytes": 125000000,
+        "photos": [
+            {
+                "filename": "moth_2024_01_15.jpg",
+                "xmp_sidecar": "moth_2024_01_15.xmp",
+                "latitude": 37.7749,
+                "longitude": -122.4194,
+                "timestamp": "2024-01-15T10:00:00",
+                "species": "Actias luna"
+            }
+        ]
+    }
+
+    Args:
+        photo_paths: List of photo file paths
+        metadata_list: List of ExportMetadata instances
+        options: ZipExportOptions instance
+
+    Returns:
+        Manifest dictionary
+    """
+    # Calculate total size of all photos
+    total_size_bytes = 0
+    for path in photo_paths:
+        if path.exists():
+            total_size_bytes += path.stat().st_size
+
+    # Build photo entries
+    photos = []
+    for metadata in metadata_list:
+        photo_entry = {
+            'filename': metadata.filename,
+            'latitude': metadata.latitude,
+            'longitude': metadata.longitude,
+            'timestamp': metadata.timestamp,
+            'species': metadata.species,
+        }
+
+        # Add XMP sidecar filename if enabled
+        if options.include_xmp_sidecars and metadata.filename:
+            xmp_filename = get_xmp_sidecar_filename(metadata.filename)
+            photo_entry['xmp_sidecar'] = xmp_filename
+
+        photos.append(photo_entry)
+
+    manifest = {
+        'version': '1.0',
+        'generator': 'Mothbox',
+        'generator_version': GENERATOR_VERSION,
+        'created_at': datetime.now(UTC).isoformat(),
+        'photo_count': len(metadata_list),
+        'total_size_bytes': total_size_bytes,
+        'photos': photos,
+    }
+
+    return manifest
+
+
+# ============================================================================
+# Add Photo to ZIP
+# ============================================================================
+
+
+def add_photo_to_zip(
+    zip_file: ZipFile,
+    photo_path: Path,
+    metadata: 'ExportMetadata',
+    include_xmp: bool = True,
+) -> dict:
+    """Add photo and optional XMP sidecar to ZIP.
+
+    Args:
+        zip_file: ZipFile instance (opened in write mode)
+        photo_path: Path to photo file
+        metadata: ExportMetadata instance
+        include_xmp: Whether to include XMP sidecar
+
+    Returns:
+        Dict with: filename, xmp_filename (if generated), size, success, error
+    """
+    result = {
+        'filename': metadata.filename,
+        'xmp_filename': None,
+        'size': 0,
+        'success': False,
+    }
+
+    try:
+        # Add photo to ZIP
+        if not photo_path.exists():
+            result['error'] = f"Photo file not found: {photo_path}"
+            return result
+
+        # Write photo with no compression (already JPEG)
+        zip_file.write(photo_path, arcname=metadata.filename, compress_type=ZIP_STORED)
+        result['size'] = photo_path.stat().st_size
+
+        # Generate and add XMP sidecar if requested
+        if include_xmp:
+            xmp_content = generate_xmp_xml(metadata)
+            xmp_filename = get_xmp_sidecar_filename(metadata.filename)
+            zip_file.writestr(xmp_filename, xmp_content, compress_type=ZIP_STORED)
+            result['xmp_filename'] = xmp_filename
+
+        result['success'] = True
+
+    except Exception as e:
+        result['error'] = str(e)
+
+    return result
+
+
+# ============================================================================
+# ZIP Integrity Validation
+# ============================================================================
+
+
+def validate_zip_integrity(zip_path: Path) -> bool:
+    """Validate ZIP file integrity (can be opened and read).
+
+    Args:
+        zip_path: Path to ZIP file
+
+    Returns:
+        True if ZIP is valid, False otherwise
+    """
+    try:
+        if not zip_path.exists():
+            return False
+
+        with ZipFile(zip_path, 'r') as zf:
+            # Test ZIP integrity
+            zf.testzip()  # Returns None if OK, filename if error
+            return True
+
+    except Exception:
+        return False
+
+
+# ============================================================================
+# ZIP Size Estimation
+# ============================================================================
+
+
+def estimate_zip_size(
+    photo_paths: list[Path],
+    include_xmp: bool = True,
+) -> int:
+    """Estimate final ZIP size in bytes (for progress/validation).
+
+    Args:
+        photo_paths: List of photo file paths
+        include_xmp: Whether XMP sidecars will be included
+
+    Returns:
+        Estimated ZIP size in bytes
+    """
+    total_size = 0
+
+    for path in photo_paths:
+        try:
+            # Add photo size
+            total_size += path.stat().st_size
+
+            # Estimate XMP overhead (~2-5KB per file)
+            if include_xmp:
+                total_size += 3000  # Conservative estimate
+
+        except FileNotFoundError:
+            pass  # Skip missing files
+
+    # Add overhead for ZIP structure, manifest, CSV (~5%)
+    total_size = int(total_size * 1.05)
+
+    return total_size
+
+
+# ============================================================================
+# Create ZIP Export
+# ============================================================================
+
+
+def create_zip_export(
+    photo_paths: list[Path],
+    metadata_list: list['ExportMetadata'],
+    output_path: Path,
+    options: ZipExportOptions | None = None,
+) -> ZipExportResult:
+    """Create ZIP archive with photos and XMP sidecars.
+
+    Creates a ZIP containing:
+    - Original photos (uncompressed - already JPEG)
+    - XMP sidecar files ({photo}.xmp) if include_xmp_sidecars=True
+    - manifest.json if include_manifest=True
+    - summary.csv if include_csv_summary=True
+
+    Args:
+        photo_paths: List of photo file paths
+        metadata_list: List of ExportMetadata instances
+        output_path: Path where ZIP file will be created
+        options: ZipExportOptions (uses defaults if None)
+
+    Returns:
+        ZipExportResult with success status and statistics
+    """
+    start_time = time.time()
+    options = options or ZipExportOptions()
+
+    photo_count = 0
+    xmp_count = 0
+    errors = []
+
+    try:
+        with ZipFile(output_path, 'w', compression=ZIP_STORED) as zf:
+            # Add photos and XMP sidecars
+            for photo_path, metadata in zip(photo_paths, metadata_list, strict=True):
+                result = add_photo_to_zip(
+                    zf, photo_path, metadata, include_xmp=options.include_xmp_sidecars
+                )
+
+                if result['success']:
+                    photo_count += 1
+                    if result['xmp_filename']:
+                        xmp_count += 1
+                else:
+                    errors.append({
+                        'filename': metadata.filename,
+                        'error': result.get('error', 'Unknown error'),
+                    })
+
+            # Add manifest.json
+            if options.include_manifest:
+                manifest = generate_manifest(photo_paths, metadata_list, options)
+                manifest_json = json.dumps(manifest, indent=2)
+                zf.writestr(MANIFEST_FILENAME, manifest_json, compress_type=ZIP_STORED)
+
+            # Add summary.csv
+            if options.include_csv_summary:
+                csv_content = generate_csv_summary(metadata_list)
+                zf.writestr(SUMMARY_FILENAME, csv_content, compress_type=ZIP_STORED)
+
+        # Get final ZIP size
+        zip_size_bytes = output_path.stat().st_size if output_path.exists() else 0
+
+        # Calculate elapsed time
+        took_ms = (time.time() - start_time) * 1000
+
+        return ZipExportResult(
+            success=True,
+            zip_path=output_path,
+            zip_size_bytes=zip_size_bytes,
+            photo_count=photo_count,
+            xmp_count=xmp_count,
+            errors=errors,
+            took_ms=took_ms,
+        )
+
+    except Exception as e:
+        took_ms = (time.time() - start_time) * 1000
+        errors.append({'error': str(e)})
+
+        return ZipExportResult(
+            success=False,
+            zip_path=None,
+            zip_size_bytes=0,
+            photo_count=photo_count,
+            xmp_count=xmp_count,
+            errors=errors,
+            took_ms=took_ms,
+        )
+
+
+# ============================================================================
+# Stream ZIP Export
+# ============================================================================
+
+
+def stream_zip_export(
+    photo_paths: list[Path],
+    metadata_list: list['ExportMetadata'],
+    options: ZipExportOptions | None = None,
+) -> Generator[bytes | ZipExportResult]:
+    """Stream ZIP archive for HTTP response (memory efficient).
+
+    Yields bytes as ZIP is built, then yields ZipExportResult when done.
+
+    Args:
+        photo_paths: List of photo file paths
+        metadata_list: List of ExportMetadata instances
+        options: ZipExportOptions (uses defaults if None)
+
+    Yields:
+        ZIP file bytes in chunks, then ZipExportResult at the end
+    """
+    start_time = time.time()
+    options = options or ZipExportOptions()
+
+    photo_count = 0
+    xmp_count = 0
+    errors = []
+    total_bytes = 0
+
+    # Create in-memory ZIP file
+    zip_buffer = io.BytesIO()
+
+    try:
+        with ZipFile(zip_buffer, 'w', compression=ZIP_STORED) as zf:
+            # Add photos and XMP sidecars
+            for photo_path, metadata in zip(photo_paths, metadata_list, strict=True):
+                result = add_photo_to_zip(
+                    zf, photo_path, metadata, include_xmp=options.include_xmp_sidecars
+                )
+
+                if result['success']:
+                    photo_count += 1
+                    if result['xmp_filename']:
+                        xmp_count += 1
+                else:
+                    errors.append({
+                        'filename': metadata.filename,
+                        'error': result.get('error', 'Unknown error'),
+                    })
+
+            # Add manifest.json
+            if options.include_manifest:
+                manifest = generate_manifest(photo_paths, metadata_list, options)
+                manifest_json = json.dumps(manifest, indent=2)
+                zf.writestr(MANIFEST_FILENAME, manifest_json, compress_type=ZIP_STORED)
+
+            # Add summary.csv
+            if options.include_csv_summary:
+                csv_content = generate_csv_summary(metadata_list)
+                zf.writestr(SUMMARY_FILENAME, csv_content, compress_type=ZIP_STORED)
+
+        # Get ZIP content
+        zip_buffer.seek(0)
+        zip_content = zip_buffer.getvalue()
+        total_bytes = len(zip_content)
+
+        # Yield ZIP content in chunks
+        offset = 0
+        while offset < total_bytes:
+            chunk = zip_content[offset:offset + ZIP_BUFFER_SIZE]
+            yield chunk
+            offset += len(chunk)
+
+        # Calculate elapsed time
+        took_ms = (time.time() - start_time) * 1000
+
+        # Yield final result
+        yield ZipExportResult(
+            success=True,
+            zip_path=None,  # No file path for streaming
+            zip_size_bytes=total_bytes,
+            photo_count=photo_count,
+            xmp_count=xmp_count,
+            errors=errors,
+            took_ms=took_ms,
+        )
+
+    except Exception as e:
+        took_ms = (time.time() - start_time) * 1000
+        errors.append({'error': str(e)})
+
+        yield ZipExportResult(
+            success=False,
+            zip_path=None,
+            zip_size_bytes=total_bytes,
+            photo_count=photo_count,
+            xmp_count=xmp_count,
+            errors=errors,
+            took_ms=took_ms,
+        )

--- a/Firmware/webui/backend/routes/export.py
+++ b/Firmware/webui/backend/routes/export.py
@@ -930,61 +930,74 @@ def export_inaturalist_batch():
                 }), 403
             resolved_paths.append(Path(validated_path))
 
-        # Create temporary directory for ZIP file (auto-cleaned on context exit)
+        # Create temporary file for ZIP
         import tempfile
-        with tempfile.TemporaryDirectory(prefix='inaturalist_export_') as tmpdir:
-            output_path = Path(tmpdir) / "export.zip"
+        with tempfile.NamedTemporaryFile(
+            suffix='.zip', prefix='inaturalist_export_', delete=False
+        ) as temp_fd:
+            output_path = Path(temp_fd.name)
 
-            try:
-                # Generate ZIP export
-                result = service.transform_batch_to_inaturalist_zip(
-                    resolved_paths,
+        try:
+            # Generate ZIP export
+            result = service.transform_batch_to_inaturalist_zip(
+                resolved_paths,
+                output_path,
+                options
+            )
+
+            if not result.success:
+                # Clean up temp file on error
+                if output_path.exists():
+                    output_path.unlink()
+                return jsonify({
+                    "error": "ZIP export failed",
+                    "details": result.errors
+                }), 500
+
+            # Determine response format based on Accept header
+            accept = request.headers.get('Accept', 'application/json')
+
+            if 'application/zip' in accept:
+                # ZIP file download with cleanup after response
+                from flask import after_this_request, send_file
+                timestamp = datetime.now(UTC).strftime('%Y%m%d_%H%M%S')
+                filename = f"inaturalist_export_{timestamp}.zip"
+
+                @after_this_request
+                def cleanup_temp_file(response):
+                    try:
+                        if output_path.exists():
+                            output_path.unlink()
+                    except Exception:
+                        pass  # Best effort cleanup
+                    return response
+
+                return send_file(
                     output_path,
-                    options
+                    mimetype='application/zip',
+                    as_attachment=True,
+                    download_name=filename,
                 )
+            else:
+                # JSON response - clean up temp file immediately
+                zip_size = result.zip_size_bytes
+                if output_path.exists():
+                    output_path.unlink()
+                return jsonify({
+                    "success": result.success,
+                    "zip_size_bytes": zip_size,
+                    "photo_count": result.photo_count,
+                    "xmp_count": result.xmp_count,
+                    "errors": result.errors,
+                    "took_ms": result.took_ms,
+                }), 200
 
-                if not result.success:
-                    return jsonify({
-                        "error": "ZIP export failed",
-                        "details": result.errors
-                    }), 500
-
-                # Determine response format based on Accept header
-                accept = request.headers.get('Accept', 'application/json')
-
-                if 'application/zip' in accept:
-                    # ZIP file download - read into memory for response
-                    # (temp dir cleaned after response sent)
-                    import io
-
-                    from flask import send_file
-                    timestamp = datetime.now(UTC).strftime('%Y%m%d_%H%M%S')
-                    filename = f"inaturalist_export_{timestamp}.zip"
-
-                    # Read file into BytesIO to allow temp dir cleanup
-                    zip_data = io.BytesIO(output_path.read_bytes())
-                    zip_data.seek(0)
-
-                    return send_file(
-                        zip_data,
-                        mimetype='application/zip',
-                        as_attachment=True,
-                        download_name=filename,
-                    )
-                else:
-                    # JSON with status - temp file path not useful to client
-                    return jsonify({
-                        "success": result.success,
-                        "zip_size_bytes": result.zip_size_bytes,
-                        "photo_count": result.photo_count,
-                        "xmp_count": result.xmp_count,
-                        "errors": result.errors,
-                        "took_ms": result.took_ms,
-                    }), 200
-
-            except Exception as e:
-                logger.error("Error creating iNaturalist ZIP: %s", e, exc_info=True)
-                return jsonify({"error": "ZIP export failed"}), 500
+        except Exception as e:
+            logger.error("Error creating iNaturalist ZIP: %s", e, exc_info=True)
+            # Clean up temp file on error
+            if output_path.exists():
+                output_path.unlink()
+            return jsonify({"error": "ZIP export failed"}), 500
 
     except Exception as e:
         logger.error("Error in iNaturalist batch export: %s", e, exc_info=True)
@@ -1069,63 +1082,76 @@ def export_deployment_inaturalist(deployment_path: str):
             flatten_structure=False,
         )
 
-        # Create temporary directory for ZIP file (auto-cleaned on context exit)
+        # Create temporary file for ZIP
         import tempfile
-        with tempfile.TemporaryDirectory(prefix='inaturalist_deployment_') as tmpdir:
-            output_path = Path(tmpdir) / "export.zip"
+        with tempfile.NamedTemporaryFile(
+            suffix='.zip', prefix='inaturalist_deployment_', delete=False
+        ) as temp_fd:
+            output_path = Path(temp_fd.name)
 
-            try:
-                # Generate ZIP export
-                result = service.transform_batch_to_inaturalist_zip(
-                    photo_paths,
+        try:
+            # Generate ZIP export
+            result = service.transform_batch_to_inaturalist_zip(
+                photo_paths,
+                output_path,
+                options
+            )
+
+            if not result.success:
+                # Clean up temp file on error
+                if output_path.exists():
+                    output_path.unlink()
+                return jsonify({
+                    "error": "ZIP export failed",
+                    "details": result.errors
+                }), 500
+
+            # Determine response format based on Accept header
+            accept = request.headers.get('Accept', 'application/json')
+
+            if 'application/zip' in accept:
+                # ZIP file download with cleanup after response
+                from flask import after_this_request, send_file
+                timestamp = datetime.now(UTC).strftime('%Y%m%d_%H%M%S')
+                # Sanitize deployment path for filename
+                safe_name = deployment_path.replace('/', '_').replace('\\', '_')
+                filename = f"inaturalist_{safe_name}_{timestamp}.zip"
+
+                @after_this_request
+                def cleanup_deployment_temp_file(response):
+                    try:
+                        if output_path.exists():
+                            output_path.unlink()
+                    except Exception:
+                        pass  # Best effort cleanup
+                    return response
+
+                return send_file(
                     output_path,
-                    options
+                    mimetype='application/zip',
+                    as_attachment=True,
+                    download_name=filename,
                 )
+            else:
+                # JSON response - clean up temp file immediately
+                zip_size = result.zip_size_bytes
+                if output_path.exists():
+                    output_path.unlink()
+                return jsonify({
+                    "success": result.success,
+                    "zip_size_bytes": zip_size,
+                    "photo_count": result.photo_count,
+                    "xmp_count": result.xmp_count,
+                    "errors": result.errors,
+                    "took_ms": result.took_ms,
+                }), 200
 
-                if not result.success:
-                    return jsonify({
-                        "error": "ZIP export failed",
-                        "details": result.errors
-                    }), 500
-
-                # Determine response format based on Accept header
-                accept = request.headers.get('Accept', 'application/json')
-
-                if 'application/zip' in accept:
-                    # ZIP file download - read into memory for response
-                    # (temp dir cleaned after response sent)
-                    import io
-
-                    from flask import send_file
-                    timestamp = datetime.now(UTC).strftime('%Y%m%d_%H%M%S')
-                    # Sanitize deployment path for filename
-                    safe_name = deployment_path.replace('/', '_').replace('\\', '_')
-                    filename = f"inaturalist_{safe_name}_{timestamp}.zip"
-
-                    # Read file into BytesIO to allow temp dir cleanup
-                    zip_data = io.BytesIO(output_path.read_bytes())
-                    zip_data.seek(0)
-
-                    return send_file(
-                        zip_data,
-                        mimetype='application/zip',
-                        as_attachment=True,
-                        download_name=filename,
-                    )
-                else:
-                    # JSON with status - temp file path not useful to client
-                    return jsonify({
-                        "success": result.success,
-                        "zip_size_bytes": result.zip_size_bytes,
-                        "photo_count": result.photo_count,
-                        "xmp_count": result.xmp_count,
-                        "errors": result.errors,
-                        "took_ms": result.took_ms,
-                    }), 200
-
-            except Exception as e:
-                logger.error("Error creating iNaturalist ZIP: %s", e, exc_info=True)
-                return jsonify({"error": "ZIP export failed"}), 500
+        except Exception as e:
+            logger.error("Error creating iNaturalist ZIP: %s", e, exc_info=True)
+            # Clean up temp file on error
+            if output_path.exists():
+                output_path.unlink()
+            return jsonify({"error": "ZIP export failed"}), 500
 
     except Exception as e:
         logger.error("Error in iNaturalist deployment export: %s", e, exc_info=True)

--- a/Firmware/webui/backend/routes/export.py
+++ b/Firmware/webui/backend/routes/export.py
@@ -1,13 +1,16 @@
 """
-Export API routes (Issues #112, #116)
+Export API routes (Issues #112, #116, #118)
 
-Endpoints for export metadata service with Darwin Core CSV support.
+Endpoints for export metadata service with Darwin Core CSV and iNaturalist ZIP support.
 
 Endpoints:
 - GET /api/export/metadata/<path:photo_path> - Get export metadata for single photo
 - POST /api/export/metadata/batch - Get export metadata for multiple photos
 - POST /api/export/darwin-core/batch - Batch Darwin Core CSV export
 - GET /api/export/darwin-core/deployment/<path> - Export deployment as Darwin Core CSV
+- POST /api/export/inaturalist/batch - Batch iNaturalist ZIP export
+- GET /api/export/inaturalist/deployment/<path> - Export deployment as iNaturalist ZIP
+- POST /api/export/inaturalist/preview - Preview iNaturalist export (dry run)
 - GET /api/export/formats - List supported export formats
 - GET /api/export/stats - Get service statistics
 
@@ -300,9 +303,9 @@ def list_export_formats():
                 },
                 {
                     "id": "inaturalist",
-                    "name": "iNaturalist CSV",
-                    "description": "iNaturalist observation format",
-                    "implemented": false
+                    "name": "iNaturalist ZIP",
+                    "description": "iNaturalist-compatible ZIP with XMP sidecars",
+                    "implemented": true
                 },
                 {
                     "id": "json",
@@ -329,10 +332,18 @@ def list_export_formats():
             },
             {
                 "id": ExportFormat.INATURALIST.value,
-                "name": "iNaturalist CSV",
-                "description": "iNaturalist observation format",
-                "implemented": False,
-                "note": "Will be implemented in Issue #118"
+                "name": "iNaturalist ZIP",
+                "description": "iNaturalist-compatible ZIP with XMP sidecars",
+                "implemented": True,
+                "features": [
+                    "XMP sidecar files",
+                    "Hierarchical taxonomy keywords",
+                    "GPS coordinates",
+                    "Observation notes",
+                    "License information",
+                    "CSV summary",
+                    "JSON manifest"
+                ]
             },
             {
                 "id": ExportFormat.GENERIC_JSON.value,
@@ -794,3 +805,486 @@ def export_deployment_darwin_core(deployment_path: str):
     except Exception as e:
         logger.error("Error in Darwin Core deployment export: %s", e, exc_info=True)
         return jsonify({"error": "Darwin Core deployment export failed"}), 500
+
+
+# ============================================================================
+# iNaturalist Export Endpoints
+# ============================================================================
+
+
+@export_bp.route("/inaturalist/batch", methods=["POST"])
+@limiter.limit("5 per minute")
+def export_inaturalist_batch():
+    """
+    Export multiple photos as iNaturalist ZIP with XMP sidecars.
+
+    Supports dual response format based on Accept header:
+    - Accept: application/zip → ZIP file download
+    - Accept: application/json → JSON with status and file path
+
+    Request Body:
+        {
+            "photo_paths": ["photo1.jpg", "subdir/photo2.jpg", ...],
+            "options": {
+                "include_xmp_sidecars": true,
+                "include_manifest": true,
+                "include_csv_summary": true,
+                "flatten_structure": false
+            }
+        }
+
+    Returns:
+        200: ZIP file or JSON with status
+        400: Invalid request body
+        500: Internal error
+
+    Response (JSON):
+        {
+            "success": true,
+            "zip_path": "/tmp/export_123.zip",
+            "zip_size_bytes": 12500000,
+            "photo_count": 50,
+            "xmp_count": 50,
+            "took_ms": 3500.5
+        }
+
+    Error Response:
+        {
+            "error": "No photos specified",
+            "details": "photo_paths array is required and must not be empty"
+        }
+    """
+    try:
+        # Get service from app config
+        service = current_app.config.get('EXPORT_METADATA_SERVICE')
+        if service is None:
+            return jsonify({"error": "Export service not available"}), 500
+
+        # Validate request body
+        if not request.is_json:
+            return jsonify({"error": "Request must be JSON"}), 400
+
+        try:
+            data = request.get_json()
+        except Exception:
+            return jsonify({"error": "Invalid JSON in request body"}), 400
+
+        if not data or 'photo_paths' not in data:
+            return jsonify({
+                "error": "No photos specified",
+                "details": "photo_paths array is required and must not be empty"
+            }), 400
+
+        photo_paths = data['photo_paths']
+
+        if not isinstance(photo_paths, list):
+            return jsonify({"error": "'photo_paths' must be an array"}), 400
+
+        # Validate all paths are non-empty strings
+        if not all(isinstance(p, str) and p.strip() for p in photo_paths):
+            return jsonify({"error": "All photo_paths must be non-empty strings"}), 400
+
+        if len(photo_paths) == 0:
+            return jsonify({
+                "error": "No photos specified",
+                "details": "photo_paths array is required and must not be empty"
+            }), 400
+
+        # Get configurable batch size limit
+        max_batch_size = current_app.config.get('EXPORT_MAX_BATCH_SIZE', 1000)
+
+        if len(photo_paths) > max_batch_size:
+            return jsonify({
+                "error": f"Batch size exceeds maximum limit of {max_batch_size} photos"
+            }), 400
+
+        # Parse options
+        from webui.backend.lib.zip_export import ZipExportOptions
+
+        options_data = data.get('options', {})
+        options = ZipExportOptions(
+            include_xmp_sidecars=options_data.get('include_xmp_sidecars', True),
+            include_manifest=options_data.get('include_manifest', True),
+            include_csv_summary=options_data.get('include_csv_summary', True),
+            flatten_structure=options_data.get('flatten_structure', False),
+        )
+
+        # Validate and resolve all paths with security checks
+        from pathlib import Path
+        resolved_paths = []
+        for photo_path in photo_paths:
+            # Path traversal protection
+            validated_path = validate_photo_path(photo_path, PHOTOS_DIR)
+            if validated_path is None:
+                return jsonify({
+                    "error": "Invalid path",
+                    "details": f"Path validation failed for: {photo_path}"
+                }), 403
+            resolved_paths.append(Path(validated_path))
+
+        # Create temporary ZIP file
+        import tempfile
+        temp_fd, temp_path = tempfile.mkstemp(suffix='.zip', prefix='inaturalist_export_')
+        import os
+        os.close(temp_fd)  # Close file descriptor
+        output_path = Path(temp_path)
+
+        try:
+            # Generate ZIP export
+            result = service.transform_batch_to_inaturalist_zip(
+                resolved_paths,
+                output_path,
+                options
+            )
+
+            if not result.success:
+                return jsonify({
+                    "error": "ZIP export failed",
+                    "details": result.errors
+                }), 500
+
+            # Determine response format based on Accept header
+            accept = request.headers.get('Accept', 'application/json')
+
+            if 'application/zip' in accept:
+                # ZIP file download
+                from flask import send_file
+                timestamp = datetime.now(UTC).strftime('%Y%m%d_%H%M%S')
+                filename = f"inaturalist_export_{timestamp}.zip"
+
+                return send_file(
+                    output_path,
+                    mimetype='application/zip',
+                    as_attachment=True,
+                    download_name=filename,
+                )
+            else:
+                # JSON with status
+                return jsonify({
+                    "success": result.success,
+                    "zip_path": str(result.zip_path),
+                    "zip_size_bytes": result.zip_size_bytes,
+                    "photo_count": result.photo_count,
+                    "xmp_count": result.xmp_count,
+                    "errors": result.errors,
+                    "took_ms": result.took_ms,
+                }), 200
+
+        except Exception as e:
+            logger.error("Error creating iNaturalist ZIP: %s", e, exc_info=True)
+            # Clean up temp file on error
+            if output_path.exists():
+                output_path.unlink()
+            return jsonify({"error": "ZIP export failed"}), 500
+
+    except Exception as e:
+        logger.error("Error in iNaturalist batch export: %s", e, exc_info=True)
+        return jsonify({"error": "iNaturalist batch export failed"}), 500
+
+
+@export_bp.route("/inaturalist/deployment/<path:deployment_path>", methods=["GET"])
+@limiter.limit("5 per minute")
+def export_deployment_inaturalist(deployment_path: str):
+    """
+    Export all photos in a deployment directory as iNaturalist ZIP.
+
+    Supports dual response format based on Accept header:
+    - Accept: application/zip → ZIP file download
+    - Accept: application/json → JSON with status and file path
+
+    Path Parameters:
+        deployment_path: Path to deployment directory (relative to PHOTOS_DIR)
+
+    Query Parameters:
+        include_xmp (bool): Include XMP sidecars (default: true)
+        include_manifest (bool): Include manifest.json (default: true)
+        include_csv_summary (bool): Include summary.csv (default: true)
+
+    Returns:
+        200: ZIP file or JSON with status
+        403: Path traversal attempt blocked
+        404: Deployment directory not found
+        500: Internal error
+
+    Example:
+        GET /api/export/inaturalist/deployment/2024/oak-ridge?include_xmp=true
+        Accept: application/zip
+
+        Response: ZIP file download with all photos from deployment
+    """
+    try:
+        # Get service from app config
+        service = current_app.config.get('EXPORT_METADATA_SERVICE')
+        if service is None:
+            return jsonify({"error": "Export service not available"}), 500
+
+        # Validate path to prevent traversal attacks
+        from pathlib import Path
+        validated_path = validate_photo_path(deployment_path, PHOTOS_DIR)
+        if validated_path is None:
+            return jsonify({"error": "Invalid path"}), 403
+
+        deployment_dir = Path(validated_path)
+
+        # Check if directory exists
+        if not deployment_dir.exists():
+            return jsonify({"error": "Deployment directory not found"}), 404
+
+        if not deployment_dir.is_dir():
+            return jsonify({"error": "Path is not a directory"}), 400
+
+        # Query parameters
+        include_xmp = request.args.get('include_xmp', 'true').lower() == 'true'
+        include_manifest = request.args.get('include_manifest', 'true').lower() == 'true'
+        include_csv_summary = request.args.get('include_csv_summary', 'true').lower() == 'true'
+
+        # Get all photos in deployment (jpg, jpeg, png)
+        photo_extensions = {'.jpg', '.jpeg', '.png', '.JPG', '.JPEG', '.PNG'}
+        photo_paths = [
+            p for p in deployment_dir.rglob('*')
+            if p.is_file() and p.suffix in photo_extensions
+        ]
+
+        if not photo_paths:
+            return jsonify({
+                "error": "No photos found in deployment directory"
+            }), 400
+
+        # Create export options
+        from webui.backend.lib.zip_export import ZipExportOptions
+
+        options = ZipExportOptions(
+            include_xmp_sidecars=include_xmp,
+            include_manifest=include_manifest,
+            include_csv_summary=include_csv_summary,
+            flatten_structure=False,
+        )
+
+        # Create temporary ZIP file
+        import tempfile
+        temp_fd, temp_path = tempfile.mkstemp(suffix='.zip', prefix='inaturalist_deployment_')
+        import os
+        os.close(temp_fd)  # Close file descriptor
+        output_path = Path(temp_path)
+
+        try:
+            # Generate ZIP export
+            result = service.transform_batch_to_inaturalist_zip(
+                photo_paths,
+                output_path,
+                options
+            )
+
+            if not result.success:
+                return jsonify({
+                    "error": "ZIP export failed",
+                    "details": result.errors
+                }), 500
+
+            # Determine response format based on Accept header
+            accept = request.headers.get('Accept', 'application/json')
+
+            if 'application/zip' in accept:
+                # ZIP file download
+                from flask import send_file
+                timestamp = datetime.now(UTC).strftime('%Y%m%d_%H%M%S')
+                # Sanitize deployment path for filename
+                safe_name = deployment_path.replace('/', '_').replace('\\', '_')
+                filename = f"inaturalist_{safe_name}_{timestamp}.zip"
+
+                return send_file(
+                    output_path,
+                    mimetype='application/zip',
+                    as_attachment=True,
+                    download_name=filename,
+                )
+            else:
+                # JSON with status
+                return jsonify({
+                    "success": result.success,
+                    "zip_path": str(result.zip_path),
+                    "zip_size_bytes": result.zip_size_bytes,
+                    "photo_count": result.photo_count,
+                    "xmp_count": result.xmp_count,
+                    "errors": result.errors,
+                    "took_ms": result.took_ms,
+                }), 200
+
+        except Exception as e:
+            logger.error("Error creating iNaturalist ZIP: %s", e, exc_info=True)
+            # Clean up temp file on error
+            if output_path.exists():
+                output_path.unlink()
+            return jsonify({"error": "ZIP export failed"}), 500
+
+    except Exception as e:
+        logger.error("Error in iNaturalist deployment export: %s", e, exc_info=True)
+        return jsonify({"error": "iNaturalist deployment export failed"}), 500
+
+
+@export_bp.route("/inaturalist/preview", methods=["POST"])
+def preview_inaturalist_export():
+    """
+    Preview iNaturalist export without creating ZIP (dry run).
+
+    Validates photos and generates sample XMP to help users verify
+    metadata before creating the full export.
+
+    Request Body:
+        {
+            "photo_paths": ["photo1.jpg", "subdir/photo2.jpg", ...]
+        }
+
+    Returns:
+        200: JSON with validation results
+        400: Invalid request body
+        500: Internal error
+
+    Response:
+        {
+            "valid_photos": 45,
+            "invalid_photos": 5,
+            "estimated_zip_size_bytes": 125000000,
+            "validation_results": [
+                {
+                    "photo": "photo1.jpg",
+                    "is_valid": true,
+                    "missing_required": [],
+                    "warnings": ["Missing species name"]
+                },
+                {
+                    "photo": "photo2.jpg",
+                    "is_valid": false,
+                    "missing_required": ["latitude", "longitude"],
+                    "warnings": []
+                }
+            ],
+            "sample_xmp": "<?xpacket...?>..."
+        }
+    """
+    try:
+        # Get service from app config
+        service = current_app.config.get('EXPORT_METADATA_SERVICE')
+        if service is None:
+            return jsonify({"error": "Export service not available"}), 500
+
+        # Validate request body
+        if not request.is_json:
+            return jsonify({"error": "Request must be JSON"}), 400
+
+        try:
+            data = request.get_json()
+        except Exception:
+            return jsonify({"error": "Invalid JSON in request body"}), 400
+
+        if not data or 'photo_paths' not in data:
+            return jsonify({"error": "Missing 'photo_paths' in request body"}), 400
+
+        photo_paths = data['photo_paths']
+
+        if not isinstance(photo_paths, list):
+            return jsonify({"error": "'photo_paths' must be an array"}), 400
+
+        # Validate all paths are non-empty strings
+        if not all(isinstance(p, str) and p.strip() for p in photo_paths):
+            return jsonify({"error": "All photo_paths must be non-empty strings"}), 400
+
+        if len(photo_paths) == 0:
+            return jsonify({"error": "No photos provided"}), 400
+
+        # Get configurable batch size limit
+        max_batch_size = current_app.config.get('EXPORT_MAX_BATCH_SIZE', 1000)
+
+        if len(photo_paths) > max_batch_size:
+            return jsonify({
+                "error": f"Batch size exceeds maximum limit of {max_batch_size} photos"
+            }), 400
+
+        # Validate and resolve paths
+        from pathlib import Path
+
+        from webui.backend.lib.zip_export import estimate_zip_size
+
+        resolved_paths = []
+        validation_results = []
+        valid_count = 0
+        invalid_count = 0
+
+        for photo_path in photo_paths:
+            # Path traversal protection
+            validated_path = validate_photo_path(photo_path, PHOTOS_DIR)
+            if validated_path is None:
+                validation_results.append({
+                    'photo': photo_path,
+                    'is_valid': False,
+                    'missing_required': ['path'],
+                    'warnings': [],
+                    'error': 'Invalid path'
+                })
+                invalid_count += 1
+                continue
+
+            path = Path(validated_path)
+            if not path.exists():
+                validation_results.append({
+                    'photo': photo_path,
+                    'is_valid': False,
+                    'missing_required': ['file'],
+                    'warnings': [],
+                    'error': 'File not found'
+                })
+                invalid_count += 1
+                continue
+
+            # Get metadata and validate
+            metadata = service.get_export_metadata(path)
+
+            if isinstance(metadata, dict) and 'error' in metadata:
+                validation_results.append({
+                    'photo': photo_path,
+                    'is_valid': False,
+                    'missing_required': ['metadata'],
+                    'warnings': [],
+                    'error': metadata['error']
+                })
+                invalid_count += 1
+                continue
+
+            # Validate for iNaturalist
+            validation = service.validate_for_format(metadata, ExportFormat.INATURALIST)
+
+            validation_results.append({
+                'photo': photo_path,
+                'is_valid': validation.is_valid,
+                'missing_required': validation.missing_fields,
+                'warnings': validation.warnings,
+            })
+
+            if validation.is_valid:
+                valid_count += 1
+                resolved_paths.append(path)
+            else:
+                invalid_count += 1
+
+        # Estimate ZIP size
+        estimated_size = estimate_zip_size(resolved_paths, include_xmp=True)
+
+        # Generate sample XMP from first valid photo
+        sample_xmp = None
+        if resolved_paths:
+            from webui.backend.lib.xmp_sidecar import generate_xmp_xml
+            first_metadata = service.get_export_metadata(resolved_paths[0])
+            if not isinstance(first_metadata, dict) or 'error' not in first_metadata:
+                sample_xmp = generate_xmp_xml(first_metadata)
+
+        return jsonify({
+            'valid_photos': valid_count,
+            'invalid_photos': invalid_count,
+            'estimated_zip_size_bytes': estimated_size,
+            'validation_results': validation_results,
+            'sample_xmp': sample_xmp,
+        }), 200
+
+    except Exception as e:
+        logger.error("Error in iNaturalist preview: %s", e, exc_info=True)
+        return jsonify({"error": "Preview failed"}), 500

--- a/Firmware/webui/backend/routes/export.py
+++ b/Firmware/webui/backend/routes/export.py
@@ -52,6 +52,14 @@ logger = logging.getLogger(__name__)
 export_bp = Blueprint("export", __name__)
 
 
+@export_bp.after_request
+def add_etag(response):
+    """Add ETag header for GET responses to enable client-side caching."""
+    if request.method == 'GET' and response.status_code == 200:
+        response.add_etag()
+    return response
+
+
 # ============================================================================
 # Metadata Endpoints
 # ============================================================================
@@ -922,60 +930,61 @@ def export_inaturalist_batch():
                 }), 403
             resolved_paths.append(Path(validated_path))
 
-        # Create temporary ZIP file
+        # Create temporary directory for ZIP file (auto-cleaned on context exit)
         import tempfile
-        temp_fd, temp_path = tempfile.mkstemp(suffix='.zip', prefix='inaturalist_export_')
-        import os
-        os.close(temp_fd)  # Close file descriptor
-        output_path = Path(temp_path)
+        with tempfile.TemporaryDirectory(prefix='inaturalist_export_') as tmpdir:
+            output_path = Path(tmpdir) / "export.zip"
 
-        try:
-            # Generate ZIP export
-            result = service.transform_batch_to_inaturalist_zip(
-                resolved_paths,
-                output_path,
-                options
-            )
-
-            if not result.success:
-                return jsonify({
-                    "error": "ZIP export failed",
-                    "details": result.errors
-                }), 500
-
-            # Determine response format based on Accept header
-            accept = request.headers.get('Accept', 'application/json')
-
-            if 'application/zip' in accept:
-                # ZIP file download
-                from flask import send_file
-                timestamp = datetime.now(UTC).strftime('%Y%m%d_%H%M%S')
-                filename = f"inaturalist_export_{timestamp}.zip"
-
-                return send_file(
+            try:
+                # Generate ZIP export
+                result = service.transform_batch_to_inaturalist_zip(
+                    resolved_paths,
                     output_path,
-                    mimetype='application/zip',
-                    as_attachment=True,
-                    download_name=filename,
+                    options
                 )
-            else:
-                # JSON with status
-                return jsonify({
-                    "success": result.success,
-                    "zip_path": str(result.zip_path),
-                    "zip_size_bytes": result.zip_size_bytes,
-                    "photo_count": result.photo_count,
-                    "xmp_count": result.xmp_count,
-                    "errors": result.errors,
-                    "took_ms": result.took_ms,
-                }), 200
 
-        except Exception as e:
-            logger.error("Error creating iNaturalist ZIP: %s", e, exc_info=True)
-            # Clean up temp file on error
-            if output_path.exists():
-                output_path.unlink()
-            return jsonify({"error": "ZIP export failed"}), 500
+                if not result.success:
+                    return jsonify({
+                        "error": "ZIP export failed",
+                        "details": result.errors
+                    }), 500
+
+                # Determine response format based on Accept header
+                accept = request.headers.get('Accept', 'application/json')
+
+                if 'application/zip' in accept:
+                    # ZIP file download - read into memory for response
+                    # (temp dir cleaned after response sent)
+                    import io
+
+                    from flask import send_file
+                    timestamp = datetime.now(UTC).strftime('%Y%m%d_%H%M%S')
+                    filename = f"inaturalist_export_{timestamp}.zip"
+
+                    # Read file into BytesIO to allow temp dir cleanup
+                    zip_data = io.BytesIO(output_path.read_bytes())
+                    zip_data.seek(0)
+
+                    return send_file(
+                        zip_data,
+                        mimetype='application/zip',
+                        as_attachment=True,
+                        download_name=filename,
+                    )
+                else:
+                    # JSON with status - temp file path not useful to client
+                    return jsonify({
+                        "success": result.success,
+                        "zip_size_bytes": result.zip_size_bytes,
+                        "photo_count": result.photo_count,
+                        "xmp_count": result.xmp_count,
+                        "errors": result.errors,
+                        "took_ms": result.took_ms,
+                    }), 200
+
+            except Exception as e:
+                logger.error("Error creating iNaturalist ZIP: %s", e, exc_info=True)
+                return jsonify({"error": "ZIP export failed"}), 500
 
     except Exception as e:
         logger.error("Error in iNaturalist batch export: %s", e, exc_info=True)
@@ -1060,62 +1069,63 @@ def export_deployment_inaturalist(deployment_path: str):
             flatten_structure=False,
         )
 
-        # Create temporary ZIP file
+        # Create temporary directory for ZIP file (auto-cleaned on context exit)
         import tempfile
-        temp_fd, temp_path = tempfile.mkstemp(suffix='.zip', prefix='inaturalist_deployment_')
-        import os
-        os.close(temp_fd)  # Close file descriptor
-        output_path = Path(temp_path)
+        with tempfile.TemporaryDirectory(prefix='inaturalist_deployment_') as tmpdir:
+            output_path = Path(tmpdir) / "export.zip"
 
-        try:
-            # Generate ZIP export
-            result = service.transform_batch_to_inaturalist_zip(
-                photo_paths,
-                output_path,
-                options
-            )
-
-            if not result.success:
-                return jsonify({
-                    "error": "ZIP export failed",
-                    "details": result.errors
-                }), 500
-
-            # Determine response format based on Accept header
-            accept = request.headers.get('Accept', 'application/json')
-
-            if 'application/zip' in accept:
-                # ZIP file download
-                from flask import send_file
-                timestamp = datetime.now(UTC).strftime('%Y%m%d_%H%M%S')
-                # Sanitize deployment path for filename
-                safe_name = deployment_path.replace('/', '_').replace('\\', '_')
-                filename = f"inaturalist_{safe_name}_{timestamp}.zip"
-
-                return send_file(
+            try:
+                # Generate ZIP export
+                result = service.transform_batch_to_inaturalist_zip(
+                    photo_paths,
                     output_path,
-                    mimetype='application/zip',
-                    as_attachment=True,
-                    download_name=filename,
+                    options
                 )
-            else:
-                # JSON with status
-                return jsonify({
-                    "success": result.success,
-                    "zip_path": str(result.zip_path),
-                    "zip_size_bytes": result.zip_size_bytes,
-                    "photo_count": result.photo_count,
-                    "xmp_count": result.xmp_count,
-                    "errors": result.errors,
-                    "took_ms": result.took_ms,
-                }), 200
 
-        except Exception as e:
-            logger.error("Error creating iNaturalist ZIP: %s", e, exc_info=True)
-            # Clean up temp file on error
-            if output_path.exists():
-                output_path.unlink()
-            return jsonify({"error": "ZIP export failed"}), 500
+                if not result.success:
+                    return jsonify({
+                        "error": "ZIP export failed",
+                        "details": result.errors
+                    }), 500
+
+                # Determine response format based on Accept header
+                accept = request.headers.get('Accept', 'application/json')
+
+                if 'application/zip' in accept:
+                    # ZIP file download - read into memory for response
+                    # (temp dir cleaned after response sent)
+                    import io
+
+                    from flask import send_file
+                    timestamp = datetime.now(UTC).strftime('%Y%m%d_%H%M%S')
+                    # Sanitize deployment path for filename
+                    safe_name = deployment_path.replace('/', '_').replace('\\', '_')
+                    filename = f"inaturalist_{safe_name}_{timestamp}.zip"
+
+                    # Read file into BytesIO to allow temp dir cleanup
+                    zip_data = io.BytesIO(output_path.read_bytes())
+                    zip_data.seek(0)
+
+                    return send_file(
+                        zip_data,
+                        mimetype='application/zip',
+                        as_attachment=True,
+                        download_name=filename,
+                    )
+                else:
+                    # JSON with status - temp file path not useful to client
+                    return jsonify({
+                        "success": result.success,
+                        "zip_size_bytes": result.zip_size_bytes,
+                        "photo_count": result.photo_count,
+                        "xmp_count": result.xmp_count,
+                        "errors": result.errors,
+                        "took_ms": result.took_ms,
+                    }), 200
+
+            except Exception as e:
+                logger.error("Error creating iNaturalist ZIP: %s", e, exc_info=True)
+                return jsonify({"error": "ZIP export failed"}), 500
 
     except Exception as e:
         logger.error("Error in iNaturalist deployment export: %s", e, exc_info=True)

--- a/Firmware/webui/backend/services/export_metadata_service.py
+++ b/Firmware/webui/backend/services/export_metadata_service.py
@@ -13,7 +13,7 @@ Architecture:
 - Thin wrapper over existing services (no business logic duplication)
 - Generic JSON/CSV transformer implemented
 - Darwin Core transformer implemented (Issue #116)
-- iNaturalist transformer is a stub (Issue #118)
+- iNaturalist transformer implemented (Issue #118)
 
 Usage:
     from webui.backend.services.export_metadata_service import (
@@ -64,6 +64,7 @@ from webui.backend.services.metadata_service import MetadataService
 from webui.backend.services.sidecar_service import SidecarMetadata, SidecarService
 
 if TYPE_CHECKING:
+    from webui.backend.lib.zip_export import ZipExportOptions, ZipExportResult
     from webui.backend.services.deployment_service import DeploymentService
     from webui.backend.services.series_service import SeriesService
 
@@ -703,20 +704,78 @@ class ExportMetadataService:
 
         return headers, rows
 
+    def transform_batch_to_inaturalist_zip(
+        self,
+        photo_paths: list[Path],
+        output_path: Path | None = None,
+        options: "ZipExportOptions | None" = None,
+    ) -> "ZipExportResult":
+        """Export multiple photos as iNaturalist ZIP with XMP sidecars.
+
+        Creates a ZIP archive containing:
+        - Original photos (uncompressed)
+        - XMP sidecar files with iNaturalist-compatible metadata
+        - manifest.json with collection metadata
+        - summary.csv with tabular data
+
+        Args:
+            photo_paths: List of paths to photos to export
+            output_path: Path for output ZIP file. If None, uses temp file.
+            options: ZipExportOptions for customization
+
+        Returns:
+            ZipExportResult with success status and statistics
+
+        Raises:
+            ValueError: If photo_paths is empty
+        """
+        from webui.backend.lib.zip_export import (
+            ZipExportOptions,
+            create_zip_export,
+        )
+
+        if not photo_paths:
+            raise ValueError("photo_paths cannot be empty")
+
+        # Get metadata for all photos
+        metadata_list = self.batch_get_export_metadata(photo_paths)
+
+        # Use temp file if output_path not provided
+        if output_path is None:
+            import tempfile
+            # Create temp file securely, then use its path for ZIP creation
+            temp_fd = tempfile.NamedTemporaryFile(suffix='.zip', delete=False)
+            output_path = Path(temp_fd.name)
+            temp_fd.close()
+
+        # Create ZIP with default options if not provided
+        if options is None:
+            options = ZipExportOptions()
+
+        return create_zip_export(photo_paths, metadata_list, output_path, options)
+
     def transform_to_inaturalist(self, metadata: ExportMetadata) -> dict:
         """Transform to iNaturalist format.
 
-        STUB: Raises NotImplementedError - full implementation in Issue #118.
+        Maps Mothbox metadata fields to iNaturalist-compatible structure
+        for XMP sidecar generation and observation data.
 
         Args:
             metadata: ExportMetadata to transform
 
-        Raises:
-            NotImplementedError: iNaturalist transformer not yet implemented
+        Returns:
+            dict with iNaturalist-compatible fields including:
+            - title: "Common Name (Scientific Name)"
+            - notes: Combined notes and tags
+            - latitude, longitude: GPS coordinates
+            - timestamp: ISO 8601 datetime
+            - quality_grade: Mapped from species_confidence
+            - taxonomy_keywords: Hierarchical taxonomy for dc:subject
+            - license: Default CC BY-NC 4.0
+            - creator: Default "Mothbox"
         """
-        raise NotImplementedError(
-            "iNaturalist transformation will be implemented in Issue #118"
-        )
+        from webui.backend.lib.inaturalist_mapping import transform_metadata_to_inaturalist
+        return transform_metadata_to_inaturalist(metadata)
 
     # ========================================================================
     # Validation
@@ -744,31 +803,12 @@ class ExportMetadataService:
         if format == ExportFormat.DARWIN_CORE:
             return self._validate_darwin_core(metadata)
 
-        # Get required fields for other formats
-        required = {
-            ExportFormat.INATURALIST: INATURALIST_REQUIRED,
-        }.get(format, [])
-
-        # Check for missing fields
-        missing = []
-        for field_name in required:
-            value = getattr(metadata, field_name, None)
-            if value is None:
-                missing.append(field_name)
-
-        # Add warning for stub formats (validation is incomplete)
-        warnings = []
+        # iNaturalist has comprehensive validation
         if format == ExportFormat.INATURALIST:
-            warnings.append(
-                "iNaturalist validation is incomplete (stub). "
-                "Full validation will be implemented in Issue #118."
-            )
+            return self._validate_inaturalist(metadata)
 
-        return ValidationResult(
-            is_valid=len(missing) == 0,
-            missing_fields=missing,
-            warnings=warnings
-        )
+        # Unknown format - return generic validation
+        return ValidationResult(is_valid=True)
 
     def _validate_darwin_core(self, metadata: ExportMetadata) -> ValidationResult:
         """Comprehensive validation for Darwin Core export.
@@ -822,6 +862,33 @@ class ExportMetadataService:
             is_valid=len(missing_fields) == 0,
             missing_fields=missing_fields,
             warnings=warnings,
+        )
+
+    def _validate_inaturalist(self, metadata: ExportMetadata) -> ValidationResult:
+        """Validate metadata for iNaturalist export.
+
+        Checks:
+        - Required fields: latitude, longitude, timestamp
+        - Valid coordinate ranges (-90 to 90 for lat, -180 to 180 for lon)
+        - Warns for missing species/common_name
+
+        Args:
+            metadata: ExportMetadata to validate
+
+        Returns:
+            ValidationResult with validation status and details
+        """
+        from webui.backend.lib.inaturalist_mapping import validate_for_inaturalist
+
+        # Use the library's validation function
+        lib_result = validate_for_inaturalist(metadata)
+
+        # Convert library's ValidationResult to service's ValidationResult
+        # Note: Both have the same structure, but different imports
+        return ValidationResult(
+            is_valid=lib_result.is_valid,
+            missing_fields=lib_result.missing_required,
+            warnings=lib_result.warnings + [f"Missing recommended: {', '.join(lib_result.missing_recommended)}"] if lib_result.missing_recommended else lib_result.warnings,
         )
 
     # ========================================================================

--- a/Firmware/webui/backend/services/export_metadata_service.py
+++ b/Firmware/webui/backend/services/export_metadata_service.py
@@ -744,9 +744,8 @@ class ExportMetadataService:
         if output_path is None:
             import tempfile
             # Create temp file securely, then use its path for ZIP creation
-            temp_fd = tempfile.NamedTemporaryFile(suffix='.zip', delete=False)
-            output_path = Path(temp_fd.name)
-            temp_fd.close()
+            with tempfile.NamedTemporaryFile(suffix='.zip', delete=False) as temp_fd:
+                output_path = Path(temp_fd.name)
 
         # Create ZIP with default options if not provided
         if options is None:

--- a/Firmware/webui/docs/dev/api/inaturalist-export.md
+++ b/Firmware/webui/docs/dev/api/inaturalist-export.md
@@ -1,0 +1,500 @@
+# iNaturalist Export API
+
+## Overview
+
+The Mothbox Photo Gallery supports exporting photos with XMP sidecar files for import into iNaturalist, a citizen science platform for sharing biodiversity observations. The export creates ZIP archives containing original photos paired with metadata-rich XMP files compatible with iNaturalist's import workflow.
+
+**Related Issue:** [#118](https://github.com/zane-lazare/Mothbox/issues/118)
+
+## iNaturalist Import Workflow
+
+iNaturalist uses XMP sidecar files to read metadata during bulk photo imports. The workflow is:
+
+1. Export photos from Mothbox as iNaturalist ZIP
+2. Extract ZIP archive
+3. Upload photos to iNaturalist (bulk uploader reads XMP files for metadata)
+4. Review and publish observations
+
+**Key Resources:**
+- [iNaturalist Help: Bulk Upload](https://www.inaturalist.org/pages/help#bulk)
+- [XMP Specification](https://www.adobe.com/devnet/xmp.html)
+
+---
+
+## API Endpoints
+
+### Export Batch
+
+**POST /api/export/inaturalist/batch**
+
+Export multiple photos as iNaturalist-compatible ZIP archive.
+
+**Rate Limit**: 5 requests per minute
+
+#### Request Body
+
+```json
+{
+    "photo_paths": ["photo1.jpg", "photo2.jpg", "subdir/photo3.jpg"],
+    "options": {
+        "include_xmp_sidecars": true,
+        "include_manifest": true,
+        "include_csv_summary": true,
+        "flatten_structure": false
+    }
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| photo_paths | array | Yes | List of relative photo paths |
+| options.include_xmp_sidecars | boolean | No | Include XMP files (default: true) |
+| options.include_manifest | boolean | No | Include manifest.json (default: true) |
+| options.include_csv_summary | boolean | No | Include summary.csv (default: true) |
+| options.flatten_structure | boolean | No | Flatten directory structure (default: false) |
+
+#### Response Format
+
+Based on `Accept` header:
+
+**`Accept: application/json` (default):**
+
+```json
+{
+    "success": true,
+    "zip_path": "/tmp/export_abc123.zip",
+    "zip_size_bytes": 12500000,
+    "photo_count": 50,
+    "xmp_count": 50,
+    "took_ms": 3500.5
+}
+```
+
+**`Accept: application/zip`:**
+
+Returns ZIP file download with `Content-Disposition` header:
+```
+Content-Disposition: attachment; filename="inaturalist_export_20240115_103000.zip"
+```
+
+#### Error Responses
+
+| Code | Error | Cause |
+|------|-------|-------|
+| 400 | "Request must be JSON" | Missing Content-Type: application/json |
+| 400 | "No photos specified" | Empty or missing photo_paths array |
+| 400 | "All photo_paths must be non-empty strings" | Invalid path format |
+| 400 | "Batch size exceeds maximum limit" | Too many photos (default max: 1000) |
+| 403 | "Invalid path" | Path traversal attempt |
+| 500 | "ZIP export failed" | Internal error during export |
+
+---
+
+### Export Deployment
+
+**GET /api/export/inaturalist/deployment/{path}**
+
+Export entire deployment directory as iNaturalist ZIP.
+
+**Rate Limit**: 5 requests per minute
+
+#### Path Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| path | string | Yes | Deployment directory path (relative to PHOTOS_DIR) |
+
+#### Query Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| include_xmp | boolean | true | Include XMP sidecars |
+| include_manifest | boolean | true | Include manifest.json |
+| include_csv_summary | boolean | true | Include summary.csv |
+
+#### Response Format
+
+Same as batch export - based on `Accept` header.
+
+#### Example
+
+```bash
+# JSON response with file path
+curl -X GET \
+  'http://localhost:5000/api/export/inaturalist/deployment/2024/oak-ridge' \
+  -H 'Accept: application/json'
+
+# Direct ZIP download
+curl -X GET \
+  'http://localhost:5000/api/export/inaturalist/deployment/2024/oak-ridge?include_xmp=true' \
+  -H 'Accept: application/zip' \
+  -o inaturalist_export.zip
+```
+
+---
+
+### Preview Export
+
+**POST /api/export/inaturalist/preview**
+
+Preview export without creating ZIP (dry run).
+
+**Rate Limit**: 5 requests per minute
+
+#### Request Body
+
+```json
+{
+    "photo_paths": ["photo1.jpg", "photo2.jpg"]
+}
+```
+
+#### Response
+
+```json
+{
+    "valid_photos": 45,
+    "invalid_photos": 5,
+    "estimated_zip_size_bytes": 125000000,
+    "validation_results": [
+        {
+            "photo_path": "no_gps.jpg",
+            "is_valid": false,
+            "missing_fields": ["GPS coordinates"],
+            "warnings": []
+        }
+    ],
+    "sample_xmp": "<?xpacket begin='...' id='W5M0MpCehiHzreSzNTczkc9d'?>..."
+}
+```
+
+---
+
+## XMP Metadata Format
+
+Photos are paired with XMP sidecar files containing metadata in multiple namespaces:
+
+### Dublin Core (dc:)
+
+| XMP Field | Mothbox Source | iNaturalist Import |
+|-----------|---------------|-------------------|
+| dc:title | species + species_common_name | Parsed for taxon |
+| dc:description | notes + tags | Observation notes |
+| dc:subject | tags + taxonomy hierarchy | Tags + taxonomy |
+| dc:creator | "Mothbox" | Observer |
+| dc:rights | "CC BY-NC 4.0" | License info |
+
+### XMP Core (xmp:)
+
+| XMP Field | Mothbox Source | Description |
+|-----------|---------------|-------------|
+| xmp:CreateDate | timestamp | Photo capture timestamp |
+| xmp:ModifyDate | timestamp | Same as CreateDate |
+
+### IPTC Extension (Iptc4xmpExt:)
+
+| XMP Field | Mothbox Source | Description |
+|-----------|---------------|-------------|
+| Iptc4xmpExt:LocationShown | latitude, longitude | GPS coordinates |
+
+### Photoshop (photoshop:)
+
+| XMP Field | Mothbox Source | Description |
+|-----------|---------------|-------------|
+| photoshop:DateCreated | timestamp | ISO 8601 date |
+
+---
+
+## Taxonomy Keywords
+
+Species are tagged with hierarchical keywords for improved discoverability:
+
+```xml
+<dc:subject>
+  <rdf:Bag>
+    <rdf:li>moth</rdf:li>
+    <rdf:li>lepidoptera</rdf:li>
+    <rdf:li>taxonomy:kingdom=Animalia</rdf:li>
+    <rdf:li>taxonomy:phylum=Arthropoda</rdf:li>
+    <rdf:li>taxonomy:class=Insecta</rdf:li>
+    <rdf:li>taxonomy:order=Lepidoptera</rdf:li>
+    <rdf:li>taxonomy:genus=Actias</rdf:li>
+    <rdf:li>taxonomy:species=Actias luna</rdf:li>
+  </rdf:Bag>
+</dc:subject>
+```
+
+The taxonomy hierarchy is automatically generated when species name is present.
+
+---
+
+## ZIP Archive Structure
+
+### Flat Structure (flatten_structure: true)
+
+```
+inaturalist_export.zip
+├── photo1.jpg
+├── photo1.xmp
+├── photo2.jpg
+├── photo2.xmp
+├── manifest.json
+└── summary.csv
+```
+
+### Preserved Structure (flatten_structure: false, default)
+
+```
+inaturalist_export.zip
+├── 2024/
+│   ├── oak-ridge/
+│   │   ├── photo1.jpg
+│   │   ├── photo1.xmp
+│   │   ├── photo2.jpg
+│   │   └── photo2.xmp
+├── manifest.json
+└── summary.csv
+```
+
+---
+
+## Example XMP Sidecar
+
+```xml
+<?xpacket begin='﻿' id='W5M0MpCehiHzreSzNTczkc9d'?>
+<x:xmpmeta xmlns:x='adobe:ns:meta/'>
+  <rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
+    <rdf:Description rdf:about=''
+        xmlns:dc='http://purl.org/dc/elements/1.1/'
+        xmlns:xmp='http://ns.adobe.com/xap/1.0/'
+        xmlns:photoshop='http://ns.adobe.com/photoshop/1.0/'
+        xmlns:Iptc4xmpExt='http://iptc.org/std/Iptc4xmpExt/2008-02-29/'>
+
+      <dc:title>
+        <rdf:Alt>
+          <rdf:li xml:lang='x-default'>Luna Moth (Actias luna)</rdf:li>
+        </rdf:Alt>
+      </dc:title>
+
+      <dc:description>
+        <rdf:Alt>
+          <rdf:li xml:lang='x-default'>Beautiful specimen captured at night. Tags: moth, lepidoptera, night</rdf:li>
+        </rdf:Alt>
+      </dc:description>
+
+      <dc:subject>
+        <rdf:Bag>
+          <rdf:li>moth</rdf:li>
+          <rdf:li>lepidoptera</rdf:li>
+          <rdf:li>night</rdf:li>
+          <rdf:li>taxonomy:kingdom=Animalia</rdf:li>
+          <rdf:li>taxonomy:phylum=Arthropoda</rdf:li>
+          <rdf:li>taxonomy:class=Insecta</rdf:li>
+          <rdf:li>taxonomy:order=Lepidoptera</rdf:li>
+          <rdf:li>taxonomy:species=Actias luna</rdf:li>
+        </rdf:Bag>
+      </dc:subject>
+
+      <dc:creator>
+        <rdf:Seq>
+          <rdf:li>Mothbox</rdf:li>
+        </rdf:Seq>
+      </dc:creator>
+
+      <dc:rights>
+        <rdf:Alt>
+          <rdf:li xml:lang='x-default'>CC BY-NC 4.0</rdf:li>
+        </rdf:Alt>
+      </dc:rights>
+
+      <xmp:CreateDate>2024-01-15T10:30:00</xmp:CreateDate>
+      <xmp:ModifyDate>2024-01-15T10:30:00</xmp:ModifyDate>
+
+      <photoshop:DateCreated>2024-01-15</photoshop:DateCreated>
+
+      <Iptc4xmpExt:LocationShown>
+        <rdf:Bag>
+          <rdf:li rdf:parseType='Resource'>
+            <Iptc4xmpExt:City>San Francisco</Iptc4xmpExt:City>
+            <Iptc4xmpExt:ProvinceState>CA</Iptc4xmpExt:ProvinceState>
+            <Iptc4xmpExt:CountryName>USA</Iptc4xmpExt:CountryName>
+            <Iptc4xmpExt:GPSLatitude>37.7749</Iptc4xmpExt:GPSLatitude>
+            <Iptc4xmpExt:GPSLongitude>-122.4194</Iptc4xmpExt:GPSLongitude>
+          </rdf:li>
+        </rdf:Bag>
+      </Iptc4xmpExt:LocationShown>
+
+    </rdf:Description>
+  </rdf:RDF>
+</x:xmpmeta>
+<?xpacket end='w'?>
+```
+
+---
+
+## Performance
+
+| Operation | Target | Typical |
+|-----------|--------|---------|
+| Single XMP generation | <10ms | ~5ms |
+| 50 photos ZIP | <5 seconds | ~3.5s |
+| 100 photos ZIP | <10 seconds | ~7s |
+| Throughput | >10 photos/sec | ~15 photos/sec |
+
+---
+
+## Code Examples
+
+### Python
+
+```python
+import requests
+
+# Batch export (JSON response)
+response = requests.post(
+    'http://localhost:5000/api/export/inaturalist/batch',
+    json={
+        'photo_paths': ['photo1.jpg', 'photo2.jpg'],
+        'options': {
+            'include_xmp_sidecars': True,
+            'include_manifest': True
+        }
+    }
+)
+data = response.json()
+print(f"Exported {data['photo_count']} photos to {data['zip_path']}")
+
+# Batch export (ZIP download)
+response = requests.post(
+    'http://localhost:5000/api/export/inaturalist/batch',
+    json={'photo_paths': ['photo1.jpg', 'photo2.jpg']},
+    headers={'Accept': 'application/zip'}
+)
+with open('inaturalist_export.zip', 'wb') as f:
+    f.write(response.content)
+
+# Deployment export
+response = requests.get(
+    'http://localhost:5000/api/export/inaturalist/deployment/2024/oak-ridge',
+    headers={'Accept': 'application/zip'}
+)
+with open('deployment_export.zip', 'wb') as f:
+    f.write(response.content)
+
+# Preview export
+response = requests.post(
+    'http://localhost:5000/api/export/inaturalist/preview',
+    json={'photo_paths': ['photo1.jpg', 'photo2.jpg']}
+)
+preview = response.json()
+print(f"Valid photos: {preview['valid_photos']}")
+print(f"Estimated size: {preview['estimated_zip_size_bytes'] / (1024*1024):.1f} MB")
+```
+
+### JavaScript
+
+```javascript
+// Batch export (JSON)
+const response = await fetch('/api/export/inaturalist/batch', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'Accept': 'application/json'
+  },
+  body: JSON.stringify({
+    photo_paths: ['photo1.jpg', 'photo2.jpg'],
+    options: {
+      include_xmp_sidecars: true,
+      include_manifest: true
+    }
+  })
+});
+const data = await response.json();
+console.log(`Exported ${data.photo_count} photos`);
+
+// Batch export (ZIP download)
+const response = await fetch('/api/export/inaturalist/batch', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'Accept': 'application/zip'
+  },
+  body: JSON.stringify({
+    photo_paths: ['photo1.jpg', 'photo2.jpg']
+  })
+});
+const blob = await response.blob();
+const url = window.URL.createObjectURL(blob);
+const a = document.createElement('a');
+a.href = url;
+a.download = 'inaturalist_export.zip';
+a.click();
+```
+
+---
+
+## iNaturalist Upload Guide
+
+### Step 1: Export from Mothbox
+
+Choose photos to export and create iNaturalist ZIP:
+
+```bash
+curl -X POST \
+  'http://localhost:5000/api/export/inaturalist/batch' \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/zip' \
+  -d '{"photo_paths": ["photo1.jpg", "photo2.jpg"]}' \
+  -o inaturalist_export.zip
+```
+
+### Step 2: Extract ZIP
+
+```bash
+unzip inaturalist_export.zip -d inaturalist_photos
+```
+
+### Step 3: Upload to iNaturalist
+
+1. Log in to iNaturalist
+2. Navigate to "Upload" → "Bulk Upload"
+3. Select photos from extracted directory
+4. iNaturalist reads XMP sidecars automatically
+5. Review pre-filled metadata (species, location, date)
+6. Publish observations
+
+### Best Practices
+
+- **GPS Required**: iNaturalist requires GPS coordinates. Ensure Mothbox GPS is enabled.
+- **Species Identification**: Review species names before upload. Use `species_confidence` to indicate uncertainty.
+- **Tags**: Use descriptive tags for better discoverability.
+- **License**: Default CC BY-NC 4.0 license is compatible with iNaturalist's license options.
+
+---
+
+## Validation
+
+Photos are validated before export. Warnings are included for:
+
+- Missing GPS coordinates (iNaturalist requires location)
+- Missing species identification
+- Missing timestamp
+
+Use the preview endpoint to check validation before exporting:
+
+```bash
+curl -X POST \
+  'http://localhost:5000/api/export/inaturalist/preview' \
+  -H 'Content-Type: application/json' \
+  -d '{"photo_paths": ["photo1.jpg", "photo2.jpg"]}' \
+  | jq '.validation_results'
+```
+
+---
+
+## Related Documentation
+
+- [Export Metadata Service](../services/export-metadata-service.md)
+- [Sidecar Metadata Schema](../schemas/sidecar-metadata.md)
+- [Deployment Metadata Schema](../schemas/deployment-metadata.md)
+- [Darwin Core Export API](./darwin-core-export.md)


### PR DESCRIPTION
## Summary
- Implement iNaturalist-compatible ZIP export for photo gallery (#118)
- Bundle photos with XMP sidecar files containing observation metadata
- Support hierarchical taxonomy keywords, GPS coordinates, and CC BY-NC 4.0 licensing
- Meet performance targets: 50 photos < 5 seconds, XMP generation < 10ms

## Changes

### Core Libraries
- **xmp_sidecar.py**: XMP XML generator with Dublin Core/IPTC namespaces
- **inaturalist_mapping.py**: Field mapping and validation for iNaturalist
- **zip_export.py**: Memory-efficient ZIP archive creation with streaming

### API Endpoints
- `POST /api/export/inaturalist/batch` - Export selected photos as ZIP
- `GET /api/export/inaturalist/deployment/<path>` - Export entire deployment
- `POST /api/export/inaturalist/preview` - Validation dry run before export

### Testing
- 227 tests passing (unit, integration, performance)
- 98%+ coverage on core libraries
- Performance benchmarks met:
  - XMP generation: <10ms per photo
  - ZIP creation: 50 photos <5s, 100 photos <10s
  - Memory usage: <100MB for 100 photos

## Test plan
- [x] All unit tests pass (pytest Tests/unit/test_xmp_sidecar.py Tests/unit/test_inaturalist_mapping.py Tests/unit/test_zip_export.py Tests/unit/test_inaturalist_export_routes.py)
- [x] Integration tests pass (pytest Tests/integration/test_inaturalist_export_workflow.py)
- [x] Performance benchmarks pass (pytest Tests/performance/test_inaturalist_export_performance.py)
- [x] Ruff linting clean (ruff check .)
- [x] Bandit security scan clean (bandit -c pyproject.toml -r . --severity-level medium)
- [ ] Manual verification: Export photos and import to iNaturalist

Closes #118