### PR TITLE
feat(export): Add generic JSON and CSV export endpoints (#120)

### DIFF
--- a/Firmware/Tests/unit/test_export_metadata_service.py
+++ b/Firmware/Tests/unit/test_export_metadata_service.py
@@ -7,22 +7,21 @@ TDD approach: tests written first, then implementation.
 Coverage Target: 90%+
 """
 
-import pytest
 import threading
 import time
+from dataclasses import asdict, dataclass
 from pathlib import Path
-from unittest.mock import Mock, patch, MagicMock
-from dataclasses import dataclass, asdict
-from enum import Enum
+from unittest.mock import Mock
 
+import pytest
 
 # Import will fail until implementation exists - that's expected in TDD
 try:
     from webui.backend.services.export_metadata_service import (
-        ExportMetadataService,
-        ExportMetadata,
-        ValidationResult,
         ExportFormat,
+        ExportMetadata,
+        ExportMetadataService,
+        ValidationResult,
     )
     IMPLEMENTATION_EXISTS = True
 except ImportError:
@@ -196,13 +195,22 @@ def mock_series_service_none():
 
 
 @pytest.fixture
-def service(mock_metadata_service, mock_sidecar_service, mock_series_service):
+def mock_deployment_service():
+    """Mock DeploymentService returning None (no deployment found)."""
+    service = Mock()
+    service.find_deployment_for_photo.return_value = None
+    return service
+
+
+@pytest.fixture
+def service(mock_metadata_service, mock_sidecar_service, mock_series_service, mock_deployment_service):
     """Create ExportMetadataService with mocked dependencies."""
     return ExportMetadataService(
         cache_ttl=1,  # 1 second TTL for fast testing
         metadata_service=mock_metadata_service,
         sidecar_service=mock_sidecar_service,
-        series_service=mock_series_service
+        series_service=mock_series_service,
+        deployment_service=mock_deployment_service,
     )
 
 
@@ -543,6 +551,10 @@ class TestGetExportMetadata:
         self, service, sample_photo_path
     ):
         """get_export_metadata should complete in <100ms."""
+        # Warmup call to ensure all lazy imports are loaded
+        service.get_export_metadata(sample_photo_path)
+        service.invalidate_cache()  # Clear cache so we measure actual work
+
         start = time.perf_counter()
         service.get_export_metadata(sample_photo_path)
         elapsed_ms = (time.perf_counter() - start) * 1000

--- a/Firmware/Tests/unit/test_generic_export_routes.py
+++ b/Firmware/Tests/unit/test_generic_export_routes.py
@@ -1,0 +1,1392 @@
+"""
+Unit tests for generic JSON/CSV export routes (Issue #120)
+
+Tests REST API endpoints for generic JSON and CSV export functionality.
+Focuses on security (path traversal), field filtering, response formats,
+and file download handling.
+
+Coverage Target: 85%+
+"""
+
+import csv
+import io
+from unittest.mock import Mock
+
+import pytest
+from flask import Flask
+
+from webui.backend.services.export_metadata_service import (
+    ExportMetadata,
+    ExportMetadataService,
+)
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture(scope="module", autouse=True)
+def temp_photos_dir(tmp_path_factory):
+    """
+    Temporary PHOTOS_DIR for export route tests (module-scoped, autouse)
+
+    Creates temporary directory and patches PHOTOS_DIR globally for this test module.
+    """
+    photos_dir = tmp_path_factory.mktemp("photos")
+
+    # Patch PHOTOS_DIR in all relevant modules
+    import routes.export
+
+    import mothbox_paths
+
+    original_mothbox_paths_photos_dir = mothbox_paths.PHOTOS_DIR
+    original_routes_export_photos_dir = routes.export.PHOTOS_DIR
+
+    mothbox_paths.PHOTOS_DIR = photos_dir
+    routes.export.PHOTOS_DIR = photos_dir
+
+    yield photos_dir
+
+    # Restore original values
+    mothbox_paths.PHOTOS_DIR = original_mothbox_paths_photos_dir
+    routes.export.PHOTOS_DIR = original_routes_export_photos_dir
+
+
+@pytest.fixture(scope="module")
+def mock_metadata_service():
+    """Mock MetadataService that returns sample EXIF data."""
+    mock = Mock()
+    mock.get_photo_metadata.return_value = {
+        'camera': {
+            'make': 'Arducam',
+            'model': 'OwlSight 64MP',
+            'sensor': 'OV64A40',
+        },
+        'location': {
+            'latitude': 37.7749,
+            'longitude': -122.4194,
+            'altitude': 10.0,
+            'gps_accuracy': 2.5,
+        },
+        'capture': {
+            'timestamp': '2024-01-15T10:30:00',
+            'exposure_time': '1/100',
+            'iso': 400,
+            'focal_length': '16mm',
+        },
+        'deployment': {
+            'mothbox_id': 'MB-TEST-001',
+            'firmware_version': '5.0.0',
+        },
+        'file': {
+            'path': '/photos/test.jpg',
+            'size': 1024000,
+            'width': 4000,
+            'height': 3000,
+        },
+    }
+    return mock
+
+
+@pytest.fixture(scope="module")
+def export_app(temp_photos_dir, mock_metadata_service):
+    """Flask app with export blueprint for testing (module-scoped)"""
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+
+    # Register blueprint
+    from routes.export import export_bp
+    app.register_blueprint(export_bp, url_prefix='/api/export')
+
+    # Create service with mocked MetadataService to avoid real image parsing
+    service = ExportMetadataService(
+        cache_ttl=300,
+        metadata_service=mock_metadata_service,
+    )
+    app.config['EXPORT_METADATA_SERVICE'] = service
+
+    return app
+
+
+@pytest.fixture(scope="module")
+def export_client(export_app):
+    """Test client for export routes (module-scoped)"""
+    return export_app.test_client()
+
+
+@pytest.fixture(scope="module")
+def sample_photo(temp_photos_dir):
+    """Create a sample JPEG photo (module-scoped)"""
+    photo_path = temp_photos_dir / "test_photo.jpg"
+
+    # Skip if already exists
+    if photo_path.exists():
+        return photo_path
+
+    # Create minimal JPEG header (no PIL dependency issues)
+    photo_path.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 1000)
+
+    return photo_path
+
+
+@pytest.fixture(scope="module")
+def nested_photo(temp_photos_dir):
+    """Create a photo in a subdirectory (module-scoped)"""
+    subdir = temp_photos_dir / "2024" / "01"
+    subdir.mkdir(parents=True, exist_ok=True)
+
+    photo_path = subdir / "nested_photo.jpg"
+
+    if photo_path.exists():
+        return photo_path
+
+    # Create minimal JPEG header (no PIL dependency issues)
+    photo_path.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 1000)
+
+    return photo_path
+
+
+@pytest.fixture(scope="module")
+def deployment_dir(temp_photos_dir):
+    """Create a deployment directory with photos (module-scoped)"""
+    deploy_dir = temp_photos_dir / "deployment_2024"
+    deploy_dir.mkdir(exist_ok=True)
+
+    # Create multiple photos
+    for i in range(3):
+        photo = deploy_dir / f"photo_{i}.jpg"
+        if not photo.exists():
+            photo.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 1000)
+
+    return deploy_dir
+
+
+def create_sample_export_metadata(filename="test.jpg", **kwargs):
+    """Helper to create sample ExportMetadata instances."""
+    defaults = {
+        'photo_path': f'/photos/{filename}',
+        'filename': filename,
+        'timestamp': '2024-01-15T10:00:00',
+        'latitude': 37.7749,
+        'longitude': -122.4194,
+        'altitude': 10.0,
+        'gps_accuracy': 2.5,
+        'camera_make': 'Arducam',
+        'camera_model': 'OwlSight 64MP',
+        'exposure_time': '1/100',
+        'iso': 400,
+        'focal_length': '16mm',
+        'species': 'Actias luna',
+        'species_common_name': 'Luna Moth',
+        'species_confidence': 'probable',
+        'tags': ['moth', 'lepidoptera', 'nocturnal'],
+        'notes': 'Sample observation',
+        'mothbox_id': 'MB-TEST-001',
+        'firmware_version': '5.0.0',
+        'deployment_name': 'Test Deployment',
+        'deployment_location_name': 'Oak Ridge, TN',
+        'deployment_start_date': '2024-01-01',
+        'deployment_end_date': '2024-01-31',
+        'environmental_conditions': {'habitat': 'forest'},
+        'series_type': None,
+        'series_index': None,
+        'series_count': None,
+        'file_size': 1024000,
+        'width': 4000,
+        'height': 3000,
+    }
+    defaults.update(kwargs)
+    return ExportMetadata(**defaults)
+
+
+# ============================================================================
+# Tests for GET /api/export/json/<path> - Single Photo JSON Export
+# ============================================================================
+
+
+class TestSinglePhotoJsonExport:
+    """Tests for GET /api/export/json/<photo_path>"""
+
+    def test_valid_photo_returns_json_metadata(self, export_client, sample_photo, temp_photos_dir):
+        """Valid photo should return JSON with nested structure."""
+        relative_path = sample_photo.relative_to(temp_photos_dir)
+
+        response = export_client.get(f'/api/export/json/{relative_path}')
+
+        assert response.status_code == 200
+        data = response.get_json()
+
+        # Verify nested structure (from transform_to_generic(flat=False))
+        assert 'file' in data
+        assert 'location' in data
+        assert 'camera' in data
+        assert 'species' in data
+        assert 'user_data' in data
+        assert 'deployment' in data
+
+    def test_nested_photo_path_works(self, export_client, nested_photo, temp_photos_dir):
+        """Nested photo paths should work correctly."""
+        relative_path = nested_photo.relative_to(temp_photos_dir)
+
+        response = export_client.get(f'/api/export/json/{relative_path}')
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert 'nested_photo.jpg' in data['file']['filename']
+
+    def test_path_traversal_returns_403(self, export_client):
+        """Path traversal attempts should return 403."""
+        response = export_client.get('/api/export/json/../../../etc/passwd')
+
+        assert response.status_code == 403
+        data = response.get_json()
+        assert 'error' in data
+
+    def test_nonexistent_photo_returns_404(self, export_client):
+        """Nonexistent photo should return 404."""
+        response = export_client.get('/api/export/json/nonexistent_photo.jpg')
+
+        assert response.status_code == 404
+        data = response.get_json()
+        assert 'error' in data
+
+    def test_file_download_with_octet_stream_accept(self, temp_photos_dir):
+        """Accept: application/octet-stream should return JSON file download."""
+        from routes.export import export_bp
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.register_blueprint(export_bp, url_prefix='/api/export')
+
+        # Create mock service
+        mock_service = Mock()
+        mock_metadata = create_sample_export_metadata()
+        mock_service.get_export_metadata.return_value = mock_metadata
+
+        # Use real transformation
+        real_service = ExportMetadataService()
+        mock_service.transform_to_generic.side_effect = real_service.transform_to_generic
+        mock_service.transform_to_generic_filtered = real_service.transform_to_generic_filtered
+
+        app.config['EXPORT_METADATA_SERVICE'] = mock_service
+
+        client = app.test_client()
+
+        # Create a test file
+        test_file = temp_photos_dir / "download_json_test.jpg"
+        test_file.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+
+        response = client.get(
+            '/api/export/json/download_json_test.jpg',
+            headers={'Accept': 'application/octet-stream'}
+        )
+
+        assert response.status_code == 200
+        assert response.content_type == 'application/json'
+        assert 'Content-Disposition' in response.headers
+        assert 'attachment' in response.headers['Content-Disposition']
+        assert '.json' in response.headers['Content-Disposition']
+
+    def test_field_filtering_with_fields_param(self, temp_photos_dir):
+        """Fields parameter should limit returned fields."""
+        from routes.export import export_bp
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.register_blueprint(export_bp, url_prefix='/api/export')
+
+        # Create mock service with transform_to_generic_filtered
+        mock_service = Mock()
+        mock_metadata = create_sample_export_metadata()
+        mock_service.get_export_metadata.return_value = mock_metadata
+
+        # Mock filtered transform
+        mock_service.transform_to_generic_filtered.return_value = {
+            'file': {'filename': 'test.jpg'},
+            'location': {'latitude': 37.7749, 'longitude': -122.4194}
+        }
+
+        app.config['EXPORT_METADATA_SERVICE'] = mock_service
+
+        client = app.test_client()
+
+        # Create a test file
+        test_file = temp_photos_dir / "field_filter_test.jpg"
+        test_file.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+
+        response = client.get(
+            '/api/export/json/field_filter_test.jpg?fields=filename,latitude,longitude'
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+
+        # Should only have requested fields
+        assert 'file' in data
+        assert 'location' in data
+        # Camera and other sections should not be present
+        assert 'camera' not in data or data.get('camera') is None
+
+    def test_field_filtering_with_exclude_param(self, temp_photos_dir):
+        """Exclude parameter should remove specified fields."""
+        from routes.export import export_bp
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.register_blueprint(export_bp, url_prefix='/api/export')
+
+        mock_service = Mock()
+        mock_metadata = create_sample_export_metadata()
+        mock_service.get_export_metadata.return_value = mock_metadata
+
+        # Mock filtered transform without notes and tags
+        mock_service.transform_to_generic_filtered.return_value = {
+            'file': {'filename': 'test.jpg'},
+            'location': {'latitude': 37.7749},
+            'user_data': {}  # Empty - notes and tags excluded
+        }
+
+        app.config['EXPORT_METADATA_SERVICE'] = mock_service
+
+        client = app.test_client()
+
+        test_file = temp_photos_dir / "exclude_filter_test.jpg"
+        test_file.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+
+        response = client.get(
+            '/api/export/json/exclude_filter_test.jpg?exclude=notes,tags'
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+
+        # User data section should have empty or missing notes/tags
+        user_data = data.get('user_data', {})
+        assert 'notes' not in user_data or user_data.get('notes') is None
+        assert 'tags' not in user_data or user_data.get('tags') == []
+
+    def test_both_fields_and_exclude_returns_400(self, export_client, sample_photo, temp_photos_dir):
+        """Using both fields and exclude should return 400."""
+        relative_path = sample_photo.relative_to(temp_photos_dir)
+
+        response = export_client.get(
+            f'/api/export/json/{relative_path}?fields=filename&exclude=notes'
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert 'error' in data
+
+    def test_service_unavailable_returns_500(self):
+        """Missing service should return 500."""
+        from routes.export import export_bp
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.register_blueprint(export_bp, url_prefix='/api/export')
+
+        client = app.test_client()
+
+        response = client.get('/api/export/json/test.jpg')
+
+        assert response.status_code == 500
+        data = response.get_json()
+        assert 'error' in data
+        assert 'not available' in data['error']
+
+
+# ============================================================================
+# Tests for POST /api/export/json/batch - Batch JSON Export
+# ============================================================================
+
+
+class TestBatchJsonExport:
+    """Tests for POST /api/export/json/batch"""
+
+    def test_batch_returns_array_of_metadata(self, export_client, sample_photo, nested_photo, temp_photos_dir):
+        """Batch export should return array of photo metadata."""
+        photo1_rel = str(sample_photo.relative_to(temp_photos_dir))
+        photo2_rel = str(nested_photo.relative_to(temp_photos_dir))
+
+        response = export_client.post(
+            '/api/export/json/batch',
+            json={'photo_paths': [photo1_rel, photo2_rel]}
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+
+        assert 'results' in data
+        assert 'total' in data
+        assert 'successful' in data
+        assert 'failed' in data
+        assert isinstance(data['results'], list)
+
+    def test_batch_handles_invalid_paths(self, export_client, sample_photo, temp_photos_dir):
+        """Batch should handle mix of valid and invalid paths."""
+        photo_rel = str(sample_photo.relative_to(temp_photos_dir))
+
+        response = export_client.post(
+            '/api/export/json/batch',
+            json={'photo_paths': [photo_rel, '../../../etc/passwd', 'nonexistent.jpg']}
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+
+        assert data['total'] == 3
+        assert data['successful'] >= 1
+        assert data['failed'] >= 2
+
+    def test_batch_empty_list_returns_empty(self, export_client):
+        """Empty photo list should return empty results."""
+        response = export_client.post(
+            '/api/export/json/batch',
+            json={'photo_paths': []}
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+
+        assert data['total'] == 0
+        assert data['successful'] == 0
+        assert len(data['results']) == 0
+
+    def test_batch_invalid_json_returns_400(self, export_client):
+        """Invalid JSON should return 400."""
+        response = export_client.post(
+            '/api/export/json/batch',
+            data='invalid json',
+            headers={'Content-Type': 'application/json'}
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert 'error' in data
+
+    def test_batch_missing_photo_paths_returns_400(self, export_client):
+        """Missing photo_paths key should return 400."""
+        response = export_client.post(
+            '/api/export/json/batch',
+            json={'format': 'json'}
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert 'error' in data
+        assert 'photo_paths' in data['error']
+
+    def test_batch_photo_paths_not_array_returns_400(self, export_client):
+        """photo_paths must be an array."""
+        response = export_client.post(
+            '/api/export/json/batch',
+            json={'photo_paths': 'not_an_array'}
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert 'error' in data
+        assert 'array' in data['error']
+
+    def test_batch_with_field_filtering(self, temp_photos_dir):
+        """Batch should support field filtering."""
+        from routes.export import export_bp
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.register_blueprint(export_bp, url_prefix='/api/export')
+
+        mock_service = Mock()
+        mock_metadata = create_sample_export_metadata()
+        mock_service.get_export_metadata.return_value = mock_metadata
+        mock_service.transform_to_generic_filtered.return_value = {
+            'file': {'filename': 'test.jpg'},
+            'location': {'latitude': 37.7749}
+        }
+
+        app.config['EXPORT_METADATA_SERVICE'] = mock_service
+
+        client = app.test_client()
+
+        test_file = temp_photos_dir / "batch_filter_test.jpg"
+        test_file.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+
+        response = client.post(
+            '/api/export/json/batch',
+            json={
+                'photo_paths': ['batch_filter_test.jpg'],
+                'fields': ['filename', 'latitude']
+            }
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data['successful'] >= 1
+
+    def test_batch_file_download_with_octet_stream(self, temp_photos_dir):
+        """Accept: application/octet-stream should return JSON file download."""
+        from routes.export import export_bp
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.register_blueprint(export_bp, url_prefix='/api/export')
+
+        mock_service = Mock()
+        mock_metadata = create_sample_export_metadata()
+        mock_service.get_export_metadata.return_value = mock_metadata
+
+        real_service = ExportMetadataService()
+        mock_service.transform_to_generic.side_effect = real_service.transform_to_generic
+
+        app.config['EXPORT_METADATA_SERVICE'] = mock_service
+
+        client = app.test_client()
+
+        test_file = temp_photos_dir / "batch_download_test.jpg"
+        test_file.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+
+        response = client.post(
+            '/api/export/json/batch',
+            json={'photo_paths': ['batch_download_test.jpg']},
+            headers={'Accept': 'application/octet-stream'}
+        )
+
+        assert response.status_code == 200
+        assert response.content_type == 'application/json'
+        assert 'Content-Disposition' in response.headers
+        assert 'attachment' in response.headers['Content-Disposition']
+
+    def test_batch_exceeds_max_size_returns_400(self, temp_photos_dir):
+        """Batch exceeding max size should return 400."""
+        from routes.export import export_bp
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.config['EXPORT_MAX_BATCH_SIZE'] = 5  # Set low limit for testing
+        app.register_blueprint(export_bp, url_prefix='/api/export')
+
+        mock_service = Mock()
+        app.config['EXPORT_METADATA_SERVICE'] = mock_service
+
+        client = app.test_client()
+
+        # Request more than max batch size
+        response = client.post(
+            '/api/export/json/batch',
+            json={'photo_paths': [f'photo_{i}.jpg' for i in range(10)]}
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert 'error' in data
+        assert 'limit' in data['error'].lower() or 'exceeds' in data['error'].lower()
+
+    def test_batch_service_unavailable_returns_500(self):
+        """Missing service should return 500."""
+        from routes.export import export_bp
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.register_blueprint(export_bp, url_prefix='/api/export')
+
+        client = app.test_client()
+
+        response = client.post(
+            '/api/export/json/batch',
+            json={'photo_paths': ['test.jpg']}
+        )
+
+        assert response.status_code == 500
+        data = response.get_json()
+        assert 'error' in data
+        assert 'not available' in data['error']
+
+
+# ============================================================================
+# Tests for GET /api/export/json/deployment/<path> - Deployment JSON Export
+# ============================================================================
+
+
+class TestDeploymentJsonExport:
+    """Tests for GET /api/export/json/deployment/<path>"""
+
+    def test_deployment_returns_all_photos_metadata(self, temp_photos_dir):
+        """Deployment export should return metadata for all photos in directory."""
+        from routes.export import export_bp
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.register_blueprint(export_bp, url_prefix='/api/export')
+
+        # Create deployment directory with photos
+        deploy_dir = temp_photos_dir / "test_deployment"
+        deploy_dir.mkdir(exist_ok=True)
+
+        for i in range(3):
+            photo = deploy_dir / f"photo_{i}.jpg"
+            photo.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+
+        mock_service = Mock()
+        mock_service.get_export_metadata.return_value = create_sample_export_metadata()
+
+        real_service = ExportMetadataService()
+        mock_service.transform_to_generic.side_effect = real_service.transform_to_generic
+
+        app.config['EXPORT_METADATA_SERVICE'] = mock_service
+
+        client = app.test_client()
+
+        response = client.get('/api/export/json/deployment/test_deployment')
+
+        assert response.status_code == 200
+        data = response.get_json()
+
+        assert 'results' in data
+        assert 'total' in data
+        assert data['total'] >= 3
+
+    def test_deployment_path_traversal_returns_403(self, export_client):
+        """Path traversal attempts should return 403."""
+        response = export_client.get('/api/export/json/deployment/../../../etc')
+
+        assert response.status_code == 403
+        data = response.get_json()
+        assert 'error' in data
+
+    def test_deployment_empty_directory_returns_empty(self, temp_photos_dir):
+        """Empty deployment directory should return empty results."""
+        from routes.export import export_bp
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.register_blueprint(export_bp, url_prefix='/api/export')
+
+        # Create empty directory
+        empty_dir = temp_photos_dir / "empty_deployment"
+        empty_dir.mkdir(exist_ok=True)
+
+        mock_service = Mock()
+        app.config['EXPORT_METADATA_SERVICE'] = mock_service
+
+        client = app.test_client()
+
+        response = client.get('/api/export/json/deployment/empty_deployment')
+
+        # Should return 200 with empty results or 400 for no photos
+        assert response.status_code in [200, 400]
+
+    def test_deployment_nonexistent_returns_404(self, export_client):
+        """Nonexistent deployment should return 404."""
+        response = export_client.get('/api/export/json/deployment/nonexistent_deployment')
+
+        assert response.status_code == 404
+        data = response.get_json()
+        assert 'error' in data
+
+    def test_deployment_with_field_filtering(self, temp_photos_dir):
+        """Deployment export should support field filtering."""
+        from routes.export import export_bp
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.register_blueprint(export_bp, url_prefix='/api/export')
+
+        deploy_dir = temp_photos_dir / "filter_deployment"
+        deploy_dir.mkdir(exist_ok=True)
+
+        photo = deploy_dir / "photo.jpg"
+        photo.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+
+        mock_service = Mock()
+        mock_service.get_export_metadata.return_value = create_sample_export_metadata()
+        mock_service.transform_to_generic_filtered.return_value = {
+            'file': {'filename': 'photo.jpg'},
+        }
+
+        app.config['EXPORT_METADATA_SERVICE'] = mock_service
+
+        client = app.test_client()
+
+        response = client.get('/api/export/json/deployment/filter_deployment?fields=filename')
+
+        assert response.status_code == 200
+
+    def test_deployment_service_unavailable_returns_500(self):
+        """Missing service should return 500."""
+        from routes.export import export_bp
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.register_blueprint(export_bp, url_prefix='/api/export')
+
+        client = app.test_client()
+
+        response = client.get('/api/export/json/deployment/test')
+
+        assert response.status_code == 500
+        data = response.get_json()
+        assert 'error' in data
+
+
+# ============================================================================
+# Tests for POST /api/export/csv/batch - Batch CSV Export
+# ============================================================================
+
+
+class TestBatchCsvExport:
+    """Tests for POST /api/export/csv/batch"""
+
+    def test_batch_csv_json_response(self, temp_photos_dir):
+        """Default response should be JSON with csv_data field."""
+        from routes.export import export_bp
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.register_blueprint(export_bp, url_prefix='/api/export')
+
+        mock_service = Mock()
+        mock_metadata = create_sample_export_metadata()
+        mock_service.get_export_metadata.return_value = mock_metadata
+
+        real_service = ExportMetadataService()
+        mock_service.transform_to_generic.side_effect = real_service.transform_to_generic
+
+        app.config['EXPORT_METADATA_SERVICE'] = mock_service
+
+        client = app.test_client()
+
+        test_file = temp_photos_dir / "csv_test.jpg"
+        test_file.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+
+        response = client.post(
+            '/api/export/csv/batch',
+            json={'photo_paths': ['csv_test.jpg']},
+            headers={'Accept': 'application/json'}
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+
+        assert 'csv_data' in data
+        assert 'headers' in data
+        assert 'row_count' in data
+
+    def test_batch_csv_file_download(self, temp_photos_dir):
+        """Accept: text/csv should return CSV file download."""
+        from routes.export import export_bp
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.register_blueprint(export_bp, url_prefix='/api/export')
+
+        mock_service = Mock()
+        mock_metadata = create_sample_export_metadata()
+        mock_service.get_export_metadata.return_value = mock_metadata
+
+        real_service = ExportMetadataService()
+        mock_service.transform_to_generic.side_effect = real_service.transform_to_generic
+
+        app.config['EXPORT_METADATA_SERVICE'] = mock_service
+
+        client = app.test_client()
+
+        test_file = temp_photos_dir / "csv_download_test.jpg"
+        test_file.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+
+        response = client.post(
+            '/api/export/csv/batch',
+            json={'photo_paths': ['csv_download_test.jpg']},
+            headers={'Accept': 'text/csv'}
+        )
+
+        assert response.status_code == 200
+        assert response.content_type == 'text/csv; charset=utf-8'
+        assert 'Content-Disposition' in response.headers
+        assert 'attachment' in response.headers['Content-Disposition']
+        assert '.csv' in response.headers['Content-Disposition']
+
+    def test_batch_csv_excel_bom(self, temp_photos_dir):
+        """include_bom=true should add UTF-8 BOM for Excel compatibility."""
+        from routes.export import export_bp
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.register_blueprint(export_bp, url_prefix='/api/export')
+
+        mock_service = Mock()
+        mock_metadata = create_sample_export_metadata()
+        mock_service.get_export_metadata.return_value = mock_metadata
+
+        real_service = ExportMetadataService()
+        mock_service.transform_to_generic.side_effect = real_service.transform_to_generic
+
+        app.config['EXPORT_METADATA_SERVICE'] = mock_service
+
+        client = app.test_client()
+
+        test_file = temp_photos_dir / "csv_bom_test.jpg"
+        test_file.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+
+        response = client.post(
+            '/api/export/csv/batch',
+            json={'photo_paths': ['csv_bom_test.jpg'], 'include_bom': True},
+            headers={'Accept': 'text/csv'}
+        )
+
+        assert response.status_code == 200
+        # Check for UTF-8 BOM at start of response
+        csv_content = response.data
+        assert csv_content.startswith(b'\xef\xbb\xbf')  # UTF-8 BOM
+
+    def test_batch_csv_handles_invalid_paths(self, export_client, sample_photo, temp_photos_dir):
+        """CSV batch should handle mix of valid and invalid paths."""
+        photo_rel = str(sample_photo.relative_to(temp_photos_dir))
+
+        response = export_client.post(
+            '/api/export/csv/batch',
+            json={'photo_paths': [photo_rel, '../../../etc/passwd', 'nonexistent.jpg']}
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+
+        assert 'csv_data' in data
+        assert data['total'] == 3
+        assert data['failed'] >= 2
+
+    def test_batch_csv_with_field_filtering(self, temp_photos_dir):
+        """CSV batch should support field filtering."""
+        from routes.export import export_bp
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.register_blueprint(export_bp, url_prefix='/api/export')
+
+        mock_service = Mock()
+        mock_metadata = create_sample_export_metadata()
+        mock_service.get_export_metadata.return_value = mock_metadata
+        mock_service.transform_to_generic_filtered.return_value = {
+            'filename': 'test.jpg',
+            'latitude': 37.7749,
+        }
+
+        app.config['EXPORT_METADATA_SERVICE'] = mock_service
+
+        client = app.test_client()
+
+        test_file = temp_photos_dir / "csv_filter_test.jpg"
+        test_file.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+
+        response = client.post(
+            '/api/export/csv/batch',
+            json={
+                'photo_paths': ['csv_filter_test.jpg'],
+                'fields': ['filename', 'latitude']
+            },
+            headers={'Accept': 'text/csv'}
+        )
+
+        assert response.status_code == 200
+        # CSV should only have selected columns
+        csv_content = response.data.decode('utf-8')
+        assert 'filename' in csv_content
+        assert 'latitude' in csv_content
+
+    def test_batch_csv_empty_list_returns_headers_only(self, export_client):
+        """Empty photo list should return headers only or error."""
+        response = export_client.post(
+            '/api/export/csv/batch',
+            json={'photo_paths': []}
+        )
+
+        # Either returns 200 with just headers or 400 for no photos
+        assert response.status_code in [200, 400]
+
+    def test_batch_csv_invalid_json_returns_400(self, export_client):
+        """Invalid JSON should return 400."""
+        response = export_client.post(
+            '/api/export/csv/batch',
+            data='invalid json',
+            headers={'Content-Type': 'application/json'}
+        )
+
+        assert response.status_code == 400
+
+    def test_batch_csv_service_unavailable_returns_500(self):
+        """Missing service should return 500."""
+        from routes.export import export_bp
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.register_blueprint(export_bp, url_prefix='/api/export')
+
+        client = app.test_client()
+
+        response = client.post(
+            '/api/export/csv/batch',
+            json={'photo_paths': ['test.jpg']}
+        )
+
+        assert response.status_code == 500
+
+
+# ============================================================================
+# Tests for GET /api/export/csv/deployment/<path> - Deployment CSV Export
+# ============================================================================
+
+
+class TestDeploymentCsvExport:
+    """Tests for GET /api/export/csv/deployment/<path>"""
+
+    def test_deployment_csv_returns_all_photos(self, temp_photos_dir):
+        """Deployment CSV should include all photos in directory."""
+        from routes.export import export_bp
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.register_blueprint(export_bp, url_prefix='/api/export')
+
+        deploy_dir = temp_photos_dir / "csv_deployment"
+        deploy_dir.mkdir(exist_ok=True)
+
+        for i in range(3):
+            photo = deploy_dir / f"photo_{i}.jpg"
+            photo.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+
+        mock_service = Mock()
+        mock_service.get_export_metadata.return_value = create_sample_export_metadata()
+
+        real_service = ExportMetadataService()
+        mock_service.transform_to_generic.side_effect = real_service.transform_to_generic
+
+        app.config['EXPORT_METADATA_SERVICE'] = mock_service
+
+        client = app.test_client()
+
+        response = client.get('/api/export/csv/deployment/csv_deployment')
+
+        assert response.status_code == 200
+        data = response.get_json()
+
+        assert 'csv_data' in data
+        assert data['total'] >= 3
+
+    def test_deployment_csv_file_download(self, temp_photos_dir):
+        """Accept: text/csv should return CSV file download."""
+        from routes.export import export_bp
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.register_blueprint(export_bp, url_prefix='/api/export')
+
+        deploy_dir = temp_photos_dir / "csv_deploy_download"
+        deploy_dir.mkdir(exist_ok=True)
+
+        photo = deploy_dir / "photo.jpg"
+        photo.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+
+        mock_service = Mock()
+        mock_service.get_export_metadata.return_value = create_sample_export_metadata()
+
+        real_service = ExportMetadataService()
+        mock_service.transform_to_generic.side_effect = real_service.transform_to_generic
+
+        app.config['EXPORT_METADATA_SERVICE'] = mock_service
+
+        client = app.test_client()
+
+        response = client.get(
+            '/api/export/csv/deployment/csv_deploy_download',
+            headers={'Accept': 'text/csv'}
+        )
+
+        assert response.status_code == 200
+        assert response.content_type == 'text/csv; charset=utf-8'
+        assert 'Content-Disposition' in response.headers
+
+    def test_deployment_csv_path_traversal_returns_403(self, export_client):
+        """Path traversal attempts should return 403."""
+        response = export_client.get('/api/export/csv/deployment/../../../etc')
+
+        assert response.status_code == 403
+
+    def test_deployment_csv_nonexistent_returns_404(self, export_client):
+        """Nonexistent deployment should return 404."""
+        response = export_client.get('/api/export/csv/deployment/nonexistent')
+
+        assert response.status_code == 404
+
+    def test_deployment_csv_with_field_filtering(self, temp_photos_dir):
+        """Deployment CSV should support field filtering via query params."""
+        from routes.export import export_bp
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.register_blueprint(export_bp, url_prefix='/api/export')
+
+        deploy_dir = temp_photos_dir / "csv_filter_deployment"
+        deploy_dir.mkdir(exist_ok=True)
+
+        photo = deploy_dir / "photo.jpg"
+        photo.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+
+        mock_service = Mock()
+        mock_service.get_export_metadata.return_value = create_sample_export_metadata()
+        mock_service.transform_to_generic_filtered.return_value = {
+            'filename': 'photo.jpg',
+            'latitude': 37.7749
+        }
+
+        app.config['EXPORT_METADATA_SERVICE'] = mock_service
+
+        client = app.test_client()
+
+        response = client.get(
+            '/api/export/csv/deployment/csv_filter_deployment?fields=filename,latitude'
+        )
+
+        assert response.status_code == 200
+
+    def test_deployment_csv_with_bom(self, temp_photos_dir):
+        """include_bom query param should add UTF-8 BOM."""
+        from routes.export import export_bp
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.register_blueprint(export_bp, url_prefix='/api/export')
+
+        deploy_dir = temp_photos_dir / "csv_bom_deployment"
+        deploy_dir.mkdir(exist_ok=True)
+
+        photo = deploy_dir / "photo.jpg"
+        photo.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+
+        mock_service = Mock()
+        mock_service.get_export_metadata.return_value = create_sample_export_metadata()
+
+        real_service = ExportMetadataService()
+        mock_service.transform_to_generic.side_effect = real_service.transform_to_generic
+
+        app.config['EXPORT_METADATA_SERVICE'] = mock_service
+
+        client = app.test_client()
+
+        response = client.get(
+            '/api/export/csv/deployment/csv_bom_deployment?include_bom=true',
+            headers={'Accept': 'text/csv'}
+        )
+
+        assert response.status_code == 200
+        csv_content = response.data
+        assert csv_content.startswith(b'\xef\xbb\xbf')
+
+    def test_deployment_csv_service_unavailable_returns_500(self):
+        """Missing service should return 500."""
+        from routes.export import export_bp
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.register_blueprint(export_bp, url_prefix='/api/export')
+
+        client = app.test_client()
+
+        response = client.get('/api/export/csv/deployment/test')
+
+        assert response.status_code == 500
+
+
+# ============================================================================
+# Tests for Field Filtering Logic
+# ============================================================================
+
+
+class TestFieldFiltering:
+    """Tests for field filtering functionality."""
+
+    def test_fields_param_limits_output(self, temp_photos_dir):
+        """Fields parameter should limit output to specified fields."""
+        from routes.export import export_bp
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.register_blueprint(export_bp, url_prefix='/api/export')
+
+        mock_service = Mock()
+        mock_metadata = create_sample_export_metadata()
+        mock_service.get_export_metadata.return_value = mock_metadata
+
+        # Simulate filtered output
+        mock_service.transform_to_generic_filtered.return_value = {
+            'file': {'filename': 'test.jpg'},
+            'location': {'latitude': 37.7749, 'longitude': -122.4194}
+        }
+
+        app.config['EXPORT_METADATA_SERVICE'] = mock_service
+
+        client = app.test_client()
+
+        test_file = temp_photos_dir / "fields_test.jpg"
+        test_file.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+
+        response = client.get('/api/export/json/fields_test.jpg?fields=filename,latitude,longitude')
+
+        assert response.status_code == 200
+        # transform_to_generic_filtered should have been called
+        mock_service.transform_to_generic_filtered.assert_called()
+
+    def test_exclude_param_removes_fields(self, temp_photos_dir):
+        """Exclude parameter should remove specified fields."""
+        from routes.export import export_bp
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.register_blueprint(export_bp, url_prefix='/api/export')
+
+        mock_service = Mock()
+        mock_metadata = create_sample_export_metadata()
+        mock_service.get_export_metadata.return_value = mock_metadata
+
+        # Simulate output with excluded fields
+        mock_service.transform_to_generic_filtered.return_value = {
+            'file': {'filename': 'test.jpg', 'path': '/photos/test.jpg'},
+            'location': {'latitude': 37.7749},
+            'camera': {'make': 'Arducam'},
+            # user_data with notes/tags excluded
+            'user_data': {},
+        }
+
+        app.config['EXPORT_METADATA_SERVICE'] = mock_service
+
+        client = app.test_client()
+
+        test_file = temp_photos_dir / "exclude_test.jpg"
+        test_file.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+
+        response = client.get('/api/export/json/exclude_test.jpg?exclude=notes,tags')
+
+        assert response.status_code == 200
+        mock_service.transform_to_generic_filtered.assert_called()
+
+    def test_unknown_fields_silently_ignored(self, temp_photos_dir):
+        """Unknown field names should be silently ignored."""
+        from routes.export import export_bp
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.register_blueprint(export_bp, url_prefix='/api/export')
+
+        mock_service = Mock()
+        mock_metadata = create_sample_export_metadata()
+        mock_service.get_export_metadata.return_value = mock_metadata
+
+        mock_service.transform_to_generic_filtered.return_value = {
+            'file': {'filename': 'test.jpg'}
+        }
+
+        app.config['EXPORT_METADATA_SERVICE'] = mock_service
+
+        client = app.test_client()
+
+        test_file = temp_photos_dir / "unknown_field_test.jpg"
+        test_file.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+
+        # Include unknown fields - should not error
+        response = client.get('/api/export/json/unknown_field_test.jpg?fields=filename,unknown_field,another_fake')
+
+        assert response.status_code == 200
+
+
+# ============================================================================
+# Tests for /api/export/formats - Format List Updates
+# ============================================================================
+
+
+class TestFormatsEndpointUpdates:
+    """Tests for updated /api/export/formats endpoint."""
+
+    def test_includes_generic_json_format(self, export_client):
+        """Formats list should include generic JSON."""
+        response = export_client.get('/api/export/formats')
+
+        assert response.status_code == 200
+        data = response.get_json()
+
+        format_ids = [f['id'] for f in data['formats']]
+        assert 'json' in format_ids
+
+    def test_includes_generic_csv_format(self, export_client):
+        """Formats list should include generic CSV."""
+        response = export_client.get('/api/export/formats')
+
+        assert response.status_code == 200
+        data = response.get_json()
+
+        format_ids = [f['id'] for f in data['formats']]
+        assert 'csv' in format_ids
+
+    def test_generic_json_has_correct_structure(self, export_client):
+        """Generic JSON format should have correct metadata."""
+        response = export_client.get('/api/export/formats')
+
+        data = response.get_json()
+        json_format = next(f for f in data['formats'] if f['id'] == 'json')
+
+        assert json_format['implemented'] is True
+        assert 'name' in json_format
+        assert 'description' in json_format
+        assert 'endpoints' in json_format or 'features' in json_format
+
+    def test_generic_csv_has_correct_structure(self, export_client):
+        """Generic CSV format should have correct metadata."""
+        response = export_client.get('/api/export/formats')
+
+        data = response.get_json()
+        csv_format = next(f for f in data['formats'] if f['id'] == 'csv')
+
+        assert csv_format['implemented'] is True
+        assert 'name' in csv_format
+        assert 'description' in csv_format
+
+
+# ============================================================================
+# Integration Tests
+# ============================================================================
+
+
+class TestGenericExportIntegration:
+    """Integration tests for generic export routes."""
+
+    def test_full_json_workflow(self, export_client, sample_photo, temp_photos_dir):
+        """Test complete JSON export workflow."""
+        relative_path = sample_photo.relative_to(temp_photos_dir)
+
+        # Step 1: Check formats
+        formats_response = export_client.get('/api/export/formats')
+        assert formats_response.status_code == 200
+
+        # Step 2: Single photo JSON export
+        single_response = export_client.get(f'/api/export/json/{relative_path}')
+        assert single_response.status_code == 200
+        single_data = single_response.get_json()
+        assert 'file' in single_data
+
+        # Step 3: Check stats
+        stats_response = export_client.get('/api/export/stats')
+        assert stats_response.status_code == 200
+
+    def test_full_csv_workflow(self, export_client, sample_photo, nested_photo, temp_photos_dir):
+        """Test complete CSV export workflow."""
+        photo1_rel = str(sample_photo.relative_to(temp_photos_dir))
+        photo2_rel = str(nested_photo.relative_to(temp_photos_dir))
+
+        # Batch CSV export
+        batch_response = export_client.post(
+            '/api/export/csv/batch',
+            json={'photo_paths': [photo1_rel, photo2_rel]}
+        )
+
+        assert batch_response.status_code == 200
+        data = batch_response.get_json()
+
+        # Verify CSV structure
+        assert 'csv_data' in data
+        assert 'headers' in data
+
+        # Parse CSV to verify structure
+        csv_reader = csv.reader(io.StringIO(data['csv_data']))
+        rows = list(csv_reader)
+
+        # Should have header row plus data rows
+        assert len(rows) >= 1  # At least headers
+
+    def test_batch_then_single_caching(self, export_client, sample_photo, nested_photo, temp_photos_dir):
+        """Test that batch populates cache for subsequent single requests."""
+        photo1_rel = str(sample_photo.relative_to(temp_photos_dir))
+        photo2_rel = str(nested_photo.relative_to(temp_photos_dir))
+
+        # Get initial stats
+        stats1 = export_client.get('/api/export/stats').get_json()
+
+        # Batch request
+        export_client.post(
+            '/api/export/json/batch',
+            json={'photo_paths': [photo1_rel, photo2_rel]}
+        )
+
+        # Single requests (should hit cache)
+        export_client.get(f'/api/export/json/{photo1_rel}')
+        export_client.get(f'/api/export/json/{photo2_rel}')
+
+        # Get updated stats
+        stats2 = export_client.get('/api/export/stats').get_json()
+
+        # Cache hits should have increased
+        assert stats2['cache_hits'] >= stats1['cache_hits']
+
+
+# ============================================================================
+# Error Handling Tests
+# ============================================================================
+
+
+class TestGenericExportErrorHandling:
+    """Tests for error handling in generic export endpoints."""
+
+    def test_json_permission_denied_returns_403(self, temp_photos_dir):
+        """Permission denied error should return 403."""
+        from routes.export import export_bp
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.register_blueprint(export_bp, url_prefix='/api/export')
+
+        mock_service = Mock()
+        mock_service.get_export_metadata.return_value = {
+            'error': 'Permission denied',
+            'photo_path': '/photos/test.jpg'
+        }
+        app.config['EXPORT_METADATA_SERVICE'] = mock_service
+
+        client = app.test_client()
+
+        test_file = temp_photos_dir / "perm_test.jpg"
+        test_file.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+
+        response = client.get('/api/export/json/perm_test.jpg')
+
+        assert response.status_code == 403
+
+    def test_json_generic_error_returns_500(self, temp_photos_dir):
+        """Generic service error should return 500."""
+        from routes.export import export_bp
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        app.register_blueprint(export_bp, url_prefix='/api/export')
+
+        mock_service = Mock()
+        mock_service.get_export_metadata.return_value = {
+            'error': 'Internal processing error'
+        }
+        app.config['EXPORT_METADATA_SERVICE'] = mock_service
+
+        client = app.test_client()
+
+        test_file = temp_photos_dir / "error_test.jpg"
+        test_file.write_bytes(b'\xFF\xD8\xFF\xE0' + b'\x00' * 100)
+
+        response = client.get('/api/export/json/error_test.jpg')
+
+        assert response.status_code == 500
+
+    def test_csv_batch_with_all_invalid_paths(self, export_client):
+        """Batch with all invalid paths should still return 200 with errors."""
+        response = export_client.post(
+            '/api/export/csv/batch',
+            json={'photo_paths': ['../etc/passwd', 'nonexistent1.jpg', 'nonexistent2.jpg']}
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data['failed'] == 3
+        assert data['successful'] == 0

--- a/Firmware/webui/__init__.py
+++ b/Firmware/webui/__init__.py
@@ -1,0 +1,1 @@
+# Mothbox Web UI package

--- a/Firmware/webui/backend/__init__.py
+++ b/Firmware/webui/backend/__init__.py
@@ -1,0 +1,1 @@
+# Mothbox Web UI Backend package

--- a/Firmware/webui/backend/app.py
+++ b/Firmware/webui/backend/app.py
@@ -4,14 +4,27 @@ Mothbox Web UI Backend
 Flask API server for Mothbox control and monitoring
 """
 
-import atexit
-import logging
-import signal
+# isort: off
+# Path setup must happen before webui.* imports
 import sys
 from pathlib import Path
 
-# Load configuration based on environment
+# Setup path to import mothbox modules
+# mothbox_paths.py is in the Firmware root directory, three levels up from this file
+# This works for all installation types: production (/opt/mothbox), legacy, custom, and dev
+backend_dir = Path(__file__).resolve().parent
+webui_dir = backend_dir.parent
+firmware_root = webui_dir.parent  # backend -> webui -> Firmware (or /opt/mothbox)
+sys.path.insert(0, str(firmware_root))
+
+# Load configuration based on environment (requires sys.path setup above)
 from webui.backend.config import get_config
+# isort: on
+
+import atexit
+import logging
+import signal
+
 from flask import Flask, jsonify, request, send_from_directory
 from flask_cors import CORS
 from flask_limiter import Limiter
@@ -24,14 +37,6 @@ config = get_config()
 # Reduce Werkzeug request logging verbosity
 # Only show warnings and errors, not every request
 logging.getLogger('werkzeug').setLevel(logging.WARNING)
-
-# Setup path to import mothbox modules
-# mothbox_paths.py is in the Firmware root directory, three levels up from this file
-# This works for all installation types: production (/opt/mothbox), legacy, custom, and dev
-backend_dir = Path(__file__).resolve().parent
-webui_dir = backend_dir.parent
-firmware_root = webui_dir.parent  # backend -> webui -> Firmware (or /opt/mothbox)
-sys.path.insert(0, str(firmware_root))
 
 app = Flask(__name__, static_folder="../frontend/dist")
 

--- a/Firmware/webui/backend/routes/export.py
+++ b/Firmware/webui/backend/routes/export.py
@@ -52,6 +52,17 @@ logger = logging.getLogger(__name__)
 
 export_bp = Blueprint("export", __name__)
 
+# Photo file extensions supported for export
+PHOTO_EXTENSIONS = {'.jpg', '.jpeg', '.png', '.JPG', '.JPEG', '.PNG'}
+
+
+def find_photos_in_directory(directory: Path) -> list[Path]:
+    """Find all photo files in directory and subdirectories."""
+    return [
+        p for p in directory.rglob('*')
+        if p.is_file() and p.suffix in PHOTO_EXTENSIONS
+    ]
+
 
 @export_bp.after_request
 def add_etag(response):
@@ -748,12 +759,8 @@ def export_deployment_darwin_core(deployment_path: str):
         validate = request.args.get('validate', 'true').lower() == 'true'
         include_warnings = request.args.get('include_warnings', 'false').lower() == 'true'
 
-        # Get all photos in deployment (jpg, jpeg, png)
-        photo_extensions = {'.jpg', '.jpeg', '.png', '.JPG', '.JPEG', '.PNG'}
-        photo_paths = [
-            p for p in deployment_dir.rglob('*')
-            if p.is_file() and p.suffix in photo_extensions
-        ]
+        # Get all photos in deployment
+        photo_paths = find_photos_in_directory(deployment_dir)
 
         if not photo_paths:
             return jsonify({
@@ -1083,12 +1090,8 @@ def export_deployment_inaturalist(deployment_path: str):
         include_manifest = request.args.get('include_manifest', 'true').lower() == 'true'
         include_csv_summary = request.args.get('include_csv_summary', 'true').lower() == 'true'
 
-        # Get all photos in deployment (jpg, jpeg, png)
-        photo_extensions = {'.jpg', '.jpeg', '.png', '.JPG', '.JPEG', '.PNG'}
-        photo_paths = [
-            p for p in deployment_dir.rglob('*')
-            if p.is_file() and p.suffix in photo_extensions
-        ]
+        # Get all photos in deployment
+        photo_paths = find_photos_in_directory(deployment_dir)
 
         if not photo_paths:
             return jsonify({
@@ -1706,10 +1709,7 @@ def export_deployment_json(deployment_path: str):
             return jsonify({"error": str(e)}), 400
 
         # Find all photos in deployment directory
-        photo_patterns = ['*.jpg', '*.jpeg', '*.JPG', '*.JPEG']
-        photo_files = []
-        for pattern in photo_patterns:
-            photo_files.extend(deployment_dir.glob(f'**/{pattern}'))
+        photo_files = find_photos_in_directory(deployment_dir)
 
         if not photo_files:
             return jsonify({
@@ -1889,8 +1889,11 @@ def export_batch_csv():
             return jsonify({"error": "'photo_paths' must be an array"}), 400
 
         # Validate all paths are non-empty strings
-        if photo_paths and not all(isinstance(p, str) and p.strip() for p in photo_paths):
+        if not all(isinstance(p, str) and p.strip() for p in photo_paths):
             return jsonify({"error": "All photo_paths must be non-empty strings"}), 400
+
+        if len(photo_paths) == 0:
+            return jsonify({"error": "No photos provided"}), 400
 
         # Get configurable batch size limit
         max_batch_size = current_app.config.get('EXPORT_MAX_BATCH_SIZE', 1000)
@@ -1910,34 +1913,6 @@ def export_batch_csv():
 
         # Get headers (filtered if needed)
         headers = _get_generic_csv_headers(fields, exclude)
-
-        # Empty list handling
-        if len(photo_paths) == 0:
-            csv_content = _generate_csv_with_bom(headers, [], include_bom)
-
-            accept = request.headers.get('Accept', 'application/json')
-            if 'text/csv' in accept:
-                timestamp = datetime.now(UTC).strftime('%Y%m%d_%H%M%S')
-                filename = f"metadata_export_{timestamp}.csv"
-                response = Response(
-                    csv_content.encode('utf-8') if not include_bom else csv_content.encode('utf-8-sig'),
-                    mimetype='text/csv',
-                    headers={
-                        'Content-Disposition': f'attachment; filename="{filename}"',
-                        'Content-Type': 'text/csv; charset=utf-8',
-                    }
-                )
-                return response
-            else:
-                return jsonify({
-                    "csv_data": csv_content,
-                    "headers": headers,
-                    "row_count": 0,
-                    "total": 0,
-                    "successful": 0,
-                    "failed": 0,
-                    "errors": []
-                }), 200
 
         # Collect metadata and build rows
         rows = []
@@ -1994,9 +1969,9 @@ def export_batch_csv():
             timestamp = datetime.now(UTC).strftime('%Y%m%d_%H%M%S')
             filename = f"metadata_export_{timestamp}.csv"
 
-            # Handle BOM in bytes
+            # Handle BOM encoding
             if include_bom:
-                csv_bytes = b'\xef\xbb\xbf' + csv_content.lstrip('\ufeff').encode('utf-8')
+                csv_bytes = csv_content.encode('utf-8-sig')
             else:
                 csv_bytes = csv_content.encode('utf-8')
 
@@ -2074,10 +2049,7 @@ def export_deployment_csv(deployment_path: str):
         include_bom = request.args.get('include_bom', 'false').lower() == 'true'
 
         # Find all photos in deployment directory
-        photo_patterns = ['*.jpg', '*.jpeg', '*.JPG', '*.JPEG']
-        photo_files = []
-        for pattern in photo_patterns:
-            photo_files.extend(deployment_dir.glob(f'**/{pattern}'))
+        photo_files = find_photos_in_directory(deployment_dir)
 
         if not photo_files:
             return jsonify({
@@ -2139,9 +2111,9 @@ def export_deployment_csv(deployment_path: str):
             safe_name = deployment_path.replace('/', '_').replace('\\', '_')
             filename = f"{safe_name}_metadata_{timestamp}.csv"
 
-            # Handle BOM in bytes
+            # Handle BOM encoding
             if include_bom:
-                csv_bytes = b'\xef\xbb\xbf' + csv_content.lstrip('\ufeff').encode('utf-8')
+                csv_bytes = csv_content.encode('utf-8-sig')
             else:
                 csv_bytes = csv_content.encode('utf-8')
 

--- a/Firmware/webui/backend/routes/export.py
+++ b/Firmware/webui/backend/routes/export.py
@@ -24,6 +24,7 @@ import csv
 import io
 import logging
 from datetime import UTC, datetime
+from pathlib import Path
 
 from flask import Blueprint, Response, current_app, jsonify, request
 
@@ -356,14 +357,36 @@ def list_export_formats():
             {
                 "id": ExportFormat.GENERIC_JSON.value,
                 "name": "Generic JSON",
-                "description": "Generic JSON format with all metadata",
-                "implemented": True
+                "description": "Generic JSON format with nested metadata structure",
+                "implemented": True,
+                "endpoints": [
+                    "/json/<path>",
+                    "/json/batch",
+                    "/json/deployment/<path>"
+                ],
+                "features": [
+                    "Nested structure for easy parsing",
+                    "Field customization (include/exclude)",
+                    "File download support",
+                    "Single photo or batch export",
+                    "Deployment-level export"
+                ]
             },
             {
                 "id": ExportFormat.GENERIC_CSV.value,
                 "name": "Generic CSV",
                 "description": "Generic CSV format with flat structure",
-                "implemented": True
+                "implemented": True,
+                "endpoints": [
+                    "/csv/batch",
+                    "/csv/deployment/<path>"
+                ],
+                "features": [
+                    "Excel-compatible format",
+                    "UTF-8 BOM option for proper encoding",
+                    "Field customization (include/exclude)",
+                    "Batch or deployment export"
+                ]
             }
         ]
 
@@ -1324,3 +1347,821 @@ def preview_inaturalist_export():
     except Exception as e:
         logger.error("Error in iNaturalist preview: %s", e, exc_info=True)
         return jsonify({"error": "Preview failed"}), 500
+
+
+# ============================================================================
+# Generic JSON Export Endpoints (Issue #120)
+# ============================================================================
+
+
+def _generate_json_file_response(data: dict | list, filename: str) -> Response:
+    """Generate a JSON file download response.
+
+    Args:
+        data: JSON-serializable data
+        filename: Filename for Content-Disposition header
+
+    Returns:
+        Flask Response with JSON file download
+    """
+    import json
+    json_content = json.dumps(data, indent=2, default=str)
+
+    return Response(
+        json_content,
+        mimetype='application/json',
+        headers={
+            'Content-Disposition': f'attachment; filename="{filename}"',
+            'Content-Type': 'application/json; charset=utf-8',
+        }
+    )
+
+
+def _parse_field_filter_params(request_obj) -> tuple[list[str] | None, list[str] | None]:
+    """Parse fields and exclude parameters from request.
+
+    Handles both query params (GET) and JSON body (POST).
+
+    Args:
+        request_obj: Flask request object
+
+    Returns:
+        Tuple of (fields, exclude) lists or None
+
+    Raises:
+        ValueError: If both fields and exclude are provided
+    """
+    # Try query params first (for GET requests)
+    fields_param = request_obj.args.get('fields')
+    exclude_param = request_obj.args.get('exclude')
+
+    # Override with JSON body if present (for POST requests)
+    if request_obj.is_json:
+        data = request_obj.get_json() or {}
+        if 'fields' in data:
+            fields_param = data['fields']
+        if 'exclude' in data:
+            exclude_param = data['exclude']
+
+    # Parse comma-separated strings to lists
+    fields = None
+    exclude = None
+
+    if fields_param:
+        if isinstance(fields_param, str):
+            fields = [f.strip() for f in fields_param.split(',') if f.strip()]
+        elif isinstance(fields_param, list):
+            fields = [str(f).strip() for f in fields_param if f]
+
+    if exclude_param:
+        if isinstance(exclude_param, str):
+            exclude = [f.strip() for f in exclude_param.split(',') if f.strip()]
+        elif isinstance(exclude_param, list):
+            exclude = [str(f).strip() for f in exclude_param if f]
+
+    # Validate mutual exclusivity
+    if fields and exclude:
+        raise ValueError("Cannot specify both 'fields' and 'exclude' parameters")
+
+    return fields, exclude
+
+
+@export_bp.route("/json/<path:photo_path>", methods=["GET"])
+def export_single_json(photo_path: str):
+    """
+    Export single photo metadata as JSON.
+
+    Query Parameters:
+        fields (str): Comma-separated field names to include
+        exclude (str): Comma-separated field names to exclude
+
+    Accept Header:
+        application/json (default): Return JSON in response body
+        application/octet-stream: Return as .json file download
+
+    Returns:
+        200: JSON metadata
+        400: Invalid parameters (both fields and exclude provided)
+        403: Path traversal attempt blocked
+        404: Photo not found
+        500: Internal error
+
+    Example:
+        GET /api/export/json/moth_2024_01_15__10_00_00.jpg
+
+        GET /api/export/json/moth_2024_01_15__10_00_00.jpg?fields=filename,latitude,longitude
+    """
+    try:
+        # Get service from app config
+        service = current_app.config.get('EXPORT_METADATA_SERVICE')
+        if service is None:
+            return jsonify({"error": "Export service not available"}), 500
+
+        # Validate path to prevent traversal attacks
+        validated_path = validate_photo_path(photo_path, PHOTOS_DIR)
+        if validated_path is None:
+            return jsonify({"error": "Invalid path"}), 403
+
+        # Parse field filtering parameters
+        try:
+            fields, exclude = _parse_field_filter_params(request)
+        except ValueError as e:
+            return jsonify({"error": str(e)}), 400
+
+        # Get export metadata
+        result = service.get_export_metadata(validated_path)
+
+        # Check if result is an error dict
+        if isinstance(result, dict) and 'error' in result:
+            error_msg = result['error']
+            if error_msg == 'Photo not found':
+                return jsonify(result), 404
+            elif error_msg == 'Permission denied':
+                return jsonify(result), 403
+            else:
+                return jsonify(result), 500
+
+        # Transform to generic JSON format with optional filtering
+        if isinstance(result, ExportMetadata):
+            if fields or exclude:
+                transformed = service.transform_to_generic_filtered(
+                    result, flat=False, fields=fields, exclude=exclude
+                )
+            else:
+                transformed = service.transform_to_generic(result, flat=False)
+
+            # Determine response format based on Accept header
+            accept = request.headers.get('Accept', 'application/json')
+
+            if 'application/octet-stream' in accept:
+                # JSON file download
+                filename = Path(photo_path).stem + '_metadata.json'
+                return _generate_json_file_response(transformed, filename)
+            else:
+                # JSON in response body
+                return jsonify(transformed), 200
+        else:
+            return jsonify(result), 200
+
+    except Exception as e:
+        logger.error("Error exporting JSON for %s: %s", photo_path, e, exc_info=True)
+        return jsonify({"error": "Failed to export JSON metadata"}), 500
+
+
+@export_bp.route("/json/batch", methods=["POST"])
+@limiter.limit("10 per minute")
+def export_batch_json():
+    """
+    Export multiple photos as JSON bundle.
+
+    Request Body:
+        {
+            "photo_paths": ["photo1.jpg", "subdir/photo2.jpg", ...],
+            "fields": ["filename", "latitude"],  // optional
+            "exclude": ["notes", "tags"]  // optional, mutually exclusive with fields
+        }
+
+    Accept Header:
+        application/json (default): Return JSON in response body
+        application/octet-stream: Return as .json file download
+
+    Returns:
+        200: JSON with results array
+        400: Invalid request body or parameters
+        500: Internal error
+
+    Example:
+        POST /api/export/json/batch
+        Content-Type: application/json
+
+        {"photo_paths": ["photo1.jpg", "photo2.jpg"]}
+
+        Response:
+        {
+            "results": [
+                {"file": {...}, "location": {...}, ...},
+                {"file": {...}, "location": {...}, ...}
+            ],
+            "total": 2,
+            "successful": 2,
+            "failed": 0,
+            "errors": []
+        }
+    """
+    try:
+        # Get service from app config
+        service = current_app.config.get('EXPORT_METADATA_SERVICE')
+        if service is None:
+            return jsonify({"error": "Export service not available"}), 500
+
+        # Validate request body
+        if not request.is_json:
+            return jsonify({"error": "Request must be JSON"}), 400
+
+        try:
+            data = request.get_json()
+        except Exception:
+            return jsonify({"error": "Invalid JSON in request body"}), 400
+
+        if not data or 'photo_paths' not in data:
+            return jsonify({"error": "Missing 'photo_paths' in request body"}), 400
+
+        photo_paths = data['photo_paths']
+
+        if not isinstance(photo_paths, list):
+            return jsonify({"error": "'photo_paths' must be an array"}), 400
+
+        # Validate all paths are non-empty strings
+        if not all(isinstance(p, str) and p.strip() for p in photo_paths):
+            return jsonify({"error": "All photo_paths must be non-empty strings"}), 400
+
+        if len(photo_paths) == 0:
+            return jsonify({
+                "results": [],
+                "total": 0,
+                "successful": 0,
+                "failed": 0,
+                "errors": []
+            }), 200
+
+        # Get configurable batch size limit
+        max_batch_size = current_app.config.get('EXPORT_MAX_BATCH_SIZE', 1000)
+
+        if len(photo_paths) > max_batch_size:
+            return jsonify({
+                "error": f"Batch size exceeds maximum limit of {max_batch_size} photos"
+            }), 400
+
+        # Parse field filtering parameters
+        try:
+            fields, exclude = _parse_field_filter_params(request)
+        except ValueError as e:
+            return jsonify({"error": str(e)}), 400
+
+        # Collect metadata for all photos
+        results = []
+        errors = []
+
+        for photo_path in photo_paths:
+            # Path traversal protection
+            validated_path = validate_photo_path(photo_path, PHOTOS_DIR)
+            if validated_path is None:
+                errors.append({
+                    "photo_path": photo_path,
+                    "error": "Invalid path"
+                })
+                continue
+
+            result = service.get_export_metadata(validated_path)
+
+            if isinstance(result, dict) and 'error' in result:
+                errors.append({
+                    "photo_path": photo_path,
+                    "error": result['error']
+                })
+                continue
+
+            if isinstance(result, ExportMetadata):
+                # Transform with optional filtering
+                if fields or exclude:
+                    transformed = service.transform_to_generic_filtered(
+                        result, flat=False, fields=fields, exclude=exclude
+                    )
+                else:
+                    transformed = service.transform_to_generic(result, flat=False)
+                results.append(transformed)
+
+        # Build response
+        response_data = {
+            "results": results,
+            "total": len(photo_paths),
+            "successful": len(results),
+            "failed": len(errors),
+            "errors": errors
+        }
+
+        # Determine response format based on Accept header
+        accept = request.headers.get('Accept', 'application/json')
+
+        if 'application/octet-stream' in accept:
+            # JSON file download
+            timestamp = datetime.now(UTC).strftime('%Y%m%d_%H%M%S')
+            filename = f"metadata_export_{timestamp}.json"
+            return _generate_json_file_response(response_data, filename)
+        else:
+            # JSON in response body
+            return jsonify(response_data), 200
+
+    except Exception as e:
+        logger.error("Error in batch JSON export: %s", e, exc_info=True)
+        return jsonify({"error": "Batch JSON export failed"}), 500
+
+
+@export_bp.route("/json/deployment/<path:deployment_path>", methods=["GET"])
+@limiter.limit("5 per minute")
+def export_deployment_json(deployment_path: str):
+    """
+    Export all photos in deployment directory as JSON bundle.
+
+    Query Parameters:
+        fields (str): Comma-separated field names to include
+        exclude (str): Comma-separated field names to exclude
+
+    Accept Header:
+        application/json (default): Return JSON in response body
+        application/octet-stream: Return as .json file download
+
+    Returns:
+        200: JSON with results array
+        400: Empty deployment or invalid parameters
+        403: Path traversal attempt blocked
+        404: Deployment directory not found
+        500: Internal error
+
+    Example:
+        GET /api/export/json/deployment/2024/january_survey
+    """
+    try:
+        # Get service from app config
+        service = current_app.config.get('EXPORT_METADATA_SERVICE')
+        if service is None:
+            return jsonify({"error": "Export service not available"}), 500
+
+        # Validate path to prevent traversal attacks
+        validated_path = validate_photo_path(deployment_path, PHOTOS_DIR)
+        if validated_path is None:
+            return jsonify({"error": "Invalid path"}), 403
+
+        deployment_dir = Path(validated_path)
+        if not deployment_dir.exists():
+            return jsonify({"error": "Deployment directory not found"}), 404
+
+        if not deployment_dir.is_dir():
+            return jsonify({"error": "Path is not a directory"}), 400
+
+        # Parse field filtering parameters
+        try:
+            fields, exclude = _parse_field_filter_params(request)
+        except ValueError as e:
+            return jsonify({"error": str(e)}), 400
+
+        # Find all photos in deployment directory
+        photo_patterns = ['*.jpg', '*.jpeg', '*.JPG', '*.JPEG']
+        photo_files = []
+        for pattern in photo_patterns:
+            photo_files.extend(deployment_dir.glob(f'**/{pattern}'))
+
+        if not photo_files:
+            return jsonify({
+                "error": "No photos found in deployment directory",
+                "results": [],
+                "total": 0,
+                "successful": 0,
+                "failed": 0
+            }), 400
+
+        # Collect metadata for all photos
+        results = []
+        errors = []
+
+        for photo_file in photo_files:
+            result = service.get_export_metadata(photo_file)
+
+            if isinstance(result, dict) and 'error' in result:
+                errors.append({
+                    "photo_path": str(photo_file.relative_to(PHOTOS_DIR)),
+                    "error": result['error']
+                })
+                continue
+
+            if isinstance(result, ExportMetadata):
+                # Transform with optional filtering
+                if fields or exclude:
+                    transformed = service.transform_to_generic_filtered(
+                        result, flat=False, fields=fields, exclude=exclude
+                    )
+                else:
+                    transformed = service.transform_to_generic(result, flat=False)
+                results.append(transformed)
+
+        # Build response
+        response_data = {
+            "deployment_path": deployment_path,
+            "results": results,
+            "total": len(photo_files),
+            "successful": len(results),
+            "failed": len(errors),
+            "errors": errors
+        }
+
+        # Determine response format based on Accept header
+        accept = request.headers.get('Accept', 'application/json')
+
+        if 'application/octet-stream' in accept:
+            # JSON file download
+            timestamp = datetime.now(UTC).strftime('%Y%m%d_%H%M%S')
+            safe_name = deployment_path.replace('/', '_').replace('\\', '_')
+            filename = f"{safe_name}_metadata_{timestamp}.json"
+            return _generate_json_file_response(response_data, filename)
+        else:
+            # JSON in response body
+            return jsonify(response_data), 200
+
+    except Exception as e:
+        logger.error("Error in deployment JSON export for %s: %s", deployment_path, e, exc_info=True)
+        return jsonify({"error": "Deployment JSON export failed"}), 500
+
+
+# ============================================================================
+# Generic CSV Export Endpoints (Issue #120)
+# ============================================================================
+
+
+def _get_generic_csv_headers(fields: list[str] | None = None, exclude: list[str] | None = None) -> list[str]:
+    """Get CSV headers for generic export format.
+
+    Args:
+        fields: If provided, only include these fields
+        exclude: If provided, exclude these fields
+
+    Returns:
+        List of header names for CSV
+    """
+    all_headers = [
+        'photo_path', 'filename', 'timestamp',
+        'latitude', 'longitude', 'altitude', 'gps_accuracy',
+        'camera_make', 'camera_model', 'exposure_time', 'iso', 'focal_length',
+        'species', 'species_common_name', 'species_confidence',
+        'tags', 'notes',
+        'mothbox_id', 'firmware_version',
+        'deployment_name', 'deployment_location_name',
+        'deployment_start_date', 'deployment_end_date',
+        'environmental_conditions',
+        'series_type', 'series_index', 'series_count',
+        'file_size', 'width', 'height'
+    ]
+
+    if fields:
+        return [h for h in all_headers if h in fields]
+    elif exclude:
+        return [h for h in all_headers if h not in exclude]
+    else:
+        return all_headers
+
+
+def _generate_csv_with_bom(headers: list[str], rows: list[list[str]], include_bom: bool = False) -> str:
+    """Generate CSV content with optional UTF-8 BOM.
+
+    Args:
+        headers: CSV column headers
+        rows: CSV data rows
+        include_bom: If True, prepend UTF-8 BOM for Excel compatibility
+
+    Returns:
+        CSV content as string
+    """
+    output = io.StringIO()
+
+    if include_bom:
+        output.write('\ufeff')  # UTF-8 BOM
+
+    writer = csv.writer(output, quoting=csv.QUOTE_MINIMAL)
+    writer.writerow(headers)
+    writer.writerows(rows)
+
+    csv_content = output.getvalue()
+    output.close()
+
+    return csv_content
+
+
+@export_bp.route("/csv/batch", methods=["POST"])
+@limiter.limit("10 per minute")
+def export_batch_csv():
+    """
+    Export multiple photos as CSV.
+
+    Request Body:
+        {
+            "photo_paths": ["photo1.jpg", "subdir/photo2.jpg", ...],
+            "fields": ["filename", "latitude"],  // optional
+            "exclude": ["notes", "tags"],  // optional, mutually exclusive with fields
+            "include_bom": false  // optional, UTF-8 BOM for Excel compatibility
+        }
+
+    Accept Header:
+        text/csv: Return CSV file download
+        application/json (default): Return JSON with csv_data field
+
+    Returns:
+        200: CSV file or JSON with CSV data
+        400: Invalid request body or parameters
+        500: Internal error
+
+    Example:
+        POST /api/export/csv/batch
+        Content-Type: application/json
+        Accept: text/csv
+
+        {"photo_paths": ["photo1.jpg", "photo2.jpg"]}
+    """
+    try:
+        # Get service from app config
+        service = current_app.config.get('EXPORT_METADATA_SERVICE')
+        if service is None:
+            return jsonify({"error": "Export service not available"}), 500
+
+        # Validate request body
+        if not request.is_json:
+            return jsonify({"error": "Request must be JSON"}), 400
+
+        try:
+            data = request.get_json()
+        except Exception:
+            return jsonify({"error": "Invalid JSON in request body"}), 400
+
+        if not data or 'photo_paths' not in data:
+            return jsonify({"error": "Missing 'photo_paths' in request body"}), 400
+
+        photo_paths = data['photo_paths']
+
+        if not isinstance(photo_paths, list):
+            return jsonify({"error": "'photo_paths' must be an array"}), 400
+
+        # Validate all paths are non-empty strings
+        if photo_paths and not all(isinstance(p, str) and p.strip() for p in photo_paths):
+            return jsonify({"error": "All photo_paths must be non-empty strings"}), 400
+
+        # Get configurable batch size limit
+        max_batch_size = current_app.config.get('EXPORT_MAX_BATCH_SIZE', 1000)
+
+        if len(photo_paths) > max_batch_size:
+            return jsonify({
+                "error": f"Batch size exceeds maximum limit of {max_batch_size} photos"
+            }), 400
+
+        # Parse field filtering parameters
+        try:
+            fields, exclude = _parse_field_filter_params(request)
+        except ValueError as e:
+            return jsonify({"error": str(e)}), 400
+
+        include_bom = data.get('include_bom', False)
+
+        # Get headers (filtered if needed)
+        headers = _get_generic_csv_headers(fields, exclude)
+
+        # Empty list handling
+        if len(photo_paths) == 0:
+            csv_content = _generate_csv_with_bom(headers, [], include_bom)
+
+            accept = request.headers.get('Accept', 'application/json')
+            if 'text/csv' in accept:
+                timestamp = datetime.now(UTC).strftime('%Y%m%d_%H%M%S')
+                filename = f"metadata_export_{timestamp}.csv"
+                response = Response(
+                    csv_content.encode('utf-8') if not include_bom else csv_content.encode('utf-8-sig'),
+                    mimetype='text/csv',
+                    headers={
+                        'Content-Disposition': f'attachment; filename="{filename}"',
+                        'Content-Type': 'text/csv; charset=utf-8',
+                    }
+                )
+                return response
+            else:
+                return jsonify({
+                    "csv_data": csv_content,
+                    "headers": headers,
+                    "row_count": 0,
+                    "total": 0,
+                    "successful": 0,
+                    "failed": 0,
+                    "errors": []
+                }), 200
+
+        # Collect metadata and build rows
+        rows = []
+        errors = []
+
+        for photo_path in photo_paths:
+            # Path traversal protection
+            validated_path = validate_photo_path(photo_path, PHOTOS_DIR)
+            if validated_path is None:
+                errors.append({
+                    "photo_path": photo_path,
+                    "error": "Invalid path"
+                })
+                continue
+
+            result = service.get_export_metadata(validated_path)
+
+            if isinstance(result, dict) and 'error' in result:
+                errors.append({
+                    "photo_path": photo_path,
+                    "error": result['error']
+                })
+                continue
+
+            if isinstance(result, ExportMetadata):
+                # Transform to flat format with optional filtering
+                if fields or exclude:
+                    flat_data = service.transform_to_generic_filtered(
+                        result, flat=True, fields=fields, exclude=exclude
+                    )
+                else:
+                    flat_data = service.transform_to_generic(result, flat=True)
+
+                # Build row in header order
+                row = [str(flat_data.get(h, '')) for h in headers]
+                rows.append(row)
+
+        # Generate CSV content
+        csv_content = _generate_csv_with_bom(headers, rows, include_bom)
+
+        # Stats
+        stats = {
+            "total": len(photo_paths),
+            "successful": len(rows),
+            "failed": len(errors),
+            "errors": errors
+        }
+
+        # Determine response format based on Accept header
+        accept = request.headers.get('Accept', 'application/json')
+
+        if 'text/csv' in accept:
+            # CSV file download
+            timestamp = datetime.now(UTC).strftime('%Y%m%d_%H%M%S')
+            filename = f"metadata_export_{timestamp}.csv"
+
+            # Handle BOM in bytes
+            if include_bom:
+                csv_bytes = b'\xef\xbb\xbf' + csv_content.lstrip('\ufeff').encode('utf-8')
+            else:
+                csv_bytes = csv_content.encode('utf-8')
+
+            return Response(
+                csv_bytes,
+                mimetype='text/csv',
+                headers={
+                    'Content-Disposition': f'attachment; filename="{filename}"',
+                    'Content-Type': 'text/csv; charset=utf-8',
+                }
+            )
+        else:
+            # JSON with CSV data
+            return jsonify({
+                "csv_data": csv_content,
+                "headers": headers,
+                "row_count": len(rows),
+                **stats
+            }), 200
+
+    except Exception as e:
+        logger.error("Error in batch CSV export: %s", e, exc_info=True)
+        return jsonify({"error": "Batch CSV export failed"}), 500
+
+
+@export_bp.route("/csv/deployment/<path:deployment_path>", methods=["GET"])
+@limiter.limit("5 per minute")
+def export_deployment_csv(deployment_path: str):
+    """
+    Export all photos in deployment directory as CSV.
+
+    Query Parameters:
+        fields (str): Comma-separated field names to include
+        exclude (str): Comma-separated field names to exclude
+        include_bom (str): "true" for UTF-8 BOM for Excel compatibility
+
+    Accept Header:
+        text/csv: Return CSV file download
+        application/json (default): Return JSON with csv_data field
+
+    Returns:
+        200: CSV file or JSON with CSV data
+        400: Empty deployment or invalid parameters
+        403: Path traversal attempt blocked
+        404: Deployment directory not found
+        500: Internal error
+
+    Example:
+        GET /api/export/csv/deployment/2024/january_survey?include_bom=true
+    """
+    try:
+        # Get service from app config
+        service = current_app.config.get('EXPORT_METADATA_SERVICE')
+        if service is None:
+            return jsonify({"error": "Export service not available"}), 500
+
+        # Validate path to prevent traversal attacks
+        validated_path = validate_photo_path(deployment_path, PHOTOS_DIR)
+        if validated_path is None:
+            return jsonify({"error": "Invalid path"}), 403
+
+        deployment_dir = Path(validated_path)
+        if not deployment_dir.exists():
+            return jsonify({"error": "Deployment directory not found"}), 404
+
+        if not deployment_dir.is_dir():
+            return jsonify({"error": "Path is not a directory"}), 400
+
+        # Parse field filtering parameters
+        try:
+            fields, exclude = _parse_field_filter_params(request)
+        except ValueError as e:
+            return jsonify({"error": str(e)}), 400
+
+        include_bom = request.args.get('include_bom', 'false').lower() == 'true'
+
+        # Find all photos in deployment directory
+        photo_patterns = ['*.jpg', '*.jpeg', '*.JPG', '*.JPEG']
+        photo_files = []
+        for pattern in photo_patterns:
+            photo_files.extend(deployment_dir.glob(f'**/{pattern}'))
+
+        if not photo_files:
+            return jsonify({
+                "error": "No photos found in deployment directory",
+                "csv_data": "",
+                "headers": [],
+                "row_count": 0,
+                "total": 0
+            }), 400
+
+        # Get headers (filtered if needed)
+        headers = _get_generic_csv_headers(fields, exclude)
+
+        # Collect metadata and build rows
+        rows = []
+        errors = []
+
+        for photo_file in photo_files:
+            result = service.get_export_metadata(photo_file)
+
+            if isinstance(result, dict) and 'error' in result:
+                errors.append({
+                    "photo_path": str(photo_file.relative_to(PHOTOS_DIR)),
+                    "error": result['error']
+                })
+                continue
+
+            if isinstance(result, ExportMetadata):
+                # Transform to flat format with optional filtering
+                if fields or exclude:
+                    flat_data = service.transform_to_generic_filtered(
+                        result, flat=True, fields=fields, exclude=exclude
+                    )
+                else:
+                    flat_data = service.transform_to_generic(result, flat=True)
+
+                # Build row in header order
+                row = [str(flat_data.get(h, '')) for h in headers]
+                rows.append(row)
+
+        # Generate CSV content
+        csv_content = _generate_csv_with_bom(headers, rows, include_bom)
+
+        # Stats
+        stats = {
+            "deployment_path": deployment_path,
+            "total": len(photo_files),
+            "successful": len(rows),
+            "failed": len(errors),
+            "errors": errors
+        }
+
+        # Determine response format based on Accept header
+        accept = request.headers.get('Accept', 'application/json')
+
+        if 'text/csv' in accept:
+            # CSV file download
+            timestamp = datetime.now(UTC).strftime('%Y%m%d_%H%M%S')
+            safe_name = deployment_path.replace('/', '_').replace('\\', '_')
+            filename = f"{safe_name}_metadata_{timestamp}.csv"
+
+            # Handle BOM in bytes
+            if include_bom:
+                csv_bytes = b'\xef\xbb\xbf' + csv_content.lstrip('\ufeff').encode('utf-8')
+            else:
+                csv_bytes = csv_content.encode('utf-8')
+
+            return Response(
+                csv_bytes,
+                mimetype='text/csv',
+                headers={
+                    'Content-Disposition': f'attachment; filename="{filename}"',
+                    'Content-Type': 'text/csv; charset=utf-8',
+                }
+            )
+        else:
+            # JSON with CSV data
+            return jsonify({
+                "csv_data": csv_content,
+                "headers": headers,
+                "row_count": len(rows),
+                **stats
+            }), 200
+
+    except Exception as e:
+        logger.error("Error in deployment CSV export for %s: %s", deployment_path, e, exc_info=True)
+        return jsonify({"error": "Deployment CSV export failed"}), 500

--- a/Firmware/webui/backend/services/export_metadata_service.py
+++ b/Firmware/webui/backend/services/export_metadata_service.py
@@ -643,6 +643,140 @@ class ExportMetadataService:
                 'timestamp': metadata.timestamp,
             }
 
+    def transform_to_generic_filtered(
+        self,
+        metadata: ExportMetadata,
+        flat: bool = False,
+        fields: list[str] | None = None,
+        exclude: list[str] | None = None,
+    ) -> dict:
+        """Transform to generic format with optional field filtering.
+
+        Args:
+            metadata: ExportMetadata to transform
+            flat: If True, flatten for CSV (no nested dicts)
+            fields: If provided, only include these fields (for nested: top-level
+                    sections like 'file', 'location', or leaf fields like 'filename')
+            exclude: If provided, exclude these fields
+
+        Returns:
+            Filtered dictionary
+
+        Raises:
+            ValueError: If both fields and exclude are provided
+
+        Example:
+            >>> # Include only specific fields
+            >>> data = service.transform_to_generic_filtered(
+            ...     metadata, flat=False, fields=['filename', 'latitude', 'longitude']
+            ... )
+
+            >>> # Exclude specific fields
+            >>> data = service.transform_to_generic_filtered(
+            ...     metadata, flat=True, exclude=['notes', 'tags']
+            ... )
+        """
+        if fields is not None and exclude is not None:
+            raise ValueError("Cannot specify both 'fields' and 'exclude' parameters")
+
+        # Get full transform first
+        full_data = self.transform_to_generic(metadata, flat=flat)
+
+        # No filtering requested
+        if fields is None and exclude is None:
+            return full_data
+
+        if flat:
+            # For flat structure, filter directly by field names
+            if fields is not None:
+                return {k: v for k, v in full_data.items() if k in fields}
+            else:  # exclude is not None
+                return {k: v for k, v in full_data.items() if k not in exclude}
+        else:
+            # For nested structure, need to handle section and leaf field filtering
+            return self._filter_nested_dict(full_data, fields, exclude)
+
+    def _filter_nested_dict(
+        self,
+        data: dict,
+        fields: list[str] | None,
+        exclude: list[str] | None,
+    ) -> dict:
+        """Filter a nested dictionary based on field names.
+
+        Supports:
+        - Top-level section names (e.g., 'file', 'location', 'camera')
+        - Leaf field names (e.g., 'filename', 'latitude')
+        - Dotted paths (e.g., 'file.filename', 'location.latitude')
+
+        Args:
+            data: Nested dictionary to filter
+            fields: Fields to include (None means include all)
+            exclude: Fields to exclude (None means exclude none)
+
+        Returns:
+            Filtered dictionary
+        """
+        if fields is not None:
+            return self._include_fields(data, fields)
+        else:  # exclude is not None
+            return self._exclude_fields(data, exclude)
+
+    def _include_fields(self, data: dict, fields: list[str]) -> dict:
+        """Include only specified fields in nested dictionary."""
+        result = {}
+
+        # Build a set of section names and leaf names for quick lookup
+        field_set = set(fields)
+
+        for key, value in data.items():
+            if key in field_set:
+                # Include entire section
+                result[key] = value
+            elif isinstance(value, dict):
+                # Check if any leaf fields in this section are requested
+                section_result = {}
+                for leaf_key, leaf_value in value.items():
+                    if leaf_key in field_set:
+                        section_result[leaf_key] = leaf_value
+                    # Check dotted path (e.g., 'file.filename')
+                    dotted = f"{key}.{leaf_key}"
+                    if dotted in field_set:
+                        section_result[leaf_key] = leaf_value
+                if section_result:
+                    result[key] = section_result
+            else:
+                # Top-level non-dict field (like timestamp)
+                if key in field_set:
+                    result[key] = value
+
+        return result
+
+    def _exclude_fields(self, data: dict, exclude: list[str]) -> dict:
+        """Exclude specified fields from nested dictionary."""
+        result = {}
+        exclude_set = set(exclude)
+
+        for key, value in data.items():
+            if key in exclude_set:
+                # Skip entire section
+                continue
+            elif isinstance(value, dict):
+                # Filter fields within section
+                section_result = {}
+                for leaf_key, leaf_value in value.items():
+                    if leaf_key not in exclude_set:
+                        dotted = f"{key}.{leaf_key}"
+                        if dotted not in exclude_set:
+                            section_result[leaf_key] = leaf_value
+                if section_result:
+                    result[key] = section_result
+            else:
+                # Top-level non-dict field
+                result[key] = value
+
+        return result
+
     def transform_to_darwin_core(self, metadata: ExportMetadata) -> dict:
         """Transform to Darwin Core format for GBIF-compatible export.
 

--- a/Firmware/webui/docs/dev/api/generic-export.md
+++ b/Firmware/webui/docs/dev/api/generic-export.md
@@ -1,0 +1,619 @@
+# Generic Export API
+
+Generic JSON and CSV export endpoints for photo metadata. These endpoints provide flexible, human-readable export formats with field customization support.
+
+## Overview
+
+The generic export endpoints provide two output formats:
+
+| Format | Description | Use Case |
+|--------|-------------|----------|
+| **JSON** | Nested structure preserving metadata hierarchy | Programmatic access, data interchange |
+| **CSV** | Flat structure with one row per photo | Spreadsheets, simple data analysis |
+
+Both formats support:
+- Single photo, batch, and deployment-level exports
+- Field filtering (include or exclude specific fields)
+- Content negotiation via `Accept` header
+- File download responses
+
+## JSON Endpoints
+
+### GET /api/export/json/{photo_path}
+
+Export metadata for a single photo as JSON.
+
+**Parameters:**
+
+| Name | Type | Location | Description |
+|------|------|----------|-------------|
+| `photo_path` | string | path | Relative path to photo from photos directory |
+| `fields` | string | query | Comma-separated list of fields to include |
+| `exclude` | string | query | Comma-separated list of fields to exclude |
+
+**Headers:**
+
+| Header | Value | Effect |
+|--------|-------|--------|
+| `Accept: application/json` | Default | Returns JSON response body |
+| `Accept: application/octet-stream` | File download | Returns `.json` file attachment |
+
+**Example Request:**
+
+```bash
+# Get JSON response
+curl -X GET "http://localhost:5000/api/export/json/2024/photo001.jpg" \
+  -H "Accept: application/json"
+
+# Get file download
+curl -X GET "http://localhost:5000/api/export/json/2024/photo001.jpg" \
+  -H "Accept: application/octet-stream" \
+  -o photo001_metadata.json
+
+# With field filtering
+curl -X GET "http://localhost:5000/api/export/json/2024/photo001.jpg?fields=filename,location,species"
+```
+
+**Response (200 OK):**
+
+```json
+{
+  "filename": "photo001.jpg",
+  "photo_path": "2024/photo001.jpg",
+  "capture": {
+    "timestamp": "2024-06-15T14:30:00",
+    "camera": {
+      "make": "Arducam",
+      "model": "OwlSight 64MP"
+    },
+    "settings": {
+      "iso": 400,
+      "aperture": 2.8,
+      "shutter_speed": "1/250"
+    }
+  },
+  "location": {
+    "latitude": 35.9606,
+    "longitude": -83.9207,
+    "altitude": 350.5,
+    "gps_accuracy": 2.5
+  },
+  "identification": {
+    "species": "Actias luna",
+    "common_name": "Luna Moth",
+    "tags": ["moth", "saturniidae", "green"]
+  },
+  "notes": "Specimen in good condition",
+  "deployment": {
+    "name": "Oak Ridge Survey 2024",
+    "mothbox_id": "mothbox-001"
+  },
+  "series": {
+    "type": "hdr",
+    "index": 0,
+    "total": 3
+  }
+}
+```
+
+**Error Responses:**
+
+| Status | Condition |
+|--------|-----------|
+| 400 | Both `fields` and `exclude` specified |
+| 403 | Path traversal attempt detected |
+| 404 | Photo not found |
+
+---
+
+### POST /api/export/json/batch
+
+Export metadata for multiple photos as a JSON array.
+
+**Rate Limit:** 10 requests per minute
+
+**Request Body:**
+
+```json
+{
+  "photo_paths": ["2024/photo001.jpg", "2024/photo002.jpg"],
+  "fields": ["filename", "location", "species"],
+  "exclude": null
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `photo_paths` | array | Yes | List of photo paths to export |
+| `fields` | array | No | Fields to include (mutually exclusive with `exclude`) |
+| `exclude` | array | No | Fields to exclude (mutually exclusive with `fields`) |
+
+**Headers:**
+
+| Header | Value | Effect |
+|--------|-------|--------|
+| `Accept: application/json` | Default | Returns JSON response body |
+| `Accept: application/octet-stream` | File download | Returns `.json` file attachment |
+
+**Example Request:**
+
+```bash
+curl -X POST "http://localhost:5000/api/export/json/batch" \
+  -H "Content-Type: application/json" \
+  -H "X-CSRFToken: <token>" \
+  -d '{
+    "photo_paths": ["2024/photo001.jpg", "2024/photo002.jpg"],
+    "fields": ["filename", "location", "species"]
+  }'
+```
+
+**Response (200 OK):**
+
+```json
+{
+  "results": [
+    {
+      "filename": "photo001.jpg",
+      "location": { "latitude": 35.9606, "longitude": -83.9207 },
+      "species": "Actias luna"
+    },
+    {
+      "filename": "photo002.jpg",
+      "location": { "latitude": 35.9610, "longitude": -83.9210 },
+      "species": "Automeris io"
+    }
+  ],
+  "total": 2,
+  "successful": 2,
+  "failed": 0,
+  "errors": []
+}
+```
+
+**Error Responses:**
+
+| Status | Condition |
+|--------|-----------|
+| 400 | Missing `photo_paths`, empty array, both `fields` and `exclude` specified, or batch size exceeded |
+| 403 | Path traversal attempt in any photo path |
+
+---
+
+### GET /api/export/json/deployment/{deployment_path}
+
+Export metadata for all photos in a deployment directory.
+
+**Rate Limit:** 5 requests per minute
+
+**Parameters:**
+
+| Name | Type | Location | Description |
+|------|------|----------|-------------|
+| `deployment_path` | string | path | Relative path to deployment directory |
+| `fields` | string | query | Comma-separated list of fields to include |
+| `exclude` | string | query | Comma-separated list of fields to exclude |
+
+**Headers:**
+
+| Header | Value | Effect |
+|--------|-------|--------|
+| `Accept: application/json` | Default | Returns JSON response body |
+| `Accept: application/octet-stream` | File download | Returns `.json` file attachment |
+
+**Example Request:**
+
+```bash
+curl -X GET "http://localhost:5000/api/export/json/deployment/forest_survey_2024" \
+  -H "Accept: application/octet-stream" \
+  -o forest_survey_metadata.json
+```
+
+**Response (200 OK):**
+
+Same structure as batch export response.
+
+---
+
+## CSV Endpoints
+
+### POST /api/export/csv/batch
+
+Export metadata for multiple photos as CSV.
+
+**Rate Limit:** 10 requests per minute
+
+**Request Body:**
+
+```json
+{
+  "photo_paths": ["2024/photo001.jpg", "2024/photo002.jpg"],
+  "fields": ["filename", "latitude", "longitude", "species"],
+  "exclude": null,
+  "include_bom": true
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `photo_paths` | array | Yes | List of photo paths to export |
+| `fields` | array | No | Fields to include |
+| `exclude` | array | No | Fields to exclude |
+| `include_bom` | boolean | No | Include UTF-8 BOM for Excel compatibility (default: false) |
+
+**Headers:**
+
+| Header | Value | Effect |
+|--------|-------|--------|
+| `Accept: application/json` | Returns JSON with embedded CSV | `{"csv_data": "..."}` |
+| `Accept: text/csv` | File download | Returns `.csv` file attachment |
+
+**Example Request:**
+
+```bash
+# Get CSV file download
+curl -X POST "http://localhost:5000/api/export/csv/batch" \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/csv" \
+  -H "X-CSRFToken: <token>" \
+  -d '{
+    "photo_paths": ["2024/photo001.jpg", "2024/photo002.jpg"],
+    "include_bom": true
+  }' \
+  -o photos.csv
+
+# Get CSV as JSON response
+curl -X POST "http://localhost:5000/api/export/csv/batch" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -H "X-CSRFToken: <token>" \
+  -d '{"photo_paths": ["2024/photo001.jpg"]}'
+```
+
+**Response (Accept: text/csv):**
+
+```csv
+filename,photo_path,timestamp,latitude,longitude,altitude,gps_accuracy,species,common_name,tags,notes,deployment_name,mothbox_id,series_type,series_index
+photo001.jpg,2024/photo001.jpg,2024-06-15T14:30:00,35.9606,-83.9207,350.5,2.5,Actias luna,Luna Moth,"moth,saturniidae,green",Good specimen,Oak Ridge Survey,mothbox-001,hdr,0
+photo002.jpg,2024/photo002.jpg,2024-06-15T14:31:00,35.9610,-83.9210,352.0,2.3,Automeris io,Io Moth,"moth,saturniidae,yellow",,Oak Ridge Survey,mothbox-001,,
+```
+
+**Response (Accept: application/json):**
+
+```json
+{
+  "csv_data": "filename,photo_path,...\nphoto001.jpg,...",
+  "total": 2,
+  "successful": 2,
+  "failed": 0
+}
+```
+
+---
+
+### GET /api/export/csv/deployment/{deployment_path}
+
+Export metadata for all photos in a deployment directory as CSV.
+
+**Rate Limit:** 5 requests per minute
+
+**Parameters:**
+
+| Name | Type | Location | Description |
+|------|------|----------|-------------|
+| `deployment_path` | string | path | Relative path to deployment directory |
+| `fields` | string | query | Comma-separated list of fields to include |
+| `exclude` | string | query | Comma-separated list of fields to exclude |
+| `include_bom` | boolean | query | Include UTF-8 BOM (default: false) |
+
+**Example Request:**
+
+```bash
+curl -X GET "http://localhost:5000/api/export/csv/deployment/forest_2024?include_bom=true" \
+  -H "Accept: text/csv" \
+  -o forest_2024.csv
+```
+
+---
+
+## Field Reference
+
+The following fields are available for filtering. Use these names with `fields` or `exclude` parameters.
+
+### Core Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `filename` | string | Photo filename |
+| `photo_path` | string | Relative path from photos directory |
+| `timestamp` | string | Capture timestamp (ISO 8601) |
+
+### Location Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `latitude` | number | GPS latitude (decimal degrees) |
+| `longitude` | number | GPS longitude (decimal degrees) |
+| `altitude` | number | GPS altitude (meters) |
+| `gps_accuracy` | number | GPS horizontal accuracy (HDOP) |
+
+### Camera Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `camera_make` | string | Camera manufacturer |
+| `camera_model` | string | Camera model |
+| `iso` | integer | ISO sensitivity |
+| `aperture` | number | Aperture (f-number) |
+| `shutter_speed` | string | Shutter speed |
+| `focal_length` | number | Focal length (mm) |
+
+### Identification Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `species` | string | Scientific species name |
+| `common_name` | string | Common species name |
+| `tags` | array/string | Photo tags (array in JSON, comma-separated in CSV) |
+| `notes` | string | User notes |
+
+### Deployment Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `deployment_name` | string | Deployment name |
+| `mothbox_id` | string | Mothbox device ID |
+| `firmware_version` | string | Firmware version |
+
+### Series Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `series_type` | string | Series type (hdr, focus_bracket, or null) |
+| `series_index` | integer | Index within series |
+| `series_total` | integer | Total photos in series |
+
+---
+
+## Field Filtering
+
+### Include Mode
+
+Only export specified fields:
+
+```bash
+# Query parameter (single photo, deployment)
+?fields=filename,latitude,longitude,species
+
+# Request body (batch)
+{"photo_paths": [...], "fields": ["filename", "latitude", "longitude", "species"]}
+```
+
+### Exclude Mode
+
+Export all fields except specified:
+
+```bash
+# Query parameter
+?exclude=notes,tags,camera_make,camera_model
+
+# Request body
+{"photo_paths": [...], "exclude": ["notes", "tags"]}
+```
+
+### Rules
+
+1. Cannot use both `fields` and `exclude` together (returns 400 error)
+2. Unknown field names are silently ignored
+3. For nested JSON: filtering applies to all levels
+4. For flat CSV: filtering applies to column headers
+
+---
+
+## Response Formats
+
+### JSON Response Structure
+
+When `Accept: application/json` is specified:
+
+**Single Photo:**
+```json
+{
+  "filename": "...",
+  "capture": { ... },
+  "location": { ... },
+  "identification": { ... },
+  ...
+}
+```
+
+**Batch/Deployment:**
+```json
+{
+  "results": [ ... ],
+  "total": 10,
+  "successful": 9,
+  "failed": 1,
+  "errors": [
+    {"photo_path": "missing.jpg", "error": "Photo not found"}
+  ]
+}
+```
+
+### File Download
+
+When `Accept: application/octet-stream` (JSON) or `Accept: text/csv` (CSV):
+
+- `Content-Type`: `application/json` or `text/csv; charset=utf-8`
+- `Content-Disposition`: `attachment; filename="<name>_<timestamp>.<ext>"`
+
+---
+
+## Error Handling
+
+### Error Response Format
+
+```json
+{
+  "error": "Error message describing the problem"
+}
+```
+
+### HTTP Status Codes
+
+| Status | Meaning |
+|--------|---------|
+| 200 | Success |
+| 400 | Invalid request (missing fields, validation error) |
+| 403 | Path traversal attempt or access denied |
+| 404 | Photo or deployment not found |
+| 429 | Rate limit exceeded |
+| 500 | Internal server error |
+
+### Partial Failures
+
+Batch operations continue processing even if some photos fail. Failed photos are reported in the `errors` array:
+
+```json
+{
+  "results": [ ... ],
+  "total": 10,
+  "successful": 8,
+  "failed": 2,
+  "errors": [
+    {"photo_path": "missing1.jpg", "error": "Photo not found"},
+    {"photo_path": "bad/path", "error": "Invalid path"}
+  ]
+}
+```
+
+---
+
+## Code Examples
+
+### Python
+
+```python
+import requests
+
+BASE_URL = "http://localhost:5000/api/export"
+
+# Get CSRF token first
+session = requests.Session()
+csrf_resp = session.get(f"{BASE_URL.replace('/api/export', '/api/csrf-token')}")
+csrf_token = csrf_resp.json()["csrf_token"]
+
+# Single photo JSON export
+response = requests.get(
+    f"{BASE_URL}/json/2024/photo001.jpg",
+    params={"fields": "filename,species,latitude,longitude"}
+)
+metadata = response.json()
+print(f"Species: {metadata.get('species')}")
+
+# Batch JSON export
+response = session.post(
+    f"{BASE_URL}/json/batch",
+    headers={"X-CSRFToken": csrf_token},
+    json={
+        "photo_paths": ["2024/photo001.jpg", "2024/photo002.jpg"],
+        "exclude": ["notes", "tags"]
+    }
+)
+result = response.json()
+print(f"Exported {result['successful']} of {result['total']} photos")
+
+# Deployment CSV download
+response = requests.get(
+    f"{BASE_URL}/csv/deployment/forest_2024",
+    headers={"Accept": "text/csv"},
+    params={"include_bom": "true"}
+)
+with open("forest_2024.csv", "wb") as f:
+    f.write(response.content)
+```
+
+### JavaScript
+
+```javascript
+const BASE_URL = 'http://localhost:5000/api/export';
+
+// Get CSRF token
+async function getCsrfToken() {
+  const resp = await fetch('/api/csrf-token');
+  const data = await resp.json();
+  return data.csrf_token;
+}
+
+// Single photo JSON export
+async function exportSinglePhoto(photoPath, fields = null) {
+  const params = new URLSearchParams();
+  if (fields) params.set('fields', fields.join(','));
+
+  const response = await fetch(
+    `${BASE_URL}/json/${photoPath}?${params}`,
+    { credentials: 'include' }
+  );
+  return response.json();
+}
+
+// Batch JSON export
+async function exportBatchJson(photoPaths, options = {}) {
+  const csrfToken = await getCsrfToken();
+
+  const response = await fetch(`${BASE_URL}/json/batch`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRFToken': csrfToken
+    },
+    credentials: 'include',
+    body: JSON.stringify({
+      photo_paths: photoPaths,
+      fields: options.fields,
+      exclude: options.exclude
+    })
+  });
+
+  return response.json();
+}
+
+// Deployment CSV download
+async function downloadDeploymentCsv(deploymentPath) {
+  const response = await fetch(
+    `${BASE_URL}/csv/deployment/${deploymentPath}?include_bom=true`,
+    {
+      headers: { 'Accept': 'text/csv' },
+      credentials: 'include'
+    }
+  );
+
+  const blob = await response.blob();
+  const url = URL.createObjectURL(blob);
+
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `${deploymentPath.replace('/', '_')}.csv`;
+  a.click();
+
+  URL.revokeObjectURL(url);
+}
+
+// Usage
+const metadata = await exportSinglePhoto('2024/photo001.jpg', ['filename', 'species']);
+console.log(metadata);
+
+const batch = await exportBatchJson(
+  ['2024/photo001.jpg', '2024/photo002.jpg'],
+  { exclude: ['notes'] }
+);
+console.log(`Exported ${batch.successful} photos`);
+```
+
+---
+
+## Related Documentation
+
+- [Darwin Core Export API](./export.md#darwin-core-endpoints) - GBIF-compatible export format
+- [iNaturalist Export API](./export.md#inaturalist-endpoints) - iNaturalist-compatible ZIP export
+- [Deployment Metadata API](./deployment.md) - Deployment-level metadata management
+- [Gallery API](./gallery.md) - Photo listing and series detection


### PR DESCRIPTION
## Summary

Implements generic JSON and CSV metadata export endpoints for flexible photo data export.

- **JSON endpoints**: Single photo, batch (array format), and deployment-level exports with nested structure
- **CSV endpoints**: Batch and deployment-level exports with flat structure, Excel-compatible
- **Field filtering**: Include/exclude parameters for customizing exported fields
- **Content negotiation**: Accept header support for JSON response vs file download
- **UTF-8 BOM option**: Excel compatibility for CSV exports

## New Endpoints

| Endpoint | Method | Description |
|----------|--------|-------------|
| `/api/export/json/<path>` | GET | Single photo JSON export |
| `/api/export/json/batch` | POST | Batch JSON bundle |
| `/api/export/json/deployment/<path>` | GET | Deployment-level JSON |
| `/api/export/csv/batch` | POST | Batch CSV export |
| `/api/export/csv/deployment/<path>` | GET | Deployment-level CSV |

## Test Plan

- [x] 53 new unit tests covering all endpoints and edge cases
- [x] All 110 tests passing (53 new + 57 existing)
- [x] Ruff linting passes
- [x] Field filtering works for both include and exclude modes
- [x] Path traversal protection validated
- [x] Rate limiting configured (10/min batch, 5/min deployment)

Closes #120