### PR TITLE
feat(export): Implement export preset save/load system (#123)

### DIFF
--- a/Firmware/CLAUDE.md
+++ b/Firmware/CLAUDE.md
@@ -475,6 +475,75 @@ stats = service.build_index()
 - Cancellation is graceful (job stops at next checkpoint, partial results may exist)
 - Download endpoint has path traversal protection
 
+### Export Preset System (Issue #123)
+
+**Overview**: Reusable export configurations for common export scenarios. Presets store export format, filter criteria, and format-specific options that can be applied when creating export jobs.
+
+**Architecture**:
+- **Types**: `webui/backend/lib/export_preset_types.py` - Data structures
+  - `ExportPreset`: Dataclass with format, filter, options, metadata
+  - `ExportPresetCategory`: Enum (BUILT_IN, USER)
+  - Serialization: `to_dict()`, `from_dict()` methods
+
+- **Manager**: `webui/backend/export_preset_manager.py` - CRUD operations
+  - `ExportPresetManager`: Preset file management with validation
+  - Methods: `list_presets()`, `get_preset()`, `save_preset()`, `delete_preset()`
+  - File locking for concurrent access
+  - Built-in preset protection (read-only)
+
+- **API**: `webui/backend/routes/export_presets.py` - REST endpoints
+  - `GET /api/export/presets`: List all presets (with optional format filter)
+  - `GET /api/export/presets/<name>`: Get preset details
+  - `POST /api/export/presets`: Create user preset
+  - `DELETE /api/export/presets/<name>`: Delete user preset
+
+**Built-in Presets** (6 presets in `webui/backend/presets_builtin/export/`):
+- `gbif_biodiversity`: Darwin Core for GBIF submission (has_species: true)
+- `inaturalist_upload`: iNaturalist export with XMP sidecars
+- `simple_json`: Generic JSON metadata export
+- `simple_csv`: Excel-compatible CSV with UTF-8 BOM
+- `hdr_series`: JSON export for HDR photo series
+- `focus_bracket_series`: JSON export for focus bracket series
+
+**Preset Usage in Jobs**:
+```python
+# Create job using preset
+POST /api/export/jobs
+{
+    "preset": "gbif_biodiversity",
+    "filter": {"date_start": "2024-01-01"}  # Additional filter merged
+}
+```
+
+Presets provide defaults; explicit values override preset values.
+
+**Directory Structure**:
+```
+CONFIG_DIR/presets/
+├── built-in/
+│   └── export/           # Built-in export presets (read-only)
+│       ├── gbif_biodiversity.json
+│       ├── inaturalist_upload.json
+│       └── ...
+└── user/
+    └── export/           # User export presets
+```
+
+**Testing**:
+- Unit tests: `Tests/unit/test_export_preset_types.py` (21 tests)
+- Unit tests: `Tests/unit/test_export_preset_manager.py` (40 tests)
+- Unit tests: `Tests/unit/test_export_preset_routes.py` (18 tests)
+- Integration tests: `Tests/integration/test_export_preset_workflow.py` (14 tests)
+
+**Documentation**:
+- `webui/docs/dev/api/export-presets.md`: Complete API documentation
+
+**Important Notes**:
+- Built-in presets are protected (cannot be modified or deleted)
+- User presets stored in `CONFIG_DIR/presets/user/export/`
+- Presets integrate with Export Job Queue (Issue #122)
+- File locking prevents race conditions on concurrent access
+
 ### Deployment Metadata Sidecar System (Issue #114)
 
 **Overview**: Directory-level metadata files for describing photo collections. Deployment metadata captures location, time period, environmental conditions, and project information at the collection level (not individual photos).

--- a/Firmware/Tests/conftest.py
+++ b/Firmware/Tests/conftest.py
@@ -1567,8 +1567,9 @@ def pytest_collection_modifyitems(config, items):
         is_deployment_workflow = 'test_deployment_workflow' in fspath_str  # Uses threading/tmp_path, no camera/GPIO
         is_inaturalist_export_workflow = 'test_inaturalist_export_workflow' in fspath_str  # Uses tmp_path/zipfile, no camera/GPIO
         is_export_job_workflow = 'test_export_job_workflow' in fspath_str  # Uses tmp_path/Flask test client/threading, no camera/GPIO
+        is_export_preset_workflow = 'test_export_preset_workflow' in fspath_str  # Uses tmp_path/Flask test client, no camera/GPIO (Issue #123)
 
-        if is_integration and not is_manual and not is_installer and not is_focus_bracket_integration and not is_gallery_pagination and not is_gps_exif_workflow and not is_verification_workflow and not is_batch_tagging_workflow and not is_map_locations_integration and not is_clustering_workflow and not is_sidecar_concurrent and not is_sidecar_search_integration and not is_search_workflow and not is_deployment_workflow and not is_inaturalist_export_workflow and not is_export_job_workflow:
+        if is_integration and not is_manual and not is_installer and not is_focus_bracket_integration and not is_gallery_pagination and not is_gps_exif_workflow and not is_verification_workflow and not is_batch_tagging_workflow and not is_map_locations_integration and not is_clustering_workflow and not is_sidecar_concurrent and not is_sidecar_search_integration and not is_search_workflow and not is_deployment_workflow and not is_inaturalist_export_workflow and not is_export_job_workflow and not is_export_preset_workflow:
             item.add_marker(pytest.mark.hardware)
 
 

--- a/Firmware/Tests/integration/test_export_preset_workflow.py
+++ b/Firmware/Tests/integration/test_export_preset_workflow.py
@@ -1,0 +1,498 @@
+"""
+Integration tests for export preset workflow (Issue #123).
+
+Tests end-to-end workflows:
+- Preset creation, listing, and deletion
+- Using presets with export job creation
+- Preset filter and options merging
+- Built-in preset loading
+
+Run with: MOTHBOX_ENV=test pytest Tests/integration/test_export_preset_workflow.py -v
+
+These tests are marked as @pytest.mark.integration but NOT @pytest.mark.hardware
+since they test multi-layer integration without requiring Pi hardware.
+
+Author: Mothbox Team
+Date: 2024
+"""
+
+import json
+import os
+import sys
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+# Mark all tests in this module as integration tests (but not hardware)
+pytestmark = pytest.mark.integration
+
+# Setup path
+FIRMWARE_DIR = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(FIRMWARE_DIR))
+sys.path.insert(0, str(FIRMWARE_DIR / "webui" / "backend"))
+os.environ.setdefault("MOTHBOX_ENV", "test")
+
+from flask import Flask
+
+from webui.backend.lib.export_job_types import ExportJobFilter, ExportJobFormat
+from webui.backend.lib.export_preset_types import ExportPreset, ExportPresetCategory
+from webui.backend.export_preset_manager import ExportPresetManager
+from webui.backend.routes.export_presets import export_presets_bp
+from webui.backend.routes.export import export_bp
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def preset_dirs(tmp_path):
+    """Create temporary directories for presets."""
+    builtin_dir = tmp_path / "built-in" / "export"
+    user_dir = tmp_path / "user" / "export"
+    builtin_dir.mkdir(parents=True)
+    user_dir.mkdir(parents=True)
+
+    # Create a built-in preset
+    builtin_preset = {
+        "name": "test_builtin",
+        "display_name": "Test Built-in Preset",
+        "export_format": "darwin_core",
+        "description": "A test built-in preset",
+        "version": "1.0",
+        "author": "system",
+        "category": "built-in",
+        "filter": {"has_species": True},
+        "options": {"validate": True},
+    }
+    (builtin_dir / "test_builtin.json").write_text(json.dumps(builtin_preset))
+
+    return builtin_dir, user_dir
+
+
+@pytest.fixture
+def preset_manager(preset_dirs):
+    """Create ExportPresetManager with temp directories."""
+    builtin_dir, user_dir = preset_dirs
+    return ExportPresetManager(builtin_dir=builtin_dir, user_dir=user_dir)
+
+
+@pytest.fixture
+def mock_export_job_service():
+    """Mock ExportJobService."""
+    from webui.backend.lib.export_job_types import (
+        ExportJob,
+        ExportJobProgress,
+        ExportJobStatus,
+    )
+    from datetime import datetime
+
+    service = MagicMock()
+
+    # Default: create job returns a pending job
+    def create_job(**kwargs):
+        return ExportJob(
+            job_id="test-job-123",
+            status=ExportJobStatus.PENDING,
+            format=kwargs.get("format", ExportJobFormat.DARWIN_CORE),
+            filter=kwargs.get("filter", ExportJobFilter()),
+            progress=ExportJobProgress(),
+            created_at=datetime.now().timestamp(),
+        )
+
+    service.create_job.side_effect = create_job
+    service.list_jobs.return_value = ([], 0)
+    service.get_job.return_value = None
+
+    return service
+
+
+@pytest.fixture
+def app(preset_manager, mock_export_job_service):
+    """Create Flask app with preset manager and export service."""
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["WTF_CSRF_ENABLED"] = False
+    app.config["EXPORT_PRESET_MANAGER"] = preset_manager
+    app.config["EXPORT_JOB_SERVICE"] = mock_export_job_service
+
+    app.register_blueprint(export_presets_bp, url_prefix="/api/export/presets")
+    app.register_blueprint(export_bp, url_prefix="/api/export")
+
+    return app
+
+
+@pytest.fixture
+def client(app):
+    """Flask test client."""
+    return app.test_client()
+
+
+# ============================================================================
+# Preset CRUD Workflow Tests
+# ============================================================================
+
+
+class TestPresetCRUDWorkflow:
+    """Test complete preset CRUD workflow."""
+
+    def test_list_builtin_presets(self, client):
+        """List presets includes built-in presets."""
+        response = client.get("/api/export/presets")
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert "presets" in data
+        assert "counts" in data
+
+        # Should have at least the test_builtin preset
+        names = [p["name"] for p in data["presets"]]
+        assert "test_builtin" in names
+
+    def test_create_and_list_user_preset(self, client):
+        """Create user preset and verify it appears in list."""
+        # Create preset
+        create_response = client.post(
+            "/api/export/presets",
+            json={
+                "name": "my_preset",
+                "display_name": "My Custom Preset",
+                "export_format": "json",
+                "description": "A custom preset",
+                "filter": {"tags": ["moth"]},
+            },
+        )
+
+        assert create_response.status_code == 201
+        create_data = create_response.get_json()
+        assert create_data["success"] is True
+        assert create_data["name"] == "my_preset"
+
+        # List presets
+        list_response = client.get("/api/export/presets")
+        assert list_response.status_code == 200
+        list_data = list_response.get_json()
+
+        # Should have both built-in and user preset
+        names = [p["name"] for p in list_data["presets"]]
+        assert "test_builtin" in names
+        assert "my_preset" in names
+
+        # Check counts
+        assert list_data["counts"]["user"] >= 1
+
+    def test_get_preset_details(self, client):
+        """Get preset returns full details."""
+        response = client.get("/api/export/presets/test_builtin")
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["name"] == "test_builtin"
+        assert data["export_format"] == "darwin_core"
+        assert data["filter"]["has_species"] is True
+        assert data["options"]["validate"] is True
+        assert data["category"] == "built-in"
+
+    def test_create_and_delete_user_preset(self, client):
+        """Create and delete user preset."""
+        # Create
+        client.post(
+            "/api/export/presets",
+            json={
+                "name": "temp_preset",
+                "display_name": "Temporary Preset",
+                "export_format": "csv",
+            },
+        )
+
+        # Verify it exists
+        get_response = client.get("/api/export/presets/temp_preset")
+        assert get_response.status_code == 200
+
+        # Delete
+        delete_response = client.delete("/api/export/presets/temp_preset")
+        assert delete_response.status_code == 200
+        assert delete_response.get_json()["success"] is True
+
+        # Verify it's gone
+        get_response = client.get("/api/export/presets/temp_preset")
+        assert get_response.status_code == 404
+
+    def test_cannot_delete_builtin_preset(self, client):
+        """Built-in presets are protected from deletion."""
+        response = client.delete("/api/export/presets/test_builtin")
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "built-in" in data["error"].lower()
+
+    def test_filter_presets_by_format(self, client):
+        """Filter presets by export format."""
+        # Create presets with different formats
+        client.post(
+            "/api/export/presets",
+            json={
+                "name": "json_preset",
+                "display_name": "JSON Preset",
+                "export_format": "json",
+            },
+        )
+        client.post(
+            "/api/export/presets",
+            json={
+                "name": "csv_preset",
+                "display_name": "CSV Preset",
+                "export_format": "csv",
+            },
+        )
+
+        # Filter by JSON
+        response = client.get("/api/export/presets?format=json")
+        assert response.status_code == 200
+        data = response.get_json()
+
+        formats = [p["export_format"] for p in data["presets"]]
+        assert all(f == "json" for f in formats)
+
+
+# ============================================================================
+# Preset Integration with Export Jobs
+# ============================================================================
+
+
+class TestPresetJobIntegration:
+    """Test preset integration with export job creation."""
+
+    def test_create_job_with_preset(self, client, mock_export_job_service):
+        """Create export job using preset."""
+        response = client.post(
+            "/api/export/jobs",
+            json={"preset": "test_builtin"},
+        )
+
+        assert response.status_code == 202
+        data = response.get_json()
+        assert data["job_id"] == "test-job-123"
+        assert data["format"] == "darwin_core"
+
+        # Verify service was called with preset values
+        mock_export_job_service.create_job.assert_called_once()
+        call_kwargs = mock_export_job_service.create_job.call_args[1]
+        assert call_kwargs["format"] == ExportJobFormat.DARWIN_CORE
+        assert call_kwargs["filter"].has_species is True
+        assert call_kwargs["options"]["validate"] is True
+
+    def test_create_job_preset_with_filter_merge(self, client, mock_export_job_service):
+        """Preset filter merged with explicit filter."""
+        response = client.post(
+            "/api/export/jobs",
+            json={
+                "preset": "test_builtin",
+                "filter": {
+                    "date_start": "2024-01-01",
+                    "tags": ["moth"],
+                },
+            },
+        )
+
+        assert response.status_code == 202
+
+        call_kwargs = mock_export_job_service.create_job.call_args[1]
+        filter_obj = call_kwargs["filter"]
+        # From preset
+        assert filter_obj.has_species is True
+        # From explicit
+        assert filter_obj.date_start == "2024-01-01"
+        assert filter_obj.tags == ["moth"]
+
+    def test_create_job_preset_with_format_override(
+        self, client, mock_export_job_service
+    ):
+        """Explicit format overrides preset format."""
+        response = client.post(
+            "/api/export/jobs",
+            json={
+                "preset": "test_builtin",  # darwin_core
+                "format": "csv",  # Override
+            },
+        )
+
+        assert response.status_code == 202
+
+        call_kwargs = mock_export_job_service.create_job.call_args[1]
+        assert call_kwargs["format"] == ExportJobFormat.CSV
+
+    def test_create_job_preset_with_options_merge(
+        self, client, mock_export_job_service
+    ):
+        """Preset options merged with explicit options."""
+        response = client.post(
+            "/api/export/jobs",
+            json={
+                "preset": "test_builtin",
+                "options": {
+                    "include_header": True,  # Add new option
+                },
+            },
+        )
+
+        assert response.status_code == 202
+
+        call_kwargs = mock_export_job_service.create_job.call_args[1]
+        options = call_kwargs["options"]
+        # From preset
+        assert options["validate"] is True
+        # From explicit
+        assert options["include_header"] is True
+
+    def test_create_job_invalid_preset_returns_400(
+        self, client, mock_export_job_service
+    ):
+        """Invalid preset name returns 400."""
+        response = client.post(
+            "/api/export/jobs",
+            json={"preset": "nonexistent_preset"},
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "preset" in data["error"].lower()
+        assert "nonexistent_preset" in data["error"]
+
+    def test_create_job_user_preset(self, client, mock_export_job_service):
+        """Create job using user-defined preset."""
+        # First create user preset
+        client.post(
+            "/api/export/presets",
+            json={
+                "name": "my_export",
+                "display_name": "My Export",
+                "export_format": "json",
+                "filter": {"series_type": "hdr"},
+                "options": {"pretty_print": True},
+            },
+        )
+
+        # Create job with user preset
+        response = client.post(
+            "/api/export/jobs",
+            json={"preset": "my_export"},
+        )
+
+        assert response.status_code == 202
+
+        call_kwargs = mock_export_job_service.create_job.call_args[1]
+        assert call_kwargs["format"] == ExportJobFormat.JSON
+        assert call_kwargs["filter"].series_type == "hdr"
+        assert call_kwargs["options"]["pretty_print"] is True
+
+
+# ============================================================================
+# End-to-End Workflow Tests
+# ============================================================================
+
+
+class TestEndToEndWorkflows:
+    """Test complete end-to-end workflows."""
+
+    def test_workflow_create_preset_and_use_in_job(
+        self, client, mock_export_job_service
+    ):
+        """Complete workflow: create preset, use in job, delete preset."""
+        # 1. Create custom preset
+        create_response = client.post(
+            "/api/export/presets",
+            json={
+                "name": "summer_moths",
+                "display_name": "Summer Moth Export",
+                "export_format": "darwin_core",
+                "description": "Export moths from summer 2024",
+                "filter": {
+                    "tags": ["moth", "nocturnal"],
+                    "has_species": True,
+                },
+                "options": {
+                    "validate": True,
+                },
+            },
+        )
+        assert create_response.status_code == 201
+
+        # 2. Verify preset in list
+        list_response = client.get("/api/export/presets")
+        names = [p["name"] for p in list_response.get_json()["presets"]]
+        assert "summer_moths" in names
+
+        # 3. Create job using preset with additional filter
+        job_response = client.post(
+            "/api/export/jobs",
+            json={
+                "preset": "summer_moths",
+                "filter": {
+                    "date_start": "2024-06-01",
+                    "date_end": "2024-08-31",
+                },
+            },
+        )
+        assert job_response.status_code == 202
+
+        # Verify merged filter
+        call_kwargs = mock_export_job_service.create_job.call_args[1]
+        filter_obj = call_kwargs["filter"]
+        assert filter_obj.tags == ["moth", "nocturnal"]
+        assert filter_obj.has_species is True
+        assert filter_obj.date_start == "2024-06-01"
+        assert filter_obj.date_end == "2024-08-31"
+
+        # 4. Delete preset
+        delete_response = client.delete("/api/export/presets/summer_moths")
+        assert delete_response.status_code == 200
+
+        # 5. Verify preset is gone
+        get_response = client.get("/api/export/presets/summer_moths")
+        assert get_response.status_code == 404
+
+    def test_workflow_multiple_presets_same_format(
+        self, client, mock_export_job_service
+    ):
+        """Create multiple presets for same format with different filters."""
+        # Create HDR series preset
+        client.post(
+            "/api/export/presets",
+            json={
+                "name": "hdr_only",
+                "display_name": "HDR Series Only",
+                "export_format": "json",
+                "filter": {"series_type": "hdr"},
+            },
+        )
+
+        # Create focus bracket preset
+        client.post(
+            "/api/export/presets",
+            json={
+                "name": "focus_only",
+                "display_name": "Focus Bracket Only",
+                "export_format": "json",
+                "filter": {"series_type": "focus_bracket"},
+            },
+        )
+
+        # Use HDR preset
+        hdr_response = client.post(
+            "/api/export/jobs",
+            json={"preset": "hdr_only"},
+        )
+        assert hdr_response.status_code == 202
+        hdr_filter = mock_export_job_service.create_job.call_args[1]["filter"]
+        assert hdr_filter.series_type == "hdr"
+
+        # Use focus bracket preset
+        fb_response = client.post(
+            "/api/export/jobs",
+            json={"preset": "focus_only"},
+        )
+        assert fb_response.status_code == 202
+        fb_filter = mock_export_job_service.create_job.call_args[1]["filter"]
+        assert fb_filter.series_type == "focus_bracket"

--- a/Firmware/Tests/unit/test_export_job_routes.py
+++ b/Firmware/Tests/unit/test_export_job_routes.py
@@ -1059,3 +1059,345 @@ class TestServiceUnavailable:
         # POST /jobs/<id>/cancel
         response = client.post("/api/export/jobs/test-job/cancel")
         assert response.status_code == 500
+
+
+# ============================================================================
+# Preset Integration Tests (Issue #123)
+# ============================================================================
+
+
+@pytest.fixture
+def mock_export_preset_manager():
+    """Mock ExportPresetManager for preset integration testing."""
+    from unittest.mock import Mock
+
+    from webui.backend.lib.export_job_types import ExportJobFilter, ExportJobFormat
+    from webui.backend.lib.export_preset_types import ExportPreset, ExportPresetCategory
+
+    manager = Mock()
+
+    # Default: no preset found
+    manager.get_preset.return_value = None
+
+    return manager
+
+
+@pytest.fixture
+def app_with_preset_manager(mock_export_job_service, mock_export_preset_manager, tmp_path):
+    """Flask app with both export job service and preset manager."""
+    from webui.backend.routes.export import export_bp
+
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    app.config['EXPORT_JOB_SERVICE'] = mock_export_job_service
+    app.config['EXPORT_PRESET_MANAGER'] = mock_export_preset_manager
+
+    app.register_blueprint(export_bp, url_prefix='/api/export')
+
+    return app
+
+
+@pytest.fixture
+def client_with_presets(app_with_preset_manager):
+    """Test client with preset manager configured."""
+    return app_with_preset_manager.test_client()
+
+
+class TestCreateExportJobWithPreset:
+    """Tests for POST /api/export/jobs with preset parameter (Issue #123)."""
+
+    def test_create_job_with_valid_preset(
+        self, client_with_presets, mock_export_job_service, mock_export_preset_manager
+    ):
+        """Test creating job using a preset name."""
+        from webui.backend.lib.export_job_types import ExportJobFilter, ExportJobFormat
+        from webui.backend.lib.export_preset_types import ExportPreset, ExportPresetCategory
+
+        # Set up mock preset
+        preset = ExportPreset(
+            name="gbif_biodiversity",
+            display_name="GBIF Export",
+            export_format=ExportJobFormat.DARWIN_CORE,
+            description="Export for GBIF",
+            filter=ExportJobFilter(has_species=True),
+            options={"validate": True},
+            category=ExportPresetCategory.BUILT_IN,
+        )
+        mock_export_preset_manager.get_preset.return_value = preset
+
+        job = create_test_job(format=ExportJobFormat.DARWIN_CORE)
+        mock_export_job_service.create_job.return_value = job
+
+        response = client_with_presets.post(
+            "/api/export/jobs",
+            json={"preset": "gbif_biodiversity"},
+        )
+
+        assert response.status_code == 202
+        data = response.get_json()
+        assert data["job_id"] == "test-job-123"
+        assert data["format"] == "darwin_core"
+
+        # Verify preset was looked up
+        mock_export_preset_manager.get_preset.assert_called_once_with("gbif_biodiversity")
+
+        # Verify job was created with preset values
+        call_kwargs = mock_export_job_service.create_job.call_args[1]
+        assert call_kwargs["format"] == ExportJobFormat.DARWIN_CORE
+        assert call_kwargs["filter"].has_species is True
+        assert call_kwargs["options"]["validate"] is True
+
+    def test_create_job_preset_overridden_by_explicit_values(
+        self, client_with_presets, mock_export_job_service, mock_export_preset_manager
+    ):
+        """Test that explicit values override preset defaults."""
+        from webui.backend.lib.export_job_types import ExportJobFilter, ExportJobFormat
+        from webui.backend.lib.export_preset_types import ExportPreset, ExportPresetCategory
+
+        # Preset with default values
+        preset = ExportPreset(
+            name="simple_json",
+            display_name="Simple JSON",
+            export_format=ExportJobFormat.JSON,
+            filter=ExportJobFilter(has_species=False, tags=["default"]),
+            options={"pretty": True},
+        )
+        mock_export_preset_manager.get_preset.return_value = preset
+
+        job = create_test_job(format=ExportJobFormat.CSV)
+        mock_export_job_service.create_job.return_value = job
+
+        # Override format, filter, and options
+        response = client_with_presets.post(
+            "/api/export/jobs",
+            json={
+                "preset": "simple_json",
+                "format": "csv",  # Override preset format
+                "filter": {
+                    "tags": ["moth", "identified"],  # Override preset tags
+                    "date_start": "2024-01-01",  # Add new filter
+                },
+                "options": {
+                    "include_bom": True,  # Override options
+                },
+            },
+        )
+
+        assert response.status_code == 202
+
+        # Verify overrides were applied
+        call_kwargs = mock_export_job_service.create_job.call_args[1]
+        assert call_kwargs["format"] == ExportJobFormat.CSV  # Overridden
+        assert call_kwargs["filter"].tags == ["moth", "identified"]  # Overridden
+        assert call_kwargs["filter"].date_start == "2024-01-01"  # Added
+        assert call_kwargs["filter"].has_species is False  # From preset (not overridden)
+        assert call_kwargs["options"]["include_bom"] is True  # Overridden
+
+    def test_create_job_invalid_preset_name(
+        self, client_with_presets, mock_export_job_service, mock_export_preset_manager
+    ):
+        """Test 400 error for non-existent preset."""
+        mock_export_preset_manager.get_preset.return_value = None
+
+        response = client_with_presets.post(
+            "/api/export/jobs",
+            json={"preset": "nonexistent_preset"},
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "error" in data
+        assert "preset" in data["error"].lower()
+        assert "nonexistent_preset" in data["error"]
+
+    def test_create_job_preset_with_format_only(
+        self, client_with_presets, mock_export_job_service, mock_export_preset_manager
+    ):
+        """Test that preset provides format when not specified."""
+        from webui.backend.lib.export_job_types import ExportJobFormat
+        from webui.backend.lib.export_preset_types import ExportPreset
+
+        preset = ExportPreset(
+            name="hdr_series",
+            display_name="HDR Series",
+            export_format=ExportJobFormat.JSON,
+        )
+        mock_export_preset_manager.get_preset.return_value = preset
+
+        job = create_test_job(format=ExportJobFormat.JSON)
+        mock_export_job_service.create_job.return_value = job
+
+        # Only provide preset, no format
+        response = client_with_presets.post(
+            "/api/export/jobs",
+            json={"preset": "hdr_series"},
+        )
+
+        assert response.status_code == 202
+
+        call_kwargs = mock_export_job_service.create_job.call_args[1]
+        assert call_kwargs["format"] == ExportJobFormat.JSON
+
+    def test_create_job_preset_filter_merged_with_explicit(
+        self, client_with_presets, mock_export_job_service, mock_export_preset_manager
+    ):
+        """Test that preset filter and explicit filter are merged."""
+        from webui.backend.lib.export_job_types import ExportJobFilter, ExportJobFormat
+        from webui.backend.lib.export_preset_types import ExportPreset
+
+        # Preset with partial filter
+        preset = ExportPreset(
+            name="focus_bracket_series",
+            display_name="Focus Bracket Series",
+            export_format=ExportJobFormat.JSON,
+            filter=ExportJobFilter(series_type="focus_bracket"),
+        )
+        mock_export_preset_manager.get_preset.return_value = preset
+
+        job = create_test_job()
+        mock_export_job_service.create_job.return_value = job
+
+        # Add additional filter criteria
+        response = client_with_presets.post(
+            "/api/export/jobs",
+            json={
+                "preset": "focus_bracket_series",
+                "filter": {
+                    "date_start": "2024-06-01",
+                    "deployment": "summer_2024",
+                },
+            },
+        )
+
+        assert response.status_code == 202
+
+        call_kwargs = mock_export_job_service.create_job.call_args[1]
+        filter_obj = call_kwargs["filter"]
+        # From preset
+        assert filter_obj.series_type == "focus_bracket"
+        # From explicit filter
+        assert filter_obj.date_start == "2024-06-01"
+        assert filter_obj.deployment == "summer_2024"
+
+    def test_create_job_preset_options_merged(
+        self, client_with_presets, mock_export_job_service, mock_export_preset_manager
+    ):
+        """Test that preset options and explicit options are merged."""
+        from webui.backend.lib.export_job_types import ExportJobFormat
+        from webui.backend.lib.export_preset_types import ExportPreset
+
+        preset = ExportPreset(
+            name="simple_csv",
+            display_name="Simple CSV",
+            export_format=ExportJobFormat.CSV,
+            options={"include_bom": True, "delimiter": ","},
+        )
+        mock_export_preset_manager.get_preset.return_value = preset
+
+        job = create_test_job()
+        mock_export_job_service.create_job.return_value = job
+
+        response = client_with_presets.post(
+            "/api/export/jobs",
+            json={
+                "preset": "simple_csv",
+                "options": {
+                    "delimiter": ";",  # Override
+                    "quote_char": '"',  # Add
+                },
+            },
+        )
+
+        assert response.status_code == 202
+
+        call_kwargs = mock_export_job_service.create_job.call_args[1]
+        options = call_kwargs["options"]
+        assert options["include_bom"] is True  # From preset
+        assert options["delimiter"] == ";"  # Overridden
+        assert options["quote_char"] == '"'  # Added
+
+    def test_create_job_both_preset_and_format(
+        self, client_with_presets, mock_export_job_service, mock_export_preset_manager
+    ):
+        """Test that explicit format overrides preset format."""
+        from webui.backend.lib.export_job_types import ExportJobFormat
+        from webui.backend.lib.export_preset_types import ExportPreset
+
+        preset = ExportPreset(
+            name="gbif_biodiversity",
+            display_name="GBIF Export",
+            export_format=ExportJobFormat.DARWIN_CORE,
+        )
+        mock_export_preset_manager.get_preset.return_value = preset
+
+        job = create_test_job(format=ExportJobFormat.CSV)
+        mock_export_job_service.create_job.return_value = job
+
+        response = client_with_presets.post(
+            "/api/export/jobs",
+            json={
+                "preset": "gbif_biodiversity",
+                "format": "csv",  # Override darwin_core
+            },
+        )
+
+        assert response.status_code == 202
+
+        call_kwargs = mock_export_job_service.create_job.call_args[1]
+        assert call_kwargs["format"] == ExportJobFormat.CSV
+
+    def test_create_job_preset_with_ttl(
+        self, client_with_presets, mock_export_job_service, mock_export_preset_manager
+    ):
+        """Test that TTL can be specified with preset."""
+        from webui.backend.lib.export_job_types import ExportJobFormat
+        from webui.backend.lib.export_preset_types import ExportPreset
+
+        preset = ExportPreset(
+            name="simple_json",
+            display_name="Simple JSON",
+            export_format=ExportJobFormat.JSON,
+        )
+        mock_export_preset_manager.get_preset.return_value = preset
+
+        job = create_test_job()
+        mock_export_job_service.create_job.return_value = job
+
+        response = client_with_presets.post(
+            "/api/export/jobs",
+            json={
+                "preset": "simple_json",
+                "ttl_seconds": 7200,
+            },
+        )
+
+        assert response.status_code == 202
+
+        call_kwargs = mock_export_job_service.create_job.call_args[1]
+        assert call_kwargs["ttl_seconds"] == 7200
+
+    def test_create_job_no_preset_manager_configured(
+        self, client, mock_export_job_service
+    ):
+        """Test that preset parameter is ignored if no preset manager configured."""
+        # Use regular client (no preset manager)
+        response = client.post(
+            "/api/export/jobs",
+            json={
+                "preset": "some_preset",
+                "format": "csv",  # Must provide format since no preset manager
+            },
+        )
+
+        # Should work since format is provided
+        # Preset is silently ignored when manager not configured
+        job = create_test_job()
+        mock_export_job_service.create_job.return_value = job
+
+        response = client.post(
+            "/api/export/jobs",
+            json={"format": "csv"},
+        )
+
+        assert response.status_code == 202

--- a/Firmware/Tests/unit/test_export_preset_manager.py
+++ b/Firmware/Tests/unit/test_export_preset_manager.py
@@ -6,9 +6,9 @@ Tests are written before implementation.
 """
 
 import json
-import pytest
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+
+import pytest
 
 
 @pytest.fixture
@@ -97,7 +97,7 @@ class TestExportPresetManagerInit:
 
         assert not user_dir.exists()
 
-        manager = ExportPresetManager(builtin_dir, user_dir)
+        ExportPresetManager(builtin_dir, user_dir)
 
         assert user_dir.exists()
 
@@ -172,6 +172,91 @@ class TestListPresets:
         assert result == []
 
 
+class TestCorruptedPresetHandling:
+    """Tests for handling corrupted/malformed preset files."""
+
+    def test_list_presets_skips_corrupted_user_preset(self, preset_manager):
+        """Corrupted user preset files are skipped without crashing."""
+        # Create a corrupted JSON file
+        corrupt_file = preset_manager.user_dir / "corrupt.json"
+        corrupt_file.write_text("{invalid json")
+
+        presets = preset_manager.list_presets()
+
+        # Should not crash and should not include corrupt preset
+        assert "corrupt" not in [p["name"] for p in presets]
+
+    def test_list_presets_skips_corrupted_builtin_preset(self, preset_manager):
+        """Corrupted built-in preset files are skipped without crashing."""
+        # Create a corrupted JSON file in builtin directory
+        corrupt_file = preset_manager.builtin_dir / "corrupt_builtin.json"
+        corrupt_file.write_text("not valid json at all {{{")
+
+        presets = preset_manager.list_presets()
+
+        # Should not crash and should not include corrupt preset
+        assert "corrupt_builtin" not in [p["name"] for p in presets]
+
+    def test_list_presets_returns_valid_presets_when_some_corrupted(
+        self, preset_manager, sample_user_preset
+    ):
+        """Valid presets are still returned when some files are corrupted."""
+        # Create a valid preset
+        valid_file = preset_manager.user_dir / "valid_preset.json"
+        with open(valid_file, "w") as f:
+            json.dump(sample_user_preset, f)
+
+        # Create a corrupted preset
+        corrupt_file = preset_manager.user_dir / "corrupt.json"
+        corrupt_file.write_text("{truncated")
+
+        presets = preset_manager.list_presets()
+
+        # Should include valid preset but not corrupt one
+        preset_names = [p["name"] for p in presets]
+        assert "my_preset" in preset_names
+        assert "corrupt" not in preset_names
+
+    def test_get_preset_returns_none_for_corrupted_file(self, preset_manager):
+        """get_preset returns None for corrupted preset files."""
+        # Create a corrupted JSON file
+        corrupt_file = preset_manager.user_dir / "bad_preset.json"
+        corrupt_file.write_text("{incomplete json")
+
+        result = preset_manager.get_preset("bad_preset")
+
+        assert result is None
+
+    def test_get_preset_handles_truncated_json(self, preset_manager):
+        """get_preset handles truncated JSON gracefully."""
+        # Simulate file truncated mid-write
+        truncated_file = preset_manager.user_dir / "truncated.json"
+        truncated_file.write_text('{"name": "truncated", "display_name": "Test", "export_for')
+
+        result = preset_manager.get_preset("truncated")
+
+        assert result is None
+
+    def test_get_preset_handles_empty_file(self, preset_manager):
+        """get_preset handles empty files gracefully."""
+        empty_file = preset_manager.user_dir / "empty.json"
+        empty_file.write_text("")
+
+        result = preset_manager.get_preset("empty")
+
+        assert result is None
+
+    def test_list_presets_handles_binary_garbage(self, preset_manager):
+        """list_presets handles files with binary garbage."""
+        garbage_file = preset_manager.user_dir / "garbage.json"
+        garbage_file.write_bytes(b"\x00\x01\x02\xff\xfe\xfd")
+
+        presets = preset_manager.list_presets()
+
+        # Should not crash and should not include garbage file
+        assert "garbage" not in [p["name"] for p in presets]
+
+
 class TestGetPreset:
     """Tests for get_preset method."""
 
@@ -224,8 +309,8 @@ class TestSavePreset:
 
     def test_saves_new_preset(self, preset_manager):
         """Saves new user preset successfully."""
+        from webui.backend.lib.export_job_types import ExportJobFilter, ExportJobFormat
         from webui.backend.lib.export_preset_types import ExportPreset
-        from webui.backend.lib.export_job_types import ExportJobFormat, ExportJobFilter
 
         preset = ExportPreset(
             name="new_preset",
@@ -246,8 +331,8 @@ class TestSavePreset:
 
     def test_validates_preset_name_alphanumeric(self, preset_manager):
         """Rejects invalid preset names."""
-        from webui.backend.lib.export_preset_types import ExportPreset
         from webui.backend.lib.export_job_types import ExportJobFormat
+        from webui.backend.lib.export_preset_types import ExportPreset
 
         preset = ExportPreset(
             name="invalid-name!",  # Invalid characters
@@ -262,8 +347,8 @@ class TestSavePreset:
 
     def test_allows_underscore_in_name(self, preset_manager):
         """Allows underscores in preset names."""
-        from webui.backend.lib.export_preset_types import ExportPreset
         from webui.backend.lib.export_job_types import ExportJobFormat
+        from webui.backend.lib.export_preset_types import ExportPreset
 
         preset = ExportPreset(
             name="my_custom_preset",
@@ -277,11 +362,11 @@ class TestSavePreset:
 
     def test_rejects_builtin_category(self, preset_manager):
         """Cannot save preset with built-in category."""
+        from webui.backend.lib.export_job_types import ExportJobFormat
         from webui.backend.lib.export_preset_types import (
             ExportPreset,
             ExportPresetCategory,
         )
-        from webui.backend.lib.export_job_types import ExportJobFormat
 
         preset = ExportPreset(
             name="fake_builtin",
@@ -297,8 +382,8 @@ class TestSavePreset:
 
     def test_overwrites_existing_user_preset(self, preset_manager_with_presets):
         """Can overwrite existing user preset."""
-        from webui.backend.lib.export_preset_types import ExportPreset
         from webui.backend.lib.export_job_types import ExportJobFormat
+        from webui.backend.lib.export_preset_types import ExportPreset
 
         preset = ExportPreset(
             name="my_preset",  # Same name as existing
@@ -318,8 +403,8 @@ class TestSavePreset:
 
     def test_saved_preset_contains_timestamp(self, preset_manager):
         """Saved preset contains created_at timestamp."""
-        from webui.backend.lib.export_preset_types import ExportPreset
         from webui.backend.lib.export_job_types import ExportJobFormat
+        from webui.backend.lib.export_preset_types import ExportPreset
 
         preset = ExportPreset(
             name="timestamped",
@@ -465,8 +550,9 @@ class TestFileLocking:
     def test_concurrent_saves_dont_corrupt(self, preset_manager):
         """Concurrent save operations don't corrupt files."""
         import threading
-        from webui.backend.lib.export_preset_types import ExportPreset
+
         from webui.backend.lib.export_job_types import ExportJobFormat
+        from webui.backend.lib.export_preset_types import ExportPreset
 
         errors = []
         success_count = [0]
@@ -532,7 +618,6 @@ class TestBuiltinPresets:
     @pytest.fixture
     def builtin_preset_manager(self):
         """Manager pointing to real built-in presets directory."""
-        from pathlib import Path
         from webui.backend.export_preset_manager import ExportPresetManager
 
         # Point to actual built-in presets

--- a/Firmware/Tests/unit/test_export_preset_manager.py
+++ b/Firmware/Tests/unit/test_export_preset_manager.py
@@ -1,0 +1,623 @@
+"""
+Unit tests for export preset manager.
+
+Tests the ExportPresetManager class following TDD principles.
+Tests are written before implementation.
+"""
+
+import json
+import pytest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+
+@pytest.fixture
+def temp_preset_dirs(tmp_path):
+    """Create temporary preset directories for testing."""
+    builtin_dir = tmp_path / "built-in" / "export"
+    user_dir = tmp_path / "user" / "export"
+    builtin_dir.mkdir(parents=True)
+    user_dir.mkdir(parents=True)
+    return builtin_dir, user_dir
+
+
+@pytest.fixture
+def sample_builtin_preset():
+    """Sample built-in preset data."""
+    return {
+        "name": "gbif_biodiversity",
+        "display_name": "GBIF Biodiversity Export",
+        "export_format": "darwin_core",
+        "description": "Export for GBIF submission",
+        "version": "1.0",
+        "created_at": "2024-12-14T00:00:00Z",
+        "author": "system",
+        "category": "built-in",
+        "filter": {"has_species": True},
+        "options": {"validate": True},
+    }
+
+
+@pytest.fixture
+def sample_user_preset():
+    """Sample user preset data."""
+    return {
+        "name": "my_preset",
+        "display_name": "My Custom Preset",
+        "export_format": "json",
+        "description": "My custom export settings",
+        "version": "1.0",
+        "created_at": "2024-12-14T12:00:00Z",
+        "author": "user",
+        "category": "user",
+        "filter": {"tags": ["moth"]},
+        "options": {},
+    }
+
+
+@pytest.fixture
+def preset_manager(temp_preset_dirs):
+    """Create ExportPresetManager with temp directories."""
+    from webui.backend.export_preset_manager import ExportPresetManager
+
+    builtin_dir, user_dir = temp_preset_dirs
+    return ExportPresetManager(builtin_dir, user_dir)
+
+
+@pytest.fixture
+def preset_manager_with_presets(temp_preset_dirs, sample_builtin_preset, sample_user_preset):
+    """Create ExportPresetManager with sample presets."""
+    from webui.backend.export_preset_manager import ExportPresetManager
+
+    builtin_dir, user_dir = temp_preset_dirs
+
+    # Write built-in preset
+    builtin_path = builtin_dir / "gbif_biodiversity.json"
+    with open(builtin_path, "w") as f:
+        json.dump(sample_builtin_preset, f)
+
+    # Write user preset
+    user_path = user_dir / "my_preset.json"
+    with open(user_path, "w") as f:
+        json.dump(sample_user_preset, f)
+
+    return ExportPresetManager(builtin_dir, user_dir)
+
+
+class TestExportPresetManagerInit:
+    """Tests for ExportPresetManager initialization."""
+
+    def test_creates_user_directory(self, tmp_path):
+        """User directory is created if it doesn't exist."""
+        from webui.backend.export_preset_manager import ExportPresetManager
+
+        builtin_dir = tmp_path / "built-in" / "export"
+        user_dir = tmp_path / "user" / "export"
+        builtin_dir.mkdir(parents=True)
+
+        assert not user_dir.exists()
+
+        manager = ExportPresetManager(builtin_dir, user_dir)
+
+        assert user_dir.exists()
+
+    def test_accepts_path_objects(self, temp_preset_dirs):
+        """Accepts Path objects for directories."""
+        from webui.backend.export_preset_manager import ExportPresetManager
+
+        builtin_dir, user_dir = temp_preset_dirs
+        manager = ExportPresetManager(builtin_dir, user_dir)
+
+        assert manager.builtin_dir == builtin_dir
+        assert manager.user_dir == user_dir
+
+
+class TestListPresets:
+    """Tests for list_presets method."""
+
+    def test_returns_empty_list_when_no_presets(self, preset_manager):
+        """Returns empty list when no presets exist."""
+        result = preset_manager.list_presets()
+        assert result == []
+
+    def test_lists_builtin_presets(self, preset_manager_with_presets):
+        """Lists built-in presets."""
+        result = preset_manager_with_presets.list_presets()
+
+        builtin = [p for p in result if p["category"] == "built-in"]
+        assert len(builtin) == 1
+        assert builtin[0]["name"] == "gbif_biodiversity"
+        assert builtin[0]["display_name"] == "GBIF Biodiversity Export"
+
+    def test_lists_user_presets(self, preset_manager_with_presets):
+        """Lists user presets."""
+        result = preset_manager_with_presets.list_presets()
+
+        user = [p for p in result if p["category"] == "user"]
+        assert len(user) == 1
+        assert user[0]["name"] == "my_preset"
+        assert user[0]["display_name"] == "My Custom Preset"
+
+    def test_lists_both_builtin_and_user(self, preset_manager_with_presets):
+        """Lists both built-in and user presets."""
+        result = preset_manager_with_presets.list_presets()
+        assert len(result) == 2
+
+    def test_filter_by_format(self, preset_manager_with_presets):
+        """Can filter presets by export format."""
+        result = preset_manager_with_presets.list_presets(format_filter="darwin_core")
+
+        assert len(result) == 1
+        assert result[0]["name"] == "gbif_biodiversity"
+
+    def test_filter_by_format_returns_empty(self, preset_manager_with_presets):
+        """Returns empty list when no presets match format filter."""
+        result = preset_manager_with_presets.list_presets(format_filter="csv")
+        assert result == []
+
+    def test_skips_invalid_json_files(self, temp_preset_dirs):
+        """Skips files with invalid JSON."""
+        from webui.backend.export_preset_manager import ExportPresetManager
+
+        builtin_dir, user_dir = temp_preset_dirs
+
+        # Write invalid JSON
+        invalid_path = builtin_dir / "invalid.json"
+        with open(invalid_path, "w") as f:
+            f.write("{ invalid json }")
+
+        manager = ExportPresetManager(builtin_dir, user_dir)
+        result = manager.list_presets()
+
+        assert result == []
+
+
+class TestGetPreset:
+    """Tests for get_preset method."""
+
+    def test_gets_builtin_preset(self, preset_manager_with_presets):
+        """Gets built-in preset by name."""
+        result = preset_manager_with_presets.get_preset("gbif_biodiversity")
+
+        assert result is not None
+        assert result.name == "gbif_biodiversity"
+        assert result.export_format.value == "darwin_core"
+
+    def test_gets_user_preset(self, preset_manager_with_presets):
+        """Gets user preset by name."""
+        result = preset_manager_with_presets.get_preset("my_preset")
+
+        assert result is not None
+        assert result.name == "my_preset"
+        assert result.export_format.value == "json"
+
+    def test_returns_none_for_missing(self, preset_manager):
+        """Returns None for non-existent preset."""
+        result = preset_manager.get_preset("nonexistent")
+        assert result is None
+
+    def test_builtin_takes_precedence(self, temp_preset_dirs, sample_builtin_preset, sample_user_preset):
+        """Built-in preset takes precedence over user preset with same name."""
+        from webui.backend.export_preset_manager import ExportPresetManager
+
+        builtin_dir, user_dir = temp_preset_dirs
+
+        # Write both with same name
+        builtin_preset = {**sample_builtin_preset, "name": "same_name"}
+        user_preset = {**sample_user_preset, "name": "same_name", "description": "User version"}
+
+        with open(builtin_dir / "same_name.json", "w") as f:
+            json.dump(builtin_preset, f)
+
+        with open(user_dir / "same_name.json", "w") as f:
+            json.dump(user_preset, f)
+
+        manager = ExportPresetManager(builtin_dir, user_dir)
+        result = manager.get_preset("same_name")
+
+        # Built-in should be returned
+        assert result.description == "Export for GBIF submission"
+
+
+class TestSavePreset:
+    """Tests for save_preset method."""
+
+    def test_saves_new_preset(self, preset_manager):
+        """Saves new user preset successfully."""
+        from webui.backend.lib.export_preset_types import ExportPreset
+        from webui.backend.lib.export_job_types import ExportJobFormat, ExportJobFilter
+
+        preset = ExportPreset(
+            name="new_preset",
+            display_name="New Preset",
+            export_format=ExportJobFormat.CSV,
+            description="A new preset",
+            filter=ExportJobFilter(has_species=True),
+        )
+
+        success, message = preset_manager.save_preset(preset)
+
+        assert success is True
+        assert "saved" in message.lower()
+
+        # Verify file was created
+        preset_file = preset_manager.user_dir / "new_preset.json"
+        assert preset_file.exists()
+
+    def test_validates_preset_name_alphanumeric(self, preset_manager):
+        """Rejects invalid preset names."""
+        from webui.backend.lib.export_preset_types import ExportPreset
+        from webui.backend.lib.export_job_types import ExportJobFormat
+
+        preset = ExportPreset(
+            name="invalid-name!",  # Invalid characters
+            display_name="Invalid",
+            export_format=ExportJobFormat.JSON,
+        )
+
+        success, message = preset_manager.save_preset(preset)
+
+        assert success is False
+        assert "alphanumeric" in message.lower() or "letters" in message.lower()
+
+    def test_allows_underscore_in_name(self, preset_manager):
+        """Allows underscores in preset names."""
+        from webui.backend.lib.export_preset_types import ExportPreset
+        from webui.backend.lib.export_job_types import ExportJobFormat
+
+        preset = ExportPreset(
+            name="my_custom_preset",
+            display_name="My Custom Preset",
+            export_format=ExportJobFormat.JSON,
+        )
+
+        success, message = preset_manager.save_preset(preset)
+
+        assert success is True
+
+    def test_rejects_builtin_category(self, preset_manager):
+        """Cannot save preset with built-in category."""
+        from webui.backend.lib.export_preset_types import (
+            ExportPreset,
+            ExportPresetCategory,
+        )
+        from webui.backend.lib.export_job_types import ExportJobFormat
+
+        preset = ExportPreset(
+            name="fake_builtin",
+            display_name="Fake Built-in",
+            export_format=ExportJobFormat.JSON,
+            category=ExportPresetCategory.BUILT_IN,
+        )
+
+        success, message = preset_manager.save_preset(preset)
+
+        assert success is False
+        assert "built-in" in message.lower()
+
+    def test_overwrites_existing_user_preset(self, preset_manager_with_presets):
+        """Can overwrite existing user preset."""
+        from webui.backend.lib.export_preset_types import ExportPreset
+        from webui.backend.lib.export_job_types import ExportJobFormat
+
+        preset = ExportPreset(
+            name="my_preset",  # Same name as existing
+            display_name="Updated Preset",
+            export_format=ExportJobFormat.CSV,
+            description="Updated description",
+        )
+
+        success, message = preset_manager_with_presets.save_preset(preset)
+
+        assert success is True
+
+        # Verify it was updated
+        loaded = preset_manager_with_presets.get_preset("my_preset")
+        assert loaded.description == "Updated description"
+        assert loaded.export_format.value == "csv"
+
+    def test_saved_preset_contains_timestamp(self, preset_manager):
+        """Saved preset contains created_at timestamp."""
+        from webui.backend.lib.export_preset_types import ExportPreset
+        from webui.backend.lib.export_job_types import ExportJobFormat
+
+        preset = ExportPreset(
+            name="timestamped",
+            display_name="Timestamped",
+            export_format=ExportJobFormat.JSON,
+        )
+
+        preset_manager.save_preset(preset)
+
+        # Read the file directly
+        preset_file = preset_manager.user_dir / "timestamped.json"
+        with open(preset_file) as f:
+            data = json.load(f)
+
+        assert "created_at" in data
+        assert data["created_at"]  # Not empty
+
+
+class TestDeletePreset:
+    """Tests for delete_preset method."""
+
+    def test_deletes_user_preset(self, preset_manager_with_presets):
+        """Deletes user preset successfully."""
+        success, message = preset_manager_with_presets.delete_preset("my_preset")
+
+        assert success is True
+        assert "deleted" in message.lower()
+
+        # Verify file was removed
+        preset_file = preset_manager_with_presets.user_dir / "my_preset.json"
+        assert not preset_file.exists()
+
+    def test_protects_builtin_presets(self, preset_manager_with_presets):
+        """Cannot delete built-in presets."""
+        success, message = preset_manager_with_presets.delete_preset("gbif_biodiversity")
+
+        assert success is False
+        assert "built-in" in message.lower()
+
+        # Verify file still exists
+        preset_file = preset_manager_with_presets.builtin_dir / "gbif_biodiversity.json"
+        assert preset_file.exists()
+
+    def test_returns_error_for_nonexistent(self, preset_manager):
+        """Returns error for non-existent preset."""
+        success, message = preset_manager.delete_preset("nonexistent")
+
+        assert success is False
+        assert "not found" in message.lower()
+
+
+class TestValidatePreset:
+    """Tests for validate_preset method."""
+
+    def test_valid_preset_passes(self, preset_manager, sample_user_preset):
+        """Valid preset passes validation."""
+        valid, message = preset_manager.validate_preset(sample_user_preset)
+
+        assert valid is True
+
+    def test_missing_name_fails(self, preset_manager):
+        """Preset without name fails validation."""
+        data = {
+            "display_name": "Test",
+            "export_format": "json",
+        }
+
+        valid, message = preset_manager.validate_preset(data)
+
+        assert valid is False
+        assert "name" in message.lower()
+
+    def test_missing_display_name_fails(self, preset_manager):
+        """Preset without display_name fails validation."""
+        data = {
+            "name": "test",
+            "export_format": "json",
+        }
+
+        valid, message = preset_manager.validate_preset(data)
+
+        assert valid is False
+        assert "display_name" in message.lower()
+
+    def test_missing_export_format_fails(self, preset_manager):
+        """Preset without export_format fails validation."""
+        data = {
+            "name": "test",
+            "display_name": "Test",
+        }
+
+        valid, message = preset_manager.validate_preset(data)
+
+        assert valid is False
+        assert "export_format" in message.lower() or "format" in message.lower()
+
+    def test_invalid_export_format_fails(self, preset_manager):
+        """Invalid export_format fails validation."""
+        data = {
+            "name": "test",
+            "display_name": "Test",
+            "export_format": "invalid_format",
+        }
+
+        valid, message = preset_manager.validate_preset(data)
+
+        assert valid is False
+        assert "format" in message.lower()
+
+
+class TestNormalizePreset:
+    """Tests for normalize_preset method."""
+
+    def test_adds_missing_defaults(self, preset_manager):
+        """Adds missing optional fields with defaults."""
+        data = {
+            "name": "minimal",
+            "display_name": "Minimal",
+            "export_format": "json",
+        }
+
+        result = preset_manager.normalize_preset(data)
+
+        assert result["description"] == ""
+        assert result["version"] == "1.0"
+        assert result["author"] == "user"
+        assert result["category"] == "user"
+        assert "filter" in result
+        assert "options" in result
+
+    def test_preserves_existing_values(self, preset_manager, sample_user_preset):
+        """Preserves existing values when normalizing."""
+        result = preset_manager.normalize_preset(sample_user_preset)
+
+        assert result["name"] == "my_preset"
+        assert result["description"] == "My custom export settings"
+        assert result["filter"]["tags"] == ["moth"]
+
+
+class TestFileLocking:
+    """Tests for file locking during save operations."""
+
+    def test_concurrent_saves_dont_corrupt(self, preset_manager):
+        """Concurrent save operations don't corrupt files."""
+        import threading
+        from webui.backend.lib.export_preset_types import ExportPreset
+        from webui.backend.lib.export_job_types import ExportJobFormat
+
+        errors = []
+        success_count = [0]
+
+        def save_preset(name):
+            try:
+                preset = ExportPreset(
+                    name=name,
+                    display_name=f"Preset {name}",
+                    export_format=ExportJobFormat.JSON,
+                )
+                success, _ = preset_manager.save_preset(preset)
+                if success:
+                    success_count[0] += 1
+            except Exception as e:
+                errors.append(str(e))
+
+        threads = []
+        for i in range(10):
+            t = threading.Thread(target=save_preset, args=(f"concurrent_{i}",))
+            threads.append(t)
+            t.start()
+
+        for t in threads:
+            t.join()
+
+        # All saves should succeed
+        assert len(errors) == 0
+        assert success_count[0] == 10
+
+        # All files should be valid JSON
+        for i in range(10):
+            preset_file = preset_manager.user_dir / f"concurrent_{i}.json"
+            assert preset_file.exists()
+            with open(preset_file) as f:
+                data = json.load(f)  # Should not raise
+                assert data["name"] == f"concurrent_{i}"
+
+
+class TestGetPresetCount:
+    """Tests for get_preset_count method."""
+
+    def test_empty_directories(self, preset_manager):
+        """Returns zero counts for empty directories."""
+        counts = preset_manager.get_preset_count()
+
+        assert counts["built_in"] == 0
+        assert counts["user"] == 0
+        assert counts["total"] == 0
+
+    def test_counts_presets(self, preset_manager_with_presets):
+        """Counts presets correctly."""
+        counts = preset_manager_with_presets.get_preset_count()
+
+        assert counts["built_in"] == 1
+        assert counts["user"] == 1
+        assert counts["total"] == 2
+
+
+class TestBuiltinPresets:
+    """Tests for the actual built-in export presets shipped with Mothbox."""
+
+    @pytest.fixture
+    def builtin_preset_manager(self):
+        """Manager pointing to real built-in presets directory."""
+        from pathlib import Path
+        from webui.backend.export_preset_manager import ExportPresetManager
+
+        # Point to actual built-in presets
+        builtin_dir = Path(__file__).parent.parent.parent / "webui" / "backend" / "presets_builtin" / "export"
+        user_dir = Path("/tmp/test_export_user_presets")
+        user_dir.mkdir(parents=True, exist_ok=True)
+
+        return ExportPresetManager(builtin_dir, user_dir)
+
+    def test_gbif_biodiversity_preset_loads(self, builtin_preset_manager):
+        """GBIF biodiversity preset loads and validates."""
+        preset = builtin_preset_manager.get_preset("gbif_biodiversity")
+
+        assert preset is not None
+        assert preset.name == "gbif_biodiversity"
+        assert preset.export_format.value == "darwin_core"
+        assert preset.filter.has_species is True
+
+    def test_inaturalist_upload_preset_loads(self, builtin_preset_manager):
+        """iNaturalist upload preset loads and validates."""
+        preset = builtin_preset_manager.get_preset("inaturalist_upload")
+
+        assert preset is not None
+        assert preset.name == "inaturalist_upload"
+        assert preset.export_format.value == "inaturalist"
+
+    def test_simple_json_preset_loads(self, builtin_preset_manager):
+        """Simple JSON preset loads and validates."""
+        preset = builtin_preset_manager.get_preset("simple_json")
+
+        assert preset is not None
+        assert preset.name == "simple_json"
+        assert preset.export_format.value == "json"
+
+    def test_simple_csv_preset_loads(self, builtin_preset_manager):
+        """Simple CSV preset loads and validates."""
+        preset = builtin_preset_manager.get_preset("simple_csv")
+
+        assert preset is not None
+        assert preset.name == "simple_csv"
+        assert preset.export_format.value == "csv"
+
+    def test_hdr_series_preset_loads(self, builtin_preset_manager):
+        """HDR series preset loads and validates."""
+        preset = builtin_preset_manager.get_preset("hdr_series")
+
+        assert preset is not None
+        assert preset.name == "hdr_series"
+        assert preset.export_format.value == "json"
+        # Check filter for series_type
+        filter_dict = preset.filter.to_dict()
+        assert filter_dict.get("series_type") == "hdr"
+
+    def test_focus_bracket_series_preset_loads(self, builtin_preset_manager):
+        """Focus bracket series preset loads and validates."""
+        preset = builtin_preset_manager.get_preset("focus_bracket_series")
+
+        assert preset is not None
+        assert preset.name == "focus_bracket_series"
+        assert preset.export_format.value == "json"
+        # Check filter for series_type
+        filter_dict = preset.filter.to_dict()
+        assert filter_dict.get("series_type") == "focus_bracket"
+
+    def test_all_builtin_presets_have_descriptions(self, builtin_preset_manager):
+        """All built-in presets have meaningful descriptions."""
+        presets = builtin_preset_manager.list_presets()
+
+        for preset in presets:
+            assert preset["description"], f"Preset {preset['name']} has no description"
+            assert len(preset["description"]) > 20, f"Preset {preset['name']} description too short"
+
+    def test_lists_all_six_builtin_presets(self, builtin_preset_manager):
+        """Lists all 6 built-in export presets."""
+        presets = builtin_preset_manager.list_presets()
+        builtin_presets = [p for p in presets if p["category"] == "built-in"]
+
+        assert len(builtin_presets) == 6
+        preset_names = {p["name"] for p in builtin_presets}
+        expected_names = {
+            "gbif_biodiversity",
+            "inaturalist_upload",
+            "simple_json",
+            "simple_csv",
+            "hdr_series",
+            "focus_bracket_series",
+        }
+        assert preset_names == expected_names

--- a/Firmware/Tests/unit/test_export_preset_routes.py
+++ b/Firmware/Tests/unit/test_export_preset_routes.py
@@ -1,0 +1,356 @@
+"""
+Unit tests for export preset management routes.
+
+Tests all export preset endpoints with comprehensive mocking.
+Focus areas: preset CRUD operations, validation, format filtering.
+
+Test structure:
+- TestListExportPresetsEndpoint: GET /api/export/presets tests
+- TestGetExportPresetEndpoint: GET /api/export/presets/<name> tests
+- TestCreateExportPresetEndpoint: POST /api/export/presets tests
+- TestDeleteExportPresetEndpoint: DELETE /api/export/presets/<name> tests
+"""
+
+import json
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+@pytest.fixture
+def mock_export_preset_manager():
+    """Create a mock ExportPresetManager for testing."""
+    mock = MagicMock()
+
+    # Default return values
+    mock.list_presets.return_value = []
+    mock.get_preset.return_value = None
+    mock.save_preset.return_value = (True, "Saved")
+    mock.delete_preset.return_value = (True, "Deleted")
+    mock.get_preset_count.return_value = {"built_in": 0, "user": 0, "total": 0}
+
+    return mock
+
+
+@pytest.fixture
+def app_with_export_presets(mock_export_preset_manager):
+    """Create Flask app with mocked export preset manager."""
+    from flask import Flask
+    from webui.backend.routes.export_presets import export_presets_bp
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["WTF_CSRF_ENABLED"] = False  # Disable CSRF for testing
+    app.config["EXPORT_PRESET_MANAGER"] = mock_export_preset_manager
+
+    app.register_blueprint(export_presets_bp, url_prefix="/api/export/presets")
+
+    return app
+
+
+@pytest.fixture
+def client(app_with_export_presets):
+    """Flask test client."""
+    return app_with_export_presets.test_client()
+
+
+class TestListExportPresetsEndpoint:
+    """Tests for GET /api/export/presets endpoint."""
+
+    def test_list_presets_returns_all(self, client, mock_export_preset_manager):
+        """GET /api/export/presets returns all presets."""
+        mock_export_preset_manager.list_presets.return_value = [
+            {
+                "name": "gbif_biodiversity",
+                "display_name": "GBIF Export",
+                "export_format": "darwin_core",
+                "category": "built-in",
+            },
+            {
+                "name": "my_preset",
+                "display_name": "My Preset",
+                "export_format": "json",
+                "category": "user",
+            },
+        ]
+        mock_export_preset_manager.get_preset_count.return_value = {
+            "built_in": 6,
+            "user": 1,
+            "total": 7,
+        }
+
+        response = client.get("/api/export/presets")
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert len(data["presets"]) == 2
+        assert data["counts"]["total"] == 7
+        assert data["presets"][0]["name"] == "gbif_biodiversity"
+
+    def test_list_presets_filter_by_format(self, client, mock_export_preset_manager):
+        """GET /api/export/presets?format=darwin_core filters by format."""
+        mock_export_preset_manager.list_presets.return_value = [
+            {"name": "gbif", "export_format": "darwin_core"},
+        ]
+        mock_export_preset_manager.get_preset_count.return_value = {
+            "built_in": 1,
+            "user": 0,
+            "total": 1,
+        }
+
+        response = client.get("/api/export/presets?format=darwin_core")
+
+        assert response.status_code == 200
+        mock_export_preset_manager.list_presets.assert_called_with(
+            format_filter="darwin_core"
+        )
+
+    def test_list_presets_empty(self, client, mock_export_preset_manager):
+        """GET /api/export/presets returns empty list when no presets."""
+        mock_export_preset_manager.list_presets.return_value = []
+        mock_export_preset_manager.get_preset_count.return_value = {
+            "built_in": 0,
+            "user": 0,
+            "total": 0,
+        }
+
+        response = client.get("/api/export/presets")
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["presets"] == []
+        assert data["counts"]["total"] == 0
+
+    def test_list_presets_handles_error(self, client, mock_export_preset_manager):
+        """GET /api/export/presets returns 500 on error."""
+        mock_export_preset_manager.list_presets.side_effect = RuntimeError("Error")
+
+        response = client.get("/api/export/presets")
+
+        assert response.status_code == 500
+        data = response.get_json()
+        assert "error" in data
+
+
+class TestGetExportPresetEndpoint:
+    """Tests for GET /api/export/presets/<name> endpoint."""
+
+    def test_get_preset_returns_data(self, client, mock_export_preset_manager):
+        """GET /api/export/presets/<name> returns preset data."""
+        from webui.backend.lib.export_preset_types import ExportPreset
+        from webui.backend.lib.export_job_types import ExportJobFormat, ExportJobFilter
+
+        mock_preset = ExportPreset(
+            name="gbif_biodiversity",
+            display_name="GBIF Export",
+            export_format=ExportJobFormat.DARWIN_CORE,
+            description="GBIF export",
+            filter=ExportJobFilter(has_species=True),
+        )
+        mock_export_preset_manager.get_preset.return_value = mock_preset
+
+        response = client.get("/api/export/presets/gbif_biodiversity")
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["name"] == "gbif_biodiversity"
+        assert data["export_format"] == "darwin_core"
+        assert data["filter"]["has_species"] is True
+
+    def test_get_preset_returns_404(self, client, mock_export_preset_manager):
+        """GET /api/export/presets/<name> returns 404 when not found."""
+        mock_export_preset_manager.get_preset.return_value = None
+
+        response = client.get("/api/export/presets/nonexistent")
+
+        assert response.status_code == 404
+        data = response.get_json()
+        assert "not found" in data["error"].lower()
+
+    def test_get_preset_handles_error(self, client, mock_export_preset_manager):
+        """GET /api/export/presets/<name> returns 500 on error."""
+        mock_export_preset_manager.get_preset.side_effect = PermissionError("Error")
+
+        response = client.get("/api/export/presets/test")
+
+        assert response.status_code == 500
+        data = response.get_json()
+        assert "error" in data
+
+
+class TestCreateExportPresetEndpoint:
+    """Tests for POST /api/export/presets endpoint."""
+
+    def test_create_preset_success(self, client, mock_export_preset_manager):
+        """POST /api/export/presets creates preset successfully."""
+        mock_export_preset_manager.save_preset.return_value = (
+            True,
+            "Preset saved successfully",
+        )
+
+        response = client.post(
+            "/api/export/presets",
+            json={
+                "name": "my_preset",
+                "display_name": "My Preset",
+                "export_format": "json",
+                "description": "My custom preset",
+                "filter": {"tags": ["moth"]},
+                "options": {},
+            },
+        )
+
+        assert response.status_code == 201
+        data = response.get_json()
+        assert data["success"] is True
+        assert data["name"] == "my_preset"
+
+        # Verify save_preset was called
+        mock_export_preset_manager.save_preset.assert_called_once()
+
+    def test_create_preset_missing_name(self, client, mock_export_preset_manager):
+        """POST /api/export/presets returns 400 without name."""
+        response = client.post(
+            "/api/export/presets",
+            json={
+                "display_name": "My Preset",
+                "export_format": "json",
+            },
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "name" in data["error"].lower()
+
+    def test_create_preset_missing_display_name(self, client, mock_export_preset_manager):
+        """POST /api/export/presets returns 400 without display_name."""
+        response = client.post(
+            "/api/export/presets",
+            json={
+                "name": "my_preset",
+                "export_format": "json",
+            },
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "display_name" in data["error"].lower()
+
+    def test_create_preset_missing_format(self, client, mock_export_preset_manager):
+        """POST /api/export/presets returns 400 without export_format."""
+        response = client.post(
+            "/api/export/presets",
+            json={
+                "name": "my_preset",
+                "display_name": "My Preset",
+            },
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "format" in data["error"].lower()
+
+    def test_create_preset_invalid_format(self, client, mock_export_preset_manager):
+        """POST /api/export/presets returns 400 for invalid format."""
+        response = client.post(
+            "/api/export/presets",
+            json={
+                "name": "my_preset",
+                "display_name": "My Preset",
+                "export_format": "invalid_format",
+            },
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "format" in data["error"].lower()
+
+    def test_create_preset_rejects_builtin_category(self, client, mock_export_preset_manager):
+        """POST /api/export/presets rejects built-in category."""
+        response = client.post(
+            "/api/export/presets",
+            json={
+                "name": "fake_builtin",
+                "display_name": "Fake Built-in",
+                "export_format": "json",
+                "category": "built-in",
+            },
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "built-in" in data["error"].lower()
+
+    def test_create_preset_save_fails(self, client, mock_export_preset_manager):
+        """POST /api/export/presets returns 400 when save fails."""
+        mock_export_preset_manager.save_preset.return_value = (
+            False,
+            "Invalid preset name",
+        )
+
+        response = client.post(
+            "/api/export/presets",
+            json={
+                "name": "invalid-name!",
+                "display_name": "Invalid",
+                "export_format": "json",
+            },
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "error" in data
+
+
+class TestDeleteExportPresetEndpoint:
+    """Tests for DELETE /api/export/presets/<name> endpoint."""
+
+    def test_delete_preset_success(self, client, mock_export_preset_manager):
+        """DELETE /api/export/presets/<name> deletes preset successfully."""
+        mock_export_preset_manager.delete_preset.return_value = (
+            True,
+            "Preset deleted",
+        )
+
+        response = client.delete("/api/export/presets/my_preset")
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["success"] is True
+        mock_export_preset_manager.delete_preset.assert_called_with("my_preset")
+
+    def test_delete_preset_protects_builtin(self, client, mock_export_preset_manager):
+        """DELETE /api/export/presets/<name> protects built-in presets."""
+        mock_export_preset_manager.delete_preset.return_value = (
+            False,
+            "Cannot delete built-in presets",
+        )
+
+        response = client.delete("/api/export/presets/gbif_biodiversity")
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "built-in" in data["error"].lower()
+
+    def test_delete_preset_not_found(self, client, mock_export_preset_manager):
+        """DELETE /api/export/presets/<name> returns 404 for missing preset."""
+        mock_export_preset_manager.delete_preset.return_value = (
+            False,
+            "Preset 'nonexistent' not found",
+        )
+
+        response = client.delete("/api/export/presets/nonexistent")
+
+        assert response.status_code == 404
+        data = response.get_json()
+        assert "not found" in data["error"].lower()
+
+    def test_delete_preset_handles_error(self, client, mock_export_preset_manager):
+        """DELETE /api/export/presets/<name> returns 500 on error."""
+        mock_export_preset_manager.delete_preset.side_effect = OSError("Error")
+
+        response = client.delete("/api/export/presets/test")
+
+        assert response.status_code == 500
+        data = response.get_json()
+        assert "error" in data

--- a/Firmware/Tests/unit/test_export_preset_types.py
+++ b/Firmware/Tests/unit/test_export_preset_types.py
@@ -1,0 +1,404 @@
+"""
+Unit tests for export preset type definitions.
+
+Tests the ExportPreset dataclass and ExportPresetCategory enum
+following TDD principles - these tests are written before implementation.
+"""
+
+import pytest
+from datetime import datetime
+
+
+class TestExportPresetCategory:
+    """Tests for ExportPresetCategory enum."""
+
+    def test_builtin_value(self):
+        """BUILT_IN enum has correct string value."""
+        from webui.backend.lib.export_preset_types import ExportPresetCategory
+
+        assert ExportPresetCategory.BUILT_IN.value == "built-in"
+
+    def test_user_value(self):
+        """USER enum has correct string value."""
+        from webui.backend.lib.export_preset_types import ExportPresetCategory
+
+        assert ExportPresetCategory.USER.value == "user"
+
+    def test_enum_from_string(self):
+        """Can create enum from string value."""
+        from webui.backend.lib.export_preset_types import ExportPresetCategory
+
+        assert ExportPresetCategory("built-in") == ExportPresetCategory.BUILT_IN
+        assert ExportPresetCategory("user") == ExportPresetCategory.USER
+
+    def test_invalid_string_raises(self):
+        """Invalid string raises ValueError."""
+        from webui.backend.lib.export_preset_types import ExportPresetCategory
+
+        with pytest.raises(ValueError):
+            ExportPresetCategory("invalid")
+
+
+class TestExportPresetDataclass:
+    """Tests for ExportPreset dataclass."""
+
+    def test_required_fields(self):
+        """Preset requires name, display_name, and export_format."""
+        from webui.backend.lib.export_preset_types import ExportPreset
+        from webui.backend.lib.export_job_types import ExportJobFormat
+
+        preset = ExportPreset(
+            name="test_preset",
+            display_name="Test Preset",
+            export_format=ExportJobFormat.JSON,
+        )
+
+        assert preset.name == "test_preset"
+        assert preset.display_name == "Test Preset"
+        assert preset.export_format == ExportJobFormat.JSON
+
+    def test_default_values(self):
+        """Preset has correct default values for optional fields."""
+        from webui.backend.lib.export_preset_types import (
+            ExportPreset,
+            ExportPresetCategory,
+        )
+        from webui.backend.lib.export_job_types import ExportJobFormat
+
+        preset = ExportPreset(
+            name="test_preset",
+            display_name="Test Preset",
+            export_format=ExportJobFormat.JSON,
+        )
+
+        assert preset.description == ""
+        assert preset.version == "1.0"
+        assert preset.created_at == ""
+        assert preset.author == "user"
+        assert preset.category == ExportPresetCategory.USER
+        assert preset.filter is not None
+        assert preset.options == {}
+
+    def test_all_export_formats_supported(self):
+        """All ExportJobFormat values work as export_format."""
+        from webui.backend.lib.export_preset_types import ExportPreset
+        from webui.backend.lib.export_job_types import ExportJobFormat
+
+        for fmt in ExportJobFormat:
+            preset = ExportPreset(
+                name=f"test_{fmt.value}",
+                display_name=f"Test {fmt.value}",
+                export_format=fmt,
+            )
+            assert preset.export_format == fmt
+
+    def test_filter_default_is_empty_filter(self):
+        """Default filter is an empty ExportJobFilter."""
+        from webui.backend.lib.export_preset_types import ExportPreset
+        from webui.backend.lib.export_job_types import ExportJobFormat, ExportJobFilter
+
+        preset = ExportPreset(
+            name="test_preset",
+            display_name="Test Preset",
+            export_format=ExportJobFormat.JSON,
+        )
+
+        # Should be an ExportJobFilter with all None defaults
+        assert isinstance(preset.filter, ExportJobFilter)
+        assert preset.filter.date_start is None
+        assert preset.filter.date_end is None
+        assert preset.filter.has_species is None
+
+    def test_custom_filter(self):
+        """Can set custom filter values."""
+        from webui.backend.lib.export_preset_types import ExportPreset
+        from webui.backend.lib.export_job_types import ExportJobFormat, ExportJobFilter
+
+        custom_filter = ExportJobFilter(
+            has_species=True,
+            tags=["moth", "butterfly"],
+        )
+
+        preset = ExportPreset(
+            name="test_preset",
+            display_name="Test Preset",
+            export_format=ExportJobFormat.DARWIN_CORE,
+            filter=custom_filter,
+        )
+
+        assert preset.filter.has_species is True
+        assert preset.filter.tags == ["moth", "butterfly"]
+
+
+class TestExportPresetSerialization:
+    """Tests for ExportPreset to_dict/from_dict serialization."""
+
+    def test_to_dict_basic(self):
+        """to_dict returns correct dictionary structure."""
+        from webui.backend.lib.export_preset_types import ExportPreset
+        from webui.backend.lib.export_job_types import ExportJobFormat
+
+        preset = ExportPreset(
+            name="test_preset",
+            display_name="Test Preset",
+            export_format=ExportJobFormat.JSON,
+        )
+
+        result = preset.to_dict()
+
+        assert result["name"] == "test_preset"
+        assert result["display_name"] == "Test Preset"
+        assert result["export_format"] == "json"
+        assert result["description"] == ""
+        assert result["version"] == "1.0"
+        assert result["author"] == "user"
+        assert result["category"] == "user"
+        assert "filter" in result
+        assert "options" in result
+
+    def test_to_dict_with_all_fields(self):
+        """to_dict preserves all fields including custom values."""
+        from webui.backend.lib.export_preset_types import (
+            ExportPreset,
+            ExportPresetCategory,
+        )
+        from webui.backend.lib.export_job_types import ExportJobFormat, ExportJobFilter
+
+        preset = ExportPreset(
+            name="gbif_export",
+            display_name="GBIF Export",
+            export_format=ExportJobFormat.DARWIN_CORE,
+            description="Export for GBIF submission",
+            version="2.0",
+            created_at="2024-12-14T10:00:00Z",
+            author="system",
+            category=ExportPresetCategory.BUILT_IN,
+            filter=ExportJobFilter(has_species=True),
+            options={"validate": True},
+        )
+
+        result = preset.to_dict()
+
+        assert result["name"] == "gbif_export"
+        assert result["display_name"] == "GBIF Export"
+        assert result["export_format"] == "darwin_core"
+        assert result["description"] == "Export for GBIF submission"
+        assert result["version"] == "2.0"
+        assert result["created_at"] == "2024-12-14T10:00:00Z"
+        assert result["author"] == "system"
+        assert result["category"] == "built-in"
+        assert result["filter"]["has_species"] is True
+        assert result["options"]["validate"] is True
+
+    def test_from_dict_basic(self):
+        """from_dict creates preset from dictionary."""
+        from webui.backend.lib.export_preset_types import ExportPreset
+        from webui.backend.lib.export_job_types import ExportJobFormat
+
+        data = {
+            "name": "test_preset",
+            "display_name": "Test Preset",
+            "export_format": "json",
+        }
+
+        preset = ExportPreset.from_dict(data)
+
+        assert preset.name == "test_preset"
+        assert preset.display_name == "Test Preset"
+        assert preset.export_format == ExportJobFormat.JSON
+
+    def test_from_dict_with_all_fields(self):
+        """from_dict handles all fields correctly."""
+        from webui.backend.lib.export_preset_types import (
+            ExportPreset,
+            ExportPresetCategory,
+        )
+        from webui.backend.lib.export_job_types import ExportJobFormat
+
+        data = {
+            "name": "gbif_export",
+            "display_name": "GBIF Export",
+            "export_format": "darwin_core",
+            "description": "Export for GBIF submission",
+            "version": "2.0",
+            "created_at": "2024-12-14T10:00:00Z",
+            "author": "system",
+            "category": "built-in",
+            "filter": {"has_species": True},
+            "options": {"validate": True},
+        }
+
+        preset = ExportPreset.from_dict(data)
+
+        assert preset.name == "gbif_export"
+        assert preset.display_name == "GBIF Export"
+        assert preset.export_format == ExportJobFormat.DARWIN_CORE
+        assert preset.description == "Export for GBIF submission"
+        assert preset.version == "2.0"
+        assert preset.created_at == "2024-12-14T10:00:00Z"
+        assert preset.author == "system"
+        assert preset.category == ExportPresetCategory.BUILT_IN
+        assert preset.filter.has_species is True
+        assert preset.options["validate"] is True
+
+    def test_from_dict_missing_optional_fields(self):
+        """from_dict uses defaults for missing optional fields."""
+        from webui.backend.lib.export_preset_types import (
+            ExportPreset,
+            ExportPresetCategory,
+        )
+        from webui.backend.lib.export_job_types import ExportJobFormat
+
+        data = {
+            "name": "minimal_preset",
+            "display_name": "Minimal",
+            "export_format": "csv",
+        }
+
+        preset = ExportPreset.from_dict(data)
+
+        assert preset.name == "minimal_preset"
+        assert preset.display_name == "Minimal"
+        assert preset.export_format == ExportJobFormat.CSV
+        assert preset.description == ""
+        assert preset.version == "1.0"
+        assert preset.created_at == ""
+        assert preset.author == "user"
+        assert preset.category == ExportPresetCategory.USER
+        assert preset.options == {}
+
+    def test_roundtrip_serialization(self):
+        """to_dict followed by from_dict preserves all data."""
+        from webui.backend.lib.export_preset_types import (
+            ExportPreset,
+            ExportPresetCategory,
+        )
+        from webui.backend.lib.export_job_types import ExportJobFormat, ExportJobFilter
+
+        original = ExportPreset(
+            name="roundtrip_test",
+            display_name="Roundtrip Test",
+            export_format=ExportJobFormat.INATURALIST,
+            description="Testing roundtrip",
+            version="1.5",
+            created_at="2024-12-14T12:00:00Z",
+            author="test_user",
+            category=ExportPresetCategory.USER,
+            filter=ExportJobFilter(tags=["test"], series_type="hdr"),
+            options={"include_xmp": True},
+        )
+
+        serialized = original.to_dict()
+        restored = ExportPreset.from_dict(serialized)
+
+        assert restored.name == original.name
+        assert restored.display_name == original.display_name
+        assert restored.export_format == original.export_format
+        assert restored.description == original.description
+        assert restored.version == original.version
+        assert restored.created_at == original.created_at
+        assert restored.author == original.author
+        assert restored.category == original.category
+        assert restored.filter.tags == original.filter.tags
+        assert restored.options == original.options
+
+    def test_from_dict_invalid_format_raises(self):
+        """from_dict raises ValueError for invalid export_format."""
+        from webui.backend.lib.export_preset_types import ExportPreset
+
+        data = {
+            "name": "bad_preset",
+            "display_name": "Bad Preset",
+            "export_format": "invalid_format",
+        }
+
+        with pytest.raises(ValueError):
+            ExportPreset.from_dict(data)
+
+    def test_from_dict_invalid_category_raises(self):
+        """from_dict raises ValueError for invalid category."""
+        from webui.backend.lib.export_preset_types import ExportPreset
+
+        data = {
+            "name": "bad_preset",
+            "display_name": "Bad Preset",
+            "export_format": "json",
+            "category": "invalid_category",
+        }
+
+        with pytest.raises(ValueError):
+            ExportPreset.from_dict(data)
+
+
+class TestExportPresetFilterIntegration:
+    """Tests for ExportPreset integration with ExportJobFilter."""
+
+    def test_filter_with_series_type_hdr(self):
+        """Filter with HDR series type works correctly."""
+        from webui.backend.lib.export_preset_types import ExportPreset
+        from webui.backend.lib.export_job_types import ExportJobFormat, ExportJobFilter
+        from webui.backend.lib.series_detection import SeriesType
+
+        preset = ExportPreset(
+            name="hdr_preset",
+            display_name="HDR Preset",
+            export_format=ExportJobFormat.JSON,
+            filter=ExportJobFilter(series_type=SeriesType.HDR),
+        )
+
+        assert preset.filter.series_type == SeriesType.HDR
+
+        # Verify serialization handles enum
+        serialized = preset.to_dict()
+        assert serialized["filter"]["series_type"] == "hdr"
+
+    def test_filter_with_series_type_focus_bracket(self):
+        """Filter with focus bracket series type works correctly."""
+        from webui.backend.lib.export_preset_types import ExportPreset
+        from webui.backend.lib.export_job_types import ExportJobFormat, ExportJobFilter
+        from webui.backend.lib.series_detection import SeriesType
+
+        preset = ExportPreset(
+            name="fb_preset",
+            display_name="Focus Bracket Preset",
+            export_format=ExportJobFormat.JSON,
+            filter=ExportJobFilter(series_type=SeriesType.FOCUS_BRACKET),
+        )
+
+        assert preset.filter.series_type == SeriesType.FOCUS_BRACKET
+
+        # Verify serialization handles enum
+        serialized = preset.to_dict()
+        assert serialized["filter"]["series_type"] == "focus_bracket"
+
+    def test_filter_with_date_range(self):
+        """Filter with date range works correctly."""
+        from webui.backend.lib.export_preset_types import ExportPreset
+        from webui.backend.lib.export_job_types import ExportJobFormat, ExportJobFilter
+
+        preset = ExportPreset(
+            name="date_range_preset",
+            display_name="Date Range Preset",
+            export_format=ExportJobFormat.CSV,
+            filter=ExportJobFilter(
+                date_start="2024-01-01",
+                date_end="2024-12-31",
+            ),
+        )
+
+        assert preset.filter.date_start == "2024-01-01"
+        assert preset.filter.date_end == "2024-12-31"
+
+    def test_filter_with_deployment(self):
+        """Filter with deployment path works correctly."""
+        from webui.backend.lib.export_preset_types import ExportPreset
+        from webui.backend.lib.export_job_types import ExportJobFormat, ExportJobFilter
+
+        preset = ExportPreset(
+            name="deployment_preset",
+            display_name="Deployment Preset",
+            export_format=ExportJobFormat.DARWIN_CORE,
+            filter=ExportJobFilter(deployment="/photos/forest_2024"),
+        )
+
+        assert preset.filter.deployment == "/photos/forest_2024"

--- a/Firmware/mothbox_paths.py
+++ b/Firmware/mothbox_paths.py
@@ -133,10 +133,14 @@ USER_PREFERENCES_FILE = CONFIG_DIR / "user_preferences.json"
 ISP_TUNING_DIR = CONFIG_DIR / "isp_tuning"
 ISP_DEFAULT_TUNING_FILE = ISP_TUNING_DIR / "camera_isp_tuning.json"
 
-# Preset configuration
+# Preset configuration (camera presets)
 PRESET_DIR = CONFIG_DIR / "presets"
 BUILTIN_PRESET_DIR = PRESET_DIR / "built-in"
 USER_PRESET_DIR = PRESET_DIR / "user"
+
+# Export preset configuration (unified namespace under presets/)
+EXPORT_BUILTIN_PRESET_DIR = BUILTIN_PRESET_DIR / "export"
+EXPORT_USER_PRESET_DIR = USER_PRESET_DIR / "export"
 
 
 # Helper function to parse controls.txt

--- a/Firmware/webui/backend/app.py
+++ b/Firmware/webui/backend/app.py
@@ -296,11 +296,41 @@ except Exception as e:
     print(f"⚠️  Failed to initialize deployment service: {e}")
     app.config['DEPLOYMENT_SERVICE'] = None
 
+# Initialize export preset manager
+from webui.backend.export_preset_manager import ExportPresetManager
+from mothbox_paths import EXPORT_BUILTIN_PRESET_DIR, EXPORT_USER_PRESET_DIR
+
+try:
+    # Use built-in presets from package if production paths don't exist
+    import importlib.resources
+
+    # Check if the production path exists, otherwise use package path
+    if EXPORT_BUILTIN_PRESET_DIR.exists():
+        builtin_dir = EXPORT_BUILTIN_PRESET_DIR
+    else:
+        # Fall back to presets shipped with the package
+        builtin_dir = Path(__file__).parent / "presets_builtin" / "export"
+
+    # Ensure user directory exists
+    EXPORT_USER_PRESET_DIR.mkdir(parents=True, exist_ok=True)
+
+    export_preset_manager = ExportPresetManager(
+        builtin_dir=builtin_dir,
+        user_dir=EXPORT_USER_PRESET_DIR
+    )
+    app.config['EXPORT_PRESET_MANAGER'] = export_preset_manager
+    counts = export_preset_manager.get_preset_count()
+    print(f"✓ Export preset manager initialized ({counts['built_in']} built-in, {counts['user']} user)")
+except Exception as e:
+    print(f"⚠️  Failed to initialize export preset manager: {e}")
+    app.config['EXPORT_PRESET_MANAGER'] = None
+
 # Import route blueprints
 from routes.camera import camera_bp
 from routes.config import config_bp
 from routes.deployment import deployment_bp
 from routes.export import export_bp
+from routes.export_presets import export_presets_bp
 from routes.gallery import gallery_bp
 from routes.gpio import gpio_bp
 from routes.gps import gps_bp
@@ -329,6 +359,7 @@ app.register_blueprint(metadata_bp, url_prefix="/api/metadata")
 app.register_blueprint(sidecar_bp, url_prefix="/api/sidecar")
 app.register_blueprint(deployment_bp, url_prefix="/api/deployment")
 app.register_blueprint(export_bp, url_prefix="/api/export")
+app.register_blueprint(export_presets_bp, url_prefix="/api/export/presets")
 app.register_blueprint(search_bp)  # Note: search_bp already includes /api/photos/search prefix
 
 # Register WebSocket handlers

--- a/Firmware/webui/backend/export_preset_manager.py
+++ b/Firmware/webui/backend/export_preset_manager.py
@@ -109,7 +109,7 @@ class ExportPresetManager:
                             "author": data.get("author", "system"),
                         }
                     )
-                except (OSError, json.JSONDecodeError) as e:
+                except (OSError, json.JSONDecodeError, UnicodeDecodeError) as e:
                     logger.warning(
                         f"Could not load built-in preset {preset_file} "
                         f"({type(e).__name__}): {e}"
@@ -160,7 +160,7 @@ class ExportPresetManager:
                             "created_at": data.get("created_at", ""),
                         }
                     )
-                except (OSError, json.JSONDecodeError) as e:
+                except (OSError, json.JSONDecodeError, UnicodeDecodeError) as e:
                     logger.warning(
                         f"Could not load user preset {preset_file} "
                         f"({type(e).__name__}): {e}"
@@ -196,7 +196,7 @@ class ExportPresetManager:
 
                 with open(builtin_path) as f:
                     preset_data = json.load(f)
-            except (OSError, json.JSONDecodeError) as e:
+            except (OSError, json.JSONDecodeError, UnicodeDecodeError) as e:
                 logger.error(f"Error loading built-in preset {name}: {e}")
                 return None
 
@@ -215,7 +215,7 @@ class ExportPresetManager:
 
                     with open(user_path) as f:
                         preset_data = json.load(f)
-                except (OSError, json.JSONDecodeError) as e:
+                except (OSError, json.JSONDecodeError, UnicodeDecodeError) as e:
                     logger.error(f"Error loading user preset {name}: {e}")
                     return None
 

--- a/Firmware/webui/backend/export_preset_manager.py
+++ b/Firmware/webui/backend/export_preset_manager.py
@@ -92,7 +92,10 @@ class ExportPresetManager:
                         }
                     )
                 except (OSError, json.JSONDecodeError) as e:
-                    logger.warning(f"Could not load built-in preset {preset_file}: {e}")
+                    logger.warning(
+                        f"Could not load built-in preset {preset_file} "
+                        f"({type(e).__name__}): {e}"
+                    )
 
         # Load user presets
         if self.user_dir.exists():
@@ -125,7 +128,10 @@ class ExportPresetManager:
                         }
                     )
                 except (OSError, json.JSONDecodeError) as e:
-                    logger.warning(f"Could not load user preset {preset_file}: {e}")
+                    logger.warning(
+                        f"Could not load user preset {preset_file} "
+                        f"({type(e).__name__}): {e}"
+                    )
 
         return presets
 

--- a/Firmware/webui/backend/export_preset_manager.py
+++ b/Firmware/webui/backend/export_preset_manager.py
@@ -76,13 +76,20 @@ class ExportPresetManager:
                         )
                         continue
 
+                    # Warn if JSON name doesn't match filename
+                    json_name = data.get("name")
+                    if json_name and json_name != preset_file.stem:
+                        logger.warning(
+                            f"Preset name mismatch: file={preset_file.stem}, json={json_name}"
+                        )
+
                     # Apply format filter
                     if format_filter and data.get("export_format") != format_filter:
                         continue
 
                     presets.append(
                         {
-                            "name": data.get("name", preset_file.stem),
+                            "name": json_name or preset_file.stem,
                             "display_name": data.get("display_name", preset_file.stem),
                             "description": data.get("description", ""),
                             "category": "built-in",
@@ -111,13 +118,20 @@ class ExportPresetManager:
                         logger.warning(f"Skipping invalid user preset {preset_file.name}: {error_msg}")
                         continue
 
+                    # Warn if JSON name doesn't match filename
+                    json_name = data.get("name")
+                    if json_name and json_name != preset_file.stem:
+                        logger.warning(
+                            f"Preset name mismatch: file={preset_file.stem}, json={json_name}"
+                        )
+
                     # Apply format filter
                     if format_filter and data.get("export_format") != format_filter:
                         continue
 
                     presets.append(
                         {
-                            "name": data.get("name", preset_file.stem),
+                            "name": json_name or preset_file.stem,
                             "display_name": data.get("display_name", preset_file.stem),
                             "description": data.get("description", ""),
                             "category": "user",

--- a/Firmware/webui/backend/export_preset_manager.py
+++ b/Firmware/webui/backend/export_preset_manager.py
@@ -24,6 +24,9 @@ from webui.backend.lib.export_preset_types import ExportPreset, ExportPresetCate
 # Setup logging
 logger = logging.getLogger(__name__)
 
+# Maximum preset file size (1MB) - prevents loading maliciously large files
+MAX_PRESET_FILE_SIZE = 1024 * 1024
+
 
 class ExportPresetManager:
     """Manages export settings presets (built-in and user-created)."""
@@ -64,6 +67,14 @@ class ExportPresetManager:
         if self.builtin_dir.exists():
             for preset_file in sorted(self.builtin_dir.glob("*.json")):
                 try:
+                    # Check file size before loading
+                    if preset_file.stat().st_size > MAX_PRESET_FILE_SIZE:
+                        logger.warning(
+                            f"Skipping oversized built-in preset {preset_file.name}: "
+                            f"exceeds {MAX_PRESET_FILE_SIZE} bytes"
+                        )
+                        continue
+
                     with open(preset_file) as f:
                         data = json.load(f)
 
@@ -108,6 +119,14 @@ class ExportPresetManager:
         if self.user_dir.exists():
             for preset_file in sorted(self.user_dir.glob("*.json")):
                 try:
+                    # Check file size before loading
+                    if preset_file.stat().st_size > MAX_PRESET_FILE_SIZE:
+                        logger.warning(
+                            f"Skipping oversized user preset {preset_file.name}: "
+                            f"exceeds {MAX_PRESET_FILE_SIZE} bytes"
+                        )
+                        continue
+
                     with open(preset_file) as f:
                         data = json.load(f)
 
@@ -167,6 +186,14 @@ class ExportPresetManager:
         builtin_path = self.builtin_dir / f"{name}.json"
         if builtin_path.exists():
             try:
+                # Check file size before loading
+                if builtin_path.stat().st_size > MAX_PRESET_FILE_SIZE:
+                    logger.error(
+                        f"Built-in preset {name} exceeds max file size "
+                        f"({MAX_PRESET_FILE_SIZE} bytes)"
+                    )
+                    return None
+
                 with open(builtin_path) as f:
                     preset_data = json.load(f)
             except (OSError, json.JSONDecodeError) as e:
@@ -178,6 +205,14 @@ class ExportPresetManager:
             user_path = self.user_dir / f"{name}.json"
             if user_path.exists():
                 try:
+                    # Check file size before loading
+                    if user_path.stat().st_size > MAX_PRESET_FILE_SIZE:
+                        logger.error(
+                            f"User preset {name} exceeds max file size "
+                            f"({MAX_PRESET_FILE_SIZE} bytes)"
+                        )
+                        return None
+
                     with open(user_path) as f:
                         preset_data = json.load(f)
                 except (OSError, json.JSONDecodeError) as e:

--- a/Firmware/webui/backend/export_preset_manager.py
+++ b/Firmware/webui/backend/export_preset_manager.py
@@ -1,0 +1,339 @@
+"""
+Export Preset Manager - Handle export settings presets.
+
+This module provides functionality to:
+- Load built-in and user export presets
+- Create new user presets
+- Apply presets to export job creation
+- Validate preset data
+- Manage preset files with file locking
+
+Author: Mothbox Team
+Date: 2024
+"""
+
+import fcntl
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+
+from webui.backend.lib.export_job_types import ExportJobFormat
+from webui.backend.lib.export_preset_types import ExportPreset, ExportPresetCategory
+
+# Setup logging
+logger = logging.getLogger(__name__)
+
+
+class ExportPresetManager:
+    """Manages export settings presets (built-in and user-created)."""
+
+    def __init__(self, builtin_dir: Path, user_dir: Path):
+        """
+        Initialize export preset manager.
+
+        Args:
+            builtin_dir: Path to built-in presets directory
+            user_dir: Path to user presets directory
+        """
+        self.builtin_dir = Path(builtin_dir)
+        self.user_dir = Path(user_dir)
+
+        # Create user directory if it doesn't exist
+        self.user_dir.mkdir(parents=True, exist_ok=True)
+
+    def list_presets(self, format_filter: str | None = None) -> list[dict]:
+        """
+        List all available presets (built-in + user).
+
+        Args:
+            format_filter: Optional filter by export format (e.g., "darwin_core")
+
+        Returns:
+            List of preset metadata dicts with keys:
+            - name: preset identifier
+            - display_name: human-readable name
+            - description: preset description
+            - category: 'built-in' or 'user'
+            - export_format: export format string
+            - version: preset version
+        """
+        presets = []
+
+        # Load built-in presets
+        if self.builtin_dir.exists():
+            for preset_file in sorted(self.builtin_dir.glob("*.json")):
+                try:
+                    with open(preset_file) as f:
+                        data = json.load(f)
+
+                    # Validate and normalize
+                    data = self.normalize_preset(data)
+                    valid, error_msg = self.validate_preset(data)
+                    if not valid:
+                        logger.warning(
+                            f"Skipping invalid built-in preset {preset_file.name}: {error_msg}"
+                        )
+                        continue
+
+                    # Apply format filter
+                    if format_filter and data.get("export_format") != format_filter:
+                        continue
+
+                    presets.append(
+                        {
+                            "name": data.get("name", preset_file.stem),
+                            "display_name": data.get("display_name", preset_file.stem),
+                            "description": data.get("description", ""),
+                            "category": "built-in",
+                            "export_format": data.get("export_format"),
+                            "version": data.get("version", "1.0"),
+                            "author": data.get("author", "system"),
+                        }
+                    )
+                except (OSError, json.JSONDecodeError) as e:
+                    logger.warning(f"Could not load built-in preset {preset_file}: {e}")
+
+        # Load user presets
+        if self.user_dir.exists():
+            for preset_file in sorted(self.user_dir.glob("*.json")):
+                try:
+                    with open(preset_file) as f:
+                        data = json.load(f)
+
+                    # Validate and normalize
+                    data = self.normalize_preset(data)
+                    valid, error_msg = self.validate_preset(data)
+                    if not valid:
+                        logger.warning(f"Skipping invalid user preset {preset_file.name}: {error_msg}")
+                        continue
+
+                    # Apply format filter
+                    if format_filter and data.get("export_format") != format_filter:
+                        continue
+
+                    presets.append(
+                        {
+                            "name": data.get("name", preset_file.stem),
+                            "display_name": data.get("display_name", preset_file.stem),
+                            "description": data.get("description", ""),
+                            "category": "user",
+                            "export_format": data.get("export_format"),
+                            "version": data.get("version", "1.0"),
+                            "author": data.get("author", "user"),
+                            "created_at": data.get("created_at", ""),
+                        }
+                    )
+                except (OSError, json.JSONDecodeError) as e:
+                    logger.warning(f"Could not load user preset {preset_file}: {e}")
+
+        return presets
+
+    def get_preset(self, name: str) -> ExportPreset | None:
+        """
+        Get specific preset by name.
+
+        Built-in presets take precedence over user presets with the same name.
+
+        Args:
+            name: Preset name (without .json extension)
+
+        Returns:
+            ExportPreset instance, or None if not found or invalid
+        """
+        preset_data = None
+
+        # Try built-in first (takes precedence)
+        builtin_path = self.builtin_dir / f"{name}.json"
+        if builtin_path.exists():
+            try:
+                with open(builtin_path) as f:
+                    preset_data = json.load(f)
+            except (OSError, json.JSONDecodeError) as e:
+                logger.error(f"Error loading built-in preset {name}: {e}")
+                return None
+
+        # Try user presets if not found in built-in
+        if not preset_data:
+            user_path = self.user_dir / f"{name}.json"
+            if user_path.exists():
+                try:
+                    with open(user_path) as f:
+                        preset_data = json.load(f)
+                except (OSError, json.JSONDecodeError) as e:
+                    logger.error(f"Error loading user preset {name}: {e}")
+                    return None
+
+        if preset_data:
+            # Normalize and validate
+            preset_data = self.normalize_preset(preset_data)
+            valid, error_msg = self.validate_preset(preset_data)
+            if not valid:
+                logger.error(f"Invalid preset '{name}': {error_msg}")
+                return None
+
+            # Convert to ExportPreset object
+            try:
+                return ExportPreset.from_dict(preset_data)
+            except (ValueError, KeyError) as e:
+                logger.error(f"Failed to create ExportPreset from '{name}': {e}")
+                return None
+
+        return None
+
+    def save_preset(self, preset: ExportPreset) -> tuple[bool, str]:
+        """
+        Save preset to user directory.
+
+        Args:
+            preset: ExportPreset instance to save
+
+        Returns:
+            Tuple of (success: bool, message: str)
+        """
+        # Validate name (alphanumeric + underscores only)
+        if not preset.name or not all(c.isalnum() or c == "_" for c in preset.name):
+            return False, "Preset name must contain only letters, numbers, and underscores"
+
+        # Built-in presets cannot be saved as built-in
+        if preset.category == ExportPresetCategory.BUILT_IN:
+            return False, "Cannot save preset with built-in category"
+
+        # Build preset data
+        preset_data = preset.to_dict()
+
+        # Ensure created_at is set
+        if not preset_data.get("created_at"):
+            preset_data["created_at"] = datetime.now(UTC).isoformat()
+
+        # Ensure category is user (enforce on save)
+        preset_data["category"] = "user"
+        preset_data["author"] = "user"
+
+        # Validate the complete preset
+        valid, error_msg = self.validate_preset(preset_data)
+        if not valid:
+            return False, error_msg
+
+        # Save to user directory with file locking
+        try:
+            preset_path = self.user_dir / f"{preset.name}.json"
+            with open(preset_path, "w") as f:
+                try:
+                    # Acquire exclusive lock
+                    fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+                    json.dump(preset_data, f, indent=2)
+                    f.flush()
+                finally:
+                    # Release lock
+                    fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+            return True, f"Preset '{preset.name}' saved successfully"
+        except OSError as e:
+            return False, f"Failed to save preset: {e}"
+
+    def delete_preset(self, name: str) -> tuple[bool, str]:
+        """
+        Delete user preset (built-in presets are protected).
+
+        Args:
+            name: Preset name to delete
+
+        Returns:
+            Tuple of (success: bool, message: str)
+        """
+        # Check if it's a built-in preset
+        builtin_path = self.builtin_dir / f"{name}.json"
+        if builtin_path.exists():
+            return False, "Cannot delete built-in presets"
+
+        # Try to delete user preset
+        user_path = self.user_dir / f"{name}.json"
+        if not user_path.exists():
+            return False, f"Preset '{name}' not found"
+
+        try:
+            user_path.unlink()
+            return True, f"Preset '{name}' deleted successfully"
+        except OSError as e:
+            return False, f"Failed to delete preset: {e}"
+
+    def validate_preset(self, preset_data: dict) -> tuple[bool, str]:
+        """
+        Validate preset structure and required fields.
+
+        Args:
+            preset_data: Preset data dict to validate
+
+        Returns:
+            Tuple of (valid: bool, error_message: str)
+        """
+        # Check required fields
+        if not preset_data.get("name"):
+            return False, "Preset must have a 'name' field"
+
+        if not preset_data.get("display_name"):
+            return False, "Preset must have a 'display_name' field"
+
+        if not preset_data.get("export_format"):
+            return False, "Preset must have an 'export_format' field"
+
+        # Validate export_format is a known format
+        export_format = preset_data.get("export_format")
+        valid_formats = [f.value for f in ExportJobFormat]
+        if export_format not in valid_formats:
+            return False, f"Invalid export_format '{export_format}'. Must be one of: {valid_formats}"
+
+        # Validate category if present
+        category = preset_data.get("category", "user")
+        valid_categories = [c.value for c in ExportPresetCategory]
+        if category not in valid_categories:
+            return False, f"Invalid category '{category}'. Must be one of: {valid_categories}"
+
+        return True, "Preset validation successful"
+
+    def normalize_preset(self, preset_data: dict) -> dict:
+        """
+        Normalize preset by adding missing fields with defaults.
+
+        Args:
+            preset_data: Raw preset data
+
+        Returns:
+            Normalized preset with all required fields
+        """
+        normalized = preset_data.copy()
+
+        # Add default values for optional fields
+        if "description" not in normalized:
+            normalized["description"] = ""
+
+        if "version" not in normalized:
+            normalized["version"] = "1.0"
+
+        if "author" not in normalized:
+            normalized["author"] = "user"
+
+        if "category" not in normalized:
+            normalized["category"] = "user"
+
+        if "filter" not in normalized:
+            normalized["filter"] = {}
+
+        if "options" not in normalized:
+            normalized["options"] = {}
+
+        return normalized
+
+    def get_preset_count(self) -> dict[str, int]:
+        """
+        Get count of presets by category.
+
+        Returns:
+            Dict with 'built_in', 'user', and 'total' counts
+        """
+        builtin_count = (
+            len(list(self.builtin_dir.glob("*.json"))) if self.builtin_dir.exists() else 0
+        )
+        user_count = len(list(self.user_dir.glob("*.json"))) if self.user_dir.exists() else 0
+
+        return {"built_in": builtin_count, "user": user_count, "total": builtin_count + user_count}

--- a/Firmware/webui/backend/export_preset_manager.py
+++ b/Firmware/webui/backend/export_preset_manager.py
@@ -27,6 +27,9 @@ logger = logging.getLogger(__name__)
 # Maximum preset file size (1MB) - prevents loading maliciously large files
 MAX_PRESET_FILE_SIZE = 1024 * 1024
 
+# Maximum preset name length
+MAX_PRESET_NAME_LENGTH = 50
+
 
 class ExportPresetManager:
     """Manages export settings presets (built-in and user-created)."""
@@ -75,7 +78,7 @@ class ExportPresetManager:
                         )
                         continue
 
-                    with open(preset_file) as f:
+                    with open(preset_file, encoding="utf-8") as f:
                         data = json.load(f)
 
                     # Validate and normalize
@@ -87,11 +90,14 @@ class ExportPresetManager:
                         )
                         continue
 
-                    # Warn if JSON name doesn't match filename
+                    # Warn if JSON name doesn't match filename.
+                    # Note: When mismatch occurs, JSON name takes precedence for the
+                    # returned preset identifier (used in get_preset lookups).
                     json_name = data.get("name")
                     if json_name and json_name != preset_file.stem:
                         logger.warning(
-                            f"Preset name mismatch: file={preset_file.stem}, json={json_name}"
+                            f"Preset name mismatch: file={preset_file.stem}, json={json_name}. "
+                            f"Using JSON name '{json_name}' as preset identifier."
                         )
 
                     # Apply format filter
@@ -127,7 +133,7 @@ class ExportPresetManager:
                         )
                         continue
 
-                    with open(preset_file) as f:
+                    with open(preset_file, encoding="utf-8") as f:
                         data = json.load(f)
 
                     # Validate and normalize
@@ -137,11 +143,14 @@ class ExportPresetManager:
                         logger.warning(f"Skipping invalid user preset {preset_file.name}: {error_msg}")
                         continue
 
-                    # Warn if JSON name doesn't match filename
+                    # Warn if JSON name doesn't match filename.
+                    # Note: When mismatch occurs, JSON name takes precedence for the
+                    # returned preset identifier (used in get_preset lookups).
                     json_name = data.get("name")
                     if json_name and json_name != preset_file.stem:
                         logger.warning(
-                            f"Preset name mismatch: file={preset_file.stem}, json={json_name}"
+                            f"Preset name mismatch: file={preset_file.stem}, json={json_name}. "
+                            f"Using JSON name '{json_name}' as preset identifier."
                         )
 
                     # Apply format filter
@@ -194,7 +203,7 @@ class ExportPresetManager:
                     )
                     return None
 
-                with open(builtin_path) as f:
+                with open(builtin_path, encoding="utf-8") as f:
                     preset_data = json.load(f)
             except (OSError, json.JSONDecodeError, UnicodeDecodeError) as e:
                 logger.error(f"Error loading built-in preset {name}: {e}")
@@ -213,7 +222,7 @@ class ExportPresetManager:
                         )
                         return None
 
-                    with open(user_path) as f:
+                    with open(user_path, encoding="utf-8") as f:
                         preset_data = json.load(f)
                 except (OSError, json.JSONDecodeError, UnicodeDecodeError) as e:
                     logger.error(f"Error loading user preset {name}: {e}")
@@ -246,9 +255,12 @@ class ExportPresetManager:
         Returns:
             Tuple of (success: bool, message: str)
         """
-        # Validate name (alphanumeric + underscores only)
+        # Validate name (alphanumeric + underscores only, max length)
         if not preset.name or not all(c.isalnum() or c == "_" for c in preset.name):
             return False, "Preset name must contain only letters, numbers, and underscores"
+
+        if len(preset.name) > MAX_PRESET_NAME_LENGTH:
+            return False, f"Preset name exceeds maximum length of {MAX_PRESET_NAME_LENGTH} characters"
 
         # Built-in presets cannot be saved as built-in
         if preset.category == ExportPresetCategory.BUILT_IN:
@@ -273,7 +285,7 @@ class ExportPresetManager:
         # Save to user directory with file locking
         try:
             preset_path = self.user_dir / f"{preset.name}.json"
-            with open(preset_path, "w") as f:
+            with open(preset_path, "w", encoding="utf-8") as f:
                 try:
                     # Acquire exclusive lock
                     fcntl.flock(f.fileno(), fcntl.LOCK_EX)

--- a/Firmware/webui/backend/lib/export_preset_types.py
+++ b/Firmware/webui/backend/lib/export_preset_types.py
@@ -1,0 +1,137 @@
+"""
+Export preset type definitions.
+
+This module defines the data structures for export presets:
+- ExportPresetCategory: Built-in vs user preset distinction
+- ExportPreset: Complete preset configuration with format, filter, and options
+
+Presets allow users to save and reuse export configurations for common
+scenarios like GBIF submission, iNaturalist upload, or simple data sharing.
+
+Author: Mothbox Team
+Date: 2024
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+from webui.backend.lib.export_job_types import ExportJobFilter, ExportJobFormat
+
+
+class ExportPresetCategory(Enum):
+    """
+    Export preset category for distinguishing system vs user presets.
+
+    Categories:
+        BUILT_IN: System-provided presets, read-only
+        USER: User-created presets, can be modified/deleted
+    """
+
+    BUILT_IN = "built-in"
+    USER = "user"
+
+
+@dataclass
+class ExportPreset:
+    """
+    Export preset configuration.
+
+    Stores a complete export configuration that can be saved, loaded,
+    and applied to export jobs. Includes format, filter criteria,
+    and format-specific options.
+
+    Attributes:
+        name: Unique identifier (alphanumeric + underscore only)
+        display_name: Human-readable name for UI display
+        export_format: Export format (DARWIN_CORE, INATURALIST, JSON, CSV)
+        description: Purpose and use case description
+        version: Schema version for compatibility
+        created_at: ISO 8601 timestamp of creation
+        author: Creator identifier ("system" for built-in, username for user)
+        category: BUILT_IN or USER
+        filter: Photo selection criteria
+        options: Format-specific export options
+    """
+
+    name: str
+    display_name: str
+    export_format: ExportJobFormat
+    description: str = ""
+    version: str = "1.0"
+    created_at: str = ""
+    author: str = "user"
+    category: ExportPresetCategory = ExportPresetCategory.USER
+    filter: ExportJobFilter = field(default_factory=ExportJobFilter)
+    options: dict = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Serialize preset to dictionary.
+
+        Converts enums to string values and nested objects to dicts.
+        Suitable for JSON serialization.
+
+        Returns:
+            Dictionary with all preset fields
+        """
+        return {
+            "name": self.name,
+            "display_name": self.display_name,
+            "export_format": self.export_format.value,
+            "description": self.description,
+            "version": self.version,
+            "created_at": self.created_at,
+            "author": self.author,
+            "category": self.category.value,
+            "filter": self.filter.to_dict(),
+            "options": self.options,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ExportPreset:
+        """
+        Deserialize preset from dictionary.
+
+        Converts string values back to enums and nested dicts to objects.
+
+        Args:
+            data: Dictionary with preset fields
+
+        Returns:
+            ExportPreset instance
+
+        Raises:
+            ValueError: If export_format or category strings are invalid
+        """
+        # Convert string format to enum
+        try:
+            export_format = ExportJobFormat(data["export_format"])
+        except ValueError as e:
+            raise ValueError(f"Invalid export_format value: {data['export_format']}") from e
+
+        # Convert string category to enum (with default)
+        category_str = data.get("category", "user")
+        try:
+            category = ExportPresetCategory(category_str)
+        except ValueError as e:
+            raise ValueError(f"Invalid category value: {category_str}") from e
+
+        # Deserialize filter if present
+        filter_data = data.get("filter", {})
+        filter_obj = ExportJobFilter.from_dict(filter_data)
+
+        return cls(
+            name=data["name"],
+            display_name=data["display_name"],
+            export_format=export_format,
+            description=data.get("description", ""),
+            version=data.get("version", "1.0"),
+            created_at=data.get("created_at", ""),
+            author=data.get("author", "user"),
+            category=category,
+            filter=filter_obj,
+            options=data.get("options", {}),
+        )

--- a/Firmware/webui/backend/presets_builtin/export/focus_bracket_series.json
+++ b/Firmware/webui/backend/presets_builtin/export/focus_bracket_series.json
@@ -1,0 +1,14 @@
+{
+  "name": "focus_bracket_series",
+  "display_name": "Focus Bracket Series Export",
+  "export_format": "json",
+  "description": "JSON export filtered to focus bracket series photos only. Useful for exporting focus stacking sequences.",
+  "version": "1.0",
+  "created_at": "2024-12-14T00:00:00Z",
+  "author": "system",
+  "category": "built-in",
+  "filter": {
+    "series_type": "focus_bracket"
+  },
+  "options": {}
+}

--- a/Firmware/webui/backend/presets_builtin/export/gbif_biodiversity.json
+++ b/Firmware/webui/backend/presets_builtin/export/gbif_biodiversity.json
@@ -1,0 +1,17 @@
+{
+  "name": "gbif_biodiversity",
+  "display_name": "GBIF Biodiversity Export",
+  "export_format": "darwin_core",
+  "description": "Darwin Core CSV export optimized for GBIF submission. Filters to only include photos with species identification for biodiversity data quality.",
+  "version": "1.0",
+  "created_at": "2024-12-14T00:00:00Z",
+  "author": "system",
+  "category": "built-in",
+  "filter": {
+    "has_species": true
+  },
+  "options": {
+    "validate": true,
+    "include_warnings": true
+  }
+}

--- a/Firmware/webui/backend/presets_builtin/export/hdr_series.json
+++ b/Firmware/webui/backend/presets_builtin/export/hdr_series.json
@@ -1,0 +1,14 @@
+{
+  "name": "hdr_series",
+  "display_name": "HDR Series Export",
+  "export_format": "json",
+  "description": "JSON export filtered to HDR (High Dynamic Range) series photos only. Useful for exporting bracketed exposure sequences.",
+  "version": "1.0",
+  "created_at": "2024-12-14T00:00:00Z",
+  "author": "system",
+  "category": "built-in",
+  "filter": {
+    "series_type": "hdr"
+  },
+  "options": {}
+}

--- a/Firmware/webui/backend/presets_builtin/export/inaturalist_upload.json
+++ b/Firmware/webui/backend/presets_builtin/export/inaturalist_upload.json
@@ -1,0 +1,16 @@
+{
+  "name": "inaturalist_upload",
+  "display_name": "iNaturalist Upload Package",
+  "export_format": "inaturalist",
+  "description": "ZIP archive with XMP sidecar files for iNaturalist bulk upload. Includes CSV manifest for easy import tracking.",
+  "version": "1.0",
+  "created_at": "2024-12-14T00:00:00Z",
+  "author": "system",
+  "category": "built-in",
+  "filter": {},
+  "options": {
+    "include_xmp_sidecars": true,
+    "include_manifest": true,
+    "include_csv_summary": true
+  }
+}

--- a/Firmware/webui/backend/presets_builtin/export/simple_csv.json
+++ b/Firmware/webui/backend/presets_builtin/export/simple_csv.json
@@ -1,0 +1,14 @@
+{
+  "name": "simple_csv",
+  "display_name": "Simple CSV Export",
+  "export_format": "csv",
+  "description": "Excel-compatible CSV metadata export with UTF-8 BOM. Includes flattened metadata fields suitable for spreadsheet analysis.",
+  "version": "1.0",
+  "created_at": "2024-12-14T00:00:00Z",
+  "author": "system",
+  "category": "built-in",
+  "filter": {},
+  "options": {
+    "include_bom": true
+  }
+}

--- a/Firmware/webui/backend/presets_builtin/export/simple_json.json
+++ b/Firmware/webui/backend/presets_builtin/export/simple_json.json
@@ -1,0 +1,12 @@
+{
+  "name": "simple_json",
+  "display_name": "Simple JSON Export",
+  "export_format": "json",
+  "description": "Generic JSON metadata export for data analysis and sharing. Includes all available metadata fields in a structured format.",
+  "version": "1.0",
+  "created_at": "2024-12-14T00:00:00Z",
+  "author": "system",
+  "category": "built-in",
+  "filter": {},
+  "options": {}
+}

--- a/Firmware/webui/backend/routes/export.py
+++ b/Firmware/webui/backend/routes/export.py
@@ -2253,17 +2253,21 @@ def create_export_job():
 
         if preset_name:
             preset_manager = current_app.config.get('EXPORT_PRESET_MANAGER')
-            if preset_manager:
-                preset = preset_manager.get_preset(preset_name)
-                if preset is None:
-                    return jsonify({
-                        "error": f"Preset not found: '{preset_name}'"
-                    }), 400
+            if not preset_manager:
+                return jsonify({
+                    "error": "Preset manager not configured"
+                }), 500
 
-                # Extract preset filter as dict for merging
-                if preset.filter:
-                    preset_filter_dict = preset.filter.to_dict()
-                preset_options = preset.options.copy() if preset.options else {}
+            preset = preset_manager.get_preset(preset_name)
+            if preset is None:
+                return jsonify({
+                    "error": f"Preset not found: '{preset_name}'"
+                }), 400
+
+            # Extract preset filter as dict for merging
+            if preset.filter:
+                preset_filter_dict = preset.filter.to_dict()
+            preset_options = preset.options.copy() if preset.options else {}
 
         # Determine format: explicit > preset > error
         format_str = data.get('format')

--- a/Firmware/webui/backend/routes/export.py
+++ b/Firmware/webui/backend/routes/export.py
@@ -2186,8 +2186,11 @@ def create_export_job():
     Create a new async export job.
 
     Request Body (JSON):
-        format (str): Required. Export format: darwin_core, inaturalist, json, csv
-        filter (dict): Optional. Photo selection criteria:
+        preset (str): Optional. Name of export preset to use as base configuration.
+                     Preset values can be overridden by explicit parameters.
+        format (str): Required (unless preset provided). Export format:
+                     darwin_core, inaturalist, json, csv
+        filter (dict): Optional. Photo selection criteria (merged with preset filter):
             - date_start (str): Start date (YYYY-MM-DD)
             - date_end (str): End date (YYYY-MM-DD)
             - deployment (str): Deployment directory path
@@ -2195,14 +2198,14 @@ def create_export_job():
             - series_type (str): Series type (hdr or focus_bracket)
             - has_species (bool): Only photos with species ID
             - photo_paths (list[str]): Explicit photo paths (overrides other filters)
-        options (dict): Optional. Format-specific options
+        options (dict): Optional. Format-specific options (merged with preset options)
         ttl_seconds (int): Optional. Custom TTL in seconds (60-86400).
                           Defaults to service TTL (3600s/1 hour).
                           Larger exports may need longer download windows.
 
     Returns:
         202: Job created successfully
-        400: Invalid format or filter
+        400: Invalid format, filter, or preset
         500: Service unavailable
 
     Example:
@@ -2214,6 +2217,14 @@ def create_export_job():
                 "tags": ["moth"]
             },
             "options": {"validate": true}
+        }
+
+        Using preset:
+        {
+            "preset": "gbif_biodiversity",
+            "filter": {
+                "date_start": "2024-01-01"
+            }
         }
 
         Response (202):
@@ -2232,10 +2243,32 @@ def create_export_job():
         return jsonify({"error": "Export job service not available"}), 500
 
     try:
-        data = request.get_json()
+        data = request.get_json() or {}
 
-        # Validate format (required)
-        format_str = data.get('format') if data else None
+        # Check for preset parameter
+        preset_name = data.get('preset')
+        preset = None
+        preset_filter_dict = {}
+        preset_options = {}
+
+        if preset_name:
+            preset_manager = current_app.config.get('EXPORT_PRESET_MANAGER')
+            if preset_manager:
+                preset = preset_manager.get_preset(preset_name)
+                if preset is None:
+                    return jsonify({
+                        "error": f"Preset not found: '{preset_name}'"
+                    }), 400
+
+                # Extract preset filter as dict for merging
+                if preset.filter:
+                    preset_filter_dict = preset.filter.to_dict()
+                preset_options = preset.options.copy() if preset.options else {}
+
+        # Determine format: explicit > preset > error
+        format_str = data.get('format')
+        if not format_str and preset:
+            format_str = preset.export_format.value
         if not format_str:
             return jsonify({"error": "format field is required"}), 400
 
@@ -2247,8 +2280,15 @@ def create_export_job():
                 "error": f"Invalid format: {format_str}. Must be one of: {', '.join(valid_formats)}"
             }), 400
 
-        # Parse filter (optional)
-        filter_data = data.get('filter', {})
+        # Parse filter: merge preset filter with explicit filter
+        # Explicit values override preset values
+        explicit_filter_data = data.get('filter', {})
+
+        # Start with preset filter, then overlay explicit filter
+        filter_data = preset_filter_dict.copy()
+        for key, value in explicit_filter_data.items():
+            if value is not None:
+                filter_data[key] = value
 
         # Validate filter fields
         valid_filter_fields = {
@@ -2306,8 +2346,11 @@ def create_export_job():
             photo_paths=filter_data.get('photo_paths'),
         )
 
-        # Parse options (optional)
-        options = data.get('options', {})
+        # Parse options: merge preset options with explicit options
+        # Explicit options override preset options
+        explicit_options = data.get('options', {})
+        options = preset_options.copy()
+        options.update(explicit_options)
 
         # Parse and validate ttl_seconds (optional)
         ttl_seconds = data.get('ttl_seconds')

--- a/Firmware/webui/backend/routes/export_presets.py
+++ b/Firmware/webui/backend/routes/export_presets.py
@@ -4,13 +4,20 @@ Export preset management endpoints.
 Provides REST API for managing export presets:
 - GET /api/export/presets - List all presets
 - GET /api/export/presets/<name> - Get preset details
-- POST /api/export/presets - Create user preset
+- POST /api/export/presets - Create user preset (rate limited: 10/min)
 - DELETE /api/export/presets/<name> - Delete user preset
+
+CSRF Protection:
+    All state-changing endpoints (POST, DELETE) require CSRF token validation.
+    GET endpoints are read-only and exempt from CSRF.
+    Clients must include X-CSRFToken header with valid token from /api/csrf-token.
 """
 
 import logging
 
 from flask import Blueprint, current_app, jsonify, request
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
 
 from webui.backend.lib.export_job_types import ExportJobFilter, ExportJobFormat
 from webui.backend.lib.export_preset_types import ExportPreset, ExportPresetCategory
@@ -18,6 +25,9 @@ from webui.backend.lib.export_preset_types import ExportPreset, ExportPresetCate
 logger = logging.getLogger(__name__)
 
 export_presets_bp = Blueprint("export_presets", __name__)
+
+# Rate limiter for preset endpoints
+limiter = Limiter(key_func=get_remote_address)
 
 
 def _get_preset_manager():
@@ -48,8 +58,8 @@ def list_export_presets():
         counts = preset_manager.get_preset_count()
 
         return jsonify({"presets": presets, "counts": counts})
-    except Exception as e:
-        logger.error(f"Error listing export presets: {e}")
+    except Exception:
+        logger.exception("Error listing export presets")
         return jsonify({"error": "Failed to list export presets"}), 500
 
 
@@ -73,15 +83,18 @@ def get_export_preset(name: str):
 
         # Convert ExportPreset to dict for JSON response
         return jsonify(preset.to_dict())
-    except Exception as e:
-        logger.error(f"Error getting export preset '{name}': {e}")
+    except Exception:
+        logger.exception("Error getting export preset '%s'", name)
         return jsonify({"error": "Failed to get export preset"}), 500
 
 
 @export_presets_bp.route("", methods=["POST"], strict_slashes=False)
+@limiter.limit("10 per minute")
 def create_export_preset():
     """
     Create new user export preset.
+
+    Rate limited to 10 requests per minute per IP.
 
     Request JSON:
         {
@@ -155,8 +168,8 @@ def create_export_preset():
         else:
             return jsonify({"error": message}), 400
 
-    except Exception as e:
-        logger.error(f"Error creating export preset: {e}")
+    except Exception:
+        logger.exception("Error creating export preset")
         return jsonify({"error": "Failed to create export preset"}), 500
 
 
@@ -186,6 +199,6 @@ def delete_export_preset(name: str):
             else:
                 return jsonify({"error": message}), 400
 
-    except Exception as e:
-        logger.error(f"Error deleting export preset '{name}': {e}")
+    except Exception:
+        logger.exception("Error deleting export preset '%s'", name)
         return jsonify({"error": "Failed to delete export preset"}), 500

--- a/Firmware/webui/backend/routes/export_presets.py
+++ b/Firmware/webui/backend/routes/export_presets.py
@@ -1,0 +1,191 @@
+"""
+Export preset management endpoints.
+
+Provides REST API for managing export presets:
+- GET /api/export/presets - List all presets
+- GET /api/export/presets/<name> - Get preset details
+- POST /api/export/presets - Create user preset
+- DELETE /api/export/presets/<name> - Delete user preset
+"""
+
+import logging
+
+from flask import Blueprint, current_app, jsonify, request
+
+from webui.backend.lib.export_job_types import ExportJobFilter, ExportJobFormat
+from webui.backend.lib.export_preset_types import ExportPreset, ExportPresetCategory
+
+logger = logging.getLogger(__name__)
+
+export_presets_bp = Blueprint("export_presets", __name__)
+
+
+def _get_preset_manager():
+    """Get ExportPresetManager from app config."""
+    return current_app.config.get("EXPORT_PRESET_MANAGER")
+
+
+@export_presets_bp.route("", methods=["GET"], strict_slashes=False)
+def list_export_presets():
+    """
+    List all available export presets (built-in + user).
+
+    Query params:
+        format: Filter by export format (darwin_core, inaturalist, json, csv)
+
+    Returns:
+        JSON object with:
+        - presets: Array of preset metadata
+        - counts: Preset counts by category
+    """
+    try:
+        preset_manager = _get_preset_manager()
+
+        # Get optional format filter
+        format_filter = request.args.get("format")
+
+        presets = preset_manager.list_presets(format_filter=format_filter)
+        counts = preset_manager.get_preset_count()
+
+        return jsonify({"presets": presets, "counts": counts})
+    except Exception as e:
+        logger.error(f"Error listing export presets: {e}")
+        return jsonify({"error": "Failed to list export presets"}), 500
+
+
+@export_presets_bp.route("/<name>", methods=["GET"])
+def get_export_preset(name: str):
+    """
+    Get specific export preset by name.
+
+    Args:
+        name: Preset name (without .json extension)
+
+    Returns:
+        JSON preset data with full configuration
+    """
+    try:
+        preset_manager = _get_preset_manager()
+        preset = preset_manager.get_preset(name)
+
+        if not preset:
+            return jsonify({"error": f"Preset '{name}' not found"}), 404
+
+        # Convert ExportPreset to dict for JSON response
+        return jsonify(preset.to_dict())
+    except Exception as e:
+        logger.error(f"Error getting export preset '{name}': {e}")
+        return jsonify({"error": "Failed to get export preset"}), 500
+
+
+@export_presets_bp.route("", methods=["POST"], strict_slashes=False)
+def create_export_preset():
+    """
+    Create new user export preset.
+
+    Request JSON:
+        {
+            "name": "my_preset",
+            "display_name": "My Preset",
+            "export_format": "json",
+            "description": "My custom preset",
+            "filter": {
+                "has_species": true,
+                "tags": ["moth"]
+            },
+            "options": {}
+        }
+
+    Returns:
+        Success/error message with preset name
+    """
+    try:
+        data = request.json
+
+        if not data:
+            return jsonify({"error": "No data provided"}), 400
+
+        # Validate required fields
+        name = data.get("name", "").strip()
+        if not name:
+            return jsonify({"error": "Preset name is required"}), 400
+
+        display_name = data.get("display_name", "").strip()
+        if not display_name:
+            return jsonify({"error": "Preset display_name is required"}), 400
+
+        export_format_str = data.get("export_format", "").strip()
+        if not export_format_str:
+            return jsonify({"error": "Preset export_format is required"}), 400
+
+        # Validate export format
+        try:
+            export_format = ExportJobFormat(export_format_str)
+        except ValueError:
+            valid_formats = [f.value for f in ExportJobFormat]
+            return jsonify(
+                {"error": f"Invalid export_format. Must be one of: {valid_formats}"}
+            ), 400
+
+        # Reject built-in category
+        if data.get("category") == "built-in":
+            return jsonify({"error": "Cannot create preset with built-in category"}), 400
+
+        # Build filter from request
+        filter_data = data.get("filter", {})
+        filter_obj = ExportJobFilter.from_dict(filter_data)
+
+        # Build preset
+        preset = ExportPreset(
+            name=name,
+            display_name=display_name,
+            export_format=export_format,
+            description=data.get("description", ""),
+            filter=filter_obj,
+            options=data.get("options", {}),
+            category=ExportPresetCategory.USER,
+        )
+
+        # Save preset
+        preset_manager = _get_preset_manager()
+        success, message = preset_manager.save_preset(preset)
+
+        if success:
+            return jsonify({"success": True, "message": message, "name": name}), 201
+        else:
+            return jsonify({"error": message}), 400
+
+    except Exception as e:
+        logger.error(f"Error creating export preset: {e}")
+        return jsonify({"error": "Failed to create export preset"}), 500
+
+
+@export_presets_bp.route("/<name>", methods=["DELETE"])
+def delete_export_preset(name: str):
+    """
+    Delete user export preset (built-in presets are protected).
+
+    Args:
+        name: Preset name to delete
+
+    Returns:
+        Success/error message
+    """
+    try:
+        preset_manager = _get_preset_manager()
+        success, message = preset_manager.delete_preset(name)
+
+        if success:
+            return jsonify({"success": True, "message": message})
+        else:
+            # Determine appropriate status code
+            if "not found" in message.lower():
+                return jsonify({"error": message}), 404
+            elif "built-in" in message.lower():
+                return jsonify({"error": message}), 400
+            else:
+                return jsonify({"error": message}), 400
+
+    except Exception as e:
+        logger.error(f"Error deleting export preset '{name}': {e}")
+        return jsonify({"error": "Failed to delete export preset"}), 500

--- a/Firmware/webui/docs/dev/api/export-jobs.md
+++ b/Firmware/webui/docs/dev/api/export-jobs.md
@@ -151,13 +151,28 @@ Create and queue a new export job.
 }
 ```
 
+**Using a Preset** (Issue #123):
+
+```json
+{
+  "preset": "gbif_biodiversity",
+  "filter": {
+    "date_start": "2024-01-01"
+  }
+}
+```
+
+When using a preset, the preset's format, filter, and options are used as defaults. Any explicit values override the preset defaults.
+
 **Field Descriptions**:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `format` | string | Yes | Export format (see [Export Formats](#export-formats)) |
-| `filter` | object | Yes | Photo selection criteria (see [Filter Options](#filter-options)) |
-| `options` | object | No | Format-specific options |
+| `preset` | string | No | Name of export preset to use as base configuration (see [Export Presets API](/api/export-presets.md)) |
+| `format` | string | Yes* | Export format (see [Export Formats](#export-formats)). *Not required if preset provides format. |
+| `filter` | object | No | Photo selection criteria (merged with preset filter, see [Filter Options](#filter-options)) |
+| `options` | object | No | Format-specific options (merged with preset options) |
+| `ttl_seconds` | integer | No | Custom TTL in seconds (60-86400). Defaults to 3600 (1 hour). |
 
 #### Response
 
@@ -231,6 +246,29 @@ curl -X POST "http://localhost:5000/api/export/jobs" \
     },
     "options": {
       "include_photos": true
+    }
+  }'
+
+# Create job using a preset (Issue #123)
+curl -X POST "http://localhost:5000/api/export/jobs" \
+  -H "Content-Type: application/json" \
+  -H "X-CSRFToken: YOUR_CSRF_TOKEN" \
+  -d '{
+    "preset": "gbif_biodiversity",
+    "filter": {
+      "date_start": "2024-01-01"
+    }
+  }'
+
+# Create job using preset with overrides
+curl -X POST "http://localhost:5000/api/export/jobs" \
+  -H "Content-Type: application/json" \
+  -H "X-CSRFToken: YOUR_CSRF_TOKEN" \
+  -d '{
+    "preset": "simple_csv",
+    "format": "json",
+    "filter": {
+      "deployment": "summer_2024"
     }
   }'
 ```
@@ -1134,14 +1172,17 @@ else:
 
 ## Related Documentation
 
+- **Export Presets API**: `webui/docs/dev/api/export-presets.md` - Preset management endpoints (Issue #123)
 - **Export Metadata Service**: `webui/backend/services/export_metadata_service.py` - Underlying export logic
 - **Job Types**: `webui/backend/lib/export_job_types.py` - Type definitions
+- **Preset Types**: `webui/backend/lib/export_preset_types.py` - Preset type definitions
+- **Preset Manager**: `webui/backend/export_preset_manager.py` - Preset CRUD operations
 - **Job Database**: `webui/backend/lib/export_job_db.py` - SQLite persistence
 - **Testing**: `Tests/unit/test_export_job_*.py` - Unit tests
 - **Integration Tests**: `Tests/integration/test_export_job_workflow.py` - E2E tests
 
 ---
 
-**Document Version**: 1.0.0
-**Last Validated**: 2025-12-13
-**Issue**: #122 - Export Job Queue System
+**Document Version**: 1.1.0
+**Last Validated**: 2025-12-14
+**Issues**: #122 - Export Job Queue System, #123 - Export Preset System

--- a/Firmware/webui/docs/dev/api/export-presets.md
+++ b/Firmware/webui/docs/dev/api/export-presets.md
@@ -1,0 +1,655 @@
+# Export Presets API Documentation
+
+**Last Updated**: 2025-12-14
+**Version**: Issue #123 Implementation
+**Base URL**: `/api/export/presets`
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Authentication](#authentication)
+3. [Error Responses](#error-responses)
+4. [Preset Schema](#preset-schema)
+5. [Built-in Presets](#built-in-presets)
+6. [Export Preset Endpoints](#export-preset-endpoints)
+7. [Usage with Export Jobs](#usage-with-export-jobs)
+8. [Usage Examples](#usage-examples)
+
+---
+
+## Overview
+
+The Export Presets API provides management of reusable export configurations. Presets store export format, filter criteria, and format-specific options that can be applied when creating export jobs.
+
+**Key Features**:
+- Built-in presets for common export scenarios (GBIF, iNaturalist, JSON, CSV)
+- User-defined presets stored in filesystem
+- Preset application during job creation with override support
+- Protected built-in presets (read-only)
+- Unified preset namespace (`CONFIG_DIR/presets/{built-in,user}/export/`)
+
+**Implementation**:
+- `webui/backend/routes/export_presets.py` - REST API endpoints
+- `webui/backend/export_preset_manager.py` - Preset management service
+- `webui/backend/lib/export_preset_types.py` - Type definitions
+- `webui/backend/presets_builtin/export/` - Built-in preset JSON files
+
+---
+
+## Authentication
+
+**Current Status**: CSRF protection required for state-changing operations
+
+**Security Measures**:
+- CSRF tokens required for POST/DELETE endpoints
+- Input validation for all parameters
+- Protected built-in presets (cannot be modified or deleted)
+
+---
+
+## Error Responses
+
+### Standard Error Format
+
+All error responses follow this JSON structure:
+
+```json
+{
+  "error": "Human-readable error message"
+}
+```
+
+### HTTP Status Codes
+
+| Code | Meaning | Usage |
+|------|---------|-------|
+| 200 | OK | Successful request |
+| 201 | Created | Preset created successfully |
+| 400 | Bad Request | Invalid parameters, validation error |
+| 403 | Forbidden | CSRF validation failed |
+| 404 | Not Found | Preset not found |
+| 500 | Internal Server Error | Unexpected server error |
+
+---
+
+## Preset Schema
+
+### ExportPreset Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | Unique identifier (alphanumeric + underscore, max 50 chars) |
+| `display_name` | string | Yes | Human-readable name (max 100 chars) |
+| `export_format` | string | Yes | Export format: `darwin_core`, `inaturalist`, `json`, `csv` |
+| `description` | string | No | Description of the preset |
+| `version` | string | No | Preset version (default: "1.0") |
+| `created_at` | string | No | ISO 8601 timestamp |
+| `author` | string | No | Author identifier (default: "user") |
+| `category` | string | Auto | Preset category: `built-in` or `user` |
+| `filter` | object | No | ExportJobFilter criteria |
+| `options` | object | No | Format-specific options |
+
+### ExportJobFilter Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `date_start` | string | Start date (YYYY-MM-DD) |
+| `date_end` | string | End date (YYYY-MM-DD) |
+| `deployment` | string | Deployment directory path |
+| `tags` | array | List of tags to match |
+| `series_type` | string | `hdr` or `focus_bracket` |
+| `has_species` | boolean | Only photos with species ID |
+| `photo_paths` | array | Explicit photo paths |
+
+### Example Preset JSON
+
+```json
+{
+  "name": "gbif_biodiversity",
+  "display_name": "GBIF Biodiversity Export",
+  "export_format": "darwin_core",
+  "description": "Darwin Core export for GBIF submission. Requires species identification.",
+  "version": "1.0",
+  "category": "built-in",
+  "filter": {
+    "has_species": true
+  },
+  "options": {
+    "validate": true
+  }
+}
+```
+
+---
+
+## Built-in Presets
+
+The system includes 6 built-in presets located in `webui/backend/presets_builtin/export/`:
+
+| Name | Format | Description | Filter |
+|------|--------|-------------|--------|
+| `gbif_biodiversity` | darwin_core | Export for GBIF/iDigBio submission | `has_species: true` |
+| `inaturalist_upload` | inaturalist | iNaturalist-compatible export with XMP sidecars | `has_species: true`, `include_xmp: true` |
+| `simple_json` | json | Generic JSON metadata export | None |
+| `simple_csv` | csv | Excel-compatible CSV with UTF-8 BOM | `include_bom: true` |
+| `hdr_series` | json | HDR photo series export | `series_type: hdr` |
+| `focus_bracket_series` | json | Focus bracket series export | `series_type: focus_bracket` |
+
+Built-in presets are **read-only** and cannot be modified or deleted.
+
+---
+
+## Export Preset Endpoints
+
+### 1. List Export Presets
+
+List all available export presets (built-in + user).
+
+**Endpoint**: `GET /api/export/presets`
+
+**Implementation**: `webui/backend/routes/export_presets.py`
+
+#### Request
+
+**Query Parameters**:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `format` | string | No | Filter by export format |
+
+#### Response
+
+**Success (200)**:
+
+```json
+{
+  "presets": [
+    {
+      "name": "gbif_biodiversity",
+      "display_name": "GBIF Biodiversity Export",
+      "export_format": "darwin_core",
+      "category": "built-in",
+      "description": "Export for GBIF/iDigBio submission"
+    },
+    {
+      "name": "my_custom_preset",
+      "display_name": "My Custom Preset",
+      "export_format": "json",
+      "category": "user",
+      "description": "Custom preset for my workflow"
+    }
+  ],
+  "counts": {
+    "built_in": 6,
+    "user": 1,
+    "total": 7
+  }
+}
+```
+
+#### Examples
+
+```bash
+# List all presets
+curl "http://localhost:5000/api/export/presets"
+
+# List only Darwin Core presets
+curl "http://localhost:5000/api/export/presets?format=darwin_core"
+
+# List only JSON presets
+curl "http://localhost:5000/api/export/presets?format=json"
+```
+
+---
+
+### 2. Get Export Preset
+
+Get detailed configuration for a specific preset.
+
+**Endpoint**: `GET /api/export/presets/<name>`
+
+**Implementation**: `webui/backend/routes/export_presets.py`
+
+#### Request
+
+**Path Parameters**:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Preset name |
+
+#### Response
+
+**Success (200)**:
+
+```json
+{
+  "name": "gbif_biodiversity",
+  "display_name": "GBIF Biodiversity Export",
+  "export_format": "darwin_core",
+  "description": "Darwin Core export for GBIF submission. Requires species identification.",
+  "version": "1.0",
+  "created_at": "",
+  "author": "system",
+  "category": "built-in",
+  "filter": {
+    "date_start": null,
+    "date_end": null,
+    "deployment": null,
+    "tags": null,
+    "series_type": null,
+    "has_species": true,
+    "photo_paths": null
+  },
+  "options": {
+    "validate": true
+  }
+}
+```
+
+**Error (404)**:
+
+```json
+{
+  "error": "Preset 'nonexistent' not found"
+}
+```
+
+#### Examples
+
+```bash
+# Get specific preset
+curl "http://localhost:5000/api/export/presets/gbif_biodiversity"
+
+# Get user preset
+curl "http://localhost:5000/api/export/presets/my_custom_preset"
+```
+
+---
+
+### 3. Create Export Preset
+
+Create a new user export preset.
+
+**Endpoint**: `POST /api/export/presets`
+
+**Implementation**: `webui/backend/routes/export_presets.py`
+
+#### Request
+
+**Headers**:
+- `Content-Type`: `application/json`
+- `X-CSRFToken`: CSRF token (required)
+
+**Body** (JSON):
+
+```json
+{
+  "name": "my_moth_export",
+  "display_name": "My Moth Export",
+  "export_format": "json",
+  "description": "Custom export for moth photos",
+  "filter": {
+    "tags": ["moth"],
+    "has_species": true
+  },
+  "options": {
+    "pretty_print": true
+  }
+}
+```
+
+**Required Fields**:
+- `name`: Unique identifier (alphanumeric + underscore)
+- `display_name`: Human-readable name
+- `export_format`: Export format
+
+#### Response
+
+**Success (201)**:
+
+```json
+{
+  "success": true,
+  "message": "Preset saved successfully",
+  "name": "my_moth_export"
+}
+```
+
+**Error (400)**:
+
+```json
+{
+  "error": "Preset name is required"
+}
+```
+
+```json
+{
+  "error": "Invalid export_format. Must be one of: ['darwin_core', 'inaturalist', 'json', 'csv']"
+}
+```
+
+```json
+{
+  "error": "Cannot create preset with built-in category"
+}
+```
+
+#### Examples
+
+```bash
+# Create user preset
+curl -X POST "http://localhost:5000/api/export/presets" \
+  -H "Content-Type: application/json" \
+  -H "X-CSRFToken: YOUR_CSRF_TOKEN" \
+  -d '{
+    "name": "summer_moths",
+    "display_name": "Summer Moth Export",
+    "export_format": "darwin_core",
+    "description": "Export moths captured during summer months",
+    "filter": {
+      "tags": ["moth", "nocturnal"],
+      "has_species": true
+    }
+  }'
+```
+
+---
+
+### 4. Delete Export Preset
+
+Delete a user export preset.
+
+**Endpoint**: `DELETE /api/export/presets/<name>`
+
+**Implementation**: `webui/backend/routes/export_presets.py`
+
+**Note**: Built-in presets cannot be deleted.
+
+#### Request
+
+**Path Parameters**:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Preset name to delete |
+
+**Headers**:
+- `X-CSRFToken`: CSRF token (required)
+
+#### Response
+
+**Success (200)**:
+
+```json
+{
+  "success": true,
+  "message": "Preset 'my_custom_preset' deleted successfully"
+}
+```
+
+**Error (400 - Built-in preset)**:
+
+```json
+{
+  "error": "Cannot delete built-in presets"
+}
+```
+
+**Error (404 - Not found)**:
+
+```json
+{
+  "error": "Preset 'nonexistent' not found"
+}
+```
+
+#### Examples
+
+```bash
+# Delete user preset
+curl -X DELETE "http://localhost:5000/api/export/presets/my_custom_preset" \
+  -H "X-CSRFToken: YOUR_CSRF_TOKEN"
+```
+
+---
+
+## Usage with Export Jobs
+
+Presets can be applied when creating export jobs via the `preset` parameter.
+
+### Basic Usage
+
+```bash
+# Create job using preset
+curl -X POST "http://localhost:5000/api/export/jobs" \
+  -H "Content-Type: application/json" \
+  -H "X-CSRFToken: YOUR_CSRF_TOKEN" \
+  -d '{
+    "preset": "gbif_biodiversity"
+  }'
+```
+
+### Override Preset Values
+
+Explicit values override preset defaults:
+
+```bash
+# Use preset but override format
+curl -X POST "http://localhost:5000/api/export/jobs" \
+  -H "Content-Type: application/json" \
+  -H "X-CSRFToken: YOUR_CSRF_TOKEN" \
+  -d '{
+    "preset": "simple_json",
+    "format": "csv",
+    "filter": {
+      "date_start": "2024-01-01"
+    }
+  }'
+```
+
+### Merge Behavior
+
+When using a preset with explicit values:
+
+1. **Format**: Explicit format overrides preset format
+2. **Filter**: Explicit filter fields are merged with preset filter (explicit wins for same field)
+3. **Options**: Explicit options are merged with preset options (explicit wins for same key)
+
+**Example**:
+
+Preset `simple_csv` has:
+- `filter.has_species: false`
+- `options.include_bom: true`
+
+Request:
+```json
+{
+  "preset": "simple_csv",
+  "filter": {
+    "date_start": "2024-01-01"
+  },
+  "options": {
+    "delimiter": ";"
+  }
+}
+```
+
+Resulting job:
+- `filter.has_species: false` (from preset)
+- `filter.date_start: "2024-01-01"` (from request)
+- `options.include_bom: true` (from preset)
+- `options.delimiter: ";"` (from request)
+
+---
+
+## Usage Examples
+
+### JavaScript/React
+
+```javascript
+// List all presets
+const listPresets = async () => {
+  const response = await fetch('/api/export/presets');
+  const data = await response.json();
+  return data.presets;
+};
+
+// Create preset
+const createPreset = async (preset) => {
+  const csrfToken = await fetch('/api/csrf-token').then(r => r.json());
+
+  const response = await fetch('/api/export/presets', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRFToken': csrfToken.csrf_token
+    },
+    body: JSON.stringify(preset)
+  });
+
+  return response.json();
+};
+
+// Create job using preset
+const createJobWithPreset = async (presetName, additionalFilters) => {
+  const csrfToken = await fetch('/api/csrf-token').then(r => r.json());
+
+  const response = await fetch('/api/export/jobs', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRFToken': csrfToken.csrf_token
+    },
+    body: JSON.stringify({
+      preset: presetName,
+      filter: additionalFilters
+    })
+  });
+
+  return response.json();
+};
+
+// Usage
+await createPreset({
+  name: 'my_preset',
+  display_name: 'My Preset',
+  export_format: 'json',
+  filter: { tags: ['moth'] }
+});
+
+await createJobWithPreset('my_preset', { date_start: '2024-01-01' });
+```
+
+### Python
+
+```python
+import requests
+
+class ExportPresetClient:
+    def __init__(self, base_url: str = "http://localhost:5000"):
+        self.base_url = base_url
+        self.session = requests.Session()
+
+        # Get CSRF token
+        response = self.session.get(f"{base_url}/api/csrf-token")
+        self.csrf_token = response.json()['csrf_token']
+
+    def list_presets(self, format_filter: str | None = None) -> list:
+        """List all presets."""
+        url = f"{self.base_url}/api/export/presets"
+        if format_filter:
+            url += f"?format={format_filter}"
+
+        response = self.session.get(url)
+        response.raise_for_status()
+        return response.json()['presets']
+
+    def get_preset(self, name: str) -> dict:
+        """Get preset by name."""
+        response = self.session.get(
+            f"{self.base_url}/api/export/presets/{name}"
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def create_preset(self, preset: dict) -> dict:
+        """Create new user preset."""
+        response = self.session.post(
+            f"{self.base_url}/api/export/presets",
+            json=preset,
+            headers={"X-CSRFToken": self.csrf_token}
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def delete_preset(self, name: str) -> dict:
+        """Delete user preset."""
+        response = self.session.delete(
+            f"{self.base_url}/api/export/presets/{name}",
+            headers={"X-CSRFToken": self.csrf_token}
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def create_job_with_preset(
+        self,
+        preset_name: str,
+        additional_filter: dict | None = None
+    ) -> dict:
+        """Create export job using preset."""
+        payload = {"preset": preset_name}
+        if additional_filter:
+            payload["filter"] = additional_filter
+
+        response = self.session.post(
+            f"{self.base_url}/api/export/jobs",
+            json=payload,
+            headers={"X-CSRFToken": self.csrf_token}
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+# Usage
+client = ExportPresetClient()
+
+# List built-in presets
+presets = client.list_presets()
+for p in presets:
+    print(f"{p['name']}: {p['display_name']} ({p['category']})")
+
+# Create custom preset
+client.create_preset({
+    "name": "my_moths",
+    "display_name": "My Moth Export",
+    "export_format": "json",
+    "filter": {"tags": ["moth"], "has_species": True}
+})
+
+# Create job using preset
+job = client.create_job_with_preset(
+    "my_moths",
+    {"date_start": "2024-06-01", "date_end": "2024-08-31"}
+)
+print(f"Created job: {job['job_id']}")
+```
+
+---
+
+## Related Documentation
+
+- **Export Jobs API**: `webui/docs/dev/api/export-jobs.md` - Job creation and management
+- **Preset Types**: `webui/backend/lib/export_preset_types.py` - Type definitions
+- **Preset Manager**: `webui/backend/export_preset_manager.py` - Preset CRUD operations
+- **Job Types**: `webui/backend/lib/export_job_types.py` - ExportJobFilter schema
+- **Testing**: `Tests/unit/test_export_preset_*.py` - Unit tests
+
+---
+
+**Document Version**: 1.0.0
+**Last Validated**: 2025-12-14
+**Issue**: #123 - Export Preset Save/Load System


### PR DESCRIPTION
## Summary

Implements a complete export preset system that allows users to save, load, and apply export configurations as reusable presets. Presets store export format, filter criteria, and format-specific options that can be applied when creating export jobs.

**Key Features:**
- 6 built-in presets for common export scenarios (GBIF, iNaturalist, JSON, CSV, HDR series, Focus Bracket series)
- User-defined presets stored in filesystem with CRUD operations
- Preset application during job creation with override support
- Protected built-in presets (read-only)
- Unified preset namespace under `CONFIG_DIR/presets/{built-in,user}/export/`

**API Endpoints:**
- `GET /api/export/presets` - List all presets (with optional format filter)
- `GET /api/export/presets/<name>` - Get preset details
- `POST /api/export/presets` - Create user preset
- `DELETE /api/export/presets/<name>` - Delete user preset

**Job Integration:**
```json
POST /api/export/jobs
{
    "preset": "gbif_biodiversity",
    "filter": {"date_start": "2024-01-01"}  // Merged with preset filter
}
```

## Test Plan

- [x] Unit tests for ExportPreset dataclass and serialization (21 tests)
- [x] Unit tests for ExportPresetManager CRUD operations (40 tests)
- [x] Unit tests for REST API endpoints (18 tests)
- [x] Unit tests for preset integration with export jobs (9 tests)
- [x] Integration tests for end-to-end workflows (14 tests)
- [x] All 6 built-in presets load correctly
- [x] Coverage ≥85% (achieved 88.89%)
- [x] Ruff linting passes
- [x] All 156 tests pass

## Files Changed

**New Files:**
- `webui/backend/lib/export_preset_types.py` - Data structures
- `webui/backend/export_preset_manager.py` - CRUD operations
- `webui/backend/routes/export_presets.py` - REST API endpoints
- 6 preset JSON files in `webui/backend/presets_builtin/export/`
- 4 test files (unit + integration)
- `webui/docs/dev/api/export-presets.md` - API documentation

**Modified Files:**
- `mothbox_paths.py` - Added export preset paths
- `webui/backend/app.py` - Manager initialization and blueprint registration
- `webui/backend/routes/export.py` - Added preset parameter to job creation
- `webui/docs/dev/api/export-jobs.md` - Updated with preset usage
- `CLAUDE.md` - Added Export Preset System section

Closes #123