### PR TITLE
feat(gallery): Add context menu and lightbox export buttons (#126)

### DIFF
--- a/Firmware/webui/frontend/src/__tests__/integration/LightboxWorkflow.test.jsx
+++ b/Firmware/webui/frontend/src/__tests__/integration/LightboxWorkflow.test.jsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import PhotoLightbox from '../../components/PhotoLightbox'
 import { LIGHTBOX_CONFIG } from '../../constants/config'
 
@@ -14,6 +15,17 @@ vi.mock('../../components/metadata/MetadataPanel', () => ({
       <div data-testid="metadata-photo-path">{photoPath}</div>
     </div>
   ),
+}))
+
+// Mock useSinglePhotoExport to avoid QueryClient dependency in tests
+vi.mock('../../hooks/useSinglePhotoExport', () => ({
+  useSinglePhotoExport: vi.fn(() => ({
+    exportPhoto: vi.fn(),
+    isExporting: false,
+    progress: null,
+    error: null,
+    reset: vi.fn(),
+  })),
 }))
 
 /**

--- a/Firmware/webui/frontend/src/components/PhotoGridItem.jsx
+++ b/Firmware/webui/frontend/src/components/PhotoGridItem.jsx
@@ -2,6 +2,7 @@ import { useState, memo, useCallback } from 'react'
 import { GALLERY_CONFIG, Z_INDEX } from '../constants/config'
 import ProgressiveImage from './ProgressiveImage'
 import QuickTagButton from './gallery/QuickTagButton'
+import PhotoContextMenu from './gallery/PhotoContextMenu'
 import { useSelectionContext } from '../contexts/SelectionContext'
 
 /**
@@ -24,6 +25,8 @@ import { useSelectionContext } from '../contexts/SelectionContext'
 function PhotoGridItem({ photo, onClick, index, photos }) {
   const [isHovered, setIsHovered] = useState(false)
   const [isTagDropdownOpen, setIsTagDropdownOpen] = useState(false)
+  const [contextMenuOpen, setContextMenuOpen] = useState(false)
+  const [contextMenuPosition, setContextMenuPosition] = useState({ x: 0, y: 0 })
 
   // Use selection context directly (returns null when not in provider)
   const selectionContext = useSelectionContext()
@@ -68,6 +71,12 @@ function PhotoGridItem({ photo, onClick, index, photos }) {
     }
   }, [togglePhoto, selectRange, photo.path, index, photos])
 
+  const handleContextMenu = useCallback((e) => {
+    e.preventDefault()  // Prevent browser context menu
+    setContextMenuPosition({ x: e.clientX, y: e.clientY })
+    setContextMenuOpen(true)
+  }, [])
+
   return (
     <div
       className={`
@@ -76,6 +85,7 @@ function PhotoGridItem({ photo, onClick, index, photos }) {
       `}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
+      onContextMenu={handleContextMenu}
     >
       <button
         type="button"
@@ -124,6 +134,14 @@ function PhotoGridItem({ photo, onClick, index, photos }) {
           onDropdownOpenChange={setIsTagDropdownOpen}
         />
       </div>
+
+      {/* Context Menu */}
+      <PhotoContextMenu
+        photo={photo}
+        isOpen={contextMenuOpen}
+        onClose={() => setContextMenuOpen(false)}
+        position={contextMenuPosition}
+      />
     </div>
   )
 }

--- a/Firmware/webui/frontend/src/components/PhotoLightbox.jsx
+++ b/Firmware/webui/frontend/src/components/PhotoLightbox.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, useCallback, useMemo } from 'react'
 import { createPortal } from 'react-dom'
+import { ArrowDownTrayIcon } from '@heroicons/react/24/outline'
 import { LIGHTBOX_CONFIG, Z_INDEX } from '../constants/config'
 import useZoomPan from '../hooks/useZoomPan'
 import useTouchGestures from '../hooks/useTouchGestures'
@@ -8,6 +9,7 @@ import { debounce, throttle } from '../utils/performance'
 import { getPhotoUrl } from '../utils/api'
 import MetadataPanel from './metadata/MetadataPanel'
 import MetadataErrorBoundary from './metadata/MetadataErrorBoundary'
+import ExportOptionsMenu from './export/ExportOptionsMenu'
 import { formatCoordinateDisplay } from '../utils/gpsCoordinates'
 
 /**
@@ -163,6 +165,7 @@ function PhotoLightbox({ photo, photos = [], onClose, onNavigate, onLocationClic
   const containerRef = useRef(null)
   const dialogRef = useRef(null)
   const panStartRef = useRef({ x: 0, y: 0 })
+  const exportButtonRef = useRef(null)
 
   // Image and container dimensions
   const [imageDimensions, setImageDimensions] = useState({ width: 0, height: 0 })
@@ -176,6 +179,9 @@ function PhotoLightbox({ photo, photos = [], onClose, onNavigate, onLocationClic
 
   // Panning state
   const [isPanning, setIsPanning] = useState(false)
+
+  // Export menu state
+  const [exportMenuOpen, setExportMenuOpen] = useState(false)
 
   // Zoom indicator auto-hide
   const [showZoomIndicator, setShowZoomIndicator] = useState(false)
@@ -584,6 +590,26 @@ function PhotoLightbox({ photo, photos = [], onClose, onNavigate, onLocationClic
           <path d="M6 18L18 6M6 6l12 12" />
         </svg>
       </button>
+
+      {/* Export button - positioned next to close button */}
+      <button
+        ref={exportButtonRef}
+        type="button"
+        onClick={() => setExportMenuOpen(true)}
+        className="absolute top-4 right-20 z-10 rounded-lg bg-black bg-opacity-50 p-2 text-white transition-all hover:bg-opacity-75 focus:outline-none focus:ring-2 focus:ring-white md:p-2 min-h-[44px] min-w-[44px] flex items-center justify-center"
+        aria-label="Export photo"
+        data-testid="export-button"
+      >
+        <ArrowDownTrayIcon className="h-6 w-6" />
+      </button>
+
+      {/* Export Options Menu */}
+      <ExportOptionsMenu
+        photoPath={photo?.path}
+        isOpen={exportMenuOpen}
+        onClose={() => setExportMenuOpen(false)}
+        anchorEl={exportButtonRef.current}
+      />
 
       {/* Photo metadata */}
       <div className="absolute top-4 left-4 z-10 rounded-lg bg-black bg-opacity-50 p-3 text-white">

--- a/Firmware/webui/frontend/src/components/__tests__/PhotoGridItem.test.jsx
+++ b/Firmware/webui/frontend/src/components/__tests__/PhotoGridItem.test.jsx
@@ -34,6 +34,23 @@ vi.mock('../gallery/QuickTagButton', () => ({
   )
 }))
 
+// Mock PhotoContextMenu to simplify testing
+vi.mock('../gallery/PhotoContextMenu', () => ({
+  default: vi.fn(({ isOpen, photo, position, onClose }) =>
+    isOpen ? (
+      <div
+        data-testid="photo-context-menu"
+        data-photo-path={photo?.path}
+        data-position-x={position?.x}
+        data-position-y={position?.y}
+        onClick={() => onClose()}
+      >
+        Context Menu
+      </div>
+    ) : null
+  ),
+}))
+
 const createWrapper = () => {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } }
@@ -863,6 +880,247 @@ describe('PhotoGridItem Selection Mode', () => {
       await user.click(photoButton)
 
       expect(onClick).toHaveBeenCalledWith(mockPhoto)
+    })
+  })
+})
+
+// ========================================
+// === CONTEXT MENU TESTS (Issue #134) ===
+// ========================================
+
+describe('PhotoGridItem Context Menu', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('Opening context menu', () => {
+    it('opens context menu on right-click', async () => {
+      const user = userEvent.setup()
+      render(<PhotoGridItem photo={mockPhoto} onClick={vi.fn()} />, { wrapper: createWrapper() })
+
+      // Right-click on the photo
+      const photoButton = screen.getByLabelText(/view photo/i)
+      await user.pointer({ keys: '[MouseRight>]', target: photoButton })
+
+      // Verify PhotoContextMenu is rendered
+      await waitFor(() => {
+        const contextMenu = screen.getByTestId('photo-context-menu')
+        expect(contextMenu).toBeInTheDocument()
+      })
+    })
+
+    it('passes correct position to context menu', async () => {
+      const user = userEvent.setup()
+      const { container } = render(
+        <PhotoGridItem photo={mockPhoto} onClick={vi.fn()} />,
+        { wrapper: createWrapper() }
+      )
+
+      // Right-click at specific coordinates
+      const gridItem = container.querySelector('.group')
+      fireEvent.contextMenu(gridItem, { clientX: 150, clientY: 200 })
+
+      // Verify position is passed correctly
+      await waitFor(() => {
+        const contextMenu = screen.getByTestId('photo-context-menu')
+        expect(contextMenu).toHaveAttribute('data-position-x', '150')
+        expect(contextMenu).toHaveAttribute('data-position-y', '200')
+      })
+    })
+
+    it('passes photo object to context menu', async () => {
+      const user = userEvent.setup()
+      const { container } = render(
+        <PhotoGridItem photo={mockPhoto} onClick={vi.fn()} />,
+        { wrapper: createWrapper() }
+      )
+
+      // Right-click
+      const gridItem = container.querySelector('.group')
+      fireEvent.contextMenu(gridItem)
+
+      // Verify photo prop is passed to PhotoContextMenu
+      await waitFor(() => {
+        const contextMenu = screen.getByTestId('photo-context-menu')
+        expect(contextMenu).toHaveAttribute('data-photo-path', mockPhoto.path)
+      })
+    })
+
+    it('prevents default browser context menu', async () => {
+      const { container } = render(
+        <PhotoGridItem photo={mockPhoto} onClick={vi.fn()} />,
+        { wrapper: createWrapper() }
+      )
+
+      // Right-click
+      const gridItem = container.querySelector('.group')
+      const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true })
+      const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+
+      gridItem.dispatchEvent(event)
+
+      // Verify e.preventDefault was called
+      expect(preventDefaultSpy).toHaveBeenCalled()
+    })
+  })
+
+  describe('Closing context menu', () => {
+    it('closes context menu on onClose callback', async () => {
+      const user = userEvent.setup()
+      const { container } = render(
+        <PhotoGridItem photo={mockPhoto} onClick={vi.fn()} />,
+        { wrapper: createWrapper() }
+      )
+
+      // Open context menu
+      const gridItem = container.querySelector('.group')
+      fireEvent.contextMenu(gridItem)
+
+      await waitFor(() => {
+        const contextMenu = screen.getByTestId('photo-context-menu')
+        expect(contextMenu).toBeInTheDocument()
+      })
+
+      // Trigger onClose (mock menu calls this on click)
+      const contextMenu = screen.getByTestId('photo-context-menu')
+      await user.click(contextMenu)
+
+      // Verify context menu is closed
+      await waitFor(() => {
+        expect(screen.queryByTestId('photo-context-menu')).not.toBeInTheDocument()
+      })
+    })
+
+    it('context menu is initially closed', () => {
+      render(<PhotoGridItem photo={mockPhoto} onClick={vi.fn()} />, { wrapper: createWrapper() })
+
+      // Context menu should not be visible initially
+      const contextMenu = screen.queryByTestId('photo-context-menu')
+      expect(contextMenu).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Interaction with existing behaviors', () => {
+    it('does not interfere with left-click (lightbox) behavior', async () => {
+      const onClick = vi.fn()
+      const user = userEvent.setup()
+
+      render(<PhotoGridItem photo={mockPhoto} onClick={onClick} />, { wrapper: createWrapper() })
+
+      // Left-click should still open lightbox
+      const photoButton = screen.getByLabelText(/view photo/i)
+      await user.click(photoButton)
+
+      expect(onClick).toHaveBeenCalledWith(mockPhoto)
+
+      // Context menu should not open on left-click
+      const contextMenu = screen.queryByTestId('photo-context-menu')
+      expect(contextMenu).not.toBeInTheDocument()
+    })
+
+    it('works alongside QuickTagButton', async () => {
+      const { container } = render(
+        <PhotoGridItem photo={mockPhoto} onClick={vi.fn()} />,
+        { wrapper: createWrapper() }
+      )
+
+      // Both QuickTagButton and context menu should be present in the component
+      const tagButton = screen.getByTestId('quick-tag-button')
+      expect(tagButton).toBeInTheDocument()
+
+      // Right-click to open context menu
+      const gridItem = container.querySelector('.group')
+      fireEvent.contextMenu(gridItem)
+
+      await waitFor(() => {
+        const contextMenu = screen.getByTestId('photo-context-menu')
+        expect(contextMenu).toBeInTheDocument()
+      })
+
+      // QuickTagButton should still be there
+      expect(tagButton).toBeInTheDocument()
+    })
+
+    it('right-click does not trigger selection mode', async () => {
+      const onClick = vi.fn()
+      const { container } = render(
+        <PhotoGridItem photo={mockPhoto} onClick={onClick} index={0} />,
+        { wrapper: createSelectionWrapper() }
+      )
+
+      // Not in select mode initially
+      const checkbox = screen.queryByRole('checkbox')
+      expect(checkbox).not.toBeInTheDocument()
+
+      // Right-click
+      const gridItem = container.querySelector('.group')
+      fireEvent.contextMenu(gridItem)
+
+      // Context menu should open
+      await waitFor(() => {
+        const contextMenu = screen.getByTestId('photo-context-menu')
+        expect(contextMenu).toBeInTheDocument()
+      })
+
+      // Should NOT trigger lightbox
+      expect(onClick).not.toHaveBeenCalled()
+
+      // Should NOT enter selection mode
+      const checkboxAfter = screen.queryByRole('checkbox')
+      expect(checkboxAfter).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Edge cases', () => {
+    it('handles multiple right-clicks correctly', async () => {
+      const { container } = render(
+        <PhotoGridItem photo={mockPhoto} onClick={vi.fn()} />,
+        { wrapper: createWrapper() }
+      )
+
+      const gridItem = container.querySelector('.group')
+
+      // First right-click
+      fireEvent.contextMenu(gridItem, { clientX: 100, clientY: 100 })
+
+      await waitFor(() => {
+        const contextMenu = screen.getByTestId('photo-context-menu')
+        expect(contextMenu).toHaveAttribute('data-position-x', '100')
+      })
+
+      // Second right-click at different position
+      fireEvent.contextMenu(gridItem, { clientX: 200, clientY: 300 })
+
+      // Position should update
+      await waitFor(() => {
+        const contextMenu = screen.getByTestId('photo-context-menu')
+        expect(contextMenu).toHaveAttribute('data-position-x', '200')
+        expect(contextMenu).toHaveAttribute('data-position-y', '300')
+      })
+    })
+
+    it('handles photo with different structures', async () => {
+      const differentPhoto = {
+        path: 'different/path.jpg',
+        filename: 'different.jpg',
+        date: '2024-01-01T00:00:00Z',
+        metadata: { tags: ['test'] }
+      }
+
+      const { container } = render(
+        <PhotoGridItem photo={differentPhoto} onClick={vi.fn()} />,
+        { wrapper: createWrapper() }
+      )
+
+      // Right-click
+      const gridItem = container.querySelector('.group')
+      fireEvent.contextMenu(gridItem)
+
+      // Context menu should open with correct photo
+      await waitFor(() => {
+        const contextMenu = screen.getByTestId('photo-context-menu')
+        expect(contextMenu).toHaveAttribute('data-photo-path', differentPhoto.path)
+      })
     })
   })
 })

--- a/Firmware/webui/frontend/src/components/__tests__/PhotoLightbox.test.jsx
+++ b/Firmware/webui/frontend/src/components/__tests__/PhotoLightbox.test.jsx
@@ -19,6 +19,21 @@ vi.mock('../metadata/MetadataPanel', () => ({
   ),
 }))
 
+// Mock ExportOptionsMenu to simplify testing
+vi.mock('../export/ExportOptionsMenu', () => ({
+  default: vi.fn(({ isOpen, photoPath, onClose, anchorEl }) =>
+    isOpen ? (
+      <div
+        data-testid="export-options-menu"
+        data-photo-path={photoPath}
+        onClick={() => onClose()}
+      >
+        Export Menu
+      </div>
+    ) : null
+  ),
+}))
+
 describe('PhotoLightbox - Basic Rendering', () => {
   const mockPhoto = {
     path: '2024-11-10/photo_001.jpg',
@@ -2497,5 +2512,202 @@ describe('PhotoLightbox - Location Header', () => {
     )
 
     expect(screen.getByText(/alt.*-430\.5.*m/i)).toBeInTheDocument()
+  })
+})
+
+describe('PhotoLightbox - Export functionality', () => {
+  const mockPhoto = {
+    path: '2024-11-10/photo_001.jpg',
+    filename: 'photo_001.jpg',
+    date: '2024-11-10T18:30:00Z',
+    size: 5242880,
+    timestamp: 1699639800,
+  }
+
+  const mockPhotos = [mockPhoto]
+  const mockOnClose = vi.fn()
+  const mockOnNavigate = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    document.body.style.overflow = ''
+  })
+
+  it('renders export button in controls area', () => {
+    render(
+      <PhotoLightbox
+        photo={mockPhoto}
+        photos={mockPhotos}
+        onClose={mockOnClose}
+        onNavigate={mockOnNavigate}
+      />
+    )
+
+    const exportButton = screen.getByTestId('export-button')
+    expect(exportButton).toBeInTheDocument()
+  })
+
+  it('export button has proper aria-label', () => {
+    render(
+      <PhotoLightbox
+        photo={mockPhoto}
+        photos={mockPhotos}
+        onClose={mockOnClose}
+        onNavigate={mockOnNavigate}
+      />
+    )
+
+    const exportButton = screen.getByLabelText(/export photo/i)
+    expect(exportButton).toBeInTheDocument()
+    expect(exportButton).toHaveAttribute('aria-label', 'Export photo')
+  })
+
+  it('opens ExportOptionsMenu on button click', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <PhotoLightbox
+        photo={mockPhoto}
+        photos={mockPhotos}
+        onClose={mockOnClose}
+        onNavigate={mockOnNavigate}
+      />
+    )
+
+    const exportButton = screen.getByTestId('export-button')
+    await user.click(exportButton)
+
+    // Verify ExportOptionsMenu is rendered with isOpen=true
+    const exportMenu = screen.getByTestId('export-options-menu')
+    expect(exportMenu).toBeInTheDocument()
+  })
+
+  it('passes current photo path to ExportOptionsMenu', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <PhotoLightbox
+        photo={mockPhoto}
+        photos={mockPhotos}
+        onClose={mockOnClose}
+        onNavigate={mockOnNavigate}
+      />
+    )
+
+    const exportButton = screen.getByTestId('export-button')
+    await user.click(exportButton)
+
+    // Verify photoPath prop matches photo.path
+    const exportMenu = screen.getByTestId('export-options-menu')
+    expect(exportMenu).toHaveAttribute('data-photo-path', mockPhoto.path)
+  })
+
+  it('closes ExportOptionsMenu on close callback', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <PhotoLightbox
+        photo={mockPhoto}
+        photos={mockPhotos}
+        onClose={mockOnClose}
+        onNavigate={mockOnNavigate}
+      />
+    )
+
+    // Open menu
+    const exportButton = screen.getByTestId('export-button')
+    await user.click(exportButton)
+
+    const exportMenu = screen.getByTestId('export-options-menu')
+    expect(exportMenu).toBeInTheDocument()
+
+    // Trigger onClose (simulated by clicking the menu in our mock)
+    await user.click(exportMenu)
+
+    // Menu should be closed
+    await waitFor(() => {
+      expect(screen.queryByTestId('export-options-menu')).not.toBeInTheDocument()
+    })
+  })
+
+  it('export button is keyboard accessible', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <PhotoLightbox
+        photo={mockPhoto}
+        photos={mockPhotos}
+        onClose={mockOnClose}
+        onNavigate={mockOnNavigate}
+      />
+    )
+
+    // Find export button
+    const exportButton = screen.getByLabelText(/export photo/i)
+
+    // Tab to export button to ensure keyboard navigation works
+    exportButton.focus()
+    expect(exportButton).toHaveFocus()
+
+    // Activate button with Enter key (userEvent click on focused element)
+    await user.click(exportButton)
+
+    // Menu should open
+    await waitFor(() => {
+      const exportMenu = screen.getByTestId('export-options-menu')
+      expect(exportMenu).toBeInTheDocument()
+    })
+  })
+
+  it('export button has consistent styling with other controls', () => {
+    render(
+      <PhotoLightbox
+        photo={mockPhoto}
+        photos={mockPhotos}
+        onClose={mockOnClose}
+        onNavigate={mockOnNavigate}
+      />
+    )
+
+    const exportButton = screen.getByTestId('export-button')
+    const closeButton = screen.getByLabelText(/close photo viewer/i)
+
+    // Both should have similar focus ring classes
+    expect(exportButton.className).toContain('focus:ring')
+    expect(closeButton.className).toContain('focus:ring')
+
+    // Both should have rounded-lg styling
+    expect(exportButton.className).toContain('rounded-lg')
+    expect(closeButton.className).toContain('rounded-lg')
+  })
+
+  it('export button is visible when lightbox is open', () => {
+    const { rerender } = render(
+      <PhotoLightbox
+        photo={null}
+        photos={mockPhotos}
+        onClose={mockOnClose}
+        onNavigate={mockOnNavigate}
+      />
+    )
+
+    // Export button should not exist when lightbox is closed
+    expect(screen.queryByTestId('export-button')).not.toBeInTheDocument()
+
+    // Open lightbox
+    rerender(
+      <PhotoLightbox
+        photo={mockPhoto}
+        photos={mockPhotos}
+        onClose={mockOnClose}
+        onNavigate={mockOnNavigate}
+      />
+    )
+
+    // Export button should be visible
+    expect(screen.getByTestId('export-button')).toBeInTheDocument()
   })
 })

--- a/Firmware/webui/frontend/src/components/export/ExportOptionsMenu.jsx
+++ b/Firmware/webui/frontend/src/components/export/ExportOptionsMenu.jsx
@@ -1,0 +1,232 @@
+import { useRef, useEffect, useState, useCallback } from 'react'
+import PropTypes from 'prop-types'
+import { useFloating, offset, flip, shift, autoUpdate } from '@floating-ui/react'
+import {
+  CircleStackIcon,
+  DocumentTextIcon,
+  TableCellsIcon,
+  BeakerIcon
+} from '@heroicons/react/20/solid'
+import { useSinglePhotoExport } from '../../hooks/useSinglePhotoExport'
+import { Z_INDEX } from '../../constants/config'
+
+const EXPORT_FORMATS = [
+  {
+    id: 'darwin_core',
+    name: 'Darwin Core',
+    description: 'For GBIF biodiversity portals',
+    icon: BeakerIcon
+  },
+  {
+    id: 'inaturalist',
+    name: 'iNaturalist',
+    description: 'With XMP sidecars',
+    icon: CircleStackIcon
+  },
+  {
+    id: 'json',
+    name: 'JSON',
+    description: 'All metadata fields',
+    icon: DocumentTextIcon
+  },
+  {
+    id: 'csv',
+    name: 'CSV',
+    description: 'Excel compatible',
+    icon: TableCellsIcon
+  },
+]
+
+function ExportOptionsMenu({ photoPath, isOpen, onClose, anchorEl, position }) {
+  const menuRef = useRef(null)
+  const [highlightedIndex, setHighlightedIndex] = useState(-1)
+
+  // Use refs to stabilize event listener dependencies
+  const onCloseRef = useRef(onClose)
+  const anchorElRef = useRef(anchorEl)
+
+  // Export hook
+  const { exportPhoto, isExporting } = useSinglePhotoExport()
+
+  // Floating UI for positioning (only used when anchorEl is provided)
+  const { refs, floatingStyles } = useFloating({
+    placement: 'bottom-start',
+    middleware: [
+      offset(4),
+      flip({ fallbackPlacements: ['top-start', 'bottom-end', 'top-end'] }),
+      shift({ padding: 8 })
+    ],
+    whileElementsMounted: autoUpdate,
+  })
+
+  // Keep refs updated with latest prop values
+  useEffect(() => {
+    onCloseRef.current = onClose
+    anchorElRef.current = anchorEl
+  })
+
+  // Update reference element for floating UI
+  useEffect(() => {
+    if (anchorEl) {
+      refs.setReference(anchorEl)
+    }
+  }, [anchorEl, refs])
+
+  // Reset highlight when menu opens
+  useEffect(() => {
+    if (isOpen) {
+      setHighlightedIndex(-1)
+    }
+  }, [isOpen])
+
+  // Handle format selection
+  const handleFormatSelect = useCallback((formatId) => {
+    if (isExporting) return
+
+    exportPhoto(photoPath, formatId)
+    onCloseRef.current()
+  }, [photoPath, exportPhoto, isExporting])
+
+  // Close on Escape or click outside
+  useEffect(() => {
+    if (!isOpen) return
+
+    const handleKeyDown = (e) => {
+      switch (e.key) {
+        case 'Escape':
+          onCloseRef.current()
+          break
+        case 'ArrowDown':
+          e.preventDefault()
+          setHighlightedIndex((prev) => {
+            if (prev === -1) return 0
+            return (prev + 1) % EXPORT_FORMATS.length
+          })
+          break
+        case 'ArrowUp':
+          e.preventDefault()
+          setHighlightedIndex((prev) => {
+            if (prev === -1) return EXPORT_FORMATS.length - 1
+            return (prev - 1 + EXPORT_FORMATS.length) % EXPORT_FORMATS.length
+          })
+          break
+        case 'Enter':
+          e.preventDefault()
+          if (highlightedIndex >= 0 && highlightedIndex < EXPORT_FORMATS.length) {
+            handleFormatSelect(EXPORT_FORMATS[highlightedIndex].id)
+          }
+          break
+      }
+    }
+
+    const handleClickOutside = (e) => {
+      if (menuRef.current &&
+          !menuRef.current.contains(e.target) &&
+          !anchorElRef.current?.contains(e.target)) {
+        onCloseRef.current()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    document.addEventListener('mousedown', handleClickOutside)
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [isOpen, highlightedIndex, handleFormatSelect])
+
+  if (!isOpen) return null
+
+  // Determine positioning style
+  const menuStyle = position
+    ? {
+        position: 'absolute',
+        left: `${position.x}px`,
+        top: `${position.y}px`,
+      }
+    : floatingStyles
+
+  return (
+    <div
+      ref={(node) => {
+        menuRef.current = node
+        if (!position) {
+          refs.setFloating(node)
+        }
+      }}
+      style={menuStyle}
+      className={`
+        ${Z_INDEX.MODAL} w-64 bg-white dark:bg-gray-800 rounded-lg shadow-xl
+        border border-gray-200 dark:border-gray-700
+        transition-all duration-150 origin-top-left
+        ${isOpen ? 'opacity-100 scale-100' : 'opacity-0 scale-95'}
+      `}
+      role="menu"
+      aria-label="Export photo"
+      tabIndex={-1}
+    >
+      {/* Header */}
+      <div className="px-3 py-2 border-b border-gray-200 dark:border-gray-700">
+        <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100">
+          Export Photo
+        </h3>
+      </div>
+
+      {/* Format Options */}
+      <div className="py-1">
+        {EXPORT_FORMATS.map((format, index) => {
+          const Icon = format.icon
+          const isHighlighted = highlightedIndex === index
+          return (
+            <button
+              key={format.id}
+              role="menuitem"
+              disabled={isExporting}
+              onClick={() => handleFormatSelect(format.id)}
+              onMouseEnter={() => setHighlightedIndex(index)}
+              className={`
+                w-full flex items-start gap-3 px-3 py-2.5 text-left
+                hover:bg-gray-100 dark:hover:bg-gray-700
+                disabled:opacity-50 disabled:cursor-not-allowed
+                ${isHighlighted ? 'ring-2 ring-blue-500 bg-gray-50 dark:bg-gray-700' : ''}
+              `}
+            >
+              <Icon className="w-5 h-5 text-gray-400 dark:text-gray-500 flex-shrink-0 mt-0.5" />
+              <div className="flex-1 min-w-0">
+                <div className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                  {format.name}
+                </div>
+                <div className="text-xs text-gray-500 dark:text-gray-400">
+                  {format.description}
+                </div>
+              </div>
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Loading indicator */}
+      {isExporting && (
+        <div className="px-3 py-2 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/50">
+          <div className="text-xs text-gray-500 dark:text-gray-400">
+            Exporting...
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+ExportOptionsMenu.propTypes = {
+  photoPath: PropTypes.string.isRequired,
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  anchorEl: PropTypes.instanceOf(Element),
+  position: PropTypes.shape({
+    x: PropTypes.number.isRequired,
+    y: PropTypes.number.isRequired,
+  }),
+}
+
+export default ExportOptionsMenu

--- a/Firmware/webui/frontend/src/components/export/__tests__/ExportOptionsMenu.test.jsx
+++ b/Firmware/webui/frontend/src/components/export/__tests__/ExportOptionsMenu.test.jsx
@@ -1,0 +1,317 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+// Mock the hook BEFORE importing the component
+vi.mock('../../../hooks/useSinglePhotoExport', () => ({
+  useSinglePhotoExport: vi.fn()
+}))
+
+import ExportOptionsMenu from '../ExportOptionsMenu'
+import { useSinglePhotoExport } from '../../../hooks/useSinglePhotoExport'
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } }
+  })
+  return ({ children }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+describe('ExportOptionsMenu', () => {
+  let mockAnchor
+  let mockExportPhoto
+  let mockReset
+
+  beforeEach(() => {
+    mockAnchor = document.createElement('button')
+    mockAnchor.textContent = 'Export Button'
+    document.body.appendChild(mockAnchor)
+
+    mockExportPhoto = vi.fn()
+    mockReset = vi.fn()
+
+    // Default mock implementation
+    useSinglePhotoExport.mockReturnValue({
+      exportPhoto: mockExportPhoto,
+      isExporting: false,
+      progress: null,
+      error: null,
+      reset: mockReset,
+    })
+  })
+
+  afterEach(() => {
+    document.body.removeChild(mockAnchor)
+    vi.clearAllMocks()
+  })
+
+  const defaultProps = {
+    photoPath: '/photos/moth.jpg',
+    isOpen: true,
+    onClose: vi.fn(),
+    anchorEl: mockAnchor,
+  }
+
+  // Basic Rendering
+  it('does not render when isOpen is false', () => {
+    render(<ExportOptionsMenu {...defaultProps} isOpen={false} />, { wrapper: createWrapper() })
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('renders when isOpen is true', () => {
+    render(<ExportOptionsMenu {...defaultProps} />, { wrapper: createWrapper() })
+    expect(screen.getByRole('menu', { name: /export photo/i })).toBeInTheDocument()
+  })
+
+  it('shows "Export Photo" header', () => {
+    render(<ExportOptionsMenu {...defaultProps} />, { wrapper: createWrapper() })
+    expect(screen.getByText('Export Photo')).toBeInTheDocument()
+  })
+
+  // Export Formats
+  it('shows all 4 export formats with descriptions', () => {
+    render(<ExportOptionsMenu {...defaultProps} />, { wrapper: createWrapper() })
+
+    // Check format names
+    expect(screen.getByText('Darwin Core')).toBeInTheDocument()
+    expect(screen.getByText('iNaturalist')).toBeInTheDocument()
+    expect(screen.getByText('JSON')).toBeInTheDocument()
+    expect(screen.getByText('CSV')).toBeInTheDocument()
+
+    // Check descriptions
+    expect(screen.getByText('For GBIF biodiversity portals')).toBeInTheDocument()
+    expect(screen.getByText('With XMP sidecars')).toBeInTheDocument()
+    expect(screen.getByText('All metadata fields')).toBeInTheDocument()
+    expect(screen.getByText('Excel compatible')).toBeInTheDocument()
+  })
+
+  it('displays correct icon for each format', () => {
+    const { container } = render(<ExportOptionsMenu {...defaultProps} />, { wrapper: createWrapper() })
+
+    // All 4 formats should have icons (SVG elements)
+    const icons = container.querySelectorAll('svg')
+    // At least 4 icons for the formats (could be more if there are other UI icons)
+    expect(icons.length).toBeGreaterThanOrEqual(4)
+  })
+
+  // Export Functionality
+  it('triggers export on format selection', async () => {
+    const user = userEvent.setup()
+    render(<ExportOptionsMenu {...defaultProps} />, { wrapper: createWrapper() })
+
+    const jsonOption = screen.getByRole('menuitem', { name: /JSON/i })
+    await user.click(jsonOption)
+
+    expect(mockExportPhoto).toHaveBeenCalledWith('/photos/moth.jpg', 'json')
+    expect(mockExportPhoto).toHaveBeenCalledTimes(1)
+  })
+
+  it('triggers darwin_core export correctly', async () => {
+    const user = userEvent.setup()
+    render(<ExportOptionsMenu {...defaultProps} />, { wrapper: createWrapper() })
+
+    const darwinCoreOption = screen.getByRole('menuitem', { name: /Darwin Core/i })
+    await user.click(darwinCoreOption)
+
+    expect(mockExportPhoto).toHaveBeenCalledWith('/photos/moth.jpg', 'darwin_core')
+  })
+
+  it('triggers inaturalist export correctly', async () => {
+    const user = userEvent.setup()
+    render(<ExportOptionsMenu {...defaultProps} />, { wrapper: createWrapper() })
+
+    const iNaturalistOption = screen.getByRole('menuitem', { name: /iNaturalist/i })
+    await user.click(iNaturalistOption)
+
+    expect(mockExportPhoto).toHaveBeenCalledWith('/photos/moth.jpg', 'inaturalist')
+  })
+
+  it('triggers csv export correctly', async () => {
+    const user = userEvent.setup()
+    render(<ExportOptionsMenu {...defaultProps} />, { wrapper: createWrapper() })
+
+    const csvOption = screen.getByRole('menuitem', { name: /CSV/i })
+    await user.click(csvOption)
+
+    expect(mockExportPhoto).toHaveBeenCalledWith('/photos/moth.jpg', 'csv')
+  })
+
+  // Loading State
+  it('shows loading state while exporting', () => {
+    useSinglePhotoExport.mockReturnValue({
+      exportPhoto: mockExportPhoto,
+      isExporting: true,
+      progress: { current: 1, total: 1, percent: 50, phase: 'exporting' },
+      error: null,
+      reset: mockReset,
+    })
+
+    render(<ExportOptionsMenu {...defaultProps} />, { wrapper: createWrapper() })
+
+    expect(screen.getByText(/exporting/i)).toBeInTheDocument()
+  })
+
+  it('disables format options while exporting', () => {
+    useSinglePhotoExport.mockReturnValue({
+      exportPhoto: mockExportPhoto,
+      isExporting: true,
+      progress: { current: 1, total: 1, percent: 50, phase: 'exporting' },
+      error: null,
+      reset: mockReset,
+    })
+
+    render(<ExportOptionsMenu {...defaultProps} />, { wrapper: createWrapper() })
+
+    const jsonOption = screen.getByRole('menuitem', { name: /JSON/i })
+    expect(jsonOption).toBeDisabled()
+  })
+
+  // Close Behavior
+  it('closes menu after selection', async () => {
+    const onClose = vi.fn()
+    const user = userEvent.setup()
+    render(<ExportOptionsMenu {...defaultProps} onClose={onClose} />, { wrapper: createWrapper() })
+
+    const jsonOption = screen.getByRole('menuitem', { name: /JSON/i })
+    await user.click(jsonOption)
+
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('closes on Escape key', async () => {
+    const onClose = vi.fn()
+    render(<ExportOptionsMenu {...defaultProps} onClose={onClose} />, { wrapper: createWrapper() })
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled()
+    })
+  })
+
+  it('closes on click outside', async () => {
+    const onClose = vi.fn()
+    render(<ExportOptionsMenu {...defaultProps} onClose={onClose} />, { wrapper: createWrapper() })
+
+    fireEvent.mouseDown(document.body)
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled()
+    })
+  })
+
+  it('does not close when clicking inside menu', () => {
+    const onClose = vi.fn()
+    render(<ExportOptionsMenu {...defaultProps} onClose={onClose} />, { wrapper: createWrapper() })
+
+    const menu = screen.getByRole('menu')
+    fireEvent.mouseDown(menu)
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('does not close when clicking anchor element', () => {
+    const onClose = vi.fn()
+
+    render(<ExportOptionsMenu {...defaultProps} onClose={onClose} />, { wrapper: createWrapper() })
+
+    // The menu includes logic to check !anchorEl?.contains(e.target)
+    // This means clicks on the anchor should not trigger onClose
+    // We verify the menu renders with the anchor element provided
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    expect(mockAnchor).toBeInTheDocument()
+
+    // In real usage, the parent component handles anchor clicks to toggle the menu
+    // The menu's click-outside handler should exclude the anchor
+    // This is a structural test - the integration behavior is tested in parent components
+  })
+
+  // Keyboard Navigation
+  it('supports keyboard navigation with ArrowDown', async () => {
+    const user = userEvent.setup()
+    render(<ExportOptionsMenu {...defaultProps} />, { wrapper: createWrapper() })
+
+    const menu = screen.getByRole('menu')
+    menu.focus()
+
+    // Press ArrowDown to move to first option
+    await user.keyboard('{ArrowDown}')
+
+    // First option should be highlighted (has ring-2 class)
+    const darwinCoreOption = screen.getByRole('menuitem', { name: /Darwin Core/i })
+    expect(darwinCoreOption).toHaveClass(/ring-2/)
+  })
+
+  it('supports keyboard navigation with ArrowUp', async () => {
+    const user = userEvent.setup()
+    render(<ExportOptionsMenu {...defaultProps} />, { wrapper: createWrapper() })
+
+    const menu = screen.getByRole('menu')
+    menu.focus()
+
+    // Press ArrowUp to move to last option (wrap around)
+    await user.keyboard('{ArrowUp}')
+
+    // Last option should be highlighted
+    const csvOption = screen.getByRole('menuitem', { name: /CSV/i })
+    expect(csvOption).toHaveClass(/ring-2/)
+  })
+
+  it('supports keyboard navigation with Enter', async () => {
+    const user = userEvent.setup()
+    render(<ExportOptionsMenu {...defaultProps} />, { wrapper: createWrapper() })
+
+    const menu = screen.getByRole('menu')
+    menu.focus()
+
+    // Press ArrowDown to highlight first option, then Enter to select
+    await user.keyboard('{ArrowDown}')
+    await user.keyboard('{Enter}')
+
+    expect(mockExportPhoto).toHaveBeenCalledWith('/photos/moth.jpg', 'darwin_core')
+  })
+
+  // Positioning
+  it('uses position prop when provided (context menu mode)', () => {
+    const { container } = render(
+      <ExportOptionsMenu
+        {...defaultProps}
+        anchorEl={null}
+        position={{ x: 100, y: 200 }}
+      />,
+      { wrapper: createWrapper() }
+    )
+
+    const menu = container.querySelector('[role="menu"]')
+    expect(menu).toHaveStyle({
+      position: 'absolute',
+      left: '100px',
+      top: '200px'
+    })
+  })
+
+  it('uses anchorEl when no position prop (lightbox button mode)', () => {
+    const { container } = render(
+      <ExportOptionsMenu {...defaultProps} />,
+      { wrapper: createWrapper() }
+    )
+
+    const menu = container.querySelector('[role="menu"]')
+    // Floating UI applies absolute positioning
+    expect(menu).toHaveStyle({ position: 'absolute' })
+  })
+
+  // ARIA Attributes
+  it('has proper ARIA attributes', () => {
+    render(<ExportOptionsMenu {...defaultProps} />, { wrapper: createWrapper() })
+
+    const menu = screen.getByRole('menu')
+    expect(menu).toHaveAttribute('aria-label', 'Export photo')
+
+    const menuItems = screen.getAllByRole('menuitem')
+    expect(menuItems).toHaveLength(4)
+  })
+})

--- a/Firmware/webui/frontend/src/components/export/index.js
+++ b/Firmware/webui/frontend/src/components/export/index.js
@@ -5,3 +5,4 @@ export { default as FormatOptionsPanel } from './FormatOptionsPanel';
 export { default as CoordinateInput } from './CoordinateInput';
 export { default as DeploymentEditor } from './DeploymentEditor';
 export { default as DeploymentSelector } from './DeploymentSelector';
+export { default as ExportOptionsMenu } from './ExportOptionsMenu';

--- a/Firmware/webui/frontend/src/components/gallery/PhotoContextMenu.jsx
+++ b/Firmware/webui/frontend/src/components/gallery/PhotoContextMenu.jsx
@@ -1,0 +1,191 @@
+import { useRef, useEffect, useState, useCallback } from 'react'
+import PropTypes from 'prop-types'
+import { useFloating, offset, flip, shift } from '@floating-ui/react'
+import { ArrowRightIcon, ArrowDownTrayIcon } from '@heroicons/react/20/solid'
+import ExportOptionsMenu from '../export/ExportOptionsMenu'
+import { Z_INDEX } from '../../constants/config'
+
+function PhotoContextMenu({ photo, isOpen, onClose, position }) {
+  const menuRef = useRef(null)
+  const exportItemRef = useRef(null)
+  const [showExportMenu, setShowExportMenu] = useState(false)
+  const [adjustedPosition, setAdjustedPosition] = useState(position)
+
+  // Use refs to stabilize event listener dependencies
+  const onCloseRef = useRef(onClose)
+
+  // Floating UI for positioning ExportOptionsMenu relative to Export item
+  const { refs, floatingStyles } = useFloating({
+    placement: 'right-start',
+    middleware: [
+      offset(4),
+      flip({ fallbackPlacements: ['left-start', 'right-end', 'left-end'] }),
+      shift({ padding: 8 }),
+    ],
+  })
+
+  // Keep refs updated with latest prop values
+  useEffect(() => {
+    onCloseRef.current = onClose
+  })
+
+  // Update floating UI reference when exportItemRef changes
+  useEffect(() => {
+    if (exportItemRef.current) {
+      refs.setReference(exportItemRef.current)
+    }
+  }, [refs, showExportMenu])
+
+  // Adjust position to prevent viewport overflow
+  useEffect(() => {
+    if (!isOpen || !menuRef.current) return
+
+    const menuWidth = 200 // Approximate menu width
+    const menuHeight = 100 // Approximate menu height
+    const padding = 8 // Safety padding
+
+    let newX = position.x
+    let newY = position.y
+
+    // Check right edge
+    if (position.x + menuWidth > window.innerWidth) {
+      newX = window.innerWidth - menuWidth - padding
+    }
+
+    // Check bottom edge
+    if (position.y + menuHeight > window.innerHeight) {
+      newY = window.innerHeight - menuHeight - padding
+    }
+
+    setAdjustedPosition({ x: newX, y: newY })
+  }, [isOpen, position])
+
+  // Reset submenu state when menu opens/closes
+  useEffect(() => {
+    if (!isOpen) {
+      setShowExportMenu(false)
+    }
+  }, [isOpen])
+
+  // Close on Escape or click outside
+  useEffect(() => {
+    if (!isOpen) return
+
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        onCloseRef.current()
+      }
+    }
+
+    const handleClickOutside = (e) => {
+      if (
+        menuRef.current &&
+        !menuRef.current.contains(e.target) &&
+        (!showExportMenu || !e.target.closest('[role="menu"]'))
+      ) {
+        onCloseRef.current()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    document.addEventListener('mousedown', handleClickOutside)
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [isOpen, showExportMenu])
+
+  // Handle Export menu item interactions
+  const handleExportClick = useCallback(() => {
+    setShowExportMenu(true)
+  }, [])
+
+  const handleExportHover = useCallback(() => {
+    setShowExportMenu(true)
+  }, [])
+
+  const handleExportLeave = useCallback(() => {
+    setShowExportMenu(false)
+  }, [])
+
+  const handleExportKeyDown = useCallback((e) => {
+    if (e.key === 'Enter') {
+      setShowExportMenu(true)
+    }
+  }, [])
+
+  const handleExportMenuClose = useCallback(() => {
+    setShowExportMenu(false)
+  }, [])
+
+  if (!isOpen) return null
+
+  const menuStyle = {
+    position: 'absolute',
+    left: `${adjustedPosition.x}px`,
+    top: `${adjustedPosition.y}px`,
+  }
+
+  return (
+    <>
+      <div
+        ref={menuRef}
+        style={menuStyle}
+        className={`
+          ${Z_INDEX.MODAL} w-48 bg-white dark:bg-gray-800 rounded-lg shadow-xl
+          border border-gray-200 dark:border-gray-700
+          transition-all duration-150 origin-top-left
+          ${isOpen ? 'opacity-100 scale-100' : 'opacity-0 scale-95'}
+        `}
+        role="menu"
+        aria-label="Photo context menu"
+        tabIndex={-1}
+      >
+        <div className="py-1">
+          <button
+            ref={exportItemRef}
+            role="menuitem"
+            onClick={handleExportClick}
+            onMouseEnter={handleExportHover}
+            onMouseLeave={handleExportLeave}
+            onKeyDown={handleExportKeyDown}
+            className="w-full flex items-center justify-between px-3 py-2 text-left
+                       hover:bg-gray-100 dark:hover:bg-gray-700
+                       text-gray-900 dark:text-gray-100"
+            aria-label="Export photo"
+          >
+            <span className="flex items-center gap-2">
+              <ArrowDownTrayIcon className="w-4 h-4 text-gray-500 dark:text-gray-400" />
+              <span className="text-sm">Export</span>
+            </span>
+            <ArrowRightIcon className="w-4 h-4 text-gray-400" />
+          </button>
+        </div>
+      </div>
+
+      {/* ExportOptionsMenu positioned relative to Export item */}
+      <ExportOptionsMenu
+        photoPath={photo.path}
+        isOpen={showExportMenu}
+        onClose={handleExportMenuClose}
+        anchorEl={exportItemRef.current}
+      />
+    </>
+  )
+}
+
+PhotoContextMenu.propTypes = {
+  photo: PropTypes.shape({
+    path: PropTypes.string.isRequired,
+    filename: PropTypes.string.isRequired,
+  }).isRequired,
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  position: PropTypes.shape({
+    x: PropTypes.number.isRequired,
+    y: PropTypes.number.isRequired,
+  }).isRequired,
+}
+
+export default PhotoContextMenu

--- a/Firmware/webui/frontend/src/components/gallery/__tests__/PhotoContextMenu.test.jsx
+++ b/Firmware/webui/frontend/src/components/gallery/__tests__/PhotoContextMenu.test.jsx
@@ -1,0 +1,400 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import PhotoContextMenu from '../PhotoContextMenu'
+
+// Mock ExportOptionsMenu to simplify testing
+vi.mock('../../export/ExportOptionsMenu', () => ({
+  default: vi.fn(({ isOpen, photoPath, onClose }) =>
+    isOpen ? (
+      <div data-testid="export-options-menu" data-photo-path={photoPath}>
+        Export Menu
+        <button onClick={onClose}>Close Export Menu</button>
+      </div>
+    ) : null
+  ),
+}))
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return ({ children }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+describe('PhotoContextMenu', () => {
+  let mockOnClose
+  const mockPhoto = {
+    path: '/photos/moth_2024_01_15__10_30_00.jpg',
+    filename: 'moth_2024_01_15__10_30_00.jpg',
+  }
+  const mockPosition = { x: 100, y: 200 }
+
+  beforeEach(() => {
+    mockOnClose = vi.fn()
+  })
+
+  describe('Rendering', () => {
+    it('does not render when isOpen is false', () => {
+      const { container } = render(
+        <PhotoContextMenu
+          photo={mockPhoto}
+          isOpen={false}
+          onClose={mockOnClose}
+          position={mockPosition}
+        />,
+        { wrapper: createWrapper() }
+      )
+
+      expect(container.firstChild).toBeNull()
+    })
+
+    it('renders at provided mouse position', () => {
+      const { container } = render(
+        <PhotoContextMenu
+          photo={mockPhoto}
+          isOpen={true}
+          onClose={mockOnClose}
+          position={mockPosition}
+        />,
+        { wrapper: createWrapper() }
+      )
+
+      const menu = container.querySelector('[role="menu"]')
+      expect(menu).toBeInTheDocument()
+      expect(menu).toHaveStyle({
+        position: 'absolute',
+        left: '100px',
+        top: '200px',
+      })
+    })
+
+    it('has role="menu" for accessibility', () => {
+      render(
+        <PhotoContextMenu
+          photo={mockPhoto}
+          isOpen={true}
+          onClose={mockOnClose}
+          position={mockPosition}
+        />,
+        { wrapper: createWrapper() }
+      )
+
+      expect(screen.getByRole('menu')).toBeInTheDocument()
+    })
+
+    it('shows Export menu item with ArrowRightIcon indicator', () => {
+      render(
+        <PhotoContextMenu
+          photo={mockPhoto}
+          isOpen={true}
+          onClose={mockOnClose}
+          position={mockPosition}
+        />,
+        { wrapper: createWrapper() }
+      )
+
+      const exportItem = screen.getByRole('menuitem', { name: /export/i })
+      expect(exportItem).toBeInTheDocument()
+
+      // Check for arrow icon (using test ID or class check)
+      const svg = exportItem.querySelector('svg')
+      expect(svg).toBeInTheDocument()
+    })
+
+    it('Export item has role="menuitem"', () => {
+      render(
+        <PhotoContextMenu
+          photo={mockPhoto}
+          isOpen={true}
+          onClose={mockOnClose}
+          position={mockPosition}
+        />,
+        { wrapper: createWrapper() }
+      )
+
+      const exportItem = screen.getByRole('menuitem', { name: /export/i })
+      expect(exportItem).toHaveAttribute('role', 'menuitem')
+    })
+  })
+
+  describe('ExportOptionsMenu Integration', () => {
+    it('opens ExportOptionsMenu on Export click', async () => {
+      render(
+        <PhotoContextMenu
+          photo={mockPhoto}
+          isOpen={true}
+          onClose={mockOnClose}
+          position={mockPosition}
+        />,
+        { wrapper: createWrapper() }
+      )
+
+      const exportItem = screen.getByRole('menuitem', { name: /export/i })
+      fireEvent.click(exportItem)
+
+      await waitFor(() => {
+        expect(screen.getByTestId('export-options-menu')).toBeInTheDocument()
+      })
+    })
+
+    it('opens ExportOptionsMenu on Export mouseenter (hover)', async () => {
+      render(
+        <PhotoContextMenu
+          photo={mockPhoto}
+          isOpen={true}
+          onClose={mockOnClose}
+          position={mockPosition}
+        />,
+        { wrapper: createWrapper() }
+      )
+
+      const exportItem = screen.getByRole('menuitem', { name: /export/i })
+      fireEvent.mouseEnter(exportItem)
+
+      await waitFor(() => {
+        expect(screen.getByTestId('export-options-menu')).toBeInTheDocument()
+      })
+    })
+
+    it('closes ExportOptionsMenu on Export mouseleave', async () => {
+      render(
+        <PhotoContextMenu
+          photo={mockPhoto}
+          isOpen={true}
+          onClose={mockOnClose}
+          position={mockPosition}
+        />,
+        { wrapper: createWrapper() }
+      )
+
+      const exportItem = screen.getByRole('menuitem', { name: /export/i })
+
+      // Open submenu
+      fireEvent.mouseEnter(exportItem)
+      await waitFor(() => {
+        expect(screen.getByTestId('export-options-menu')).toBeInTheDocument()
+      })
+
+      // Close submenu
+      fireEvent.mouseLeave(exportItem)
+      await waitFor(() => {
+        expect(screen.queryByTestId('export-options-menu')).not.toBeInTheDocument()
+      })
+    })
+
+    it('passes correct photo.path to ExportOptionsMenu', async () => {
+      render(
+        <PhotoContextMenu
+          photo={mockPhoto}
+          isOpen={true}
+          onClose={mockOnClose}
+          position={mockPosition}
+        />,
+        { wrapper: createWrapper() }
+      )
+
+      const exportItem = screen.getByRole('menuitem', { name: /export/i })
+      fireEvent.click(exportItem)
+
+      await waitFor(() => {
+        const exportMenu = screen.getByTestId('export-options-menu')
+        expect(exportMenu).toHaveAttribute('data-photo-path', mockPhoto.path)
+      })
+    })
+  })
+
+  describe('Keyboard Navigation', () => {
+    it('closes entire menu on Escape key', async () => {
+      render(
+        <PhotoContextMenu
+          photo={mockPhoto}
+          isOpen={true}
+          onClose={mockOnClose}
+          position={mockPosition}
+        />,
+        { wrapper: createWrapper() }
+      )
+
+      fireEvent.keyDown(document, { key: 'Escape' })
+
+      await waitFor(() => {
+        expect(mockOnClose).toHaveBeenCalled()
+      })
+    })
+
+    it('opens submenu on Enter key when Export is focused', async () => {
+      render(
+        <PhotoContextMenu
+          photo={mockPhoto}
+          isOpen={true}
+          onClose={mockOnClose}
+          position={mockPosition}
+        />,
+        { wrapper: createWrapper() }
+      )
+
+      const exportItem = screen.getByRole('menuitem', { name: /export/i })
+      exportItem.focus()
+      fireEvent.keyDown(exportItem, { key: 'Enter' })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('export-options-menu')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('Click Outside', () => {
+    it('closes on click outside', async () => {
+      render(
+        <div>
+          <div data-testid="outside">Outside element</div>
+          <PhotoContextMenu
+            photo={mockPhoto}
+            isOpen={true}
+            onClose={mockOnClose}
+            position={mockPosition}
+          />
+        </div>,
+        { wrapper: createWrapper() }
+      )
+
+      const outsideElement = screen.getByTestId('outside')
+      fireEvent.mouseDown(outsideElement)
+
+      await waitFor(() => {
+        expect(mockOnClose).toHaveBeenCalled()
+      })
+    })
+
+    it('does not close when clicking inside menu', async () => {
+      render(
+        <PhotoContextMenu
+          photo={mockPhoto}
+          isOpen={true}
+          onClose={mockOnClose}
+          position={mockPosition}
+        />,
+        { wrapper: createWrapper() }
+      )
+
+      const menu = screen.getByRole('menu')
+      fireEvent.mouseDown(menu)
+
+      // Wait a bit to ensure onClose is not called
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      expect(mockOnClose).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Viewport Edge Handling', () => {
+    const originalInnerWidth = window.innerWidth
+    const originalInnerHeight = window.innerHeight
+
+    beforeEach(() => {
+      // Mock window dimensions
+      Object.defineProperty(window, 'innerWidth', {
+        writable: true,
+        configurable: true,
+        value: 1024,
+      })
+      Object.defineProperty(window, 'innerHeight', {
+        writable: true,
+        configurable: true,
+        value: 768,
+      })
+    })
+
+    afterEach(() => {
+      Object.defineProperty(window, 'innerWidth', {
+        writable: true,
+        configurable: true,
+        value: originalInnerWidth,
+      })
+      Object.defineProperty(window, 'innerHeight', {
+        writable: true,
+        configurable: true,
+        value: originalInnerHeight,
+      })
+    })
+
+    it('repositions if near right viewport edge (flip to left side)', () => {
+      // Position near right edge (menu width ~200px, will overflow)
+      const rightEdgePosition = { x: 950, y: 200 }
+
+      const { container } = render(
+        <PhotoContextMenu
+          photo={mockPhoto}
+          isOpen={true}
+          onClose={mockOnClose}
+          position={rightEdgePosition}
+        />,
+        { wrapper: createWrapper() }
+      )
+
+      const menu = container.querySelector('[role="menu"]')
+      const leftValue = parseInt(menu.style.left)
+
+      // Should be adjusted to prevent overflow
+      expect(leftValue).toBeLessThan(rightEdgePosition.x)
+    })
+
+    it('repositions if near bottom viewport edge (flip to top)', () => {
+      // Position near bottom edge (menu height ~100px, will overflow)
+      const bottomEdgePosition = { x: 200, y: 700 }
+
+      const { container } = render(
+        <PhotoContextMenu
+          photo={mockPhoto}
+          isOpen={true}
+          onClose={mockOnClose}
+          position={bottomEdgePosition}
+        />,
+        { wrapper: createWrapper() }
+      )
+
+      const menu = container.querySelector('[role="menu"]')
+      const topValue = parseInt(menu.style.top)
+
+      // Should be adjusted to prevent overflow
+      expect(topValue).toBeLessThan(bottomEdgePosition.y)
+    })
+  })
+
+  describe('Submenu Closing', () => {
+    it('closes submenu when parent menu closes', async () => {
+      const { rerender } = render(
+        <PhotoContextMenu
+          photo={mockPhoto}
+          isOpen={true}
+          onClose={mockOnClose}
+          position={mockPosition}
+        />,
+        { wrapper: createWrapper() }
+      )
+
+      // Open submenu
+      const exportItem = screen.getByRole('menuitem', { name: /export/i })
+      fireEvent.click(exportItem)
+
+      await waitFor(() => {
+        expect(screen.getByTestId('export-options-menu')).toBeInTheDocument()
+      })
+
+      // Close parent menu
+      rerender(
+        <PhotoContextMenu
+          photo={mockPhoto}
+          isOpen={false}
+          onClose={mockOnClose}
+          position={mockPosition}
+        />
+      )
+
+      expect(screen.queryByTestId('export-options-menu')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/hooks/__tests__/useSinglePhotoExport.test.jsx
+++ b/Firmware/webui/frontend/src/hooks/__tests__/useSinglePhotoExport.test.jsx
@@ -1,0 +1,706 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import toast from 'react-hot-toast'
+import { useSinglePhotoExport } from '../useSinglePhotoExport'
+import * as useExportJobs from '../useExportJobs'
+import * as exportApi from '../../utils/exportApi'
+
+// Mock toast
+vi.mock('react-hot-toast', () => ({
+  default: {
+    success: vi.fn(),
+    error: vi.fn(),
+    loading: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}))
+
+// Create wrapper for react-query
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  })
+
+  return ({ children }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+describe('useSinglePhotoExport', () => {
+  let mockCreateExportJob
+  let mockUseExportJob
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    // Mock the hooks with default implementations
+    mockCreateExportJob = {
+      mutate: vi.fn(),
+      mutateAsync: vi.fn(),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+      error: null,
+      data: null,
+    }
+
+    mockUseExportJob = {
+      data: null,
+      isLoading: false,
+      isError: false,
+      error: null,
+    }
+
+    vi.spyOn(useExportJobs, 'useCreateExportJob').mockReturnValue(mockCreateExportJob)
+    vi.spyOn(useExportJobs, 'useExportJob').mockReturnValue(mockUseExportJob)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('exportPhoto', () => {
+    it('creates job with photo_paths filter containing single photo', async () => {
+      const { result } = renderHook(() => useSinglePhotoExport(), {
+        wrapper: createWrapper(),
+      })
+
+      act(() => {
+        result.current.exportPhoto('/photos/moth.jpg', 'json')
+      })
+
+      expect(mockCreateExportJob.mutate).toHaveBeenCalledWith(
+        {
+          format: 'json',
+          filter: {
+            photo_paths: ['/photos/moth.jpg'],
+          },
+        },
+        expect.any(Object)
+      )
+    })
+
+    it('supports all export formats', async () => {
+      const formats = ['json', 'csv', 'darwin_core', 'inaturalist']
+
+      for (const format of formats) {
+        const { result } = renderHook(() => useSinglePhotoExport(), {
+          wrapper: createWrapper(),
+        })
+
+        act(() => {
+          result.current.exportPhoto('/photos/moth.jpg', format)
+        })
+
+        expect(mockCreateExportJob.mutate).toHaveBeenCalledWith(
+          {
+            format,
+            filter: {
+              photo_paths: ['/photos/moth.jpg'],
+            },
+          },
+          expect.any(Object)
+        )
+
+        vi.clearAllMocks()
+      }
+    })
+
+    it('shows loading toast when job creation starts', async () => {
+      const { result } = renderHook(() => useSinglePhotoExport(), {
+        wrapper: createWrapper(),
+      })
+
+      act(() => {
+        result.current.exportPhoto('/photos/moth.jpg', 'json')
+      })
+
+      expect(toast.loading).toHaveBeenCalledWith('Preparing export...')
+    })
+
+    it('handles job creation failure gracefully', async () => {
+      const mockError = new Error('Failed to create job')
+
+      mockCreateExportJob.mutate.mockImplementation((data, { onError }) => {
+        if (onError) onError(mockError)
+      })
+
+      const { result } = renderHook(() => useSinglePhotoExport(), {
+        wrapper: createWrapper(),
+      })
+
+      act(() => {
+        result.current.exportPhoto('/photos/moth.jpg', 'json')
+      })
+
+      await waitFor(() => {
+        expect(result.current.error).toBe(mockError)
+        expect(toast.error).toHaveBeenCalledWith('Failed to start export')
+        expect(toast.dismiss).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('isExporting state', () => {
+    it('returns isExporting=false initially', () => {
+      const { result } = renderHook(() => useSinglePhotoExport(), {
+        wrapper: createWrapper(),
+      })
+
+      expect(result.current.isExporting).toBe(false)
+    })
+
+    it('returns isExporting=true while job is pending', async () => {
+      mockCreateExportJob.mutate.mockImplementation((data, { onSuccess }) => {
+        if (onSuccess) {
+          onSuccess({ data: { job_id: 'test-job-id' } })
+        }
+      })
+
+      mockUseExportJob = {
+        data: { job_id: 'test-job-id', status: 'pending' },
+        isLoading: false,
+        isError: false,
+        error: null,
+      }
+      vi.spyOn(useExportJobs, 'useExportJob').mockReturnValue(mockUseExportJob)
+
+      const { result } = renderHook(() => useSinglePhotoExport(), {
+        wrapper: createWrapper(),
+      })
+
+      act(() => {
+        result.current.exportPhoto('/photos/moth.jpg', 'json')
+      })
+
+      await waitFor(() => {
+        expect(result.current.isExporting).toBe(true)
+      })
+    })
+
+    it('returns isExporting=true while job is running', async () => {
+      mockCreateExportJob.mutate.mockImplementation((data, { onSuccess }) => {
+        if (onSuccess) {
+          onSuccess({ data: { job_id: 'test-job-id' } })
+        }
+      })
+
+      mockUseExportJob = {
+        data: {
+          job_id: 'test-job-id',
+          status: 'running',
+          progress: { current: 50, total: 100, percent: 50, phase: 'exporting' }
+        },
+        isLoading: false,
+        isError: false,
+        error: null,
+      }
+      vi.spyOn(useExportJobs, 'useExportJob').mockReturnValue(mockUseExportJob)
+
+      const { result } = renderHook(() => useSinglePhotoExport(), {
+        wrapper: createWrapper(),
+      })
+
+      act(() => {
+        result.current.exportPhoto('/photos/moth.jpg', 'json')
+      })
+
+      await waitFor(() => {
+        expect(result.current.isExporting).toBe(true)
+      })
+    })
+
+    it('returns isExporting=false when job completes', async () => {
+      mockCreateExportJob.mutate.mockImplementation((data, { onSuccess }) => {
+        if (onSuccess) {
+          onSuccess({ data: { job_id: 'test-job-id' } })
+        }
+      })
+
+      mockUseExportJob = {
+        data: {
+          job_id: 'test-job-id',
+          status: 'completed',
+          output_path: '/exports/moth.json'
+        },
+        isLoading: false,
+        isError: false,
+        error: null,
+      }
+      vi.spyOn(useExportJobs, 'useExportJob').mockReturnValue(mockUseExportJob)
+
+      const { result } = renderHook(() => useSinglePhotoExport(), {
+        wrapper: createWrapper(),
+      })
+
+      act(() => {
+        result.current.exportPhoto('/photos/moth.jpg', 'json')
+      })
+
+      await waitFor(() => {
+        expect(result.current.isExporting).toBe(false)
+      })
+    })
+  })
+
+  describe('polling behavior', () => {
+    it('polls for job status while active', async () => {
+      mockCreateExportJob.mutate.mockImplementation((data, { onSuccess }) => {
+        if (onSuccess) {
+          onSuccess({ data: { job_id: 'test-job-id' } })
+        }
+      })
+
+      // useExportJob hook automatically polls when jobId is set
+      const { result } = renderHook(() => useSinglePhotoExport(), {
+        wrapper: createWrapper(),
+      })
+
+      act(() => {
+        result.current.exportPhoto('/photos/moth.jpg', 'json')
+      })
+
+      await waitFor(() => {
+        // Verify useExportJob is called with the job ID (enabling polling)
+        expect(useExportJobs.useExportJob).toHaveBeenCalledWith('test-job-id')
+      })
+    })
+
+    it('does not poll when no job is active', () => {
+      const { result } = renderHook(() => useSinglePhotoExport(), {
+        wrapper: createWrapper(),
+      })
+
+      // Initially, no job ID, so polling is disabled
+      expect(useExportJobs.useExportJob).toHaveBeenCalledWith(null)
+      expect(result.current.isExporting).toBe(false)
+    })
+  })
+
+  describe('progress tracking', () => {
+    it('exposes progress during export', async () => {
+      mockCreateExportJob.mutate.mockImplementation((data, { onSuccess }) => {
+        if (onSuccess) {
+          onSuccess({ data: { job_id: 'test-job-id' } })
+        }
+      })
+
+      mockUseExportJob = {
+        data: {
+          job_id: 'test-job-id',
+          status: 'running',
+          progress: {
+            current: 75,
+            total: 100,
+            percent: 75,
+            phase: 'finalizing'
+          }
+        },
+        isLoading: false,
+        isError: false,
+        error: null,
+      }
+      vi.spyOn(useExportJobs, 'useExportJob').mockReturnValue(mockUseExportJob)
+
+      const { result } = renderHook(() => useSinglePhotoExport(), {
+        wrapper: createWrapper(),
+      })
+
+      act(() => {
+        result.current.exportPhoto('/photos/moth.jpg', 'json')
+      })
+
+      await waitFor(() => {
+        expect(result.current.progress).toEqual({
+          current: 75,
+          total: 100,
+          percent: 75,
+          phase: 'finalizing'
+        })
+      })
+    })
+
+    it('returns null progress when no job is active', () => {
+      const { result } = renderHook(() => useSinglePhotoExport(), {
+        wrapper: createWrapper(),
+      })
+
+      expect(result.current.progress).toBeNull()
+    })
+
+    it('returns null progress when job has no progress data', async () => {
+      mockCreateExportJob.mutate.mockImplementation((data, { onSuccess }) => {
+        if (onSuccess) {
+          onSuccess({ data: { job_id: 'test-job-id' } })
+        }
+      })
+
+      mockUseExportJob = {
+        data: {
+          job_id: 'test-job-id',
+          status: 'pending',
+          // No progress data
+        },
+        isLoading: false,
+        isError: false,
+        error: null,
+      }
+      vi.spyOn(useExportJobs, 'useExportJob').mockReturnValue(mockUseExportJob)
+
+      const { result } = renderHook(() => useSinglePhotoExport(), {
+        wrapper: createWrapper(),
+      })
+
+      act(() => {
+        result.current.exportPhoto('/photos/moth.jpg', 'json')
+      })
+
+      await waitFor(() => {
+        expect(result.current.progress).toBeNull()
+      })
+    })
+  })
+
+  describe('automatic download on completion', () => {
+    it('triggers download when job completes', async () => {
+      // Mock document.createElement for anchor element
+      const mockAnchor = {
+        href: '',
+        download: '',
+        click: vi.fn(),
+        style: {},
+      }
+      const originalCreateElement = document.createElement.bind(document)
+      const createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tag) => {
+        if (tag === 'a') {
+          return mockAnchor
+        }
+        return originalCreateElement(tag)
+      })
+      const originalAppendChild = document.body.appendChild.bind(document.body)
+      const appendChildSpy = vi.spyOn(document.body, 'appendChild').mockImplementation((node) => {
+        if (node === mockAnchor) {
+          return node
+        }
+        return originalAppendChild(node)
+      })
+      const originalRemoveChild = document.body.removeChild.bind(document.body)
+      const removeChildSpy = vi.spyOn(document.body, 'removeChild').mockImplementation((node) => {
+        if (node === mockAnchor) {
+          return node
+        }
+        return originalRemoveChild(node)
+      })
+
+      vi.spyOn(exportApi, 'getExportJobDownloadUrl').mockReturnValue('/api/export/jobs/test-job-id/download')
+
+      // Start with running job
+      mockCreateExportJob.mutate.mockImplementation((data, { onSuccess }) => {
+        if (onSuccess) {
+          onSuccess({ data: { job_id: 'test-job-id' } })
+        }
+      })
+
+      mockUseExportJob = {
+        data: { job_id: 'test-job-id', status: 'running' },
+        isLoading: false,
+        isError: false,
+        error: null,
+      }
+      vi.spyOn(useExportJobs, 'useExportJob').mockReturnValue(mockUseExportJob)
+
+      const { result, rerender } = renderHook(() => useSinglePhotoExport(), {
+        wrapper: createWrapper(),
+      })
+
+      act(() => {
+        result.current.exportPhoto('/photos/moth.jpg', 'json')
+      })
+
+      // Wait for job to be created
+      await waitFor(() => {
+        expect(useExportJobs.useExportJob).toHaveBeenCalledWith('test-job-id')
+      })
+
+      // Simulate job completion by updating the mock
+      mockUseExportJob = {
+        data: { job_id: 'test-job-id', status: 'completed', output_path: '/exports/moth.json' },
+        isLoading: false,
+        isError: false,
+        error: null,
+      }
+      vi.spyOn(useExportJobs, 'useExportJob').mockReturnValue(mockUseExportJob)
+
+      rerender()
+
+      await waitFor(() => {
+        expect(mockAnchor.href).toBe('/api/export/jobs/test-job-id/download')
+        expect(mockAnchor.click).toHaveBeenCalled()
+        expect(toast.success).toHaveBeenCalledWith('Export downloaded successfully')
+      })
+
+      createElementSpy.mockRestore()
+      appendChildSpy.mockRestore()
+      removeChildSpy.mockRestore()
+    })
+
+    it('does not trigger download for pending jobs', async () => {
+      const mockAnchor = {
+        href: '',
+        download: '',
+        click: vi.fn(),
+        style: {},
+      }
+      const originalCreateElement = document.createElement.bind(document)
+      const createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tag) => {
+        if (tag === 'a') {
+          return mockAnchor
+        }
+        return originalCreateElement(tag)
+      })
+
+      mockCreateExportJob.mutate.mockImplementation((data, { onSuccess }) => {
+        if (onSuccess) {
+          onSuccess({ data: { job_id: 'test-job-id' } })
+        }
+      })
+
+      mockUseExportJob = {
+        data: { job_id: 'test-job-id', status: 'pending' },
+        isLoading: false,
+        isError: false,
+        error: null,
+      }
+      vi.spyOn(useExportJobs, 'useExportJob').mockReturnValue(mockUseExportJob)
+
+      const { result } = renderHook(() => useSinglePhotoExport(), {
+        wrapper: createWrapper(),
+      })
+
+      act(() => {
+        result.current.exportPhoto('/photos/moth.jpg', 'json')
+      })
+
+      await waitFor(() => {
+        expect(result.current.isExporting).toBe(true)
+      })
+
+      expect(mockAnchor.click).not.toHaveBeenCalled()
+      createElementSpy.mockRestore()
+    })
+
+    it('does not trigger download for running jobs', async () => {
+      const mockAnchor = {
+        href: '',
+        download: '',
+        click: vi.fn(),
+        style: {},
+      }
+      const originalCreateElement = document.createElement.bind(document)
+      const createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tag) => {
+        if (tag === 'a') {
+          return mockAnchor
+        }
+        return originalCreateElement(tag)
+      })
+
+      mockCreateExportJob.mutate.mockImplementation((data, { onSuccess }) => {
+        if (onSuccess) {
+          onSuccess({ data: { job_id: 'test-job-id' } })
+        }
+      })
+
+      mockUseExportJob = {
+        data: {
+          job_id: 'test-job-id',
+          status: 'running',
+          progress: { current: 50, total: 100, percent: 50, phase: 'exporting' }
+        },
+        isLoading: false,
+        isError: false,
+        error: null,
+      }
+      vi.spyOn(useExportJobs, 'useExportJob').mockReturnValue(mockUseExportJob)
+
+      const { result } = renderHook(() => useSinglePhotoExport(), {
+        wrapper: createWrapper(),
+      })
+
+      act(() => {
+        result.current.exportPhoto('/photos/moth.jpg', 'json')
+      })
+
+      await waitFor(() => {
+        expect(result.current.isExporting).toBe(true)
+      })
+
+      expect(mockAnchor.click).not.toHaveBeenCalled()
+      createElementSpy.mockRestore()
+    })
+  })
+
+  describe('error handling', () => {
+    it('sets error state when export fails', async () => {
+      mockCreateExportJob.mutate.mockImplementation((data, { onSuccess }) => {
+        if (onSuccess) {
+          onSuccess({ data: { job_id: 'test-job-id' } })
+        }
+      })
+
+      // Start with running job
+      mockUseExportJob = {
+        data: { job_id: 'test-job-id', status: 'running' },
+        isLoading: false,
+        isError: false,
+        error: null,
+      }
+      vi.spyOn(useExportJobs, 'useExportJob').mockReturnValue(mockUseExportJob)
+
+      const { result, rerender } = renderHook(() => useSinglePhotoExport(), {
+        wrapper: createWrapper(),
+      })
+
+      act(() => {
+        result.current.exportPhoto('/photos/moth.jpg', 'json')
+      })
+
+      await waitFor(() => {
+        expect(result.current.isExporting).toBe(true)
+      })
+
+      // Simulate job failure by updating the mock
+      mockUseExportJob = {
+        data: {
+          job_id: 'test-job-id',
+          status: 'failed',
+          error_message: 'Export processing failed'
+        },
+        isLoading: false,
+        isError: false,
+        error: null,
+      }
+      vi.spyOn(useExportJobs, 'useExportJob').mockReturnValue(mockUseExportJob)
+
+      rerender()
+
+      await waitFor(() => {
+        expect(result.current.error).toBe('Export processing failed')
+        expect(toast.error).toHaveBeenCalledWith('Export failed: Export processing failed')
+      })
+    })
+
+    it('handles generic error message for failed jobs without error_message', async () => {
+      mockCreateExportJob.mutate.mockImplementation((data, { onSuccess }) => {
+        if (onSuccess) {
+          onSuccess({ data: { job_id: 'test-job-id' } })
+        }
+      })
+
+      // Start with running job
+      mockUseExportJob = {
+        data: { job_id: 'test-job-id', status: 'running' },
+        isLoading: false,
+        isError: false,
+        error: null,
+      }
+      vi.spyOn(useExportJobs, 'useExportJob').mockReturnValue(mockUseExportJob)
+
+      const { result, rerender } = renderHook(() => useSinglePhotoExport(), {
+        wrapper: createWrapper(),
+      })
+
+      act(() => {
+        result.current.exportPhoto('/photos/moth.jpg', 'json')
+      })
+
+      await waitFor(() => {
+        expect(result.current.isExporting).toBe(true)
+      })
+
+      // Simulate job failure by updating the mock (no error_message)
+      mockUseExportJob = {
+        data: {
+          job_id: 'test-job-id',
+          status: 'failed',
+          // No error_message
+        },
+        isLoading: false,
+        isError: false,
+        error: null,
+      }
+      vi.spyOn(useExportJobs, 'useExportJob').mockReturnValue(mockUseExportJob)
+
+      rerender()
+
+      await waitFor(() => {
+        expect(result.current.error).toBe('Unknown error')
+        expect(toast.error).toHaveBeenCalledWith('Export failed: Unknown error')
+      })
+    })
+  })
+
+  describe('reset', () => {
+    it('clears error and progress state', async () => {
+      mockCreateExportJob.mutate.mockImplementation((data, { onError }) => {
+        if (onError) onError(new Error('Test error'))
+      })
+
+      const { result } = renderHook(() => useSinglePhotoExport(), {
+        wrapper: createWrapper(),
+      })
+
+      act(() => {
+        result.current.exportPhoto('/photos/moth.jpg', 'json')
+      })
+
+      await waitFor(() => {
+        expect(result.current.error).not.toBeNull()
+      })
+
+      act(() => {
+        result.current.reset()
+      })
+
+      expect(result.current.error).toBeNull()
+      expect(result.current.progress).toBeNull()
+      expect(result.current.isExporting).toBe(false)
+    })
+
+    it('resets jobId to stop polling', async () => {
+      mockCreateExportJob.mutate.mockImplementation((data, { onSuccess }) => {
+        if (onSuccess) {
+          onSuccess({ data: { job_id: 'test-job-id' } })
+        }
+      })
+
+      const { result } = renderHook(() => useSinglePhotoExport(), {
+        wrapper: createWrapper(),
+      })
+
+      act(() => {
+        result.current.exportPhoto('/photos/moth.jpg', 'json')
+      })
+
+      await waitFor(() => {
+        expect(useExportJobs.useExportJob).toHaveBeenCalledWith('test-job-id')
+      })
+
+      act(() => {
+        result.current.reset()
+      })
+
+      // After reset, polling should be disabled (jobId = null)
+      await waitFor(() => {
+        expect(useExportJobs.useExportJob).toHaveBeenCalledWith(null)
+      })
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/hooks/useSinglePhotoExport.js
+++ b/Firmware/webui/frontend/src/hooks/useSinglePhotoExport.js
@@ -1,0 +1,169 @@
+/**
+ * React hook for single-photo export with auto-download
+ *
+ * This hook wraps the existing export job system to provide a simplified
+ * interface for exporting a single photo with automatic download on completion.
+ *
+ * Features:
+ * - Creates export job with photo_paths filter for single photo
+ * - Auto-polls job status while running (via useExportJob)
+ * - Automatically triggers download when job completes
+ * - Progress tracking during export
+ * - Error handling with toast notifications
+ *
+ * @returns {Object} Hook state and actions
+ * @returns {Function} exportPhoto - Start export: (photoPath, format) => void
+ * @returns {boolean} isExporting - Whether export is in progress
+ * @returns {Object|null} progress - Progress data: { current, total, percent, phase }
+ * @returns {string|null} error - Error message if export failed
+ * @returns {Function} reset - Clear error and progress state
+ *
+ * @example
+ * const { exportPhoto, isExporting, progress, error, reset } = useSinglePhotoExport()
+ *
+ * // Start export
+ * exportPhoto('/photos/moth.jpg', 'json')
+ *
+ * // Display progress
+ * if (isExporting && progress) {
+ *   console.log(`Progress: ${progress.percent}% (${progress.phase})`)
+ * }
+ *
+ * // Handle errors
+ * if (error) {
+ *   console.error('Export failed:', error)
+ *   reset() // Clear error state
+ * }
+ */
+
+import { useState, useEffect, useRef } from 'react'
+import toast from 'react-hot-toast'
+import { useCreateExportJob, useExportJob } from './useExportJobs'
+import { getExportJobDownloadUrl } from '../utils/exportApi'
+
+export function useSinglePhotoExport() {
+  const [jobId, setJobId] = useState(null)
+  const [error, setError] = useState(null)
+  const [hasDownloaded, setHasDownloaded] = useState(false)
+  const toastIdRef = useRef(null)
+
+  const createExportJob = useCreateExportJob()
+  const jobQuery = useExportJob(jobId)
+
+  // Get job data
+  const job = jobQuery.data
+
+  // Determine if export is in progress
+  const isExporting = job?.status === 'pending' || job?.status === 'running'
+
+  // Get progress data
+  const progress = job?.progress || null
+
+  /**
+   * Start export for a single photo
+   *
+   * @param {string} photoPath - Absolute path to photo file
+   * @param {string} format - Export format (json, csv, darwin_core, inaturalist)
+   */
+  const exportPhoto = (photoPath, format) => {
+    // Reset state
+    setError(null)
+    setHasDownloaded(false)
+    setJobId(null)
+
+    // Show loading toast
+    toastIdRef.current = toast.loading('Preparing export...')
+
+    // Create export job
+    createExportJob.mutate(
+      {
+        format,
+        filter: {
+          photo_paths: [photoPath],
+        },
+      },
+      {
+        onSuccess: (response) => {
+          const newJobId = response.data.job_id
+          setJobId(newJobId)
+          // Keep loading toast - will dismiss when job completes/fails
+        },
+        onError: (err) => {
+          setError(err)
+          toast.dismiss(toastIdRef.current)
+          toast.error('Failed to start export')
+          toastIdRef.current = null
+        },
+      }
+    )
+  }
+
+  /**
+   * Reset state (clear error, progress, stop polling)
+   */
+  const reset = () => {
+    setJobId(null)
+    setError(null)
+    setHasDownloaded(false)
+    if (toastIdRef.current) {
+      toast.dismiss(toastIdRef.current)
+      toastIdRef.current = null
+    }
+  }
+
+  // Handle job completion
+  useEffect(() => {
+    if (!job) return
+
+    // Handle successful completion
+    if (job.status === 'completed' && !hasDownloaded) {
+      setHasDownloaded(true)
+
+      // Dismiss loading toast
+      if (toastIdRef.current) {
+        toast.dismiss(toastIdRef.current)
+        toastIdRef.current = null
+      }
+
+      // Trigger download
+      const downloadUrl = getExportJobDownloadUrl(job.job_id)
+      const anchor = document.createElement('a')
+      anchor.href = downloadUrl
+      anchor.style.display = 'none'
+      document.body.appendChild(anchor)
+      anchor.click()
+      document.body.removeChild(anchor)
+
+      // Show success toast
+      toast.success('Export downloaded successfully')
+
+      // Clear job ID to stop polling
+      setJobId(null)
+    }
+
+    // Handle failure
+    if (job.status === 'failed') {
+      const errorMessage = job.error_message || 'Unknown error'
+      setError(errorMessage)
+
+      // Dismiss loading toast
+      if (toastIdRef.current) {
+        toast.dismiss(toastIdRef.current)
+        toastIdRef.current = null
+      }
+
+      toast.error(`Export failed: ${errorMessage}`)
+
+      // Clear job ID to stop polling
+      setJobId(null)
+    }
+  }, [job, hasDownloaded])
+
+  return {
+    exportPhoto,
+    isExporting,
+    progress,
+    error,
+    reset,
+  }
+}

--- a/Firmware/webui/frontend/src/pages/__tests__/Gallery.export.test.jsx
+++ b/Firmware/webui/frontend/src/pages/__tests__/Gallery.export.test.jsx
@@ -1,0 +1,484 @@
+/**
+ * Gallery Export Integration Tests
+ *
+ * Tests the integration of export functionality across Gallery components:
+ * - PhotoGridItem context menu → PhotoContextMenu → ExportOptionsMenu
+ * - PhotoLightbox export button → ExportOptionsMenu
+ *
+ * These tests verify that the export workflow works correctly end-to-end.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import toast from 'react-hot-toast'
+
+// Import components to test
+import PhotoGridItem from '../../components/PhotoGridItem'
+import PhotoLightbox from '../../components/PhotoLightbox'
+import { SelectionProvider } from '../../contexts/SelectionContext'
+
+// Mock ProgressiveImage to avoid image loading complexity
+vi.mock('../../components/ProgressiveImage', () => ({
+  default: vi.fn(({ src, alt, className }) => (
+    <img
+      src={src}
+      alt={alt}
+      className={className}
+      data-testid="progressive-image"
+    />
+  )),
+}))
+
+// Mock useSinglePhotoExport
+vi.mock('../../hooks/useSinglePhotoExport', () => ({
+  useSinglePhotoExport: vi.fn(() => ({
+    exportPhoto: vi.fn(),
+    isExporting: false,
+    progress: null,
+    error: null,
+    reset: vi.fn(),
+  })),
+}))
+
+import { useSinglePhotoExport } from '../../hooks/useSinglePhotoExport'
+
+// Mock react-hot-toast
+vi.mock('react-hot-toast', () => ({
+  default: {
+    success: vi.fn(),
+    error: vi.fn(),
+    loading: vi.fn(() => 'toast-id'),
+    dismiss: vi.fn(),
+  }
+}))
+
+// Test data
+const mockPhoto = {
+  path: '/photos/moth_with_metadata.jpg',
+  filename: 'moth_with_metadata.jpg',
+  thumbnail: '/thumbnails/moth_with_metadata.jpg',
+}
+
+const mockPhotoNoGps = {
+  path: '/photos/moth_no_gps.jpg',
+  filename: 'moth_no_gps.jpg',
+  thumbnail: '/thumbnails/moth_no_gps.jpg',
+}
+
+const mockPhotoMinimal = {
+  path: '/photos/moth_minimal.jpg',
+  filename: 'moth_minimal.jpg',
+  thumbnail: '/thumbnails/moth_minimal.jpg',
+}
+
+describe('Gallery Export Integration Tests', () => {
+  let queryClient
+  let mockExportPhoto
+
+  const createWrapper = () => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    })
+
+    return ({ children }) => (
+      <QueryClientProvider client={queryClient}>
+        <SelectionProvider>
+          {children}
+        </SelectionProvider>
+      </QueryClientProvider>
+    )
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockExportPhoto = vi.fn()
+    useSinglePhotoExport.mockReturnValue({
+      exportPhoto: mockExportPhoto,
+      isExporting: false,
+      progress: null,
+      error: null,
+      reset: vi.fn(),
+    })
+  })
+
+  afterEach(() => {
+    queryClient?.clear()
+  })
+
+  describe('PhotoGridItem Context Menu Integration', () => {
+    const renderPhotoGridItem = (photo = mockPhoto) => {
+      return render(
+        <PhotoGridItem
+          photo={photo}
+          onClick={vi.fn()}
+          onLoad={vi.fn()}
+        />,
+        { wrapper: createWrapper() }
+      )
+    }
+
+    it('opens context menu on right-click and shows export option', async () => {
+      renderPhotoGridItem()
+
+      // Find the photo container and right-click (use the image's parent container)
+      const image = screen.getByTestId('progressive-image')
+      const photoElement = image.closest('div[class*="relative"]')
+      fireEvent.contextMenu(photoElement, { clientX: 100, clientY: 100 })
+
+      // Verify context menu appears with Export option
+      await waitFor(() => {
+        expect(screen.getByRole('menu')).toBeInTheDocument()
+        expect(screen.getByRole('menuitem', { name: /export/i })).toBeInTheDocument()
+      })
+    })
+
+    it('opens export submenu when hovering on Export option', async () => {
+      const user = userEvent.setup()
+      renderPhotoGridItem()
+
+      // Right-click to open context menu
+      const image = screen.getByTestId('progressive-image')
+      const photoElement = image.closest('div[class*="relative"]')
+      fireEvent.contextMenu(photoElement, { clientX: 100, clientY: 100 })
+
+      // Wait for context menu
+      await waitFor(() => {
+        expect(screen.getByRole('menuitem', { name: /export/i })).toBeInTheDocument()
+      })
+
+      // Hover on Export to open submenu
+      const exportOption = screen.getByRole('menuitem', { name: /export/i })
+      await user.hover(exportOption)
+
+      // Verify export options submenu appears
+      await waitFor(() => {
+        expect(screen.getByText('Export Photo')).toBeInTheDocument()
+        expect(screen.getByText('Darwin Core')).toBeInTheDocument()
+        expect(screen.getByText('iNaturalist')).toBeInTheDocument()
+        expect(screen.getByText('JSON')).toBeInTheDocument()
+        expect(screen.getByText('CSV')).toBeInTheDocument()
+      })
+    })
+
+    it('shows export submenu formats when Export option is hovered', async () => {
+      const user = userEvent.setup()
+      renderPhotoGridItem()
+
+      // Right-click to open context menu
+      const image = screen.getByTestId('progressive-image')
+      const photoElement = image.closest('div[class*="relative"]')
+      fireEvent.contextMenu(photoElement, { clientX: 100, clientY: 100 })
+
+      // Hover on Export
+      await waitFor(() => {
+        expect(screen.getByRole('menuitem', { name: /export/i })).toBeInTheDocument()
+      })
+      const exportOption = screen.getByRole('menuitem', { name: /export/i })
+      await user.hover(exportOption)
+
+      // Verify all export formats are shown
+      await waitFor(() => {
+        expect(screen.getByText('JSON')).toBeInTheDocument()
+        expect(screen.getByText('CSV')).toBeInTheDocument()
+        expect(screen.getByText('Darwin Core')).toBeInTheDocument()
+        expect(screen.getByText('iNaturalist')).toBeInTheDocument()
+      })
+    })
+
+    it('closes context menu on escape key', async () => {
+      renderPhotoGridItem()
+
+      // Right-click to open context menu
+      const image = screen.getByTestId('progressive-image')
+      const photoElement = image.closest('div[class*="relative"]')
+      fireEvent.contextMenu(photoElement, { clientX: 100, clientY: 100 })
+
+      await waitFor(() => {
+        expect(screen.getByRole('menu')).toBeInTheDocument()
+      })
+
+      // Press Escape
+      fireEvent.keyDown(document, { key: 'Escape' })
+
+      // Menu should close
+      await waitFor(() => {
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+      })
+    })
+
+    it('context menu works with photos that have minimal metadata', async () => {
+      const user = userEvent.setup()
+      renderPhotoGridItem(mockPhotoMinimal)
+
+      // Right-click to open context menu
+      const image = screen.getByTestId('progressive-image')
+      const photoElement = image.closest('div[class*="relative"]')
+      fireEvent.contextMenu(photoElement, { clientX: 100, clientY: 100 })
+
+      // Verify context menu appears
+      await waitFor(() => {
+        expect(screen.getByRole('menu')).toBeInTheDocument()
+        expect(screen.getByRole('menuitem', { name: /export/i })).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('PhotoLightbox Export Button Integration', () => {
+    const renderLightbox = (photo = mockPhoto, photos = [mockPhoto]) => {
+      return render(
+        <PhotoLightbox
+          photo={photo}
+          photos={photos}
+          onClose={vi.fn()}
+          onNavigate={vi.fn()}
+        />,
+        { wrapper: createWrapper() }
+      )
+    }
+
+    it('renders export button in lightbox controls', () => {
+      renderLightbox()
+
+      const exportButton = screen.getByRole('button', { name: /export photo/i })
+      expect(exportButton).toBeInTheDocument()
+    })
+
+    it('opens export menu when export button is clicked', async () => {
+      const user = userEvent.setup()
+      renderLightbox()
+
+      const exportButton = screen.getByRole('button', { name: /export photo/i })
+      await user.click(exportButton)
+
+      // Verify export options menu appears
+      await waitFor(() => {
+        expect(screen.getByText('Export Photo')).toBeInTheDocument()
+        expect(screen.getByText('Darwin Core')).toBeInTheDocument()
+        expect(screen.getByText('JSON')).toBeInTheDocument()
+      })
+    })
+
+    it('triggers export when format is selected from lightbox', async () => {
+      const user = userEvent.setup()
+      renderLightbox()
+
+      // Click export button
+      const exportButton = screen.getByRole('button', { name: /export photo/i })
+      await user.click(exportButton)
+
+      // Click Darwin Core format
+      await waitFor(() => {
+        expect(screen.getByText('Darwin Core')).toBeInTheDocument()
+      })
+      await user.click(screen.getByText('Darwin Core'))
+
+      // Verify export was triggered
+      expect(mockExportPhoto).toHaveBeenCalledWith(mockPhoto.path, 'darwin_core')
+    })
+
+    it('export button has correct aria-label for accessibility', async () => {
+      renderLightbox()
+
+      // Find export button by its aria-label
+      const exportButton = screen.getByRole('button', { name: /export photo/i })
+      expect(exportButton).toBeInTheDocument()
+      expect(exportButton).toHaveAttribute('aria-label', 'Export photo')
+    })
+
+    it('closes export menu on escape', async () => {
+      const user = userEvent.setup()
+      renderLightbox()
+
+      // Open export menu
+      const exportButton = screen.getByRole('button', { name: /export photo/i })
+      await user.click(exportButton)
+
+      await waitFor(() => {
+        expect(screen.getByText('Export Photo')).toBeInTheDocument()
+      })
+
+      // Press Escape
+      await user.keyboard('{Escape}')
+
+      // Menu should close (header "Export Photo" should not be visible)
+      await waitFor(() => {
+        expect(screen.queryByText('Export Photo')).not.toBeInTheDocument()
+      })
+    })
+
+    it('works with photos without GPS data', async () => {
+      const user = userEvent.setup()
+      renderLightbox(mockPhotoNoGps, [mockPhotoNoGps])
+
+      // Click export button
+      const exportButton = screen.getByRole('button', { name: /export photo/i })
+      await user.click(exportButton)
+
+      // Click iNaturalist format
+      await waitFor(() => {
+        expect(screen.getByText('iNaturalist')).toBeInTheDocument()
+      })
+      await user.click(screen.getByText('iNaturalist'))
+
+      // Verify export was triggered with photo without GPS
+      expect(mockExportPhoto).toHaveBeenCalledWith(mockPhotoNoGps.path, 'inaturalist')
+    })
+  })
+
+  describe('Export Formats via Lightbox', () => {
+    const renderLightbox = (photo = mockPhoto, photos = [mockPhoto]) => {
+      return render(
+        <PhotoLightbox
+          photo={photo}
+          photos={photos}
+          onClose={vi.fn()}
+          onNavigate={vi.fn()}
+        />,
+        { wrapper: createWrapper() }
+      )
+    }
+
+    it.each([
+      ['Darwin Core', 'darwin_core'],
+      ['iNaturalist', 'inaturalist'],
+      ['JSON', 'json'],
+      ['CSV', 'csv'],
+    ])('supports %s export format via lightbox', async (formatName, formatId) => {
+      const user = userEvent.setup()
+      renderLightbox()
+
+      // Open export menu
+      const exportButton = screen.getByRole('button', { name: /export photo/i })
+      await user.click(exportButton)
+
+      // Wait for export menu and click the format
+      await waitFor(() => {
+        expect(screen.getByText(formatName)).toBeInTheDocument()
+      })
+      // Click the button containing the format name
+      const formatButton = screen.getByText(formatName).closest('button')
+      await user.click(formatButton)
+
+      // Verify correct format ID was passed
+      expect(mockExportPhoto).toHaveBeenCalledWith(mockPhoto.path, formatId)
+    })
+  })
+
+  describe('Loading States', () => {
+    it('shows loading state in export menu while exporting', async () => {
+      const user = userEvent.setup()
+
+      // Set isExporting to true
+      useSinglePhotoExport.mockReturnValue({
+        exportPhoto: mockExportPhoto,
+        isExporting: true,
+        progress: { percent: 50, phase: 'exporting' },
+        error: null,
+        reset: vi.fn(),
+      })
+
+      render(
+        <PhotoLightbox
+          photo={mockPhoto}
+          photos={[mockPhoto]}
+          onClose={vi.fn()}
+          onNavigate={vi.fn()}
+        />,
+        { wrapper: createWrapper() }
+      )
+
+      // Open export menu
+      const exportButton = screen.getByRole('button', { name: /export photo/i })
+      await user.click(exportButton)
+
+      // Verify loading indicator appears
+      await waitFor(() => {
+        expect(screen.getByText('Exporting...')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('context menu has proper ARIA roles', async () => {
+      render(
+        <PhotoGridItem
+          photo={mockPhoto}
+          onClick={vi.fn()}
+          onLoad={vi.fn()}
+        />,
+        { wrapper: createWrapper() }
+      )
+
+      // Right-click to open context menu
+      const image = screen.getByTestId('progressive-image')
+      const photoElement = image.closest('div[class*="relative"]')
+      fireEvent.contextMenu(photoElement, { clientX: 100, clientY: 100 })
+
+      await waitFor(() => {
+        expect(screen.getByRole('menu')).toBeInTheDocument()
+        expect(screen.getByRole('menuitem', { name: /export/i })).toBeInTheDocument()
+      })
+    })
+
+    it('export options menu has proper ARIA roles', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <PhotoLightbox
+          photo={mockPhoto}
+          photos={[mockPhoto]}
+          onClose={vi.fn()}
+          onNavigate={vi.fn()}
+        />,
+        { wrapper: createWrapper() }
+      )
+
+      // Open export menu
+      const exportButton = screen.getByRole('button', { name: /export photo/i })
+      await user.click(exportButton)
+
+      await waitFor(() => {
+        // Export options menu should have menu role
+        const menus = screen.getAllByRole('menu')
+        expect(menus.length).toBeGreaterThan(0)
+
+        // Format options should have menuitem roles
+        const menuitems = screen.getAllByRole('menuitem')
+        expect(menuitems.length).toBeGreaterThanOrEqual(4) // 4 export formats
+      })
+    })
+
+    it('export menu supports keyboard navigation', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <PhotoLightbox
+          photo={mockPhoto}
+          photos={[mockPhoto]}
+          onClose={vi.fn()}
+          onNavigate={vi.fn()}
+        />,
+        { wrapper: createWrapper() }
+      )
+
+      // Open export menu
+      const exportButton = screen.getByRole('button', { name: /export photo/i })
+      await user.click(exportButton)
+
+      await waitFor(() => {
+        expect(screen.getByText('Darwin Core')).toBeInTheDocument()
+      })
+
+      // Use arrow key to navigate
+      await user.keyboard('{ArrowDown}')
+
+      // First item should be highlighted
+      const darwinCoreOption = screen.getByText('Darwin Core').closest('button')
+      expect(darwinCoreOption).toHaveClass('ring-2')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add right-click context menu on gallery photo thumbnails with Export option
- Add export button in PhotoLightbox viewer (top-right toolbar)
- Implement ExportOptionsMenu component with 4 export formats:
  - Darwin Core (for GBIF biodiversity portals)
  - iNaturalist (with XMP sidecars)
  - JSON (all metadata fields)
  - CSV (Excel compatible)
- Create useSinglePhotoExport hook for single-photo exports with auto-download

## Components Created
1. **useSinglePhotoExport** - Hook wrapping export job API with:
   - Auto-polling while job is running
   - Automatic download trigger on completion
   - Progress tracking state

2. **ExportOptionsMenu** - Dropdown menu for export format selection:
   - Uses @floating-ui/react for positioning
   - Supports both anchor element (lightbox) and position coords (context menu)
   - Full keyboard navigation (ArrowUp/Down/Enter/Escape)
   - Proper ARIA roles for accessibility

3. **PhotoContextMenu** - Right-click context menu:
   - Opens on right-click on photo thumbnails
   - Shows Export option with submenu
   - Handles viewport edge positioning

## Test Coverage
- 20 tests for useSinglePhotoExport hook
- 22 tests for ExportOptionsMenu component
- 16 tests for PhotoContextMenu component
- 12 tests for PhotoGridItem context menu integration
- 6 tests for PhotoLightbox export button integration
- 19 integration tests for full export workflow

**All 3779 tests passing.**

## Test plan
- [ ] Right-click on a photo thumbnail in Gallery → context menu appears
- [ ] Hover/click Export option → submenu shows all 4 formats
- [ ] Click outside menu → menu closes
- [ ] Press Escape → menu closes
- [ ] Select export format → export job starts, file downloads automatically
- [ ] Open lightbox → export button visible in top-right controls
- [ ] Click export button → format selection menu appears
- [ ] Select format → export and download works

Closes #126