### PR TITLE
feat(gallery): Add bulk export toolbar with multi-select support (#127)

### DIFF
--- a/Firmware/webui/frontend/src/components/gallery/BulkActionsToolbar.jsx
+++ b/Firmware/webui/frontend/src/components/gallery/BulkActionsToolbar.jsx
@@ -1,11 +1,12 @@
 import { createPortal } from 'react-dom'
-import { TagIcon, BeakerIcon, TrashIcon, XMarkIcon } from '@heroicons/react/24/outline'
+import { TagIcon, BeakerIcon, ArrowDownTrayIcon, TrashIcon, XMarkIcon } from '@heroicons/react/24/outline'
 import useSelection from '../../hooks/useSelection'
 import { Z_INDEX } from '../../constants/config'
 
 export default function BulkActionsToolbar({
   onTagClick,
   onSpeciesClick,
+  onExportClick,
   onDeleteClick
 }) {
   const { selectedCount, deselectAll } = useSelection()
@@ -54,6 +55,17 @@ export default function BulkActionsToolbar({
       >
         <BeakerIcon className="h-4 w-4" />
         Species
+      </button>
+
+      <button
+        onClick={onExportClick}
+        className="flex items-center gap-1.5 px-3 py-1.5 text-sm
+                   text-gray-700 dark:text-gray-300
+                   hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md"
+        aria-label="Export selected photos"
+      >
+        <ArrowDownTrayIcon className="h-4 w-4" />
+        Export
       </button>
 
       <button

--- a/Firmware/webui/frontend/src/components/gallery/BulkExportModal.jsx
+++ b/Firmware/webui/frontend/src/components/gallery/BulkExportModal.jsx
@@ -8,37 +8,17 @@ import {
   TableCellsIcon,
   BeakerIcon
 } from '@heroicons/react/20/solid'
-import { Z_INDEX } from '@/constants/config'
+import { Z_INDEX, EXPORT_FORMATS } from '@/constants/config'
 
 /**
- * Export format options
+ * Icon mapping for export formats (UI-specific, not in config)
  */
-const EXPORT_FORMATS = [
-  {
-    id: 'darwin_core',
-    name: 'Darwin Core',
-    description: 'For GBIF biodiversity portals',
-    icon: BeakerIcon
-  },
-  {
-    id: 'inaturalist',
-    name: 'iNaturalist',
-    description: 'With XMP sidecars',
-    icon: CircleStackIcon
-  },
-  {
-    id: 'json',
-    name: 'JSON',
-    description: 'All metadata fields',
-    icon: DocumentTextIcon
-  },
-  {
-    id: 'csv',
-    name: 'CSV',
-    description: 'Excel compatible',
-    icon: TableCellsIcon
-  },
-]
+const FORMAT_ICONS = {
+  darwin_core: BeakerIcon,
+  inaturalist: CircleStackIcon,
+  json: DocumentTextIcon,
+  csv: TableCellsIcon,
+}
 
 /**
  * BulkExportModal Component
@@ -130,7 +110,7 @@ export default function BulkExportModal({
           className="space-y-2"
         >
           {EXPORT_FORMATS.map((format) => {
-            const Icon = format.icon
+            const Icon = FORMAT_ICONS[format.id]
             const isSelected = selectedFormat === format.id
             return (
               <label

--- a/Firmware/webui/frontend/src/components/gallery/BulkExportModal.jsx
+++ b/Firmware/webui/frontend/src/components/gallery/BulkExportModal.jsx
@@ -1,0 +1,238 @@
+import { useState, useEffect } from 'react'
+import { createPortal } from 'react-dom'
+import PropTypes from 'prop-types'
+import { XMarkIcon } from '@heroicons/react/24/outline'
+import {
+  CircleStackIcon,
+  DocumentTextIcon,
+  TableCellsIcon,
+  BeakerIcon
+} from '@heroicons/react/20/solid'
+import { Z_INDEX } from '@/constants/config'
+
+/**
+ * Export format options
+ */
+const EXPORT_FORMATS = [
+  {
+    id: 'darwin_core',
+    name: 'Darwin Core',
+    description: 'For GBIF biodiversity portals',
+    icon: BeakerIcon
+  },
+  {
+    id: 'inaturalist',
+    name: 'iNaturalist',
+    description: 'With XMP sidecars',
+    icon: CircleStackIcon
+  },
+  {
+    id: 'json',
+    name: 'JSON',
+    description: 'All metadata fields',
+    icon: DocumentTextIcon
+  },
+  {
+    id: 'csv',
+    name: 'CSV',
+    description: 'Excel compatible',
+    icon: TableCellsIcon
+  },
+]
+
+/**
+ * BulkExportModal Component
+ *
+ * Modal for selecting export format for bulk photo export.
+ * Displays format options as radio button cards with icons and descriptions.
+ *
+ * @component
+ * @example
+ * <BulkExportModal
+ *   isOpen={true}
+ *   onClose={() => setIsOpen(false)}
+ *   onExport={(format) => console.log('Export', format)}
+ *   selectedCount={5}
+ * />
+ */
+export default function BulkExportModal({
+  isOpen,
+  onClose,
+  onExport,
+  selectedCount,
+  isLoading = false,
+  error = null
+}) {
+  const [selectedFormat, setSelectedFormat] = useState(null)
+
+  // Reset state when modal opens/closes
+  useEffect(() => {
+    if (!isOpen) {
+      setSelectedFormat(null)
+    }
+  }, [isOpen])
+
+  // Handle Escape key
+  useEffect(() => {
+    if (!isOpen) return
+    const handleEscape = (e) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleEscape)
+    return () => document.removeEventListener('keydown', handleEscape)
+  }, [isOpen, onClose])
+
+  if (!isOpen) return null
+
+  const handleExport = () => {
+    if (selectedFormat && !isLoading) {
+      onExport(selectedFormat)
+    }
+  }
+
+  const isExportDisabled = !selectedFormat || isLoading
+
+  const modal = (
+    <div className={`fixed inset-0 ${Z_INDEX.MODAL} flex items-center justify-center`}>
+      {/* Backdrop with click-to-close */}
+      <div
+        className="absolute inset-0 bg-black/50"
+        onClick={onClose}
+      />
+
+      {/* Modal content */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="bulk-export-title"
+        className="relative bg-white dark:bg-gray-800 rounded-lg shadow-xl
+                   w-full max-w-md p-6"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between mb-4">
+          <h2 id="bulk-export-title" className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+            Export {selectedCount} photo{selectedCount !== 1 ? 's' : ''}
+          </h2>
+          <button
+            onClick={onClose}
+            aria-label="Close modal"
+            className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
+          >
+            <XMarkIcon className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* Format Selection */}
+        <div
+          role="radiogroup"
+          aria-label="Export format"
+          className="space-y-2"
+        >
+          {EXPORT_FORMATS.map((format) => {
+            const Icon = format.icon
+            const isSelected = selectedFormat === format.id
+            return (
+              <label
+                key={format.id}
+                className={`
+                  flex items-start gap-3 p-3 rounded-lg cursor-pointer
+                  border-2 transition-colors
+                  ${isSelected
+                    ? 'border-blue-500 ring-2 ring-blue-500 bg-blue-50 dark:bg-blue-900/20'
+                    : 'border-gray-200 dark:border-gray-600 hover:border-gray-300 dark:hover:border-gray-500'}
+                `}
+              >
+                <input
+                  type="radio"
+                  name="export-format"
+                  value={format.id}
+                  checked={isSelected}
+                  onChange={() => setSelectedFormat(format.id)}
+                  aria-label={format.name}
+                  className="sr-only"
+                />
+                <Icon className={`w-5 h-5 flex-shrink-0 mt-0.5 ${
+                  isSelected
+                    ? 'text-blue-600 dark:text-blue-400'
+                    : 'text-gray-400 dark:text-gray-500'
+                }`} />
+                <div className="flex-1 min-w-0">
+                  <div className={`text-sm font-medium ${
+                    isSelected
+                      ? 'text-blue-900 dark:text-blue-100'
+                      : 'text-gray-900 dark:text-gray-100'
+                  }`}>
+                    {format.name}
+                  </div>
+                  <div className={`text-xs ${
+                    isSelected
+                      ? 'text-blue-700 dark:text-blue-300'
+                      : 'text-gray-500 dark:text-gray-400'
+                  }`}>
+                    {format.description}
+                  </div>
+                </div>
+                {/* Visual check indicator */}
+                <div className={`w-4 h-4 rounded-full border-2 flex items-center justify-center flex-shrink-0 mt-0.5 ${
+                  isSelected
+                    ? 'border-blue-500 bg-blue-500'
+                    : 'border-gray-300 dark:border-gray-500'
+                }`}>
+                  {isSelected && (
+                    <div className="w-2 h-2 rounded-full bg-white" />
+                  )}
+                </div>
+              </label>
+            )
+          })}
+        </div>
+
+        {/* Error message */}
+        {error && (
+          <p role="alert" className="text-red-600 dark:text-red-400 text-sm mt-4">
+            {error}
+          </p>
+        )}
+
+        {/* Action buttons */}
+        <div className="flex gap-3 mt-6">
+          <button
+            onClick={onClose}
+            className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md
+                       hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-900 dark:text-gray-100
+                       disabled:opacity-50 disabled:cursor-not-allowed"
+            disabled={isLoading}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleExport}
+            disabled={isExportDisabled}
+            className="flex-1 px-4 py-2 bg-blue-600 text-white rounded-md
+                       hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isLoading ? 'Exporting...' : 'Export'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+
+  return createPortal(modal, document.body)
+}
+
+BulkExportModal.propTypes = {
+  /** Whether the modal is open */
+  isOpen: PropTypes.bool.isRequired,
+  /** Close handler */
+  onClose: PropTypes.func.isRequired,
+  /** Export handler - receives format id (darwin_core, inaturalist, json, csv) */
+  onExport: PropTypes.func.isRequired,
+  /** Number of selected photos */
+  selectedCount: PropTypes.number.isRequired,
+  /** Loading state */
+  isLoading: PropTypes.bool,
+  /** Error message */
+  error: PropTypes.string
+}

--- a/Firmware/webui/frontend/src/components/gallery/BulkExportModal.jsx
+++ b/Firmware/webui/frontend/src/components/gallery/BulkExportModal.jsx
@@ -74,8 +74,8 @@ export default function BulkExportModal({
 
   // Handle Escape key
   useEffect(() => {
-    if (!isOpen) return
     const handleEscape = (e) => {
+      if (!isOpen) return
       if (e.key === 'Escape') onClose()
     }
     document.addEventListener('keydown', handleEscape)

--- a/Firmware/webui/frontend/src/components/gallery/BulkProgressModal.jsx
+++ b/Firmware/webui/frontend/src/components/gallery/BulkProgressModal.jsx
@@ -3,22 +3,30 @@ import { XMarkIcon, CheckCircleIcon, ExclamationCircleIcon } from '@heroicons/re
 import { Z_INDEX } from '../../constants/config'
 
 /**
- * BulkProgressModal - Displays progress during bulk operations (tag, species, delete)
+ * BulkProgressModal - Displays progress during bulk operations (tag, species, delete, export)
+ *
+ * Supports two prop interfaces:
+ * 1. Simplified: status, current, total, message, downloadUrl
+ * 2. Detailed: status, progress, processedCount, totalCount, successCount, failedCount, errors, operation
  *
  * @param {Object} props
  * @param {boolean} props.isOpen - Whether modal is visible
  * @param {Function} props.onClose - Callback when modal closes (after completion)
  * @param {Function} [props.onCancel] - Callback when user cancels operation
  * @param {'processing'|'success'|'error'} props.status - Current operation status
- * @param {number} props.progress - Progress percentage (0-100)
+ * @param {number} [props.progress] - Progress percentage (0-100) (detailed interface)
+ * @param {number} [props.current] - Current count (simplified interface)
+ * @param {number} [props.total] - Total count (simplified interface)
+ * @param {string} [props.message] - Status message (simplified interface)
  * @param {number} [props.currentBatch] - Current batch number (for multi-batch operations)
  * @param {number} [props.totalBatches] - Total number of batches
- * @param {number} props.processedCount - Number of photos processed so far
- * @param {number} props.totalCount - Total number of photos to process
+ * @param {number} [props.processedCount] - Number of photos processed so far (detailed interface)
+ * @param {number} [props.totalCount] - Total number of photos to process (detailed interface)
  * @param {number} [props.successCount] - Number of successfully processed photos (for completion)
  * @param {number} [props.failedCount] - Number of failed photos (for completion)
  * @param {Object} [props.errors] - Map of filename -> error message
- * @param {'tag'|'species'|'delete'} [props.operation='tag'] - Type of operation
+ * @param {'tag'|'species'|'delete'|'export'} [props.operation='tag'] - Type of operation
+ * @param {string} [props.downloadUrl] - Download URL for completed export (export operation only)
  */
 export default function BulkProgressModal({
   isOpen,
@@ -26,6 +34,9 @@ export default function BulkProgressModal({
   onCancel,
   status,
   progress,
+  current,
+  total,
+  message,
   currentBatch,
   totalBatches,
   processedCount,
@@ -33,14 +44,26 @@ export default function BulkProgressModal({
   successCount,
   failedCount,
   errors,
-  operation = 'tag'
+  operation = 'tag',
+  downloadUrl
 }) {
   if (!isOpen) return null
+
+  // Support both simplified and detailed interfaces
+  const useSimplified = current !== undefined && total !== undefined
+  const displayProcessed = useSimplified ? current : processedCount
+  const displayTotal = useSimplified ? total : totalCount
+  const displayProgress = useSimplified
+    ? Math.round((current / total) * 100)
+    : progress
+  const displaySuccess = useSimplified ? current : successCount
+  const displayFailed = useSimplified ? 0 : failedCount
 
   const operationText = {
     tag: 'Tagging',
     species: 'Updating species',
-    delete: 'Deleting'
+    delete: 'Deleting',
+    export: 'Exporting'
   }[operation]
 
   const handleCancelClick = () => {
@@ -64,30 +87,32 @@ export default function BulkProgressModal({
         {status === 'processing' && (
           <>
             <h2 className="text-lg font-semibold mb-4 text-gray-900 dark:text-gray-100">
-              {operationText} photos...
+              {useSimplified && message ? message : `${operationText} photos...`}
             </h2>
 
             {/* Progress bar */}
             <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2.5 mb-4">
               <div
                 className="bg-blue-600 h-2.5 rounded-full transition-all"
-                style={{ width: `${progress}%` }}
+                style={{ width: `${displayProgress}%` }}
                 role="progressbar"
-                aria-valuenow={progress}
+                aria-valuenow={displayProgress}
                 aria-valuemin={0}
                 aria-valuemax={100}
               />
             </div>
 
-            <p
-              role="status"
-              aria-live="polite"
-              aria-atomic="true"
-              className="text-sm text-gray-600 dark:text-gray-400 mb-4"
-            >
-              Processing {processedCount} of {totalCount} photos
-              {totalBatches > 1 && ` (Batch ${currentBatch} of ${totalBatches})`}
-            </p>
+            {!useSimplified && (
+              <p
+                role="status"
+                aria-live="polite"
+                aria-atomic="true"
+                className="text-sm text-gray-600 dark:text-gray-400 mb-4"
+              >
+                Processing {displayProcessed} of {displayTotal} photos
+                {totalBatches > 1 && ` (Batch ${currentBatch} of ${totalBatches})`}
+              </p>
+            )}
 
             <button
               onClick={handleCancelClick}
@@ -103,21 +128,41 @@ export default function BulkProgressModal({
             <div className="flex items-center gap-3 mb-4">
               <CheckCircleIcon className="h-8 w-8 text-green-500" />
               <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-                Complete!
+                {useSimplified && message ? message : 'Complete!'}
               </h2>
             </div>
 
-            <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
-              Successfully processed {successCount} photos
-              {failedCount > 0 && `, ${failedCount} failed`}
-            </p>
+            {!useSimplified && (
+              <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+                Successfully processed {displaySuccess} photos
+                {displayFailed > 0 && `, ${displayFailed} failed`}
+              </p>
+            )}
 
-            <button
-              onClick={onClose}
-              className="w-full px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
-            >
-              Done
-            </button>
+            {downloadUrl ? (
+              <div className="flex gap-2">
+                <a
+                  href={downloadUrl}
+                  download
+                  className="flex-1 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors text-center"
+                >
+                  Download
+                </a>
+                <button
+                  onClick={onClose}
+                  className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+                >
+                  Close
+                </button>
+              </div>
+            ) : (
+              <button
+                onClick={onClose}
+                className="w-full px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
+              >
+                Done
+              </button>
+            )}
           </>
         )}
 
@@ -131,10 +176,10 @@ export default function BulkProgressModal({
             </div>
 
             <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
-              {failedCount} photos failed to process
+              {useSimplified && message ? message : `${displayFailed} photos failed to process`}
             </p>
 
-            {errors && Object.keys(errors).length > 0 && (
+            {!useSimplified && errors && Object.keys(errors).length > 0 && (
               <div className="max-h-32 overflow-y-auto mb-4 text-sm">
                 {Object.entries(errors).slice(0, 5).map(([file, error]) => (
                   <p key={file} className="text-red-600 dark:text-red-400 mb-1">

--- a/Firmware/webui/frontend/src/components/gallery/BulkProgressModal.jsx
+++ b/Firmware/webui/frontend/src/components/gallery/BulkProgressModal.jsx
@@ -54,7 +54,7 @@ export default function BulkProgressModal({
   const displayProcessed = useSimplified ? current : processedCount
   const displayTotal = useSimplified ? total : totalCount
   const displayProgress = useSimplified
-    ? Math.round((current / total) * 100)
+    ? (total > 0 ? Math.round((current / total) * 100) : 0)
     : progress
   const displaySuccess = useSimplified ? current : successCount
   const displayFailed = useSimplified ? 0 : failedCount

--- a/Firmware/webui/frontend/src/components/gallery/BulkProgressModal.jsx
+++ b/Firmware/webui/frontend/src/components/gallery/BulkProgressModal.jsx
@@ -5,28 +5,71 @@ import { Z_INDEX } from '../../constants/config'
 /**
  * BulkProgressModal - Displays progress during bulk operations (tag, species, delete, export)
  *
- * Supports two prop interfaces:
- * 1. Simplified: status, current, total, message, downloadUrl
- * 2. Detailed: status, progress, processedCount, totalCount, successCount, failedCount, errors, operation
+ * This modal supports two prop interfaces to accommodate different use cases:
+ *
+ * ## Simplified Interface
+ * Use for straightforward progress tracking with custom messages.
+ * The modal auto-calculates progress percentage from current/total.
+ *
+ * Required props: `isOpen`, `onClose`, `status`, `current`, `total`
+ * Optional props: `message`, `downloadUrl`, `onCancel`
+ *
+ * @example
+ * // Simplified interface - export with download
+ * <BulkProgressModal
+ *   isOpen={true}
+ *   onClose={() => setOpen(false)}
+ *   status="processing"
+ *   current={5}
+ *   total={10}
+ *   message="Exporting photos..."
+ *   downloadUrl="/api/export/download/123"  // Shows download button on success
+ * />
+ *
+ * ## Detailed Interface
+ * Use for complex operations with batch processing, error tracking, and granular counts.
+ * Provides explicit control over all display values.
+ *
+ * Required props: `isOpen`, `onClose`, `status`, `progress`, `processedCount`, `totalCount`
+ * Optional props: `successCount`, `failedCount`, `errors`, `operation`, `currentBatch`, `totalBatches`, `onCancel`
+ *
+ * @example
+ * // Detailed interface - bulk tagging with error tracking
+ * <BulkProgressModal
+ *   isOpen={true}
+ *   onClose={() => setOpen(false)}
+ *   status="processing"
+ *   operation="tag"
+ *   progress={50}
+ *   processedCount={5}
+ *   totalCount={10}
+ *   successCount={4}
+ *   failedCount={1}
+ *   currentBatch={1}
+ *   totalBatches={2}
+ *   errors={{ 'photo1.jpg': 'File not found' }}
+ * />
  *
  * @param {Object} props
  * @param {boolean} props.isOpen - Whether modal is visible
  * @param {Function} props.onClose - Callback when modal closes (after completion)
  * @param {Function} [props.onCancel] - Callback when user cancels operation
  * @param {'processing'|'success'|'error'} props.status - Current operation status
- * @param {number} [props.progress] - Progress percentage (0-100) (detailed interface)
- * @param {number} [props.current] - Current count (simplified interface)
- * @param {number} [props.total] - Total count (simplified interface)
- * @param {string} [props.message] - Status message (simplified interface)
- * @param {number} [props.currentBatch] - Current batch number (for multi-batch operations)
- * @param {number} [props.totalBatches] - Total number of batches
- * @param {number} [props.processedCount] - Number of photos processed so far (detailed interface)
- * @param {number} [props.totalCount] - Total number of photos to process (detailed interface)
- * @param {number} [props.successCount] - Number of successfully processed photos (for completion)
- * @param {number} [props.failedCount] - Number of failed photos (for completion)
- * @param {Object} [props.errors] - Map of filename -> error message
- * @param {'tag'|'species'|'delete'|'export'} [props.operation='tag'] - Type of operation
- * @param {string} [props.downloadUrl] - Download URL for completed export (export operation only)
+ *
+ * @param {number} [props.current] - Current count (simplified interface, triggers simplified mode)
+ * @param {number} [props.total] - Total count (simplified interface, required with current)
+ * @param {string} [props.message] - Custom status message (simplified interface)
+ * @param {string} [props.downloadUrl] - Download URL for completed export (simplified interface)
+ *
+ * @param {number} [props.progress] - Progress percentage 0-100 (detailed interface)
+ * @param {number} [props.processedCount] - Photos processed so far (detailed interface)
+ * @param {number} [props.totalCount] - Total photos to process (detailed interface)
+ * @param {number} [props.successCount] - Successfully processed photos (detailed interface)
+ * @param {number} [props.failedCount] - Failed photos (detailed interface)
+ * @param {Object} [props.errors] - Map of filename -> error message (detailed interface)
+ * @param {'tag'|'species'|'delete'|'export'} [props.operation='tag'] - Operation type (detailed interface)
+ * @param {number} [props.currentBatch] - Current batch number (detailed interface)
+ * @param {number} [props.totalBatches] - Total batches (detailed interface)
  */
 export default function BulkProgressModal({
   isOpen,

--- a/Firmware/webui/frontend/src/components/gallery/__tests__/BulkActionsToolbar.test.jsx
+++ b/Firmware/webui/frontend/src/components/gallery/__tests__/BulkActionsToolbar.test.jsx
@@ -743,6 +743,147 @@ describe('BulkActionsToolbar', () => {
     })
   })
 
+  describe('Export Button', () => {
+    it('shows "Export" button with ArrowDownTrayIcon', () => {
+      renderWithSelection(
+        {
+          onTagClick: vi.fn(),
+          onSpeciesClick: vi.fn(),
+          onDeleteClick: vi.fn(),
+          onExportClick: vi.fn(),
+        },
+        ['photo1.jpg']
+      )
+
+      const exportButton = screen.getByRole('button', { name: /export selected photos/i })
+      expect(exportButton).toBeInTheDocument()
+      expect(within(exportButton).getByText('Export')).toBeInTheDocument()
+
+      // Check for icon (SVG)
+      const svg = exportButton.querySelector('svg')
+      expect(svg).toBeInTheDocument()
+    })
+
+    it('Export button calls onExportClick prop', async () => {
+      const user = userEvent.setup()
+      const onExportClick = vi.fn()
+
+      renderWithSelection(
+        {
+          onTagClick: vi.fn(),
+          onSpeciesClick: vi.fn(),
+          onDeleteClick: vi.fn(),
+          onExportClick,
+        },
+        ['photo1.jpg']
+      )
+
+      const exportButton = screen.getByRole('button', { name: /export selected photos/i })
+      await user.click(exportButton)
+
+      expect(onExportClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('Export button has correct aria-label for accessibility', () => {
+      renderWithSelection(
+        {
+          onTagClick: vi.fn(),
+          onSpeciesClick: vi.fn(),
+          onDeleteClick: vi.fn(),
+          onExportClick: vi.fn(),
+        },
+        ['photo1.jpg']
+      )
+
+      const exportButton = screen.getByRole('button', { name: /export selected photos/i })
+      expect(exportButton).toHaveAttribute('aria-label', 'Export selected photos')
+    })
+
+    it('Export button uses non-destructive styling (not red)', () => {
+      renderWithSelection(
+        {
+          onTagClick: vi.fn(),
+          onSpeciesClick: vi.fn(),
+          onDeleteClick: vi.fn(),
+          onExportClick: vi.fn(),
+        },
+        ['photo1.jpg']
+      )
+
+      const exportButton = screen.getByRole('button', { name: /export selected photos/i })
+      // Should NOT have red styling (unlike Delete button)
+      expect(exportButton.className).not.toMatch(/red/)
+      // Should have gray/neutral styling like Tag and Species buttons
+      expect(exportButton.className).toMatch(/text-gray/)
+    })
+
+    it('Export button is keyboard accessible (Enter)', async () => {
+      const user = userEvent.setup()
+      const onExportClick = vi.fn()
+
+      renderWithSelection(
+        {
+          onTagClick: vi.fn(),
+          onSpeciesClick: vi.fn(),
+          onDeleteClick: vi.fn(),
+          onExportClick,
+        },
+        ['photo1.jpg']
+      )
+
+      const exportButton = screen.getByRole('button', { name: /export selected photos/i })
+      exportButton.focus()
+      await user.keyboard('{Enter}')
+
+      expect(onExportClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('Export button is keyboard accessible (Space)', async () => {
+      const user = userEvent.setup()
+      const onExportClick = vi.fn()
+
+      renderWithSelection(
+        {
+          onTagClick: vi.fn(),
+          onSpeciesClick: vi.fn(),
+          onDeleteClick: vi.fn(),
+          onExportClick,
+        },
+        ['photo1.jpg']
+      )
+
+      const exportButton = screen.getByRole('button', { name: /export selected photos/i })
+      exportButton.focus()
+      await user.keyboard(' ')
+
+      expect(onExportClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('Export button is positioned between Species and Delete buttons', () => {
+      renderWithSelection(
+        {
+          onTagClick: vi.fn(),
+          onSpeciesClick: vi.fn(),
+          onDeleteClick: vi.fn(),
+          onExportClick: vi.fn(),
+        },
+        ['photo1.jpg']
+      )
+
+      const toolbar = screen.getByRole('toolbar')
+      const buttons = toolbar.querySelectorAll('button')
+      const buttonTexts = Array.from(buttons).map(btn => btn.textContent.trim())
+
+      // Order should be: Tag, Species, Export, Delete, Deselect All
+      const speciesIndex = buttonTexts.findIndex(text => text.includes('Species'))
+      const exportIndex = buttonTexts.findIndex(text => text.includes('Export'))
+      const deleteIndex = buttonTexts.findIndex(text => text.includes('Delete'))
+
+      expect(exportIndex).toBeGreaterThan(speciesIndex)
+      expect(exportIndex).toBeLessThan(deleteIndex)
+    })
+  })
+
   describe('Dark Mode Support', () => {
     it('has dark mode classes for background', () => {
       renderWithSelection(

--- a/Firmware/webui/frontend/src/components/gallery/__tests__/BulkExportModal.test.jsx
+++ b/Firmware/webui/frontend/src/components/gallery/__tests__/BulkExportModal.test.jsx
@@ -1,0 +1,345 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import BulkExportModal from '../BulkExportModal'
+
+describe('BulkExportModal', () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    onExport: vi.fn(),
+    selectedCount: 5,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('Visibility', () => {
+    it('does NOT render when isOpen is false', () => {
+      render(<BulkExportModal {...defaultProps} isOpen={false} />)
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+
+    it('renders when isOpen is true', () => {
+      render(<BulkExportModal {...defaultProps} />)
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+  })
+
+  describe('Header', () => {
+    it('shows export count in title: "Export X photos"', () => {
+      render(<BulkExportModal {...defaultProps} selectedCount={5} />)
+
+      expect(screen.getByText(/export 5 photos/i)).toBeInTheDocument()
+    })
+
+    it('shows singular form for single photo', () => {
+      render(<BulkExportModal {...defaultProps} selectedCount={1} />)
+
+      expect(screen.getByText(/export 1 photo$/i)).toBeInTheDocument()
+    })
+
+    it('shows close button in header', () => {
+      render(<BulkExportModal {...defaultProps} />)
+
+      const closeButton = screen.getByRole('button', { name: /close modal/i })
+      expect(closeButton).toBeInTheDocument()
+    })
+  })
+
+  describe('Format Selection', () => {
+    it('displays all 4 export formats', () => {
+      render(<BulkExportModal {...defaultProps} />)
+
+      expect(screen.getByText('Darwin Core')).toBeInTheDocument()
+      expect(screen.getByText('iNaturalist')).toBeInTheDocument()
+      expect(screen.getByText('JSON')).toBeInTheDocument()
+      expect(screen.getByText('CSV')).toBeInTheDocument()
+    })
+
+    it('shows format descriptions', () => {
+      render(<BulkExportModal {...defaultProps} />)
+
+      expect(screen.getByText(/gbif biodiversity portals/i)).toBeInTheDocument()
+      expect(screen.getByText(/xmp sidecars/i)).toBeInTheDocument()
+      expect(screen.getByText(/all metadata fields/i)).toBeInTheDocument()
+      expect(screen.getByText(/excel compatible/i)).toBeInTheDocument()
+    })
+
+    it('shows format icons', () => {
+      render(<BulkExportModal {...defaultProps} />)
+
+      // Each format card (label wrapping radio) should have an SVG icon
+      const formatRadios = screen.getAllByRole('radio')
+      formatRadios.forEach((radio) => {
+        // Get the parent label element which contains the icon
+        const label = radio.closest('label')
+        const svg = label.querySelector('svg')
+        expect(svg).toBeInTheDocument()
+      })
+    })
+
+    it('allows selecting a format', async () => {
+      const user = userEvent.setup()
+      render(<BulkExportModal {...defaultProps} />)
+
+      const darwinCoreOption = screen.getByRole('radio', { name: /darwin core/i })
+      await user.click(darwinCoreOption)
+
+      expect(darwinCoreOption).toBeChecked()
+    })
+
+    it('highlights selected format visually', async () => {
+      const user = userEvent.setup()
+      render(<BulkExportModal {...defaultProps} />)
+
+      const darwinCoreOption = screen.getByRole('radio', { name: /darwin core/i })
+      await user.click(darwinCoreOption)
+
+      // Selected item should have ring/border highlight
+      const parent = darwinCoreOption.closest('label')
+      expect(parent.className).toMatch(/ring|border-blue/)
+    })
+
+    it('only allows one format to be selected at a time', async () => {
+      const user = userEvent.setup()
+      render(<BulkExportModal {...defaultProps} />)
+
+      const darwinCoreOption = screen.getByRole('radio', { name: /darwin core/i })
+      const jsonOption = screen.getByRole('radio', { name: /json/i })
+
+      await user.click(darwinCoreOption)
+      expect(darwinCoreOption).toBeChecked()
+      expect(jsonOption).not.toBeChecked()
+
+      await user.click(jsonOption)
+      expect(jsonOption).toBeChecked()
+      expect(darwinCoreOption).not.toBeChecked()
+    })
+  })
+
+  describe('Actions', () => {
+    it('Cancel button closes modal', async () => {
+      const user = userEvent.setup()
+      const onClose = vi.fn()
+      render(<BulkExportModal {...defaultProps} onClose={onClose} />)
+
+      const cancelButton = screen.getByRole('button', { name: /cancel/i })
+      await user.click(cancelButton)
+
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
+
+    it('Export button calls onExport with selected format', async () => {
+      const user = userEvent.setup()
+      const onExport = vi.fn()
+      render(<BulkExportModal {...defaultProps} onExport={onExport} />)
+
+      // Select a format first
+      const darwinCoreOption = screen.getByRole('radio', { name: /darwin core/i })
+      await user.click(darwinCoreOption)
+
+      // Click export
+      const exportButton = screen.getByRole('button', { name: /^export$/i })
+      await user.click(exportButton)
+
+      expect(onExport).toHaveBeenCalledTimes(1)
+      expect(onExport).toHaveBeenCalledWith('darwin_core')
+    })
+
+    it('Export button disabled when no format selected', () => {
+      render(<BulkExportModal {...defaultProps} />)
+
+      const exportButton = screen.getByRole('button', { name: /^export$/i })
+      expect(exportButton).toBeDisabled()
+    })
+
+    it('Export button disabled when isLoading', async () => {
+      const user = userEvent.setup()
+      render(<BulkExportModal {...defaultProps} isLoading={true} />)
+
+      // Select a format
+      const darwinCoreOption = screen.getByRole('radio', { name: /darwin core/i })
+      await user.click(darwinCoreOption)
+
+      const exportButton = screen.getByRole('button', { name: /exporting|export/i })
+      expect(exportButton).toBeDisabled()
+    })
+
+    it('Export button shows loading state when isLoading', () => {
+      render(<BulkExportModal {...defaultProps} isLoading={true} />)
+
+      expect(screen.getByText(/exporting/i)).toBeInTheDocument()
+    })
+
+    it('close button in header calls onClose', async () => {
+      const user = userEvent.setup()
+      const onClose = vi.fn()
+      render(<BulkExportModal {...defaultProps} onClose={onClose} />)
+
+      const closeButton = screen.getByRole('button', { name: /close modal/i })
+      await user.click(closeButton)
+
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('Keyboard Navigation', () => {
+    it('Escape key closes modal', async () => {
+      const user = userEvent.setup()
+      const onClose = vi.fn()
+      render(<BulkExportModal {...defaultProps} onClose={onClose} />)
+
+      await user.keyboard('{Escape}')
+
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
+
+    it('Arrow keys navigate format options', async () => {
+      const user = userEvent.setup()
+      render(<BulkExportModal {...defaultProps} />)
+
+      // Focus on the first radio button
+      const darwinCoreOption = screen.getByRole('radio', { name: /darwin core/i })
+      darwinCoreOption.focus()
+
+      // Press down arrow to move to next option
+      await user.keyboard('{ArrowDown}')
+
+      const inaturalistOption = screen.getByRole('radio', { name: /inaturalist/i })
+      expect(inaturalistOption).toHaveFocus()
+    })
+
+    it('Tab key navigates between elements', async () => {
+      const user = userEvent.setup()
+      render(<BulkExportModal {...defaultProps} />)
+
+      // Tab should move through focusable elements
+      await user.tab()
+      // First focusable element should be focused
+      expect(document.activeElement).toBeTruthy()
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('has role="dialog" and aria-modal="true"', () => {
+      render(<BulkExportModal {...defaultProps} />)
+
+      const dialog = screen.getByRole('dialog')
+      expect(dialog).toHaveAttribute('aria-modal', 'true')
+    })
+
+    it('has aria-labelledby for title', () => {
+      render(<BulkExportModal {...defaultProps} />)
+
+      const dialog = screen.getByRole('dialog')
+      const labelledBy = dialog.getAttribute('aria-labelledby')
+      expect(labelledBy).toBeTruthy()
+
+      // Title element should exist with that ID
+      const title = document.getElementById(labelledBy)
+      expect(title).toBeInTheDocument()
+      expect(title.textContent).toMatch(/export/i)
+    })
+
+    it('format options use radio role', () => {
+      render(<BulkExportModal {...defaultProps} />)
+
+      const radioGroup = screen.getByRole('radiogroup')
+      expect(radioGroup).toBeInTheDocument()
+
+      const radios = screen.getAllByRole('radio')
+      expect(radios).toHaveLength(4)
+    })
+
+    it('format options have accessible names', () => {
+      render(<BulkExportModal {...defaultProps} />)
+
+      expect(screen.getByRole('radio', { name: /darwin core/i })).toBeInTheDocument()
+      expect(screen.getByRole('radio', { name: /inaturalist/i })).toBeInTheDocument()
+      expect(screen.getByRole('radio', { name: /json/i })).toBeInTheDocument()
+      expect(screen.getByRole('radio', { name: /csv/i })).toBeInTheDocument()
+    })
+  })
+
+  describe('Backdrop', () => {
+    it('renders backdrop overlay', () => {
+      render(<BulkExportModal {...defaultProps} />)
+
+      // Look for backdrop element with bg-black/50 or similar
+      const backdrop = document.querySelector('[class*="bg-black"]')
+      expect(backdrop).toBeInTheDocument()
+    })
+
+    it('clicking backdrop closes modal', async () => {
+      const user = userEvent.setup()
+      const onClose = vi.fn()
+      render(<BulkExportModal {...defaultProps} onClose={onClose} />)
+
+      // Click on backdrop (the overlay element)
+      const backdrop = document.querySelector('[class*="bg-black"]')
+      await user.click(backdrop)
+
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
+
+    it('clicking modal content does NOT close modal', async () => {
+      const user = userEvent.setup()
+      const onClose = vi.fn()
+      render(<BulkExportModal {...defaultProps} onClose={onClose} />)
+
+      const dialog = screen.getByRole('dialog')
+      await user.click(dialog)
+
+      expect(onClose).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Error State', () => {
+    it('shows error message when error prop is provided', () => {
+      render(<BulkExportModal {...defaultProps} error="Failed to create export job" />)
+
+      expect(screen.getByText(/failed to create export job/i)).toBeInTheDocument()
+    })
+
+    it('error message has proper ARIA role', () => {
+      render(<BulkExportModal {...defaultProps} error="Export failed" />)
+
+      const errorElement = screen.getByRole('alert')
+      expect(errorElement).toBeInTheDocument()
+    })
+  })
+
+  describe('Dark Mode Support', () => {
+    it('has dark mode classes for background', () => {
+      render(<BulkExportModal {...defaultProps} />)
+
+      const dialog = screen.getByRole('dialog')
+      expect(dialog.className).toMatch(/dark:bg-/)
+    })
+
+    it('has dark mode classes for text', () => {
+      render(<BulkExportModal {...defaultProps} />)
+
+      const title = screen.getByText(/export \d+ photos?/i)
+      expect(title.className).toMatch(/dark:text-/)
+    })
+  })
+
+  describe('Portal Rendering', () => {
+    it('modal is rendered in document.body (portal)', () => {
+      const { container } = render(<BulkExportModal {...defaultProps} />)
+
+      // Modal should NOT be in the container (it's portaled to body)
+      const dialogInContainer = container.querySelector('[role="dialog"]')
+      expect(dialogInContainer).toBeNull()
+
+      // But it should be in the document (via portal)
+      const dialogInDocument = document.querySelector('[role="dialog"]')
+      expect(dialogInDocument).toBeInTheDocument()
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/constants/config.js
+++ b/Firmware/webui/frontend/src/constants/config.js
@@ -413,6 +413,45 @@ export const API_LIMITS = {
 }
 
 /**
+ * Export Format Configuration
+ *
+ * Available export formats for bulk photo export.
+ * Must match backend ExportJobFormat enum in lib/export_job_types.py.
+ *
+ * @property {string} id - Format identifier (matches backend enum value)
+ * @property {string} name - User-facing format name
+ * @property {string} description - Brief description of the format
+ */
+export const EXPORT_FORMATS = [
+  {
+    id: 'darwin_core',
+    name: 'Darwin Core',
+    description: 'For GBIF biodiversity portals',
+  },
+  {
+    id: 'inaturalist',
+    name: 'iNaturalist',
+    description: 'With XMP sidecars',
+  },
+  {
+    id: 'json',
+    name: 'JSON',
+    description: 'All metadata fields',
+  },
+  {
+    id: 'csv',
+    name: 'CSV',
+    description: 'Excel compatible',
+  },
+]
+
+/**
+ * Valid export format IDs (derived from EXPORT_FORMATS)
+ * Used for input validation in useBulkExport hook.
+ */
+export const VALID_EXPORT_FORMAT_IDS = EXPORT_FORMATS.map(f => f.id)
+
+/**
  * Z-Index Layer System
  *
  * Centralized z-index values to prevent layering conflicts.

--- a/Firmware/webui/frontend/src/hooks/__tests__/useBulkExport.test.jsx
+++ b/Firmware/webui/frontend/src/hooks/__tests__/useBulkExport.test.jsx
@@ -1,0 +1,454 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import useBulkExport from '../useBulkExport'
+import * as exportApi from '../../utils/exportApi'
+
+// Create wrapper for react-query
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  })
+
+  return ({ children }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+describe('useBulkExport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('Initial State', () => {
+    it('returns initial state correctly', () => {
+      const { result } = renderHook(() => useBulkExport(), {
+        wrapper: createWrapper(),
+      })
+
+      expect(result.current.isExporting).toBe(false)
+      expect(result.current.progress).toBeNull()
+      expect(result.current.error).toBeNull()
+      expect(result.current.jobId).toBeNull()
+      expect(result.current.downloadUrl).toBeNull()
+      expect(typeof result.current.exportPhotos).toBe('function')
+      expect(typeof result.current.cancel).toBe('function')
+      expect(typeof result.current.reset).toBe('function')
+    })
+  })
+
+  describe('exportPhotos', () => {
+    it('creates export job with photo_paths filter', async () => {
+      const mockJobResponse = {
+        data: {
+          job_id: 'test-job-123',
+          status: 'pending',
+          format: 'darwin_core',
+        },
+      }
+
+      vi.spyOn(exportApi, 'createExportJob').mockResolvedValue(mockJobResponse)
+      vi.spyOn(exportApi, 'getExportJob').mockResolvedValue({
+        data: {
+          job_id: 'test-job-123',
+          status: 'pending',
+          progress: { current: 0, total: 5, percent: 0, phase: 'initializing' },
+        },
+      })
+
+      const { result } = renderHook(() => useBulkExport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        await result.current.exportPhotos(['photo1.jpg', 'photo2.jpg', 'photo3.jpg'], 'darwin_core')
+      })
+
+      // Check first argument (data) matches expected structure
+      const callArgs = exportApi.createExportJob.mock.calls[0]
+      expect(callArgs[0]).toEqual({
+        format: 'darwin_core',
+        filter: {
+          photo_paths: ['photo1.jpg', 'photo2.jpg', 'photo3.jpg'],
+        },
+      })
+    })
+
+    it('sets jobId after successful creation', async () => {
+      const mockJobResponse = {
+        data: {
+          job_id: 'test-job-123',
+          status: 'pending',
+          format: 'json',
+        },
+      }
+
+      vi.spyOn(exportApi, 'createExportJob').mockResolvedValue(mockJobResponse)
+      vi.spyOn(exportApi, 'getExportJob').mockResolvedValue({
+        data: {
+          job_id: 'test-job-123',
+          status: 'pending',
+          progress: { current: 0, total: 2, percent: 0 },
+        },
+      })
+
+      const { result } = renderHook(() => useBulkExport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        await result.current.exportPhotos(['photo1.jpg', 'photo2.jpg'], 'json')
+      })
+
+      expect(result.current.jobId).toBe('test-job-123')
+    })
+
+    it('sets isExporting to true after job creation', async () => {
+      const mockJobResponse = {
+        data: {
+          job_id: 'test-job-123',
+          status: 'pending',
+        },
+      }
+
+      vi.spyOn(exportApi, 'createExportJob').mockResolvedValue(mockJobResponse)
+      vi.spyOn(exportApi, 'getExportJob').mockResolvedValue({
+        data: {
+          job_id: 'test-job-123',
+          status: 'running',
+          progress: { current: 0, total: 5, percent: 0 },
+        },
+      })
+
+      const { result } = renderHook(() => useBulkExport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        await result.current.exportPhotos(['photo1.jpg'], 'csv')
+      })
+
+      await waitFor(() => {
+        expect(result.current.isExporting).toBe(true)
+      })
+    })
+
+    it('handles creation errors', async () => {
+      const mockError = new Error('Rate limit exceeded')
+      vi.spyOn(exportApi, 'createExportJob').mockRejectedValue(mockError)
+
+      const { result } = renderHook(() => useBulkExport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        try {
+          await result.current.exportPhotos(['photo1.jpg'], 'json')
+        } catch {
+          // Expected to throw
+        }
+      })
+
+      expect(result.current.error).toBeTruthy()
+      expect(result.current.isExporting).toBe(false)
+    })
+  })
+
+  describe('Progress tracking', () => {
+    it('returns isExporting true when job is pending', async () => {
+      vi.spyOn(exportApi, 'createExportJob').mockResolvedValue({
+        data: { job_id: 'job-1', status: 'pending' },
+      })
+      vi.spyOn(exportApi, 'getExportJob').mockResolvedValue({
+        data: {
+          job_id: 'job-1',
+          status: 'pending',
+          progress: { current: 0, total: 10, percent: 0, phase: 'initializing' },
+        },
+      })
+
+      const { result } = renderHook(() => useBulkExport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        await result.current.exportPhotos(['p1.jpg'], 'json')
+      })
+
+      await waitFor(() => {
+        expect(result.current.isExporting).toBe(true)
+      })
+    })
+
+    it('returns isExporting true when job is running', async () => {
+      vi.spyOn(exportApi, 'createExportJob').mockResolvedValue({
+        data: { job_id: 'job-1', status: 'pending' },
+      })
+      vi.spyOn(exportApi, 'getExportJob').mockResolvedValue({
+        data: {
+          job_id: 'job-1',
+          status: 'running',
+          progress: { current: 5, total: 10, percent: 50, phase: 'exporting' },
+        },
+      })
+
+      const { result } = renderHook(() => useBulkExport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        await result.current.exportPhotos(['p1.jpg'], 'csv')
+      })
+
+      await waitFor(() => {
+        expect(result.current.isExporting).toBe(true)
+      })
+    })
+
+    it('returns progress from job data', async () => {
+      vi.spyOn(exportApi, 'createExportJob').mockResolvedValue({
+        data: { job_id: 'job-1', status: 'pending' },
+      })
+      vi.spyOn(exportApi, 'getExportJob').mockResolvedValue({
+        data: {
+          job_id: 'job-1',
+          status: 'running',
+          progress: { current: 7, total: 10, percent: 70, phase: 'exporting' },
+        },
+      })
+
+      const { result } = renderHook(() => useBulkExport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        await result.current.exportPhotos(['p1.jpg'], 'json')
+      })
+
+      await waitFor(() => {
+        expect(result.current.progress).toEqual({
+          current: 7,
+          total: 10,
+          percent: 70,
+          phase: 'exporting',
+        })
+      })
+    })
+
+    it('returns error when job fails', async () => {
+      vi.spyOn(exportApi, 'createExportJob').mockResolvedValue({
+        data: { job_id: 'job-1', status: 'pending' },
+      })
+      vi.spyOn(exportApi, 'getExportJob').mockResolvedValue({
+        data: {
+          job_id: 'job-1',
+          status: 'failed',
+          error: 'Export failed: invalid photos',
+          progress: { current: 3, total: 10, percent: 30 },
+        },
+      })
+
+      const { result } = renderHook(() => useBulkExport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        await result.current.exportPhotos(['p1.jpg'], 'json')
+      })
+
+      await waitFor(() => {
+        expect(result.current.error).toBe('Export failed: invalid photos')
+        expect(result.current.isExporting).toBe(false)
+      })
+    })
+  })
+
+  describe('Completion', () => {
+    it('returns downloadUrl when job completes', async () => {
+      vi.spyOn(exportApi, 'createExportJob').mockResolvedValue({
+        data: { job_id: 'job-123', status: 'pending' },
+      })
+      vi.spyOn(exportApi, 'getExportJob').mockResolvedValue({
+        data: {
+          job_id: 'job-123',
+          status: 'completed',
+          progress: { current: 10, total: 10, percent: 100, phase: 'completed' },
+        },
+      })
+      vi.spyOn(exportApi, 'getExportJobDownloadUrl').mockReturnValue('/api/export/jobs/job-123/download')
+
+      const { result } = renderHook(() => useBulkExport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        await result.current.exportPhotos(['p1.jpg'], 'json')
+      })
+
+      await waitFor(() => {
+        expect(result.current.downloadUrl).toBe('/api/export/jobs/job-123/download')
+        expect(result.current.isExporting).toBe(false)
+      })
+    })
+
+    it('calls onComplete callback when job completes', async () => {
+      vi.spyOn(exportApi, 'createExportJob').mockResolvedValue({
+        data: { job_id: 'job-123', status: 'pending' },
+      })
+      vi.spyOn(exportApi, 'getExportJob').mockResolvedValue({
+        data: {
+          job_id: 'job-123',
+          status: 'completed',
+          progress: { current: 10, total: 10, percent: 100 },
+        },
+      })
+      vi.spyOn(exportApi, 'getExportJobDownloadUrl').mockReturnValue('/api/export/jobs/job-123/download')
+
+      const onComplete = vi.fn()
+      const { result } = renderHook(() => useBulkExport({ onComplete }), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        await result.current.exportPhotos(['p1.jpg'], 'json')
+      })
+
+      await waitFor(() => {
+        expect(onComplete).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+
+  describe('Cancellation', () => {
+    it('cancel function cancels running job', async () => {
+      vi.spyOn(exportApi, 'createExportJob').mockResolvedValue({
+        data: { job_id: 'job-123', status: 'pending' },
+      })
+      vi.spyOn(exportApi, 'getExportJob').mockResolvedValue({
+        data: {
+          job_id: 'job-123',
+          status: 'running',
+          progress: { current: 5, total: 10, percent: 50 },
+        },
+      })
+      vi.spyOn(exportApi, 'cancelExportJob').mockResolvedValue({
+        data: { success: true },
+      })
+
+      const { result } = renderHook(() => useBulkExport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        await result.current.exportPhotos(['p1.jpg'], 'json')
+      })
+
+      await act(async () => {
+        await result.current.cancel()
+      })
+
+      expect(exportApi.cancelExportJob).toHaveBeenCalledWith('job-123')
+    })
+
+    it('cancel does nothing when no job is active', async () => {
+      vi.spyOn(exportApi, 'cancelExportJob').mockResolvedValue({
+        data: { success: true },
+      })
+
+      const { result } = renderHook(() => useBulkExport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        await result.current.cancel()
+      })
+
+      expect(exportApi.cancelExportJob).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Reset', () => {
+    it('reset clears all state', async () => {
+      vi.spyOn(exportApi, 'createExportJob').mockResolvedValue({
+        data: { job_id: 'job-123', status: 'pending' },
+      })
+      vi.spyOn(exportApi, 'getExportJob').mockResolvedValue({
+        data: {
+          job_id: 'job-123',
+          status: 'completed',
+          progress: { current: 10, total: 10, percent: 100 },
+        },
+      })
+      vi.spyOn(exportApi, 'getExportJobDownloadUrl').mockReturnValue('/api/export/jobs/job-123/download')
+
+      const { result } = renderHook(() => useBulkExport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        await result.current.exportPhotos(['p1.jpg'], 'json')
+      })
+
+      await waitFor(() => {
+        expect(result.current.jobId).toBe('job-123')
+      })
+
+      act(() => {
+        result.current.reset()
+      })
+
+      expect(result.current.jobId).toBeNull()
+      expect(result.current.isExporting).toBe(false)
+      expect(result.current.progress).toBeNull()
+      expect(result.current.error).toBeNull()
+      expect(result.current.downloadUrl).toBeNull()
+    })
+  })
+
+  describe('Format support', () => {
+    it.each([
+      ['darwin_core'],
+      ['inaturalist'],
+      ['json'],
+      ['csv'],
+    ])('supports %s format', async (format) => {
+      vi.spyOn(exportApi, 'createExportJob').mockResolvedValue({
+        data: { job_id: 'job-1', status: 'pending', format },
+      })
+      vi.spyOn(exportApi, 'getExportJob').mockResolvedValue({
+        data: {
+          job_id: 'job-1',
+          status: 'pending',
+          format,
+          progress: { current: 0, total: 1, percent: 0 },
+        },
+      })
+
+      const { result } = renderHook(() => useBulkExport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        await result.current.exportPhotos(['photo.jpg'], format)
+      })
+
+      // Check first argument (data) matches expected structure
+      const callArgs = exportApi.createExportJob.mock.calls[0]
+      expect(callArgs[0]).toEqual({
+        format,
+        filter: { photo_paths: ['photo.jpg'] },
+      })
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/hooks/__tests__/useBulkExport.test.jsx
+++ b/Firmware/webui/frontend/src/hooks/__tests__/useBulkExport.test.jsx
@@ -153,11 +153,7 @@ describe('useBulkExport', () => {
       })
 
       await act(async () => {
-        try {
-          await result.current.exportPhotos(['photo1.jpg'], 'json')
-        } catch {
-          // Expected to throw
-        }
+        await result.current.exportPhotos(['photo1.jpg'], 'json')
       })
 
       expect(result.current.error).toBeTruthy()

--- a/Firmware/webui/frontend/src/hooks/__tests__/useBulkExport.test.jsx
+++ b/Firmware/webui/frontend/src/hooks/__tests__/useBulkExport.test.jsx
@@ -219,6 +219,48 @@ describe('useBulkExport', () => {
       expect(result.current.error).toBe('Invalid export format. Must be one of: darwin_core, inaturalist, json, csv')
       expect(createSpy).not.toHaveBeenCalled()
     })
+
+    it('handles network timeout during job creation', async () => {
+      const timeoutError = new Error('Network timeout')
+      timeoutError.code = 'ECONNABORTED'
+      vi.spyOn(exportApi, 'createExportJob').mockRejectedValue(timeoutError)
+
+      const { result } = renderHook(() => useBulkExport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        await result.current.exportPhotos(['photo1.jpg'], 'json')
+      })
+
+      expect(result.current.error).toBe('Network timeout')
+      expect(result.current.isExporting).toBe(false)
+      expect(result.current.jobId).toBeNull()
+    })
+
+    it('handles rapid consecutive export calls (resets previous state)', async () => {
+      vi.spyOn(exportApi, 'createExportJob')
+        .mockResolvedValueOnce({ data: { job_id: 'job-1', status: 'pending' } })
+        .mockResolvedValueOnce({ data: { job_id: 'job-2', status: 'pending' } })
+      vi.spyOn(exportApi, 'getExportJob').mockResolvedValue({
+        data: { job_id: 'job-2', status: 'running', progress: { current: 0, total: 5, percent: 0 } },
+      })
+
+      const { result } = renderHook(() => useBulkExport(), {
+        wrapper: createWrapper(),
+      })
+
+      // Rapid consecutive calls
+      await act(async () => {
+        result.current.exportPhotos(['photo1.jpg'], 'json')
+        await result.current.exportPhotos(['photo2.jpg'], 'csv')
+      })
+
+      // Should track the second job (most recent)
+      await waitFor(() => {
+        expect(result.current.jobId).toBe('job-2')
+      })
+    })
   })
 
   describe('Progress tracking', () => {
@@ -505,6 +547,78 @@ describe('useBulkExport', () => {
         format,
         filter: { photo_paths: ['photo.jpg'] },
       })
+    })
+  })
+
+  describe('Polling errors', () => {
+    it('handles network error during job status polling', async () => {
+      vi.spyOn(exportApi, 'createExportJob').mockResolvedValue({
+        data: { job_id: 'job-123', status: 'pending' },
+      })
+      // First poll succeeds, second fails
+      vi.spyOn(exportApi, 'getExportJob')
+        .mockResolvedValueOnce({
+          data: { job_id: 'job-123', status: 'running', progress: { current: 5, total: 10, percent: 50 } },
+        })
+        .mockRejectedValueOnce(new Error('Network error'))
+
+      const { result } = renderHook(() => useBulkExport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        await result.current.exportPhotos(['p1.jpg'], 'json')
+      })
+
+      // Job should still be tracked (React Query handles retries)
+      expect(result.current.jobId).toBe('job-123')
+    })
+  })
+
+  describe('Cleanup', () => {
+    it('handles unmount during active export without errors', async () => {
+      vi.spyOn(exportApi, 'createExportJob').mockResolvedValue({
+        data: { job_id: 'job-123', status: 'pending' },
+      })
+      vi.spyOn(exportApi, 'getExportJob').mockResolvedValue({
+        data: { job_id: 'job-123', status: 'running', progress: { current: 5, total: 10, percent: 50 } },
+      })
+
+      const { result, unmount } = renderHook(() => useBulkExport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        await result.current.exportPhotos(['p1.jpg'], 'json')
+      })
+
+      // Unmount while export is running - should not throw
+      expect(() => unmount()).not.toThrow()
+    })
+
+    it('does not call onComplete after unmount', async () => {
+      vi.spyOn(exportApi, 'createExportJob').mockResolvedValue({
+        data: { job_id: 'job-123', status: 'pending' },
+      })
+      // Simulate in-progress state (not completed yet)
+      vi.spyOn(exportApi, 'getExportJob').mockResolvedValue({
+        data: { job_id: 'job-123', status: 'running', progress: { current: 5, total: 10, percent: 50 } },
+      })
+
+      const onComplete = vi.fn()
+      const { result, unmount } = renderHook(() => useBulkExport({ onComplete }), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        await result.current.exportPhotos(['p1.jpg'], 'json')
+      })
+
+      // Unmount before completion
+      unmount()
+
+      // onComplete should not be called after unmount (job was still running)
+      expect(onComplete).not.toHaveBeenCalled()
     })
   })
 })

--- a/Firmware/webui/frontend/src/hooks/__tests__/useBulkExport.test.jsx
+++ b/Firmware/webui/frontend/src/hooks/__tests__/useBulkExport.test.jsx
@@ -159,6 +159,66 @@ describe('useBulkExport', () => {
       expect(result.current.error).toBeTruthy()
       expect(result.current.isExporting).toBe(false)
     })
+
+    it('validates empty photo array', async () => {
+      const createSpy = vi.spyOn(exportApi, 'createExportJob')
+
+      const { result } = renderHook(() => useBulkExport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        await result.current.exportPhotos([], 'json')
+      })
+
+      expect(result.current.error).toBe('No photos selected for export')
+      expect(createSpy).not.toHaveBeenCalled()
+    })
+
+    it('validates undefined photo array', async () => {
+      const createSpy = vi.spyOn(exportApi, 'createExportJob')
+
+      const { result } = renderHook(() => useBulkExport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        await result.current.exportPhotos(undefined, 'json')
+      })
+
+      expect(result.current.error).toBe('No photos selected for export')
+      expect(createSpy).not.toHaveBeenCalled()
+    })
+
+    it('validates invalid format', async () => {
+      const createSpy = vi.spyOn(exportApi, 'createExportJob')
+
+      const { result } = renderHook(() => useBulkExport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        await result.current.exportPhotos(['photo1.jpg'], 'invalid_format')
+      })
+
+      expect(result.current.error).toBe('Invalid export format. Must be one of: darwin_core, inaturalist, json, csv')
+      expect(createSpy).not.toHaveBeenCalled()
+    })
+
+    it('validates missing format', async () => {
+      const createSpy = vi.spyOn(exportApi, 'createExportJob')
+
+      const { result } = renderHook(() => useBulkExport(), {
+        wrapper: createWrapper(),
+      })
+
+      await act(async () => {
+        await result.current.exportPhotos(['photo1.jpg'], null)
+      })
+
+      expect(result.current.error).toBe('Invalid export format. Must be one of: darwin_core, inaturalist, json, csv')
+      expect(createSpy).not.toHaveBeenCalled()
+    })
   })
 
   describe('Progress tracking', () => {

--- a/Firmware/webui/frontend/src/hooks/useBulkExport.js
+++ b/Firmware/webui/frontend/src/hooks/useBulkExport.js
@@ -81,6 +81,8 @@ export default function useBulkExport({ onComplete } = {}) {
   // Generate download URL when completed
   const downloadUrl = job?.status === 'completed' && jobId ? getExportJobDownloadUrl(jobId) : null
 
+  const VALID_FORMATS = ['darwin_core', 'inaturalist', 'json', 'csv']
+
   /**
    * Start export for multiple photos
    *
@@ -93,6 +95,17 @@ export default function useBulkExport({ onComplete } = {}) {
     setError(null)
     setJobId(null)
     hasCompletedRef.current = false
+
+    // Validate inputs
+    if (!Array.isArray(photoPaths) || photoPaths.length === 0) {
+      setError('No photos selected for export')
+      return
+    }
+
+    if (!format || !VALID_FORMATS.includes(format)) {
+      setError(`Invalid export format. Must be one of: ${VALID_FORMATS.join(', ')}`)
+      return
+    }
 
     try {
       // Create export job

--- a/Firmware/webui/frontend/src/hooks/useBulkExport.js
+++ b/Firmware/webui/frontend/src/hooks/useBulkExport.js
@@ -1,0 +1,164 @@
+/**
+ * React hook for bulk photo export (Issue #127)
+ *
+ * This hook wraps the existing export job system to provide a simplified
+ * interface for exporting multiple photos with progress tracking.
+ *
+ * Features:
+ * - Creates export job with photo_paths filter for multiple photos
+ * - Auto-polls job status while running (via useExportJob)
+ * - Progress tracking during export
+ * - Download URL when completed
+ * - Cancellation support
+ * - Error handling
+ * - Optional onComplete callback
+ *
+ * @param {Object} options - Hook options
+ * @param {Function} [options.onComplete] - Callback when export completes
+ * @returns {Object} Hook state and actions
+ * @returns {Function} exportPhotos - Start export: (photoPaths, format) => Promise<void>
+ * @returns {boolean} isExporting - Whether export is in progress (pending/running)
+ * @returns {Object|null} progress - Progress data: { current, total, percent, phase }
+ * @returns {string|null} error - Error message if export failed
+ * @returns {string|null} jobId - Current job ID
+ * @returns {string|null} downloadUrl - Download URL when completed
+ * @returns {Function} cancel - Cancel running job: () => Promise<void>
+ * @returns {Function} reset - Clear all state: () => void
+ *
+ * @example
+ * const { exportPhotos, isExporting, progress, downloadUrl, cancel, reset } = useBulkExport({
+ *   onComplete: () => console.log('Export complete!')
+ * })
+ *
+ * // Start export
+ * await exportPhotos(['/photos/moth1.jpg', '/photos/moth2.jpg'], 'darwin_core')
+ *
+ * // Display progress
+ * if (isExporting && progress) {
+ *   console.log(`Progress: ${progress.percent}% (${progress.phase})`)
+ * }
+ *
+ * // Cancel export
+ * await cancel()
+ *
+ * // Download completed export
+ * if (downloadUrl) {
+ *   window.open(downloadUrl)
+ * }
+ *
+ * // Reset state
+ * reset()
+ */
+
+import { useState, useEffect, useRef } from 'react'
+import { useCreateExportJob, useExportJob, useCancelExportJob } from './useExportJobs'
+import { getExportJobDownloadUrl } from '../utils/exportApi'
+
+export default function useBulkExport({ onComplete } = {}) {
+  const [jobId, setJobId] = useState(null)
+  const [error, setError] = useState(null)
+  const hasCompletedRef = useRef(false)
+
+  const createExportJob = useCreateExportJob()
+  const jobQuery = useExportJob(jobId)
+  const cancelExportJobMutation = useCancelExportJob()
+
+  // Get job data
+  const job = jobQuery.data
+
+  // Determine if export is in progress
+  const isExporting = job?.status === 'pending' || job?.status === 'running'
+
+  // Get progress data
+  const progress = job?.progress || null
+
+  // Generate download URL when completed
+  const downloadUrl = job?.status === 'completed' && jobId ? getExportJobDownloadUrl(jobId) : null
+
+  /**
+   * Start export for multiple photos
+   *
+   * @param {string[]} photoPaths - Array of absolute paths to photo files
+   * @param {string} format - Export format (darwin_core, inaturalist, json, csv)
+   * @returns {Promise<void>}
+   */
+  const exportPhotos = async (photoPaths, format) => {
+    // Reset state
+    setError(null)
+    setJobId(null)
+    hasCompletedRef.current = false
+
+    try {
+      // Create export job
+      const response = await createExportJob.mutateAsync({
+        format,
+        filter: {
+          photo_paths: photoPaths,
+        },
+      })
+
+      const newJobId = response.data.job_id
+      setJobId(newJobId)
+    } catch (err) {
+      setError(err.message || 'Failed to create export job')
+      throw err
+    }
+  }
+
+  /**
+   * Cancel running export job
+   *
+   * @returns {Promise<void>}
+   */
+  const cancel = async () => {
+    if (!jobId) return
+
+    try {
+      await cancelExportJobMutation.mutateAsync(jobId)
+    } catch (err) {
+      setError(err.message || 'Failed to cancel export job')
+      throw err
+    }
+  }
+
+  /**
+   * Reset state (clear error, progress, stop polling)
+   */
+  const reset = () => {
+    setJobId(null)
+    setError(null)
+    hasCompletedRef.current = false
+  }
+
+  // Handle job completion and failure
+  useEffect(() => {
+    if (!job) return
+
+    // Handle successful completion
+    if (job.status === 'completed' && !hasCompletedRef.current) {
+      hasCompletedRef.current = true
+
+      // Call onComplete callback if provided
+      if (onComplete) {
+        onComplete()
+      }
+    }
+
+    // Handle failure
+    if (job.status === 'failed') {
+      const errorMessage = job.error || 'Export failed'
+      setError(errorMessage)
+    }
+  }, [job, onComplete])
+
+  return {
+    exportPhotos,
+    isExporting,
+    progress,
+    error,
+    jobId,
+    downloadUrl,
+    cancel,
+    reset,
+  }
+}

--- a/Firmware/webui/frontend/src/hooks/useBulkExport.js
+++ b/Firmware/webui/frontend/src/hooks/useBulkExport.js
@@ -53,6 +53,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { useCreateExportJob, useExportJob, useCancelExportJob } from './useExportJobs'
 import { getExportJobDownloadUrl } from '../utils/exportApi'
+import { VALID_EXPORT_FORMAT_IDS } from '../constants/config'
 
 export default function useBulkExport({ onComplete } = {}) {
   const [jobId, setJobId] = useState(null)
@@ -81,8 +82,6 @@ export default function useBulkExport({ onComplete } = {}) {
   // Generate download URL when completed
   const downloadUrl = job?.status === 'completed' && jobId ? getExportJobDownloadUrl(jobId) : null
 
-  const VALID_FORMATS = ['darwin_core', 'inaturalist', 'json', 'csv']
-
   /**
    * Start export for multiple photos
    *
@@ -102,8 +101,8 @@ export default function useBulkExport({ onComplete } = {}) {
       return
     }
 
-    if (!format || !VALID_FORMATS.includes(format)) {
-      setError(`Invalid export format. Must be one of: ${VALID_FORMATS.join(', ')}`)
+    if (!format || !VALID_EXPORT_FORMAT_IDS.includes(format)) {
+      setError(`Invalid export format. Must be one of: ${VALID_EXPORT_FORMAT_IDS.join(', ')}`)
       return
     }
 

--- a/Firmware/webui/frontend/src/hooks/useBulkExport.js
+++ b/Firmware/webui/frontend/src/hooks/useBulkExport.js
@@ -107,7 +107,6 @@ export default function useBulkExport({ onComplete } = {}) {
       setJobId(newJobId)
     } catch (err) {
       setError(err.message || 'Failed to create export job')
-      throw err
     }
   }
 
@@ -123,7 +122,6 @@ export default function useBulkExport({ onComplete } = {}) {
       await cancelExportJobMutation.mutateAsync(jobId)
     } catch (err) {
       setError(err.message || 'Failed to cancel export job')
-      throw err
     }
   }
 

--- a/Firmware/webui/frontend/src/hooks/useBulkExport.js
+++ b/Firmware/webui/frontend/src/hooks/useBulkExport.js
@@ -58,6 +58,12 @@ export default function useBulkExport({ onComplete } = {}) {
   const [jobId, setJobId] = useState(null)
   const [error, setError] = useState(null)
   const hasCompletedRef = useRef(false)
+  const onCompleteRef = useRef(onComplete)
+
+  // Keep ref updated with latest callback
+  useEffect(() => {
+    onCompleteRef.current = onComplete
+  }, [onComplete])
 
   const createExportJob = useCreateExportJob()
   const jobQuery = useExportJob(jobId)
@@ -138,9 +144,9 @@ export default function useBulkExport({ onComplete } = {}) {
     if (job.status === 'completed' && !hasCompletedRef.current) {
       hasCompletedRef.current = true
 
-      // Call onComplete callback if provided
-      if (onComplete) {
-        onComplete()
+      // Call onComplete callback if provided (use ref to avoid stale closure)
+      if (onCompleteRef.current) {
+        onCompleteRef.current()
       }
     }
 
@@ -149,7 +155,7 @@ export default function useBulkExport({ onComplete } = {}) {
       const errorMessage = job.error || 'Export failed'
       setError(errorMessage)
     }
-  }, [job, onComplete])
+  }, [job])
 
   return {
     exportPhotos,

--- a/Firmware/webui/frontend/src/pages/Gallery.jsx
+++ b/Firmware/webui/frontend/src/pages/Gallery.jsx
@@ -12,6 +12,7 @@ import { usePhotoSearch } from '../hooks/usePhotoSearch'
 import useScrollRestoration from '../hooks/useScrollRestoration'
 import useBulkOperations from '../hooks/useBulkOperations'
 import useUndoToast from '../hooks/useUndoToast'
+import useBulkExport from '../hooks/useBulkExport'
 import PhotoSkeleton from '../components/PhotoSkeleton'
 import PhotoGridItem from '../components/PhotoGridItem'
 import PhotoListItem from '../components/PhotoListItem'
@@ -29,6 +30,7 @@ import BulkTagModal from '../components/gallery/BulkTagModal'
 import BulkSpeciesModal from '../components/gallery/BulkSpeciesModal'
 import BulkDeleteConfirmModal from '../components/gallery/BulkDeleteConfirmModal'
 import BulkProgressModal from '../components/gallery/BulkProgressModal'
+import BulkExportModal from '../components/gallery/BulkExportModal'
 import EmptyStateMessage from '../components/EmptyStateMessage'
 import { SearchBar } from '../components/gallery/SearchBar'
 import { AdvancedSearchBuilder } from '../components/gallery/AdvancedSearchBuilder'
@@ -82,10 +84,24 @@ function GalleryContent() {
 
   const { showUndoToast } = useUndoToast()
 
+  // Bulk export hook
+  const {
+    exportPhotos,
+    isExporting,
+    progress: exportProgress,
+    error: exportError,
+    downloadUrl,
+  } = useBulkExport({
+    onComplete: () => {
+      // Will show download button in success state
+    }
+  })
+
   // Modal state
   const [tagModalOpen, setTagModalOpen] = useState(false)
   const [speciesModalOpen, setSpeciesModalOpen] = useState(false)
   const [deleteModalOpen, setDeleteModalOpen] = useState(false)
+  const [exportModalOpen, setExportModalOpen] = useState(false)
   const [progressModalOpen, setProgressModalOpen] = useState(false)
   const [progressState, setProgressState] = useState({
     status: 'processing',
@@ -291,6 +307,34 @@ function GalleryContent() {
     }
   }, [isSeriesError, hasShownSeriesErrorToast])
 
+  // Track export progress and completion
+  useEffect(() => {
+    if (!isExporting && downloadUrl) {
+      // Export completed - show success with download button
+      setProgressState({
+        status: 'success',
+        current: selectedCount,
+        total: selectedCount,
+        message: 'Export complete!',
+        downloadUrl: downloadUrl, // Pass to progress modal
+      })
+    } else if (exportProgress) {
+      setProgressState(prev => ({
+        ...prev,
+        current: exportProgress.current,
+        total: exportProgress.total,
+        message: `${exportProgress.phase}... ${exportProgress.percent}%`,
+      }))
+    } else if (exportError) {
+      setProgressState({
+        status: 'error',
+        current: 0,
+        total: selectedCount,
+        message: exportError,
+      })
+    }
+  }, [isExporting, exportProgress, exportError, downloadUrl, selectedCount])
+
   // Keyboard shortcuts for bulk selection
   useEffect(() => {
     const handleKeyDown = (e) => {
@@ -308,6 +352,15 @@ function GalleryContent() {
       if ((e.ctrlKey || e.metaKey) && e.key === 'a') {
         e.preventDefault()
         selectAll(photos.map(p => p.path))
+        return
+      }
+
+      // Ctrl+E - open export modal (only if photos selected)
+      if ((e.ctrlKey || e.metaKey) && e.key === 'e') {
+        if (selectedCount > 0) {
+          e.preventDefault()
+          setExportModalOpen(true)
+        }
         return
       }
 
@@ -508,9 +561,24 @@ function GalleryContent() {
     }
   }, [selectedPhotos, selectedCount, bulkDelete, deselectAll, refetch])
 
+  const handleBulkExport = useCallback(async (format) => {
+    setExportModalOpen(false)
+    setProgressModalOpen(true)
+    setProgressState({
+      status: 'processing',
+      current: 0,
+      total: selectedCount,
+      message: `Exporting ${selectedCount} photos...`,
+    })
+
+    const photoPaths = Array.from(selectedPhotos)
+    await exportPhotos(photoPaths, format)
+  }, [selectedPhotos, selectedCount, exportPhotos])
+
   // Toolbar action handlers
   const handleTagClick = useCallback(() => setTagModalOpen(true), [])
   const handleSpeciesClick = useCallback(() => setSpeciesModalOpen(true), [])
+  const handleExportClick = useCallback(() => setExportModalOpen(true), [])
   const handleDeleteClick = useCallback(() => setDeleteModalOpen(true), [])
 
   if (isLoading) {
@@ -839,6 +907,7 @@ function GalleryContent() {
           selectedCount={selectedCount}
           onTagClick={handleTagClick}
           onSpeciesClick={handleSpeciesClick}
+          onExportClick={handleExportClick}
           onDeleteClick={handleDeleteClick}
           onDeselectAll={deselectAll}
         />
@@ -867,6 +936,16 @@ function GalleryContent() {
           selectedPhotos={Array.from(selectedPhotos)}
         />
 
+        {/* Bulk Export Modal */}
+        <BulkExportModal
+          isOpen={exportModalOpen}
+          onClose={() => setExportModalOpen(false)}
+          onExport={handleBulkExport}
+          selectedCount={selectedCount}
+          isLoading={isExporting}
+          error={exportError}
+        />
+
         {/* Bulk Progress Modal */}
         <BulkProgressModal
           isOpen={progressModalOpen}
@@ -874,6 +953,8 @@ function GalleryContent() {
           current={progressState.current}
           total={progressState.total}
           message={progressState.message}
+          downloadUrl={progressState.downloadUrl}
+          operation="export"
           onClose={() => setProgressModalOpen(false)}
         />
 

--- a/Firmware/webui/frontend/src/pages/Gallery.jsx
+++ b/Firmware/webui/frontend/src/pages/Gallery.jsx
@@ -103,6 +103,7 @@ function GalleryContent() {
   const [deleteModalOpen, setDeleteModalOpen] = useState(false)
   const [exportModalOpen, setExportModalOpen] = useState(false)
   const [progressModalOpen, setProgressModalOpen] = useState(false)
+  const [progressOperation, setProgressOperation] = useState(null) // 'export' | 'tag' | 'species' | 'delete'
   const [progressState, setProgressState] = useState({
     status: 'processing',
     current: 0,
@@ -307,33 +308,49 @@ function GalleryContent() {
     }
   }, [isSeriesError, hasShownSeriesErrorToast])
 
-  // Track export progress and completion
-  useEffect(() => {
-    if (!isExporting && downloadUrl) {
-      // Export completed - show success with download button
-      setProgressState({
-        status: 'success',
-        current: selectedCount,
-        total: selectedCount,
-        message: 'Export complete!',
-        downloadUrl: downloadUrl, // Pass to progress modal
-      })
-    } else if (exportProgress) {
-      setProgressState(prev => ({
-        ...prev,
-        current: exportProgress.current,
-        total: exportProgress.total,
-        message: `${exportProgress.phase}... ${exportProgress.percent}%`,
-      }))
-    } else if (exportError) {
-      setProgressState({
+  // Derive export progress state from hook (avoids race condition with manual updates)
+  const exportProgressState = useMemo(() => {
+    if (progressOperation !== 'export') return null
+
+    if (exportError) {
+      return {
         status: 'error',
         current: 0,
         total: selectedCount,
         message: exportError,
-      })
+      }
     }
-  }, [isExporting, exportProgress, exportError, downloadUrl, selectedCount])
+
+    if (!isExporting && downloadUrl) {
+      return {
+        status: 'success',
+        current: selectedCount,
+        total: selectedCount,
+        message: 'Export complete!',
+        downloadUrl: downloadUrl,
+      }
+    }
+
+    if (exportProgress) {
+      return {
+        status: 'processing',
+        current: exportProgress.current,
+        total: exportProgress.total,
+        message: `${exportProgress.phase}... ${exportProgress.percent}%`,
+      }
+    }
+
+    // Initial state while waiting for first progress update
+    return {
+      status: 'processing',
+      current: 0,
+      total: selectedCount,
+      message: `Exporting ${selectedCount} photos...`,
+    }
+  }, [progressOperation, isExporting, exportProgress, exportError, downloadUrl, selectedCount])
+
+  // Current progress state (export uses derived state, others use manual state)
+  const currentProgressState = progressOperation === 'export' ? exportProgressState : progressState
 
   // Keyboard shortcuts for bulk selection
   useEffect(() => {
@@ -564,16 +581,11 @@ function GalleryContent() {
   const handleBulkExport = useCallback(async (format) => {
     setExportModalOpen(false)
     setProgressModalOpen(true)
-    setProgressState({
-      status: 'processing',
-      current: 0,
-      total: selectedCount,
-      message: `Exporting ${selectedCount} photos...`,
-    })
+    setProgressOperation('export')
 
     const photoPaths = Array.from(selectedPhotos)
     await exportPhotos(photoPaths, format)
-  }, [selectedPhotos, selectedCount, exportPhotos])
+  }, [selectedPhotos, exportPhotos])
 
   // Toolbar action handlers
   const handleTagClick = useCallback(() => setTagModalOpen(true), [])
@@ -949,13 +961,16 @@ function GalleryContent() {
         {/* Bulk Progress Modal */}
         <BulkProgressModal
           isOpen={progressModalOpen}
-          status={progressState.status}
-          current={progressState.current}
-          total={progressState.total}
-          message={progressState.message}
-          downloadUrl={progressState.downloadUrl}
-          operation="export"
-          onClose={() => setProgressModalOpen(false)}
+          status={currentProgressState?.status}
+          current={currentProgressState?.current}
+          total={currentProgressState?.total}
+          message={currentProgressState?.message}
+          downloadUrl={currentProgressState?.downloadUrl}
+          operation={progressOperation || 'tag'}
+          onClose={() => {
+            setProgressModalOpen(false)
+            setProgressOperation(null)
+          }}
         />
 
         {/* Advanced Search Modal */}

--- a/Firmware/webui/frontend/src/pages/__tests__/Gallery.bulk-selection.test.jsx
+++ b/Firmware/webui/frontend/src/pages/__tests__/Gallery.bulk-selection.test.jsx
@@ -607,4 +607,80 @@ describe('Gallery - Bulk Selection Integration', () => {
       })
     })
   })
+
+  describe('Export Functionality (Issue #127)', () => {
+    it('Export button opens BulkExportModal when photos are selected', async () => {
+      const user = userEvent.setup()
+      renderGallery()
+
+      await screen.findByAltText('photo-1.jpg')
+
+      // Enter select mode and select a photo
+      const selectButton = screen.getByRole('button', { name: /enter selection mode/i })
+      await user.click(selectButton)
+
+      // Wait for checkboxes and select one
+      await waitFor(() => {
+        expect(screen.getAllByRole('checkbox').length).toBeGreaterThan(0)
+      })
+      await user.click(screen.getAllByRole('checkbox')[0])
+
+      // Wait for toolbar
+      await screen.findByRole('toolbar', { name: /bulk actions/i })
+
+      // Click Export button
+      const exportButton = screen.getByRole('button', { name: /export selected/i })
+      await user.click(exportButton)
+
+      // Export modal should appear
+      await waitFor(() => {
+        expect(screen.getByRole('dialog', { name: /export/i })).toBeInTheDocument()
+      })
+    })
+
+    it('Ctrl+E opens export modal when photos are selected', async () => {
+      const user = userEvent.setup()
+      renderGallery()
+
+      await screen.findByAltText('photo-1.jpg')
+
+      // Enter select mode and select a photo
+      const selectButton = screen.getByRole('button', { name: /enter selection mode/i })
+      await user.click(selectButton)
+
+      // Wait for checkboxes and select one
+      await waitFor(() => {
+        expect(screen.getAllByRole('checkbox').length).toBeGreaterThan(0)
+      })
+      await user.click(screen.getAllByRole('checkbox')[0])
+
+      // Wait for toolbar to appear
+      await screen.findByRole('toolbar', { name: /bulk actions/i })
+
+      // Press Ctrl+E
+      await user.keyboard('{Control>}e{/Control}')
+
+      // Export modal should appear
+      await waitFor(() => {
+        expect(screen.getByRole('dialog', { name: /export/i })).toBeInTheDocument()
+      })
+    })
+
+    it('Ctrl+E does nothing when no photos are selected', async () => {
+      const user = userEvent.setup()
+      renderGallery()
+
+      await screen.findByAltText('photo-1.jpg')
+
+      // Enter select mode but don't select any photos
+      const selectButton = screen.getByRole('button', { name: /enter selection mode/i })
+      await user.click(selectButton)
+
+      // Press Ctrl+E
+      await user.keyboard('{Control>}e{/Control}')
+
+      // Export modal should NOT appear
+      expect(screen.queryByRole('dialog', { name: /export/i })).not.toBeInTheDocument()
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- Add Export button to BulkActionsToolbar for bulk photo export
- Create BulkExportModal component with format selection (Darwin Core, iNaturalist, JSON, CSV)
- Create useBulkExport hook for export job management with progress tracking
- Add keyboard shortcut Ctrl+E (Cmd+E on Mac) to open export modal
- Enhance BulkProgressModal to support download URL for export completion

## Changes
- **New Files:**
  - `BulkExportModal.jsx` - Modal with radio button format cards
  - `useBulkExport.js` - Hook wrapping export job API with progress polling
  - Test files for both components

- **Modified Files:**
  - `BulkActionsToolbar.jsx` - Added Export button with ArrowDownTray icon
  - `BulkProgressModal.jsx` - Added download URL support for export completion
  - `Gallery.jsx` - Integrated export modal, hook, and Ctrl+E shortcut

## Test plan
- [x] BulkActionsToolbar tests (53 tests) - Export button renders and fires callback
- [x] BulkExportModal tests (32 tests) - Format selection, accessibility, dark mode
- [x] useBulkExport tests (18 tests) - Job creation, progress tracking, completion
- [x] Gallery.bulk-selection tests (24 tests) - Export integration, Ctrl+E shortcut
- [x] All 178 relevant tests passing
- [x] 0 lint errors

Closes #127