### PR TITLE
feat(scheduler): Add schedule schema dataclasses (#208)

### DIFF
--- a/Firmware/Tests/unit/test_schedule_schema.py
+++ b/Firmware/Tests/unit/test_schedule_schema.py
@@ -1,0 +1,1114 @@
+"""
+Unit tests for schedule schema dataclasses.
+
+Tests the core schedule schema including:
+- PatternAction, EventPattern dataclasses
+- TimeWindow and trigger dataclasses (Interval, Solar, MoonPhase, FixedTime, Sensor)
+- Schedule dataclass with embedded event patterns
+- Validation functions for all types
+
+Coverage target: 85%+
+Test count target: 40+
+
+Issue #208 - Scheduler Phase 1: Schedule Schema
+"""
+
+import json
+import re
+import uuid
+from datetime import datetime
+
+import pytest
+
+# Check if implementation exists for graceful skipping during TDD
+try:
+    from webui.backend.lib.schedule_schema import (
+        # Constants
+        ACTION_TYPES,
+        GPIO_ACTIONS,
+        MAX_ACTIONS_PER_PATTERN,
+        MAX_DESCRIPTION_LENGTH,
+        MAX_OFFSET_MINUTES,
+        MAX_PATTERN_NAME_LENGTH,
+        MAX_PATTERNS_PER_SCHEDULE,
+        MOON_PHASES,
+        SCHEDULE_SCHEMA_VERSION,
+        SENSOR_COMPARISONS,
+        SENSOR_TYPES,
+        SOLAR_EVENTS,
+        SUPPORTED_VERSIONS,
+        TRIGGER_TYPES,
+        # Dataclasses
+        EventPattern,
+        FixedTimeTrigger,
+        IntervalTrigger,
+        MoonPhaseTrigger,
+        PatternAction,
+        Schedule,
+        ScheduleValidationError,
+        SensorTrigger,
+        SolarTrigger,
+        TimeWindow,
+        # Validation functions
+        validate_event_pattern,
+        validate_fixed_time_trigger,
+        validate_interval_trigger,
+        validate_moon_phase_trigger,
+        validate_pattern_action,
+        validate_schedule,
+        validate_sensor_trigger,
+        validate_solar_trigger,
+        validate_time_window,
+    )
+
+    IMPLEMENTATION_EXISTS = True
+except ImportError:
+    IMPLEMENTATION_EXISTS = False
+
+
+pytestmark = pytest.mark.skipif(
+    not IMPLEMENTATION_EXISTS,
+    reason="schedule_schema.py not yet implemented",
+)
+
+
+# =============================================================================
+# FIXTURES
+# =============================================================================
+
+
+@pytest.fixture
+def sample_pattern_action():
+    """Create a sample PatternAction for testing."""
+    return PatternAction(
+        action_type="gpio",
+        action_name="attract_on",
+        offset_minutes=0,
+        parameters={},
+        description="Turn on attract lights",
+    )
+
+
+@pytest.fixture
+def sample_pattern_action_camera():
+    """Create a camera PatternAction for testing."""
+    return PatternAction(
+        action_type="camera",
+        action_name="takephoto",
+        offset_minutes=5,
+        parameters={"hdr": True},
+        description="Take photo with HDR",
+    )
+
+
+@pytest.fixture
+def sample_event_pattern(sample_pattern_action, sample_pattern_action_camera):
+    """Create a sample EventPattern for testing."""
+    return EventPattern(
+        pattern_id="test-pattern-id",
+        name="UV Capture Cycle",
+        description="Turn on lights, take photo, turn off lights",
+        actions=[
+            sample_pattern_action,
+            sample_pattern_action_camera,
+            PatternAction(
+                action_type="gpio",
+                action_name="attract_off",
+                offset_minutes=15,
+            ),
+        ],
+        category="user",
+        tags=["night", "moths"],
+    )
+
+
+@pytest.fixture
+def sample_time_window():
+    """Create a sample TimeWindow for testing."""
+    return TimeWindow(
+        start_time="21:00",
+        end_time="05:00",
+        start_offset_minutes=0,
+        end_offset_minutes=0,
+    )
+
+
+@pytest.fixture
+def sample_time_window_solar():
+    """Create a solar-based TimeWindow for testing."""
+    return TimeWindow(
+        start_time="sunset",
+        end_time="sunrise",
+        start_offset_minutes=30,
+        end_offset_minutes=-30,
+    )
+
+
+@pytest.fixture
+def sample_interval_trigger(sample_time_window):
+    """Create a sample IntervalTrigger for testing."""
+    return IntervalTrigger(
+        interval_minutes=60,
+        time_window=sample_time_window,
+        days_of_week=None,
+    )
+
+
+@pytest.fixture
+def sample_solar_trigger():
+    """Create a sample SolarTrigger for testing."""
+    return SolarTrigger(
+        solar_event="sunset",
+        offset_minutes=30,
+        days_of_week=[0, 1, 2, 3, 4],
+    )
+
+
+@pytest.fixture
+def sample_moon_phase_trigger(sample_time_window):
+    """Create a sample MoonPhaseTrigger for testing."""
+    return MoonPhaseTrigger(
+        phases=["full", "waxing_gibbous"],
+        offset_days=2,
+        time_window=sample_time_window,
+    )
+
+
+@pytest.fixture
+def sample_fixed_time_trigger():
+    """Create a sample FixedTimeTrigger for testing."""
+    return FixedTimeTrigger(
+        time="21:00",
+        days_of_week=[0, 1, 2, 3, 4, 5, 6],
+    )
+
+
+@pytest.fixture
+def sample_sensor_trigger(sample_time_window):
+    """Create a sample SensorTrigger for testing."""
+    return SensorTrigger(
+        sensor_type="motion",
+        threshold=0.0,
+        comparison="gt",
+        cooldown_minutes=5,
+        time_window=sample_time_window,
+    )
+
+
+@pytest.fixture
+def sample_schedule(sample_event_pattern, sample_interval_trigger):
+    """Create a sample Schedule for testing."""
+    return Schedule(
+        schedule_id="test-schedule-id",
+        name="Nightly Moth Survey",
+        description="Hourly captures from dusk to dawn",
+        event_patterns=[sample_event_pattern],
+        trigger_type="interval",
+        interval_trigger=sample_interval_trigger,
+        start_date="2024-06-01",
+        end_date="2024-08-31",
+        deployment_id=None,
+        create_deployment=False,
+        enabled=True,
+        is_active=False,
+    )
+
+
+# =============================================================================
+# CONSTANTS TESTS
+# =============================================================================
+
+
+class TestScheduleSchemaConstants:
+    """Test schema constants are defined correctly."""
+
+    def test_schema_version_defined(self):
+        """SCHEDULE_SCHEMA_VERSION should be defined."""
+        assert SCHEDULE_SCHEMA_VERSION == "2.0"
+
+    def test_supported_versions_includes_current(self):
+        """SUPPORTED_VERSIONS should include current version."""
+        assert SCHEDULE_SCHEMA_VERSION in SUPPORTED_VERSIONS
+
+    def test_action_types_defined(self):
+        """ACTION_TYPES should include all expected types."""
+        expected = ["gpio", "camera", "gps_sync", "service"]
+        assert ACTION_TYPES == expected
+
+    def test_gpio_actions_defined(self):
+        """GPIO_ACTIONS should include all expected actions."""
+        expected = ["attract_on", "attract_off", "flash_on", "flash_off"]
+        assert GPIO_ACTIONS == expected
+
+    def test_trigger_types_defined(self):
+        """TRIGGER_TYPES should include all expected types."""
+        expected = ["interval", "solar", "moon_phase", "fixed_time", "sensor"]
+        assert TRIGGER_TYPES == expected
+
+    def test_moon_phases_defined(self):
+        """MOON_PHASES should include all 8 phases."""
+        assert len(MOON_PHASES) == 8
+        assert "full" in MOON_PHASES
+        assert "new" in MOON_PHASES
+
+    def test_solar_events_defined(self):
+        """SOLAR_EVENTS should include core events."""
+        assert "dawn" in SOLAR_EVENTS
+        assert "sunrise" in SOLAR_EVENTS
+        assert "sunset" in SOLAR_EVENTS
+        assert "dusk" in SOLAR_EVENTS
+
+    def test_sensor_types_defined(self):
+        """SENSOR_TYPES should include expected types."""
+        expected = ["motion", "light", "temperature"]
+        assert SENSOR_TYPES == expected
+
+    def test_sensor_comparisons_defined(self):
+        """SENSOR_COMPARISONS should include all operators."""
+        expected = ["gt", "lt", "eq", "gte", "lte"]
+        assert SENSOR_COMPARISONS == expected
+
+    def test_validation_limits_defined(self):
+        """Validation limits should be defined."""
+        assert MAX_PATTERN_NAME_LENGTH == 200
+        assert MAX_DESCRIPTION_LENGTH == 2000
+        assert MAX_ACTIONS_PER_PATTERN == 20
+        assert MAX_PATTERNS_PER_SCHEDULE == 10
+        assert MAX_OFFSET_MINUTES == 1440
+
+
+# =============================================================================
+# PATTERN ACTION TESTS
+# =============================================================================
+
+
+class TestPatternAction:
+    """Test PatternAction dataclass."""
+
+    def test_instantiation_minimal(self):
+        """PatternAction can be created with minimal args."""
+        action = PatternAction(action_type="gpio", action_name="attract_on")
+        assert action.action_type == "gpio"
+        assert action.action_name == "attract_on"
+        assert action.offset_minutes == 0
+        assert action.parameters == {}
+        assert action.description == ""
+
+    def test_instantiation_full(self, sample_pattern_action):
+        """PatternAction can be created with all args."""
+        assert sample_pattern_action.action_type == "gpio"
+        assert sample_pattern_action.action_name == "attract_on"
+        assert sample_pattern_action.offset_minutes == 0
+        assert sample_pattern_action.description == "Turn on attract lights"
+
+    def test_to_dict(self, sample_pattern_action):
+        """PatternAction.to_dict() returns correct dict."""
+        data = sample_pattern_action.to_dict()
+        assert data["action_type"] == "gpio"
+        assert data["action_name"] == "attract_on"
+        assert data["offset_minutes"] == 0
+        assert data["parameters"] == {}
+        assert data["description"] == "Turn on attract lights"
+
+    def test_from_dict(self):
+        """PatternAction.from_dict() creates instance from dict."""
+        data = {
+            "action_type": "camera",
+            "action_name": "takephoto",
+            "offset_minutes": 5,
+            "parameters": {"hdr": True},
+            "description": "Take HDR photo",
+        }
+        action = PatternAction.from_dict(data)
+        assert action.action_type == "camera"
+        assert action.action_name == "takephoto"
+        assert action.offset_minutes == 5
+        assert action.parameters == {"hdr": True}
+        assert action.description == "Take HDR photo"
+
+    def test_round_trip_serialization(self, sample_pattern_action):
+        """PatternAction survives JSON round-trip."""
+        data = sample_pattern_action.to_dict()
+        json_str = json.dumps(data)
+        loaded = json.loads(json_str)
+        restored = PatternAction.from_dict(loaded)
+        assert restored.action_type == sample_pattern_action.action_type
+        assert restored.action_name == sample_pattern_action.action_name
+        assert restored.offset_minutes == sample_pattern_action.offset_minutes
+
+
+# =============================================================================
+# EVENT PATTERN TESTS
+# =============================================================================
+
+
+class TestEventPattern:
+    """Test EventPattern dataclass."""
+
+    def test_instantiation_minimal(self):
+        """EventPattern can be created with minimal args."""
+        pattern = EventPattern(pattern_id="", name="Test Pattern")
+        assert pattern.name == "Test Pattern"
+        assert pattern.description == ""
+        assert pattern.actions == []
+        assert pattern.category == "user"
+        assert pattern.tags == []
+
+    def test_uuid_generation_on_empty_id(self):
+        """EventPattern generates UUID when pattern_id is empty."""
+        pattern = EventPattern(pattern_id="", name="Test")
+        # Should be a valid UUID
+        uuid.UUID(pattern.pattern_id)
+
+    def test_duration_minutes_computed(self, sample_event_pattern):
+        """EventPattern.duration_minutes returns max offset."""
+        # Actions have offsets 0, 5, 15
+        assert sample_event_pattern.duration_minutes == 15
+
+    def test_duration_minutes_empty_actions(self):
+        """EventPattern.duration_minutes is 0 with no actions."""
+        pattern = EventPattern(pattern_id="test", name="Empty")
+        assert pattern.duration_minutes == 0
+
+    def test_to_dict(self, sample_event_pattern):
+        """EventPattern.to_dict() returns correct dict."""
+        data = sample_event_pattern.to_dict()
+        assert data["pattern_id"] == "test-pattern-id"
+        assert data["name"] == "UV Capture Cycle"
+        assert len(data["actions"]) == 3
+        assert data["category"] == "user"
+        assert data["tags"] == ["night", "moths"]
+        assert data["duration_minutes"] == 15
+
+    def test_from_dict(self):
+        """EventPattern.from_dict() creates instance from dict."""
+        data = {
+            "pattern_id": "p-123",
+            "name": "Test Pattern",
+            "description": "A test pattern",
+            "actions": [
+                {"action_type": "gpio", "action_name": "attract_on", "offset_minutes": 0},
+                {"action_type": "camera", "action_name": "takephoto", "offset_minutes": 5},
+            ],
+            "category": "built-in",
+            "tags": ["test"],
+        }
+        pattern = EventPattern.from_dict(data)
+        assert pattern.pattern_id == "p-123"
+        assert pattern.name == "Test Pattern"
+        assert len(pattern.actions) == 2
+        assert pattern.actions[0].action_type == "gpio"
+        assert pattern.category == "built-in"
+
+    def test_round_trip_serialization(self, sample_event_pattern):
+        """EventPattern survives JSON round-trip."""
+        data = sample_event_pattern.to_dict()
+        json_str = json.dumps(data)
+        loaded = json.loads(json_str)
+        restored = EventPattern.from_dict(loaded)
+        assert restored.name == sample_event_pattern.name
+        assert len(restored.actions) == len(sample_event_pattern.actions)
+        assert restored.duration_minutes == sample_event_pattern.duration_minutes
+
+
+# =============================================================================
+# TIME WINDOW TESTS
+# =============================================================================
+
+
+class TestTimeWindow:
+    """Test TimeWindow dataclass."""
+
+    def test_instantiation_fixed_times(self, sample_time_window):
+        """TimeWindow can be created with fixed times."""
+        assert sample_time_window.start_time == "21:00"
+        assert sample_time_window.end_time == "05:00"
+        assert sample_time_window.start_offset_minutes == 0
+        assert sample_time_window.end_offset_minutes == 0
+
+    def test_instantiation_solar_times(self, sample_time_window_solar):
+        """TimeWindow can be created with solar events."""
+        assert sample_time_window_solar.start_time == "sunset"
+        assert sample_time_window_solar.end_time == "sunrise"
+        assert sample_time_window_solar.start_offset_minutes == 30
+        assert sample_time_window_solar.end_offset_minutes == -30
+
+    def test_to_dict(self, sample_time_window):
+        """TimeWindow.to_dict() returns correct dict."""
+        data = sample_time_window.to_dict()
+        assert data["start_time"] == "21:00"
+        assert data["end_time"] == "05:00"
+        assert data["start_offset_minutes"] == 0
+        assert data["end_offset_minutes"] == 0
+
+    def test_from_dict(self):
+        """TimeWindow.from_dict() creates instance from dict."""
+        data = {
+            "start_time": "sunset",
+            "end_time": "06:00",
+            "start_offset_minutes": 15,
+            "end_offset_minutes": 0,
+        }
+        window = TimeWindow.from_dict(data)
+        assert window.start_time == "sunset"
+        assert window.end_time == "06:00"
+        assert window.start_offset_minutes == 15
+
+    def test_round_trip_serialization(self, sample_time_window_solar):
+        """TimeWindow survives JSON round-trip."""
+        data = sample_time_window_solar.to_dict()
+        json_str = json.dumps(data)
+        loaded = json.loads(json_str)
+        restored = TimeWindow.from_dict(loaded)
+        assert restored.start_time == sample_time_window_solar.start_time
+        assert restored.start_offset_minutes == sample_time_window_solar.start_offset_minutes
+
+
+# =============================================================================
+# INTERVAL TRIGGER TESTS
+# =============================================================================
+
+
+class TestIntervalTrigger:
+    """Test IntervalTrigger dataclass."""
+
+    def test_instantiation(self, sample_interval_trigger):
+        """IntervalTrigger can be created."""
+        assert sample_interval_trigger.interval_minutes == 60
+        assert sample_interval_trigger.time_window is not None
+        assert sample_interval_trigger.days_of_week is None
+
+    def test_instantiation_with_days(self, sample_time_window):
+        """IntervalTrigger can be created with days_of_week."""
+        trigger = IntervalTrigger(
+            interval_minutes=30,
+            time_window=sample_time_window,
+            days_of_week=[0, 1, 2, 3, 4],
+        )
+        assert trigger.days_of_week == [0, 1, 2, 3, 4]
+
+    def test_to_dict(self, sample_interval_trigger):
+        """IntervalTrigger.to_dict() returns correct dict."""
+        data = sample_interval_trigger.to_dict()
+        assert data["interval_minutes"] == 60
+        assert "time_window" in data
+        assert data["time_window"]["start_time"] == "21:00"
+
+    def test_from_dict(self):
+        """IntervalTrigger.from_dict() creates instance from dict."""
+        data = {
+            "interval_minutes": 120,
+            "time_window": {
+                "start_time": "22:00",
+                "end_time": "04:00",
+                "start_offset_minutes": 0,
+                "end_offset_minutes": 0,
+            },
+            "days_of_week": [5, 6],
+        }
+        trigger = IntervalTrigger.from_dict(data)
+        assert trigger.interval_minutes == 120
+        assert trigger.time_window.start_time == "22:00"
+        assert trigger.days_of_week == [5, 6]
+
+
+# =============================================================================
+# SOLAR TRIGGER TESTS
+# =============================================================================
+
+
+class TestSolarTrigger:
+    """Test SolarTrigger dataclass."""
+
+    def test_instantiation(self, sample_solar_trigger):
+        """SolarTrigger can be created."""
+        assert sample_solar_trigger.solar_event == "sunset"
+        assert sample_solar_trigger.offset_minutes == 30
+        assert sample_solar_trigger.days_of_week == [0, 1, 2, 3, 4]
+
+    def test_instantiation_minimal(self):
+        """SolarTrigger can be created with minimal args."""
+        trigger = SolarTrigger(solar_event="sunrise")
+        assert trigger.solar_event == "sunrise"
+        assert trigger.offset_minutes == 0
+        assert trigger.days_of_week is None
+
+    def test_to_dict(self, sample_solar_trigger):
+        """SolarTrigger.to_dict() returns correct dict."""
+        data = sample_solar_trigger.to_dict()
+        assert data["solar_event"] == "sunset"
+        assert data["offset_minutes"] == 30
+        assert data["days_of_week"] == [0, 1, 2, 3, 4]
+
+    def test_from_dict(self):
+        """SolarTrigger.from_dict() creates instance from dict."""
+        data = {
+            "solar_event": "astronomical_dusk",
+            "offset_minutes": -15,
+            "days_of_week": None,
+        }
+        trigger = SolarTrigger.from_dict(data)
+        assert trigger.solar_event == "astronomical_dusk"
+        assert trigger.offset_minutes == -15
+
+
+# =============================================================================
+# MOON PHASE TRIGGER TESTS
+# =============================================================================
+
+
+class TestMoonPhaseTrigger:
+    """Test MoonPhaseTrigger dataclass."""
+
+    def test_instantiation(self, sample_moon_phase_trigger):
+        """MoonPhaseTrigger can be created."""
+        assert sample_moon_phase_trigger.phases == ["full", "waxing_gibbous"]
+        assert sample_moon_phase_trigger.offset_days == 2
+        assert sample_moon_phase_trigger.time_window is not None
+
+    def test_instantiation_minimal(self):
+        """MoonPhaseTrigger can be created with minimal args."""
+        trigger = MoonPhaseTrigger(phases=["full"])
+        assert trigger.phases == ["full"]
+        assert trigger.offset_days == 0
+        assert trigger.time_window is None
+
+    def test_to_dict(self, sample_moon_phase_trigger):
+        """MoonPhaseTrigger.to_dict() returns correct dict."""
+        data = sample_moon_phase_trigger.to_dict()
+        assert data["phases"] == ["full", "waxing_gibbous"]
+        assert data["offset_days"] == 2
+        assert data["time_window"] is not None
+
+    def test_from_dict(self):
+        """MoonPhaseTrigger.from_dict() creates instance from dict."""
+        data = {
+            "phases": ["new", "waxing_crescent"],
+            "offset_days": 1,
+            "time_window": None,
+        }
+        trigger = MoonPhaseTrigger.from_dict(data)
+        assert trigger.phases == ["new", "waxing_crescent"]
+        assert trigger.offset_days == 1
+        assert trigger.time_window is None
+
+
+# =============================================================================
+# FIXED TIME TRIGGER TESTS
+# =============================================================================
+
+
+class TestFixedTimeTrigger:
+    """Test FixedTimeTrigger dataclass."""
+
+    def test_instantiation(self, sample_fixed_time_trigger):
+        """FixedTimeTrigger can be created."""
+        assert sample_fixed_time_trigger.time == "21:00"
+        assert sample_fixed_time_trigger.days_of_week == [0, 1, 2, 3, 4, 5, 6]
+
+    def test_instantiation_minimal(self):
+        """FixedTimeTrigger can be created with minimal args."""
+        trigger = FixedTimeTrigger(time="06:30")
+        assert trigger.time == "06:30"
+        assert trigger.days_of_week is None
+
+    def test_to_dict(self, sample_fixed_time_trigger):
+        """FixedTimeTrigger.to_dict() returns correct dict."""
+        data = sample_fixed_time_trigger.to_dict()
+        assert data["time"] == "21:00"
+        assert data["days_of_week"] == [0, 1, 2, 3, 4, 5, 6]
+
+    def test_from_dict(self):
+        """FixedTimeTrigger.from_dict() creates instance from dict."""
+        data = {"time": "12:00", "days_of_week": [0, 2, 4]}
+        trigger = FixedTimeTrigger.from_dict(data)
+        assert trigger.time == "12:00"
+        assert trigger.days_of_week == [0, 2, 4]
+
+
+# =============================================================================
+# SENSOR TRIGGER TESTS
+# =============================================================================
+
+
+class TestSensorTrigger:
+    """Test SensorTrigger dataclass."""
+
+    def test_instantiation(self, sample_sensor_trigger):
+        """SensorTrigger can be created."""
+        assert sample_sensor_trigger.sensor_type == "motion"
+        assert sample_sensor_trigger.threshold == 0.0
+        assert sample_sensor_trigger.comparison == "gt"
+        assert sample_sensor_trigger.cooldown_minutes == 5
+        assert sample_sensor_trigger.time_window is not None
+
+    def test_instantiation_minimal(self):
+        """SensorTrigger can be created with minimal args."""
+        trigger = SensorTrigger(sensor_type="light")
+        assert trigger.sensor_type == "light"
+        assert trigger.threshold == 0.0
+        assert trigger.comparison == "gt"
+        assert trigger.cooldown_minutes == 5
+        assert trigger.time_window is None
+
+    def test_to_dict(self, sample_sensor_trigger):
+        """SensorTrigger.to_dict() returns correct dict."""
+        data = sample_sensor_trigger.to_dict()
+        assert data["sensor_type"] == "motion"
+        assert data["threshold"] == 0.0
+        assert data["comparison"] == "gt"
+        assert data["cooldown_minutes"] == 5
+
+    def test_from_dict(self):
+        """SensorTrigger.from_dict() creates instance from dict."""
+        data = {
+            "sensor_type": "temperature",
+            "threshold": 25.0,
+            "comparison": "lt",
+            "cooldown_minutes": 10,
+            "time_window": None,
+        }
+        trigger = SensorTrigger.from_dict(data)
+        assert trigger.sensor_type == "temperature"
+        assert trigger.threshold == 25.0
+        assert trigger.comparison == "lt"
+
+
+# =============================================================================
+# SCHEDULE TESTS
+# =============================================================================
+
+
+class TestSchedule:
+    """Test Schedule dataclass."""
+
+    def test_instantiation(self, sample_schedule):
+        """Schedule can be created."""
+        assert sample_schedule.schedule_id == "test-schedule-id"
+        assert sample_schedule.name == "Nightly Moth Survey"
+        assert len(sample_schedule.event_patterns) == 1
+        assert sample_schedule.trigger_type == "interval"
+        assert sample_schedule.interval_trigger is not None
+        assert sample_schedule.enabled is True
+        assert sample_schedule.is_active is False
+
+    def test_uuid_generation_on_empty_id(self):
+        """Schedule generates UUID when schedule_id is empty."""
+        schedule = Schedule(schedule_id="", name="Test", trigger_type="interval")
+        uuid.UUID(schedule.schedule_id)
+
+    def test_timestamps_generated(self):
+        """Schedule generates timestamps when empty."""
+        schedule = Schedule(schedule_id="test", name="Test", trigger_type="interval")
+        assert schedule.created_at != ""
+        assert schedule.modified_at != ""
+        # Validate ISO format
+        datetime.fromisoformat(schedule.created_at.replace("Z", "+00:00"))
+
+    def test_total_duration_minutes(self, sample_schedule):
+        """Schedule.total_duration_minutes sums pattern durations."""
+        # Single pattern with duration 15
+        assert sample_schedule.total_duration_minutes == 15
+
+    def test_total_duration_multiple_patterns(self, sample_event_pattern):
+        """Schedule.total_duration_minutes handles multiple patterns."""
+        pattern2 = EventPattern(
+            pattern_id="p2",
+            name="Extra",
+            actions=[
+                PatternAction(action_type="gpio", action_name="flash_on", offset_minutes=10),
+            ],
+        )
+        schedule = Schedule(
+            schedule_id="s1",
+            name="Multi",
+            trigger_type="interval",
+            event_patterns=[sample_event_pattern, pattern2],
+        )
+        # 15 + 10 = 25
+        assert schedule.total_duration_minutes == 25
+
+    def test_to_dict_includes_schema_version(self, sample_schedule):
+        """Schedule.to_dict() includes schema_version."""
+        data = sample_schedule.to_dict()
+        assert data["schema_version"] == SCHEDULE_SCHEMA_VERSION
+        assert data["schedule_id"] == "test-schedule-id"
+        assert data["name"] == "Nightly Moth Survey"
+        assert len(data["event_patterns"]) == 1
+
+    def test_from_dict(self, sample_event_pattern, sample_time_window):
+        """Schedule.from_dict() creates instance from dict."""
+        data = {
+            "schema_version": "2.0",
+            "schedule_id": "s-123",
+            "name": "Test Schedule",
+            "description": "A test schedule",
+            "event_patterns": [sample_event_pattern.to_dict()],
+            "trigger_type": "interval",
+            "interval_trigger": {
+                "interval_minutes": 30,
+                "time_window": sample_time_window.to_dict(),
+                "days_of_week": None,
+            },
+            "solar_trigger": None,
+            "moon_phase_trigger": None,
+            "fixed_time_trigger": None,
+            "sensor_trigger": None,
+            "start_date": "2024-01-01",
+            "end_date": "2024-12-31",
+            "deployment_id": "dep-456",
+            "create_deployment": True,
+            "enabled": True,
+            "is_active": False,
+            "created_at": "2024-01-01T00:00:00Z",
+            "modified_at": "2024-01-01T00:00:00Z",
+            "modified_by": "user123",
+        }
+        schedule = Schedule.from_dict(data)
+        assert schedule.schedule_id == "s-123"
+        assert schedule.name == "Test Schedule"
+        assert len(schedule.event_patterns) == 1
+        assert schedule.interval_trigger is not None
+        assert schedule.interval_trigger.interval_minutes == 30
+
+    def test_round_trip_serialization(self, sample_schedule):
+        """Schedule survives JSON round-trip."""
+        data = sample_schedule.to_dict()
+        json_str = json.dumps(data)
+        loaded = json.loads(json_str)
+        restored = Schedule.from_dict(loaded)
+        assert restored.schedule_id == sample_schedule.schedule_id
+        assert restored.name == sample_schedule.name
+        assert len(restored.event_patterns) == len(sample_schedule.event_patterns)
+
+
+# =============================================================================
+# VALIDATE PATTERN ACTION TESTS
+# =============================================================================
+
+
+class TestValidatePatternAction:
+    """Test validate_pattern_action function."""
+
+    def test_valid_gpio_action(self, sample_pattern_action):
+        """Valid GPIO action passes validation."""
+        valid, error = validate_pattern_action(sample_pattern_action)
+        assert valid is True
+        assert error is None
+
+    def test_valid_camera_action(self, sample_pattern_action_camera):
+        """Valid camera action passes validation."""
+        valid, error = validate_pattern_action(sample_pattern_action_camera)
+        assert valid is True
+        assert error is None
+
+    def test_invalid_action_type(self):
+        """Invalid action_type fails validation."""
+        action = PatternAction(action_type="invalid", action_name="test")
+        valid, error = validate_pattern_action(action)
+        assert valid is False
+        assert "action type" in error.lower()
+
+    def test_negative_offset_fails(self):
+        """Negative offset_minutes fails validation."""
+        action = PatternAction(
+            action_type="gpio", action_name="attract_on", offset_minutes=-5
+        )
+        valid, error = validate_pattern_action(action)
+        assert valid is False
+        assert "negative" in error.lower() or "offset" in error.lower()
+
+    def test_offset_exceeds_max_fails(self):
+        """Offset exceeding MAX_OFFSET_MINUTES fails validation."""
+        action = PatternAction(
+            action_type="gpio",
+            action_name="attract_on",
+            offset_minutes=MAX_OFFSET_MINUTES + 1,
+        )
+        valid, error = validate_pattern_action(action)
+        assert valid is False
+        assert "offset" in error.lower()
+
+
+# =============================================================================
+# VALIDATE EVENT PATTERN TESTS
+# =============================================================================
+
+
+class TestValidateEventPattern:
+    """Test validate_event_pattern function."""
+
+    def test_valid_pattern(self, sample_event_pattern):
+        """Valid event pattern passes validation."""
+        valid, error = validate_event_pattern(sample_event_pattern)
+        assert valid is True
+        assert error is None
+
+    def test_empty_name_fails(self):
+        """Empty name fails validation."""
+        pattern = EventPattern(pattern_id="test", name="")
+        valid, error = validate_event_pattern(pattern)
+        assert valid is False
+        assert "name" in error.lower()
+
+    def test_name_too_long_fails(self):
+        """Name exceeding MAX_PATTERN_NAME_LENGTH fails validation."""
+        pattern = EventPattern(pattern_id="test", name="x" * (MAX_PATTERN_NAME_LENGTH + 1))
+        valid, error = validate_event_pattern(pattern)
+        assert valid is False
+        assert "name" in error.lower()
+
+    def test_no_actions_fails(self):
+        """Pattern with no actions fails validation."""
+        pattern = EventPattern(pattern_id="test", name="Empty Pattern", actions=[])
+        valid, error = validate_event_pattern(pattern)
+        assert valid is False
+        assert "action" in error.lower()
+
+    def test_too_many_actions_fails(self):
+        """Pattern exceeding MAX_ACTIONS_PER_PATTERN fails validation."""
+        actions = [
+            PatternAction(action_type="gpio", action_name="attract_on", offset_minutes=i)
+            for i in range(MAX_ACTIONS_PER_PATTERN + 1)
+        ]
+        pattern = EventPattern(pattern_id="test", name="Too Many", actions=actions)
+        valid, error = validate_event_pattern(pattern)
+        assert valid is False
+        assert "action" in error.lower()
+
+    def test_invalid_action_fails(self):
+        """Pattern with invalid action fails validation."""
+        pattern = EventPattern(
+            pattern_id="test",
+            name="Bad Action",
+            actions=[PatternAction(action_type="invalid", action_name="test")],
+        )
+        valid, error = validate_event_pattern(pattern)
+        assert valid is False
+
+
+# =============================================================================
+# VALIDATE TIME WINDOW TESTS
+# =============================================================================
+
+
+class TestValidateTimeWindow:
+    """Test validate_time_window function."""
+
+    def test_valid_fixed_times(self, sample_time_window):
+        """Valid fixed time window passes validation."""
+        valid, error = validate_time_window(sample_time_window)
+        assert valid is True
+        assert error is None
+
+    def test_valid_solar_times(self, sample_time_window_solar):
+        """Valid solar time window passes validation."""
+        valid, error = validate_time_window(sample_time_window_solar)
+        assert valid is True
+        assert error is None
+
+    def test_invalid_time_format_fails(self):
+        """Invalid time format fails validation."""
+        window = TimeWindow(start_time="25:00", end_time="05:00")
+        valid, error = validate_time_window(window)
+        assert valid is False
+        assert "time" in error.lower() or "format" in error.lower()
+
+    def test_invalid_solar_event_fails(self):
+        """Invalid solar event fails validation."""
+        window = TimeWindow(start_time="invalid_event", end_time="05:00")
+        valid, error = validate_time_window(window)
+        assert valid is False
+
+
+# =============================================================================
+# VALIDATE TRIGGER TESTS
+# =============================================================================
+
+
+class TestValidateIntervalTrigger:
+    """Test validate_interval_trigger function."""
+
+    def test_valid_trigger(self, sample_interval_trigger):
+        """Valid interval trigger passes validation."""
+        valid, error = validate_interval_trigger(sample_interval_trigger)
+        assert valid is True
+        assert error is None
+
+    def test_zero_interval_fails(self, sample_time_window):
+        """Zero interval_minutes fails validation."""
+        trigger = IntervalTrigger(interval_minutes=0, time_window=sample_time_window)
+        valid, error = validate_interval_trigger(trigger)
+        assert valid is False
+        assert "interval" in error.lower()
+
+    def test_negative_interval_fails(self, sample_time_window):
+        """Negative interval_minutes fails validation."""
+        trigger = IntervalTrigger(interval_minutes=-10, time_window=sample_time_window)
+        valid, error = validate_interval_trigger(trigger)
+        assert valid is False
+
+    def test_invalid_days_of_week_fails(self, sample_time_window):
+        """Invalid days_of_week fails validation."""
+        trigger = IntervalTrigger(
+            interval_minutes=60, time_window=sample_time_window, days_of_week=[7]
+        )
+        valid, error = validate_interval_trigger(trigger)
+        assert valid is False
+        assert "day" in error.lower()
+
+
+class TestValidateSolarTrigger:
+    """Test validate_solar_trigger function."""
+
+    def test_valid_trigger(self, sample_solar_trigger):
+        """Valid solar trigger passes validation."""
+        valid, error = validate_solar_trigger(sample_solar_trigger)
+        assert valid is True
+        assert error is None
+
+    def test_invalid_solar_event_fails(self):
+        """Invalid solar_event fails validation."""
+        trigger = SolarTrigger(solar_event="invalid")
+        valid, error = validate_solar_trigger(trigger)
+        assert valid is False
+        assert "solar" in error.lower()
+
+
+class TestValidateMoonPhaseTrigger:
+    """Test validate_moon_phase_trigger function."""
+
+    def test_valid_trigger(self, sample_moon_phase_trigger):
+        """Valid moon phase trigger passes validation."""
+        valid, error = validate_moon_phase_trigger(sample_moon_phase_trigger)
+        assert valid is True
+        assert error is None
+
+    def test_empty_phases_fails(self):
+        """Empty phases list fails validation."""
+        trigger = MoonPhaseTrigger(phases=[])
+        valid, error = validate_moon_phase_trigger(trigger)
+        assert valid is False
+        assert "phase" in error.lower()
+
+    def test_invalid_phase_fails(self):
+        """Invalid phase fails validation."""
+        trigger = MoonPhaseTrigger(phases=["invalid_phase"])
+        valid, error = validate_moon_phase_trigger(trigger)
+        assert valid is False
+
+
+class TestValidateFixedTimeTrigger:
+    """Test validate_fixed_time_trigger function."""
+
+    def test_valid_trigger(self, sample_fixed_time_trigger):
+        """Valid fixed time trigger passes validation."""
+        valid, error = validate_fixed_time_trigger(sample_fixed_time_trigger)
+        assert valid is True
+        assert error is None
+
+    def test_invalid_time_format_fails(self):
+        """Invalid time format fails validation."""
+        trigger = FixedTimeTrigger(time="invalid")
+        valid, error = validate_fixed_time_trigger(trigger)
+        assert valid is False
+        assert "time" in error.lower()
+
+
+class TestValidateSensorTrigger:
+    """Test validate_sensor_trigger function."""
+
+    def test_valid_trigger(self, sample_sensor_trigger):
+        """Valid sensor trigger passes validation."""
+        valid, error = validate_sensor_trigger(sample_sensor_trigger)
+        assert valid is True
+        assert error is None
+
+    def test_invalid_sensor_type_fails(self):
+        """Invalid sensor_type fails validation."""
+        trigger = SensorTrigger(sensor_type="invalid")
+        valid, error = validate_sensor_trigger(trigger)
+        assert valid is False
+        assert "sensor" in error.lower()
+
+    def test_invalid_comparison_fails(self):
+        """Invalid comparison fails validation."""
+        trigger = SensorTrigger(sensor_type="motion", comparison="invalid")
+        valid, error = validate_sensor_trigger(trigger)
+        assert valid is False
+        assert "comparison" in error.lower()
+
+
+# =============================================================================
+# VALIDATE SCHEDULE TESTS
+# =============================================================================
+
+
+class TestValidateSchedule:
+    """Test validate_schedule function."""
+
+    def test_valid_schedule(self, sample_schedule):
+        """Valid schedule passes validation."""
+        valid, error = validate_schedule(sample_schedule)
+        assert valid is True
+        assert error is None
+
+    def test_empty_name_fails(self, sample_event_pattern):
+        """Empty name fails validation."""
+        schedule = Schedule(
+            schedule_id="test",
+            name="",
+            trigger_type="interval",
+            event_patterns=[sample_event_pattern],
+        )
+        valid, error = validate_schedule(schedule)
+        assert valid is False
+        assert "name" in error.lower()
+
+    def test_no_patterns_fails(self):
+        """Schedule with no patterns fails validation."""
+        schedule = Schedule(
+            schedule_id="test", name="Empty", trigger_type="interval", event_patterns=[]
+        )
+        valid, error = validate_schedule(schedule)
+        assert valid is False
+        assert "pattern" in error.lower()
+
+    def test_invalid_trigger_type_fails(self, sample_event_pattern):
+        """Invalid trigger_type fails validation."""
+        schedule = Schedule(
+            schedule_id="test",
+            name="Bad Trigger",
+            trigger_type="invalid",
+            event_patterns=[sample_event_pattern],
+        )
+        valid, error = validate_schedule(schedule)
+        assert valid is False
+        assert "trigger" in error.lower()
+
+    def test_missing_trigger_config_fails(self, sample_event_pattern):
+        """Missing trigger config for trigger_type fails validation."""
+        schedule = Schedule(
+            schedule_id="test",
+            name="No Config",
+            trigger_type="interval",
+            event_patterns=[sample_event_pattern],
+            interval_trigger=None,
+        )
+        valid, error = validate_schedule(schedule)
+        assert valid is False
+        assert "interval" in error.lower()
+
+    def test_invalid_date_format_fails(self, sample_event_pattern, sample_interval_trigger):
+        """Invalid date format fails validation."""
+        schedule = Schedule(
+            schedule_id="test",
+            name="Bad Date",
+            trigger_type="interval",
+            event_patterns=[sample_event_pattern],
+            interval_trigger=sample_interval_trigger,
+            start_date="not-a-date",
+        )
+        valid, error = validate_schedule(schedule)
+        assert valid is False
+        assert "date" in error.lower()

--- a/Firmware/webui/backend/lib/schedule_schema.py
+++ b/Firmware/webui/backend/lib/schedule_schema.py
@@ -1,0 +1,1184 @@
+"""
+Schedule Schema for Mothbox Visual Scheduler.
+
+Defines the core data structures for the scheduler system using a two-tier model:
+- EventPattern: Reusable action sequences with relative timing (embedded in Schedule)
+- Schedule: Contains patterns + trigger configuration + date constraints
+
+Single-file storage: Each schedule is a self-contained JSON file with patterns embedded
+inline, making schedules portable and easy to export/import between Mothbox units.
+
+Schema Version: 2.0
+- PatternAction: action_type, action_name, offset_minutes, parameters, description
+- EventPattern: pattern_id, name, actions list, duration_minutes (computed property)
+- TimeWindow: start_time, end_time, offsets (supports "sunset", "01:00")
+- IntervalTrigger, SolarTrigger, MoonPhaseTrigger, FixedTimeTrigger, SensorTrigger
+- Schedule: schedule_id, name, event_patterns (embedded), trigger config, date constraints
+
+Usage:
+    from webui.backend.lib.schedule_schema import (
+        Schedule,
+        EventPattern,
+        PatternAction,
+        TimeWindow,
+        IntervalTrigger,
+        validate_schedule,
+    )
+
+    # Create a schedule
+    action = PatternAction(action_type="gpio", action_name="attract_on")
+    pattern = EventPattern(pattern_id="", name="UV Capture", actions=[action])
+    window = TimeWindow(start_time="21:00", end_time="05:00")
+    trigger = IntervalTrigger(interval_minutes=60, time_window=window)
+    schedule = Schedule(
+        schedule_id="",
+        name="Nightly Survey",
+        event_patterns=[pattern],
+        trigger_type="interval",
+        interval_trigger=trigger,
+    )
+
+    # Validate
+    valid, error = validate_schedule(schedule)
+    if valid:
+        data = schedule.to_dict()  # Serialize to JSON
+
+Issue #208 - Scheduler Phase 1: Schedule Schema
+"""
+
+import logging
+import re
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Final
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# CONSTANTS
+# =============================================================================
+
+# Schema version
+SCHEDULE_SCHEMA_VERSION: Final[str] = "2.0"
+SUPPORTED_VERSIONS: Final[list[str]] = ["2.0"]
+
+# Validation limits
+MAX_PATTERN_NAME_LENGTH: Final[int] = 200
+MAX_DESCRIPTION_LENGTH: Final[int] = 2000
+MAX_ACTIONS_PER_PATTERN: Final[int] = 20
+MAX_PATTERNS_PER_SCHEDULE: Final[int] = 10
+MAX_OFFSET_MINUTES: Final[int] = 1440  # 24 hours
+MAX_INTERVAL_MINUTES: Final[int] = 10080  # 7 days
+MIN_INTERVAL_MINUTES: Final[int] = 1
+MAX_COOLDOWN_MINUTES: Final[int] = 60
+MAX_OFFSET_DAYS: Final[int] = 7
+
+# Action types (aligned with cron_security.py ACTION_TYPE_SCRIPTS)
+ACTION_TYPES: Final[list[str]] = ["gpio", "camera", "gps_sync", "service"]
+
+# GPIO action names (UV lights = attract lights, same GPIO)
+GPIO_ACTIONS: Final[list[str]] = [
+    "attract_on",
+    "attract_off",
+    "flash_on",
+    "flash_off",
+]
+
+# Trigger types
+TRIGGER_TYPES: Final[list[str]] = [
+    "interval",
+    "solar",
+    "moon_phase",
+    "fixed_time",
+    "sensor",
+]
+
+# Moon phases (8 phases of lunar cycle)
+MOON_PHASES: Final[list[str]] = [
+    "new",
+    "waxing_crescent",
+    "first_quarter",
+    "waxing_gibbous",
+    "full",
+    "waning_gibbous",
+    "last_quarter",
+    "waning_crescent",
+]
+
+# Solar events (from astral library)
+SOLAR_EVENTS: Final[list[str]] = [
+    "dawn",
+    "sunrise",
+    "noon",
+    "sunset",
+    "dusk",
+    "civil_dawn",
+    "civil_dusk",
+    "nautical_dawn",
+    "nautical_dusk",
+    "astronomical_dawn",
+    "astronomical_dusk",
+    "golden_hour_start",
+    "golden_hour_end",
+    "blue_hour_start",
+    "blue_hour_end",
+]
+
+# Sensor types and comparisons
+SENSOR_TYPES: Final[list[str]] = ["motion", "light", "temperature"]
+SENSOR_COMPARISONS: Final[list[str]] = ["gt", "lt", "eq", "gte", "lte"]
+
+# Days of week (0=Monday, 6=Sunday per ISO 8601)
+DAYS_OF_WEEK: Final[list[int]] = [0, 1, 2, 3, 4, 5, 6]
+
+# Pattern categories
+PATTERN_CATEGORIES: Final[list[str]] = ["built-in", "user"]
+
+# Time format regex (HH:MM, 24-hour format)
+TIME_FORMAT_REGEX = re.compile(r"^([01]\d|2[0-3]):([0-5]\d)$")
+
+# Date format regex (YYYY-MM-DD)
+DATE_FORMAT_REGEX = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+# =============================================================================
+# EXCEPTIONS
+# =============================================================================
+
+
+class ScheduleValidationError(Exception):
+    """Raised when schedule validation fails."""
+
+
+# =============================================================================
+# TIER 1: PATTERN ACTION
+# =============================================================================
+
+
+@dataclass
+class PatternAction:
+    """
+    A single action within an event pattern.
+
+    Actions use relative offsets from pattern start (t=0), enabling
+    coordinated multi-action sequences like:
+    - UV_ON at t+0
+    - TakePhoto at t+5
+    - UV_OFF at t+15
+
+    Attributes:
+        action_type: Category ("gpio", "camera", "gps_sync", "service")
+        action_name: Specific action (e.g., "attract_on", "takephoto")
+        offset_minutes: Minutes from pattern start (t=0). Default 0, max 1440.
+        parameters: Action-specific configuration dict
+        description: Human-readable description (max 500 chars)
+
+    Example:
+        >>> action = PatternAction(
+        ...     action_type="gpio",
+        ...     action_name="attract_on",
+        ...     offset_minutes=0,
+        ...     description="Turn on UV attract lights"
+        ... )
+    """
+
+    action_type: str
+    action_name: str
+    offset_minutes: int = 0
+    parameters: dict = field(default_factory=dict)
+    description: str = ""
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "action_type": self.action_type,
+            "action_name": self.action_name,
+            "offset_minutes": self.offset_minutes,
+            "parameters": self.parameters,
+            "description": self.description,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "PatternAction":
+        """Create from dictionary."""
+        return cls(
+            action_type=data["action_type"],
+            action_name=data["action_name"],
+            offset_minutes=data.get("offset_minutes", 0),
+            parameters=data.get("parameters", {}),
+            description=data.get("description", ""),
+        )
+
+
+# =============================================================================
+# TIER 1: EVENT PATTERN
+# =============================================================================
+
+
+@dataclass
+class EventPattern:
+    """
+    Reusable template defining a sequence of timed actions.
+
+    Event patterns are library items that can be reused across multiple
+    schedules. Actions use relative offsets from pattern start (t=0).
+
+    Example: "UV Capture Cycle"
+    - UV_ON at offset +0 minutes
+    - TakePhoto at offset +5 minutes
+    - UV_OFF at offset +15 minutes
+    - duration_minutes = 15 (computed from max offset)
+
+    Attributes:
+        pattern_id: Unique identifier (UUID string, auto-generated if empty)
+        name: Human-readable name (required, max 200 chars)
+        description: Detailed description (max 2000 chars)
+        actions: Ordered list of PatternAction objects
+        category: "built-in" or "user"
+        tags: Tags for filtering/search
+
+    Example:
+        >>> pattern = EventPattern(
+        ...     pattern_id="",
+        ...     name="UV Capture Cycle",
+        ...     actions=[
+        ...         PatternAction(action_type="gpio", action_name="attract_on"),
+        ...         PatternAction(action_type="camera", action_name="takephoto", offset_minutes=5),
+        ...         PatternAction(action_type="gpio", action_name="attract_off", offset_minutes=15),
+        ...     ]
+        ... )
+        >>> pattern.duration_minutes
+        15
+    """
+
+    pattern_id: str
+    name: str
+    description: str = ""
+    actions: list[PatternAction] = field(default_factory=list)
+    category: str = "user"
+    tags: list[str] = field(default_factory=list)
+
+    def __post_init__(self):
+        """Generate UUID if pattern_id is empty."""
+        if not self.pattern_id:
+            self.pattern_id = str(uuid.uuid4())
+
+    @property
+    def duration_minutes(self) -> int:
+        """Total duration = max action offset."""
+        if not self.actions:
+            return 0
+        return max(action.offset_minutes for action in self.actions)
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "pattern_id": self.pattern_id,
+            "name": self.name,
+            "description": self.description,
+            "actions": [action.to_dict() for action in self.actions],
+            "category": self.category,
+            "tags": self.tags,
+            "duration_minutes": self.duration_minutes,  # Computed, read-only
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "EventPattern":
+        """Create from dictionary."""
+        return cls(
+            pattern_id=data.get("pattern_id", ""),
+            name=data["name"],
+            description=data.get("description", ""),
+            actions=[PatternAction.from_dict(a) for a in data.get("actions", [])],
+            category=data.get("category", "user"),
+            tags=data.get("tags", []),
+        )
+
+
+# =============================================================================
+# TIER 2: TIME WINDOW
+# =============================================================================
+
+
+@dataclass
+class TimeWindow:
+    """
+    Daily time window for schedule execution.
+
+    Supports both fixed times ("HH:MM") and solar events ("sunset").
+
+    Attributes:
+        start_time: Window start ("HH:MM" or solar event name)
+        end_time: Window end ("HH:MM" or solar event name)
+        start_offset_minutes: Offset from start solar event (default 0)
+        end_offset_minutes: Offset from end solar event (default 0)
+
+    Example:
+        >>> # Fixed time window
+        >>> window = TimeWindow(start_time="21:00", end_time="05:00")
+
+        >>> # Solar-based window with offsets
+        >>> window = TimeWindow(
+        ...     start_time="sunset",
+        ...     end_time="sunrise",
+        ...     start_offset_minutes=30,  # 30 min after sunset
+        ...     end_offset_minutes=-30,   # 30 min before sunrise
+        ... )
+    """
+
+    start_time: str
+    end_time: str
+    start_offset_minutes: int = 0
+    end_offset_minutes: int = 0
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "start_offset_minutes": self.start_offset_minutes,
+            "end_offset_minutes": self.end_offset_minutes,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "TimeWindow":
+        """Create from dictionary."""
+        return cls(
+            start_time=data["start_time"],
+            end_time=data["end_time"],
+            start_offset_minutes=data.get("start_offset_minutes", 0),
+            end_offset_minutes=data.get("end_offset_minutes", 0),
+        )
+
+
+# =============================================================================
+# TIER 2: TRIGGER DATACLASSES
+# =============================================================================
+
+
+@dataclass
+class IntervalTrigger:
+    """
+    Execute pattern every N minutes within time window.
+
+    Example: Every 60 minutes from 21:00 to 05:00
+
+    Attributes:
+        interval_minutes: Interval in minutes (1 to 10080, i.e., 1 min to 7 days)
+        time_window: When executions can occur
+        days_of_week: 0=Mon..6=Sun, None=every day
+    """
+
+    interval_minutes: int
+    time_window: TimeWindow
+    days_of_week: list[int] | None = None
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "interval_minutes": self.interval_minutes,
+            "time_window": self.time_window.to_dict(),
+            "days_of_week": self.days_of_week,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "IntervalTrigger":
+        """Create from dictionary."""
+        return cls(
+            interval_minutes=data["interval_minutes"],
+            time_window=TimeWindow.from_dict(data["time_window"]),
+            days_of_week=data.get("days_of_week"),
+        )
+
+
+@dataclass
+class SolarTrigger:
+    """
+    Execute pattern relative to solar event.
+
+    Example: At sunset+30 every day
+
+    Attributes:
+        solar_event: Event name ("sunset", "astronomical_dusk", etc.)
+        offset_minutes: +/- minutes from event
+        days_of_week: 0=Mon..6=Sun, None=every day
+    """
+
+    solar_event: str
+    offset_minutes: int = 0
+    days_of_week: list[int] | None = None
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "solar_event": self.solar_event,
+            "offset_minutes": self.offset_minutes,
+            "days_of_week": self.days_of_week,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "SolarTrigger":
+        """Create from dictionary."""
+        return cls(
+            solar_event=data["solar_event"],
+            offset_minutes=data.get("offset_minutes", 0),
+            days_of_week=data.get("days_of_week"),
+        )
+
+
+@dataclass
+class MoonPhaseTrigger:
+    """
+    Execute pattern on moon phases.
+
+    Example: On full moon +/- 2 days, from dusk to dawn
+
+    Attributes:
+        phases: List of phases to match (["full", "new"], etc.)
+        offset_days: +/- days from exact phase (max 7)
+        time_window: Optional execution window on phase days
+    """
+
+    phases: list[str]
+    offset_days: int = 0
+    time_window: TimeWindow | None = None
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "phases": self.phases,
+            "offset_days": self.offset_days,
+            "time_window": self.time_window.to_dict() if self.time_window else None,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "MoonPhaseTrigger":
+        """Create from dictionary."""
+        return cls(
+            phases=data["phases"],
+            offset_days=data.get("offset_days", 0),
+            time_window=(
+                TimeWindow.from_dict(data["time_window"])
+                if data.get("time_window")
+                else None
+            ),
+        )
+
+
+@dataclass
+class FixedTimeTrigger:
+    """
+    Execute pattern at specific fixed time daily.
+
+    Example: Every day at 21:00
+
+    Attributes:
+        time: Fixed time in "HH:MM" format
+        days_of_week: 0=Mon..6=Sun, None=every day
+    """
+
+    time: str
+    days_of_week: list[int] | None = None
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "time": self.time,
+            "days_of_week": self.days_of_week,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "FixedTimeTrigger":
+        """Create from dictionary."""
+        return cls(
+            time=data["time"],
+            days_of_week=data.get("days_of_week"),
+        )
+
+
+@dataclass
+class SensorTrigger:
+    """
+    Execute pattern based on sensor readings.
+
+    Supported sensors:
+    - "motion": PIR sensor, trigger on detection (threshold ignored)
+    - "light": LDR sensor, trigger when lux crosses threshold
+    - "temperature": Temp sensor, trigger on threshold crossing
+
+    Attributes:
+        sensor_type: Sensor type ("motion", "light", "temperature")
+        threshold: Trigger threshold value (ignored for motion)
+        comparison: Comparison operator ("gt", "lt", "eq", "gte", "lte")
+        cooldown_minutes: Min time between triggers (default 5, max 60)
+        time_window: Optional window to restrict sensor triggers
+    """
+
+    sensor_type: str
+    threshold: float = 0.0
+    comparison: str = "gt"
+    cooldown_minutes: int = 5
+    time_window: TimeWindow | None = None
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "sensor_type": self.sensor_type,
+            "threshold": self.threshold,
+            "comparison": self.comparison,
+            "cooldown_minutes": self.cooldown_minutes,
+            "time_window": self.time_window.to_dict() if self.time_window else None,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "SensorTrigger":
+        """Create from dictionary."""
+        return cls(
+            sensor_type=data["sensor_type"],
+            threshold=data.get("threshold", 0.0),
+            comparison=data.get("comparison", "gt"),
+            cooldown_minutes=data.get("cooldown_minutes", 5),
+            time_window=(
+                TimeWindow.from_dict(data["time_window"])
+                if data.get("time_window")
+                else None
+            ),
+        )
+
+
+# =============================================================================
+# TIER 2: SCHEDULE
+# =============================================================================
+
+
+@dataclass
+class Schedule:
+    """
+    Complete schedule with embedded event patterns (single-file storage).
+
+    Each schedule is fully self-contained with event patterns embedded inline,
+    making it portable and easy to export/import between Mothbox units.
+
+    Attributes:
+        schedule_id: Unique identifier (UUID string, auto-generated if empty)
+        name: Human-readable name (required, max 200 chars)
+        description: Detailed description (max 2000 chars)
+        event_patterns: Embedded EventPattern objects (not references)
+        trigger_type: Type of trigger ("interval", "solar", "moon_phase", etc.)
+        interval_trigger: Config for interval triggers
+        solar_trigger: Config for solar triggers
+        moon_phase_trigger: Config for moon phase triggers
+        fixed_time_trigger: Config for fixed time triggers
+        sensor_trigger: Config for sensor triggers
+        start_date: Start of schedule validity (ISO 8601 date YYYY-MM-DD)
+        end_date: End of schedule validity (ISO 8601 date YYYY-MM-DD)
+        deployment_id: Linked deployment ID
+        create_deployment: Create deployment on activation
+        enabled: Whether schedule is enabled
+        is_active: Whether schedule is currently active
+        created_at: Creation timestamp (ISO 8601)
+        modified_at: Last modification timestamp (ISO 8601)
+        modified_by: User identifier
+
+    Example:
+        >>> schedule = Schedule(
+        ...     schedule_id="",
+        ...     name="Nightly Moth Survey",
+        ...     event_patterns=[...],
+        ...     trigger_type="interval",
+        ...     interval_trigger=IntervalTrigger(
+        ...         interval_minutes=60,
+        ...         time_window=TimeWindow(start_time="21:00", end_time="05:00"),
+        ...     ),
+        ... )
+    """
+
+    schedule_id: str
+    name: str
+    description: str = ""
+    event_patterns: list[EventPattern] = field(default_factory=list)
+    trigger_type: str = "interval"
+
+    # Trigger configs (one active based on trigger_type)
+    interval_trigger: IntervalTrigger | None = None
+    solar_trigger: SolarTrigger | None = None
+    moon_phase_trigger: MoonPhaseTrigger | None = None
+    fixed_time_trigger: FixedTimeTrigger | None = None
+    sensor_trigger: SensorTrigger | None = None
+
+    # Date constraints
+    start_date: str | None = None
+    end_date: str | None = None
+
+    # Deployment linkage
+    deployment_id: str | None = None
+    create_deployment: bool = False
+
+    # State
+    enabled: bool = True
+    is_active: bool = False
+
+    # Metadata
+    created_at: str = ""
+    modified_at: str = ""
+    modified_by: str | None = None
+
+    def __post_init__(self):
+        """Generate UUID and timestamps if empty."""
+        if not self.schedule_id:
+            self.schedule_id = str(uuid.uuid4())
+        if not self.created_at:
+            self.created_at = datetime.now().isoformat()
+        if not self.modified_at:
+            self.modified_at = self.created_at
+
+    @property
+    def total_duration_minutes(self) -> int:
+        """Total duration of all event patterns combined."""
+        return sum(pattern.duration_minutes for pattern in self.event_patterns)
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "schema_version": SCHEDULE_SCHEMA_VERSION,
+            "schedule_id": self.schedule_id,
+            "name": self.name,
+            "description": self.description,
+            "event_patterns": [p.to_dict() for p in self.event_patterns],
+            "trigger_type": self.trigger_type,
+            "interval_trigger": (
+                self.interval_trigger.to_dict() if self.interval_trigger else None
+            ),
+            "solar_trigger": (
+                self.solar_trigger.to_dict() if self.solar_trigger else None
+            ),
+            "moon_phase_trigger": (
+                self.moon_phase_trigger.to_dict() if self.moon_phase_trigger else None
+            ),
+            "fixed_time_trigger": (
+                self.fixed_time_trigger.to_dict() if self.fixed_time_trigger else None
+            ),
+            "sensor_trigger": (
+                self.sensor_trigger.to_dict() if self.sensor_trigger else None
+            ),
+            "start_date": self.start_date,
+            "end_date": self.end_date,
+            "deployment_id": self.deployment_id,
+            "create_deployment": self.create_deployment,
+            "enabled": self.enabled,
+            "is_active": self.is_active,
+            "created_at": self.created_at,
+            "modified_at": self.modified_at,
+            "modified_by": self.modified_by,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Schedule":
+        """Create from dictionary."""
+        return cls(
+            schedule_id=data.get("schedule_id", ""),
+            name=data["name"],
+            description=data.get("description", ""),
+            event_patterns=[
+                EventPattern.from_dict(p) for p in data.get("event_patterns", [])
+            ],
+            trigger_type=data.get("trigger_type", "interval"),
+            interval_trigger=(
+                IntervalTrigger.from_dict(data["interval_trigger"])
+                if data.get("interval_trigger")
+                else None
+            ),
+            solar_trigger=(
+                SolarTrigger.from_dict(data["solar_trigger"])
+                if data.get("solar_trigger")
+                else None
+            ),
+            moon_phase_trigger=(
+                MoonPhaseTrigger.from_dict(data["moon_phase_trigger"])
+                if data.get("moon_phase_trigger")
+                else None
+            ),
+            fixed_time_trigger=(
+                FixedTimeTrigger.from_dict(data["fixed_time_trigger"])
+                if data.get("fixed_time_trigger")
+                else None
+            ),
+            sensor_trigger=(
+                SensorTrigger.from_dict(data["sensor_trigger"])
+                if data.get("sensor_trigger")
+                else None
+            ),
+            start_date=data.get("start_date"),
+            end_date=data.get("end_date"),
+            deployment_id=data.get("deployment_id"),
+            create_deployment=data.get("create_deployment", False),
+            enabled=data.get("enabled", True),
+            is_active=data.get("is_active", False),
+            created_at=data.get("created_at", ""),
+            modified_at=data.get("modified_at", ""),
+            modified_by=data.get("modified_by"),
+        )
+
+
+# =============================================================================
+# VALIDATION FUNCTIONS
+# =============================================================================
+
+
+def _is_valid_time_format(time_str: str) -> bool:
+    """Check if string is valid HH:MM format."""
+    return TIME_FORMAT_REGEX.match(time_str) is not None
+
+
+def _is_valid_solar_event(event: str) -> bool:
+    """Check if string is a valid solar event name."""
+    return event in SOLAR_EVENTS
+
+
+def _is_valid_time_spec(time_str: str) -> bool:
+    """Check if string is valid time specification (HH:MM or solar event)."""
+    return _is_valid_time_format(time_str) or _is_valid_solar_event(time_str)
+
+
+def _validate_days_of_week(days: list[int] | None) -> tuple[bool, str | None]:
+    """Validate days of week list."""
+    if days is None:
+        return True, None
+
+    if not isinstance(days, list):
+        return False, "days_of_week must be a list"
+
+    if len(days) == 0:
+        return False, "days_of_week cannot be empty if provided"
+
+    for day in days:
+        if not isinstance(day, int) or day < 0 or day > 6:
+            return False, f"Invalid day of week: {day}. Must be 0-6 (Mon-Sun)"
+
+    return True, None
+
+
+def _validate_date_string(date_str: str | None) -> tuple[bool, str | None]:
+    """Validate ISO 8601 date string (YYYY-MM-DD)."""
+    if date_str is None:
+        return True, None
+
+    if not DATE_FORMAT_REGEX.match(date_str):
+        return False, f"Invalid date format: {date_str}. Expected YYYY-MM-DD"
+
+    # Validate the date is actually valid (e.g., not 2024-02-30)
+    try:
+        datetime.strptime(date_str, "%Y-%m-%d")
+    except ValueError as e:
+        return False, f"Invalid date: {date_str}. {e}"
+
+    return True, None
+
+
+def validate_pattern_action(action: PatternAction) -> tuple[bool, str | None]:
+    """
+    Validate a single pattern action.
+
+    Args:
+        action: PatternAction to validate
+
+    Returns:
+        (True, None) if valid, (False, error_message) if invalid
+    """
+    # Validate action_type
+    if action.action_type not in ACTION_TYPES:
+        return (
+            False,
+            f"Invalid action type: '{action.action_type}'. "
+            f"Must be one of: {', '.join(ACTION_TYPES)}",
+        )
+
+    # Validate offset_minutes range
+    if action.offset_minutes < 0:
+        return False, "Action offset cannot be negative"
+
+    if action.offset_minutes > MAX_OFFSET_MINUTES:
+        return (
+            False,
+            f"Action offset {action.offset_minutes} exceeds maximum "
+            f"of {MAX_OFFSET_MINUTES} minutes (24 hours)",
+        )
+
+    return True, None
+
+
+def validate_event_pattern(pattern: EventPattern) -> tuple[bool, str | None]:
+    """
+    Validate an event pattern and its actions.
+
+    Args:
+        pattern: EventPattern to validate
+
+    Returns:
+        (True, None) if valid, (False, error_message) if invalid
+    """
+    # Validate name
+    if not pattern.name or not pattern.name.strip():
+        return False, "Pattern name is required"
+
+    if len(pattern.name) > MAX_PATTERN_NAME_LENGTH:
+        return (
+            False,
+            f"Pattern name exceeds {MAX_PATTERN_NAME_LENGTH} characters",
+        )
+
+    # Validate description length
+    if len(pattern.description) > MAX_DESCRIPTION_LENGTH:
+        return (
+            False,
+            f"Pattern description exceeds {MAX_DESCRIPTION_LENGTH} characters",
+        )
+
+    # Validate actions
+    if not pattern.actions:
+        return False, "Pattern must have at least one action"
+
+    if len(pattern.actions) > MAX_ACTIONS_PER_PATTERN:
+        return (
+            False,
+            f"Pattern exceeds {MAX_ACTIONS_PER_PATTERN} actions",
+        )
+
+    # Validate each action
+    for i, action in enumerate(pattern.actions):
+        valid, error = validate_pattern_action(action)
+        if not valid:
+            return False, f"Action {i + 1}: {error}"
+
+    # Validate category
+    if pattern.category not in PATTERN_CATEGORIES:
+        return (
+            False,
+            f"Invalid category: '{pattern.category}'. "
+            f"Must be one of: {', '.join(PATTERN_CATEGORIES)}",
+        )
+
+    return True, None
+
+
+def validate_time_window(window: TimeWindow) -> tuple[bool, str | None]:
+    """
+    Validate time window configuration.
+
+    Args:
+        window: TimeWindow to validate
+
+    Returns:
+        (True, None) if valid, (False, error_message) if invalid
+    """
+    # Validate start_time
+    if not _is_valid_time_spec(window.start_time):
+        return (
+            False,
+            f"Invalid start_time: '{window.start_time}'. "
+            f"Must be HH:MM format or a solar event ({', '.join(SOLAR_EVENTS[:5])}...)",
+        )
+
+    # Validate end_time
+    if not _is_valid_time_spec(window.end_time):
+        return (
+            False,
+            f"Invalid end_time: '{window.end_time}'. "
+            f"Must be HH:MM format or a solar event ({', '.join(SOLAR_EVENTS[:5])}...)",
+        )
+
+    # Validate offset ranges (allow +/- 2 hours for solar events)
+    max_offset = 120
+    if abs(window.start_offset_minutes) > max_offset:
+        return (
+            False,
+            f"start_offset_minutes {window.start_offset_minutes} exceeds "
+            f"+/- {max_offset} minutes",
+        )
+
+    if abs(window.end_offset_minutes) > max_offset:
+        return (
+            False,
+            f"end_offset_minutes {window.end_offset_minutes} exceeds "
+            f"+/- {max_offset} minutes",
+        )
+
+    return True, None
+
+
+def validate_interval_trigger(trigger: IntervalTrigger) -> tuple[bool, str | None]:
+    """
+    Validate interval trigger configuration.
+
+    Args:
+        trigger: IntervalTrigger to validate
+
+    Returns:
+        (True, None) if valid, (False, error_message) if invalid
+    """
+    # Validate interval_minutes
+    if trigger.interval_minutes < MIN_INTERVAL_MINUTES:
+        return (
+            False,
+            f"Interval must be at least {MIN_INTERVAL_MINUTES} minute",
+        )
+
+    if trigger.interval_minutes > MAX_INTERVAL_MINUTES:
+        return (
+            False,
+            f"Interval exceeds {MAX_INTERVAL_MINUTES} minutes (7 days)",
+        )
+
+    # Validate time_window
+    valid, error = validate_time_window(trigger.time_window)
+    if not valid:
+        return False, f"Time window: {error}"
+
+    # Validate days_of_week
+    valid, error = _validate_days_of_week(trigger.days_of_week)
+    if not valid:
+        return False, error
+
+    return True, None
+
+
+def validate_solar_trigger(trigger: SolarTrigger) -> tuple[bool, str | None]:
+    """
+    Validate solar trigger configuration.
+
+    Args:
+        trigger: SolarTrigger to validate
+
+    Returns:
+        (True, None) if valid, (False, error_message) if invalid
+    """
+    # Validate solar_event
+    if trigger.solar_event not in SOLAR_EVENTS:
+        return (
+            False,
+            f"Invalid solar event: '{trigger.solar_event}'. "
+            f"Must be one of: {', '.join(SOLAR_EVENTS[:5])}...",
+        )
+
+    # Validate offset_minutes (allow +/- 2 hours)
+    max_offset = 120
+    if abs(trigger.offset_minutes) > max_offset:
+        return (
+            False,
+            f"Solar trigger offset {trigger.offset_minutes} exceeds "
+            f"+/- {max_offset} minutes",
+        )
+
+    # Validate days_of_week
+    valid, error = _validate_days_of_week(trigger.days_of_week)
+    if not valid:
+        return False, error
+
+    return True, None
+
+
+def validate_moon_phase_trigger(
+    trigger: MoonPhaseTrigger,
+) -> tuple[bool, str | None]:
+    """
+    Validate moon phase trigger configuration.
+
+    Args:
+        trigger: MoonPhaseTrigger to validate
+
+    Returns:
+        (True, None) if valid, (False, error_message) if invalid
+    """
+    # Validate phases list
+    if not trigger.phases:
+        return False, "At least one moon phase must be specified"
+
+    for phase in trigger.phases:
+        if phase not in MOON_PHASES:
+            return (
+                False,
+                f"Invalid moon phase: '{phase}'. "
+                f"Must be one of: {', '.join(MOON_PHASES)}",
+            )
+
+    # Validate offset_days
+    if abs(trigger.offset_days) > MAX_OFFSET_DAYS:
+        return (
+            False,
+            f"Moon phase offset {trigger.offset_days} exceeds "
+            f"+/- {MAX_OFFSET_DAYS} days",
+        )
+
+    # Validate time_window if provided
+    if trigger.time_window:
+        valid, error = validate_time_window(trigger.time_window)
+        if not valid:
+            return False, f"Time window: {error}"
+
+    return True, None
+
+
+def validate_fixed_time_trigger(trigger: FixedTimeTrigger) -> tuple[bool, str | None]:
+    """
+    Validate fixed time trigger configuration.
+
+    Args:
+        trigger: FixedTimeTrigger to validate
+
+    Returns:
+        (True, None) if valid, (False, error_message) if invalid
+    """
+    # Validate time format
+    if not _is_valid_time_format(trigger.time):
+        return (
+            False,
+            f"Invalid time format: '{trigger.time}'. Must be HH:MM (24-hour)",
+        )
+
+    # Validate days_of_week
+    valid, error = _validate_days_of_week(trigger.days_of_week)
+    if not valid:
+        return False, error
+
+    return True, None
+
+
+def validate_sensor_trigger(trigger: SensorTrigger) -> tuple[bool, str | None]:
+    """
+    Validate sensor trigger configuration.
+
+    Args:
+        trigger: SensorTrigger to validate
+
+    Returns:
+        (True, None) if valid, (False, error_message) if invalid
+    """
+    # Validate sensor_type
+    if trigger.sensor_type not in SENSOR_TYPES:
+        return (
+            False,
+            f"Invalid sensor type: '{trigger.sensor_type}'. "
+            f"Must be one of: {', '.join(SENSOR_TYPES)}",
+        )
+
+    # Validate comparison
+    if trigger.comparison not in SENSOR_COMPARISONS:
+        return (
+            False,
+            f"Invalid comparison operator: '{trigger.comparison}'. "
+            f"Must be one of: {', '.join(SENSOR_COMPARISONS)}",
+        )
+
+    # Validate cooldown_minutes
+    if trigger.cooldown_minutes < 0:
+        return False, "cooldown_minutes cannot be negative"
+
+    if trigger.cooldown_minutes > MAX_COOLDOWN_MINUTES:
+        return (
+            False,
+            f"cooldown_minutes exceeds maximum of {MAX_COOLDOWN_MINUTES}",
+        )
+
+    # Validate time_window if provided
+    if trigger.time_window:
+        valid, error = validate_time_window(trigger.time_window)
+        if not valid:
+            return False, f"Time window: {error}"
+
+    return True, None
+
+
+def validate_schedule(schedule: Schedule) -> tuple[bool, str | None]:
+    """
+    Validate a complete schedule with all embedded patterns.
+
+    Args:
+        schedule: Schedule to validate
+
+    Returns:
+        (True, None) if valid, (False, error_message) if invalid
+    """
+    # Validate name
+    if not schedule.name or not schedule.name.strip():
+        return False, "Schedule name is required"
+
+    if len(schedule.name) > MAX_PATTERN_NAME_LENGTH:
+        return (
+            False,
+            f"Schedule name exceeds {MAX_PATTERN_NAME_LENGTH} characters",
+        )
+
+    # Validate description length
+    if len(schedule.description) > MAX_DESCRIPTION_LENGTH:
+        return (
+            False,
+            f"Schedule description exceeds {MAX_DESCRIPTION_LENGTH} characters",
+        )
+
+    # Validate event_patterns
+    if not schedule.event_patterns:
+        return False, "Schedule must have at least one event pattern"
+
+    if len(schedule.event_patterns) > MAX_PATTERNS_PER_SCHEDULE:
+        return (
+            False,
+            f"Schedule exceeds {MAX_PATTERNS_PER_SCHEDULE} event patterns",
+        )
+
+    # Validate each pattern
+    for pattern in schedule.event_patterns:
+        valid, error = validate_event_pattern(pattern)
+        if not valid:
+            return False, f"Pattern '{pattern.name}': {error}"
+
+    # Validate trigger_type
+    if schedule.trigger_type not in TRIGGER_TYPES:
+        return (
+            False,
+            f"Invalid trigger type: '{schedule.trigger_type}'. "
+            f"Must be one of: {', '.join(TRIGGER_TYPES)}",
+        )
+
+    # Validate corresponding trigger config exists and is valid
+    trigger_validators = {
+        "interval": (schedule.interval_trigger, validate_interval_trigger),
+        "solar": (schedule.solar_trigger, validate_solar_trigger),
+        "moon_phase": (schedule.moon_phase_trigger, validate_moon_phase_trigger),
+        "fixed_time": (schedule.fixed_time_trigger, validate_fixed_time_trigger),
+        "sensor": (schedule.sensor_trigger, validate_sensor_trigger),
+    }
+
+    trigger_config, validator = trigger_validators.get(
+        schedule.trigger_type, (None, None)
+    )
+
+    if trigger_config is None:
+        return (
+            False,
+            f"Missing {schedule.trigger_type}_trigger configuration "
+            f"for trigger_type='{schedule.trigger_type}'",
+        )
+
+    valid, error = validator(trigger_config)
+    if not valid:
+        return False, f"{schedule.trigger_type.title()} trigger: {error}"
+
+    # Validate date constraints
+    valid, error = _validate_date_string(schedule.start_date)
+    if not valid:
+        return False, f"start_date: {error}"
+
+    valid, error = _validate_date_string(schedule.end_date)
+    if not valid:
+        return False, f"end_date: {error}"
+
+    # If both dates provided, validate start <= end
+    if schedule.start_date and schedule.end_date:
+        start = datetime.strptime(schedule.start_date, "%Y-%m-%d")
+        end = datetime.strptime(schedule.end_date, "%Y-%m-%d")
+        if start > end:
+            return False, "start_date must be before or equal to end_date"
+
+    return True, None


### PR DESCRIPTION
## Summary

Implements the core schedule schema dataclasses for the Mothbox Visual Scheduler system (Issue #208).

### Features
- **Two-tier model**: EventPattern (reusable action sequences) + Schedule (timing triggers)
- **Single-file storage**: Schedules are self-contained with patterns embedded inline for portability
- **9 dataclasses**: PatternAction, EventPattern, TimeWindow, 5 trigger types, Schedule
- **9 validation functions**: Comprehensive validation with clear error messages
- **Schema version 2.0**: Aligned with SCHEDULER_DEV_GUIDE.md specification

### Dataclasses
| Class | Purpose |
|-------|---------|
| `PatternAction` | Actions with relative timing offsets (offset_minutes) |
| `EventPattern` | Reusable action sequences with computed duration |
| `TimeWindow` | Supports "HH:MM" and solar events ("sunset") |
| `IntervalTrigger` | Every N minutes within time window |
| `SolarTrigger` | Relative to solar events (sunset+30, etc.) |
| `MoonPhaseTrigger` | On moon phases with offset days |
| `FixedTimeTrigger` | At specific fixed times |
| `SensorTrigger` | Based on sensor readings |
| `Schedule` | Complete schedule with embedded patterns |

### Constants
- `ACTION_TYPES`: gpio, camera, gps_sync, service (aligned with cron_security.py)
- `GPIO_ACTIONS`: attract_on/off, flash_on/off (UV = attract lights)
- `TRIGGER_TYPES`: interval, solar, moon_phase, fixed_time, sensor
- `MOON_PHASES`: 8 lunar phases
- `SOLAR_EVENTS`: 15 solar events from astral library

## Test plan
- [x] 90 unit tests passing
- [x] 87.56% code coverage (exceeds 85% requirement)
- [x] `ruff check` passes
- [x] `bandit` security scan passes
- [x] All dataclasses support `to_dict()` / `from_dict()` round-trip serialization
- [x] All validation functions return `(bool, error_msg)` tuples

## Acceptance Criteria (from Issue)
- [x] PatternAction, EventPattern dataclasses defined
- [x] TimeWindow, trigger dataclasses defined  
- [x] Schedule dataclass with embedded event_patterns list
- [x] Validation functions for all types
- [x] 40+ unit tests passing (90 tests)

Closes #208