### PR TITLE
feat(scheduler): Add cron bridge library (#215)

### DIFF
--- a/Firmware/Tests/requirements-test.txt
+++ b/Firmware/Tests/requirements-test.txt
@@ -41,3 +41,4 @@ geopip>=2.0.0  # Offline GPS-to-country lookup for Darwin Core countryCode field
 # Astronomical calculations for scheduler (Issue #210)
 astral>=3.2
 pytz  # Timezone handling for solar time calculations
+croniter  # Cron expression iteration for RTC wakealarm calculation

--- a/Firmware/Tests/requirements-test.txt
+++ b/Firmware/Tests/requirements-test.txt
@@ -40,3 +40,4 @@ geopip>=2.0.0  # Offline GPS-to-country lookup for Darwin Core countryCode field
 
 # Astronomical calculations for scheduler (Issue #210)
 astral>=3.2
+pytz  # Timezone handling for solar time calculations

--- a/Firmware/Tests/unit/test_cron_bridge.py
+++ b/Firmware/Tests/unit/test_cron_bridge.py
@@ -3,6 +3,8 @@
 from datetime import date, datetime
 from unittest.mock import mock_open, patch
 
+import pytest
+
 from webui.backend.lib.cron_bridge import (
     CronBridgeResult,
     CronEntry,
@@ -822,7 +824,7 @@ class TestApplyToSystem:
 
         entries = [CronEntry(expression="0 21 * * *", command="cmd")]
         with patch("webui.backend.lib.cron_bridge.CronTab") as mock_crontab_class:
-            mock_crontab_class.side_effect = Exception("Cron error")
+            mock_crontab_class.side_effect = OSError("Cron error")
 
             result = apply_to_system(entries, schedule_id="test-123")
 
@@ -911,7 +913,7 @@ class TestRemoveFromSystem:
 
 
         with patch("webui.backend.lib.cron_bridge.CronTab") as mock_crontab_class:
-            mock_crontab_class.side_effect = Exception("Cron error")
+            mock_crontab_class.side_effect = OSError("Cron error")
 
             result = remove_from_system()
 
@@ -1326,3 +1328,107 @@ class TestEdgeCases:
         # rtc_waketime should be set
         assert result.rtc_waketime is not None
         assert result.rtc_waketime > 0
+
+
+class TestDaysAheadValidation:
+    """Tests for days_ahead parameter validation."""
+
+    def test_solar_trigger_days_ahead_zero_raises(self):
+        """solar_trigger_to_cron raises ValueError for days_ahead=0."""
+        from webui.backend.lib.cron_bridge import solar_trigger_to_cron
+        from webui.backend.lib.schedule_schema import SolarTrigger
+
+        trigger = SolarTrigger(solar_event="sunset", offset_minutes=0)
+
+        with pytest.raises(ValueError, match="days_ahead must be between 1 and 365"):
+            solar_trigger_to_cron(
+                trigger, "test_command", latitude=0.0, longitude=0.0, days_ahead=0
+            )
+
+    def test_solar_trigger_days_ahead_negative_raises(self):
+        """solar_trigger_to_cron raises ValueError for negative days_ahead."""
+        from webui.backend.lib.cron_bridge import solar_trigger_to_cron
+        from webui.backend.lib.schedule_schema import SolarTrigger
+
+        trigger = SolarTrigger(solar_event="sunrise", offset_minutes=0)
+
+        with pytest.raises(ValueError, match="days_ahead must be between 1 and 365"):
+            solar_trigger_to_cron(
+                trigger, "test_command", latitude=0.0, longitude=0.0, days_ahead=-5
+            )
+
+    def test_solar_trigger_days_ahead_too_large_raises(self):
+        """solar_trigger_to_cron raises ValueError for days_ahead > 365."""
+        from webui.backend.lib.cron_bridge import solar_trigger_to_cron
+        from webui.backend.lib.schedule_schema import SolarTrigger
+
+        trigger = SolarTrigger(solar_event="sunset", offset_minutes=0)
+
+        with pytest.raises(ValueError, match="days_ahead must be between 1 and 365"):
+            solar_trigger_to_cron(
+                trigger, "test_command", latitude=0.0, longitude=0.0, days_ahead=366
+            )
+
+    def test_moon_phase_trigger_days_ahead_zero_raises(self):
+        """moon_phase_trigger_to_cron raises ValueError for days_ahead=0."""
+        from webui.backend.lib.cron_bridge import moon_phase_trigger_to_cron
+        from webui.backend.lib.schedule_schema import MoonPhaseTrigger
+
+        trigger = MoonPhaseTrigger(phases=["full"])
+
+        with pytest.raises(ValueError, match="days_ahead must be between 1 and 365"):
+            moon_phase_trigger_to_cron(trigger, "test_command", days_ahead=0)
+
+    def test_moon_phase_trigger_days_ahead_negative_raises(self):
+        """moon_phase_trigger_to_cron raises ValueError for negative days_ahead."""
+        from webui.backend.lib.cron_bridge import moon_phase_trigger_to_cron
+        from webui.backend.lib.schedule_schema import MoonPhaseTrigger
+
+        trigger = MoonPhaseTrigger(phases=["new"])
+
+        with pytest.raises(ValueError, match="days_ahead must be between 1 and 365"):
+            moon_phase_trigger_to_cron(trigger, "test_command", days_ahead=-10)
+
+    def test_moon_phase_trigger_days_ahead_too_large_raises(self):
+        """moon_phase_trigger_to_cron raises ValueError for days_ahead > 365."""
+        from webui.backend.lib.cron_bridge import moon_phase_trigger_to_cron
+        from webui.backend.lib.schedule_schema import MoonPhaseTrigger
+
+        trigger = MoonPhaseTrigger(phases=["full"])
+
+        with pytest.raises(ValueError, match="days_ahead must be between 1 and 365"):
+            moon_phase_trigger_to_cron(trigger, "test_command", days_ahead=400)
+
+    def test_solar_trigger_days_ahead_valid_boundary(self):
+        """solar_trigger_to_cron accepts boundary values 1 and 365."""
+        from webui.backend.lib.cron_bridge import solar_trigger_to_cron
+        from webui.backend.lib.schedule_schema import SolarTrigger
+
+        trigger = SolarTrigger(solar_event="sunset", offset_minutes=0)
+
+        # days_ahead=1 should work
+        result = solar_trigger_to_cron(
+            trigger, "test_command", latitude=45.0, longitude=-93.0, days_ahead=1
+        )
+        assert isinstance(result, list)
+
+        # days_ahead=365 should work
+        result = solar_trigger_to_cron(
+            trigger, "test_command", latitude=45.0, longitude=-93.0, days_ahead=365
+        )
+        assert isinstance(result, list)
+
+    def test_moon_phase_trigger_days_ahead_valid_boundary(self):
+        """moon_phase_trigger_to_cron accepts boundary values 1 and 365."""
+        from webui.backend.lib.cron_bridge import moon_phase_trigger_to_cron
+        from webui.backend.lib.schedule_schema import MoonPhaseTrigger
+
+        trigger = MoonPhaseTrigger(phases=["full"])
+
+        # days_ahead=1 should work
+        result = moon_phase_trigger_to_cron(trigger, "test_command", days_ahead=1)
+        assert isinstance(result, list)
+
+        # days_ahead=365 should work
+        result = moon_phase_trigger_to_cron(trigger, "test_command", days_ahead=365)
+        assert isinstance(result, list)

--- a/Firmware/Tests/unit/test_cron_bridge.py
+++ b/Firmware/Tests/unit/test_cron_bridge.py
@@ -83,12 +83,37 @@ class TestCronEntryDataclass:
         # Disabled entries should start with #
         assert "# 0 21 * * * cmd" in line or line.strip().startswith("#")
 
+    def test_to_cron_line_sanitizes_comment(self):
+        """CronEntry.to_cron_line() sanitizes comments to prevent injection."""
+        # Test newline removal
+        entry = CronEntry(
+            expression="0 21 * * *",
+            command="cmd",
+            comment="Line1\nLine2\nLine3",
+        )
+        line = entry.to_cron_line()
+        assert "\n" not in line.split("\n")[0]  # First line (comment) has no newlines in content
+        assert "Line1 Line2 Line3" in line
+
+        # Test hash removal
+        entry2 = CronEntry(
+            expression="0 21 * * *",
+            command="cmd",
+            comment="Test # injection # attempt",
+        )
+        line2 = entry2.to_cron_line()
+        # The sanitized comment should not have extra # characters
+        comment_line = line2.split("\n")[0]
+        assert comment_line.count("#") == 1  # Only the leading #
+
     def test_is_valid_expression_valid(self):
         """CronEntry.is_valid_expression() accepts valid cron syntax."""
         assert CronEntry.is_valid_expression("0 21 * * *") is True
         assert CronEntry.is_valid_expression("*/5 * * * *") is True
         assert CronEntry.is_valid_expression("0,30 9-17 * * 1-5") is True
         assert CronEntry.is_valid_expression("0 0 1 1 *") is True
+        # Single-value range (start == end) should be valid
+        assert CronEntry.is_valid_expression("0 9-9 * * *") is True
 
     def test_is_valid_expression_invalid(self):
         """CronEntry.is_valid_expression() rejects invalid cron syntax."""

--- a/Firmware/Tests/unit/test_cron_bridge.py
+++ b/Firmware/Tests/unit/test_cron_bridge.py
@@ -1,0 +1,1328 @@
+"""Unit tests for cron_bridge module - Subtask 1: Data structures."""
+
+from datetime import date, datetime
+from unittest.mock import mock_open, patch
+
+from webui.backend.lib.cron_bridge import (
+    CronBridgeResult,
+    CronEntry,
+    apply_to_system,
+    calculate_next_from_entries,
+    calculate_next_waketime,
+    clear_rtc_wakealarm,
+    fixed_time_trigger_to_cron,
+    get_next_events,
+    get_solar_execution_time,
+    interval_trigger_to_cron,
+    is_moon_phase_active,
+    moon_phase_trigger_to_cron,
+    pattern_to_cron_entries,
+    remove_from_system,
+    schedule_to_cron,
+    sensor_trigger_to_cron,
+    set_rtc_wakealarm,
+    solar_trigger_to_cron,
+)
+from webui.backend.lib.schedule_schema import (
+    EventPattern,
+    FixedTimeTrigger,
+    IntervalTrigger,
+    MoonPhaseTrigger,
+    PatternAction,
+    Schedule,
+    SensorTrigger,
+    SolarTrigger,
+    TimeWindow,
+)
+
+
+class TestCronEntryDataclass:
+    """Test CronEntry dataclass."""
+
+    def test_instantiation_minimal(self):
+        """CronEntry can be created with minimal args."""
+        entry = CronEntry(expression="0 21 * * *", command="/usr/bin/python3 /opt/mothbox/TakePhoto.py")
+        assert entry.expression == "0 21 * * *"
+        assert entry.command == "/usr/bin/python3 /opt/mothbox/TakePhoto.py"
+        assert entry.comment == ""  # default
+        assert entry.enabled is True  # default
+
+    def test_instantiation_full(self):
+        """CronEntry can be created with all args."""
+        entry = CronEntry(
+            expression="*/5 * * * *",
+            command="/usr/bin/python3 /opt/mothbox/script.py",
+            comment="Mothbox: Take photo every 5 minutes",
+            enabled=False,
+        )
+        assert entry.expression == "*/5 * * * *"
+        assert entry.comment == "Mothbox: Take photo every 5 minutes"
+        assert entry.enabled is False
+
+    def test_to_cron_line_format(self):
+        """CronEntry.to_cron_line() returns valid crontab format."""
+        entry = CronEntry(expression="0 21 * * *", command="cmd", comment="Test job")
+        line = entry.to_cron_line()
+        # Format: # comment\nexpression command
+        assert "# Test job" in line
+        assert "0 21 * * *" in line
+        assert "cmd" in line
+
+    def test_to_cron_line_no_comment(self):
+        """CronEntry without comment omits comment line."""
+        entry = CronEntry(expression="0 21 * * *", command="cmd")
+        line = entry.to_cron_line()
+        assert line.strip() == "0 21 * * * cmd"
+
+    def test_to_cron_line_disabled(self):
+        """Disabled entry should have commented-out command."""
+        entry = CronEntry(expression="0 21 * * *", command="cmd", enabled=False)
+        line = entry.to_cron_line()
+        # Disabled entries should start with #
+        assert "# 0 21 * * * cmd" in line or line.strip().startswith("#")
+
+    def test_is_valid_expression_valid(self):
+        """CronEntry.is_valid_expression() accepts valid cron syntax."""
+        assert CronEntry.is_valid_expression("0 21 * * *") is True
+        assert CronEntry.is_valid_expression("*/5 * * * *") is True
+        assert CronEntry.is_valid_expression("0,30 9-17 * * 1-5") is True
+        assert CronEntry.is_valid_expression("0 0 1 1 *") is True
+
+    def test_is_valid_expression_invalid(self):
+        """CronEntry.is_valid_expression() rejects invalid cron syntax."""
+        assert CronEntry.is_valid_expression("invalid") is False
+        assert CronEntry.is_valid_expression("60 24 * * *") is False  # Invalid minute/hour
+        assert CronEntry.is_valid_expression("") is False
+        assert CronEntry.is_valid_expression("* * *") is False  # Too few fields
+
+
+class TestCronBridgeResult:
+    """Test CronBridgeResult dataclass."""
+
+    def test_instantiation(self):
+        """CronBridgeResult contains entries and metadata."""
+        result = CronBridgeResult(entries=[], rtc_waketime=None, schedule_id="test-123")
+        assert result.entries == []
+        assert result.rtc_waketime is None
+        assert result.schedule_id == "test-123"
+        assert result.errors == []
+
+    def test_with_entries_and_errors(self):
+        """CronBridgeResult can hold entries and errors."""
+        entry = CronEntry(expression="0 21 * * *", command="cmd")
+        result = CronBridgeResult(
+            entries=[entry],
+            rtc_waketime=1718463600,
+            schedule_id="test-456",
+            errors=["Warning: polar region"]
+        )
+        assert len(result.entries) == 1
+        assert result.rtc_waketime == 1718463600
+        assert len(result.errors) == 1
+
+
+class TestFixedTimeTriggerConversion:
+    """Test fixed_time_trigger_to_cron function."""
+
+    def test_simple_daily_fixed_time(self):
+        """Fixed time 21:00 daily becomes '0 21 * * *'."""
+        trigger = FixedTimeTrigger(time="21:00", days_of_week=None)
+        entries = fixed_time_trigger_to_cron(trigger, command="/usr/bin/python3 /opt/mothbox/TakePhoto.py")
+        assert len(entries) == 1
+        assert entries[0].expression == "0 21 * * *"
+        assert "TakePhoto.py" in entries[0].command
+
+    def test_fixed_time_with_days_mon_to_fri(self):
+        """Fixed time with days_of_week restriction to weekdays."""
+        # ISO weekday: 0=Mon, 1=Tue, ..., 6=Sun
+        # Cron weekday: 0=Sun, 1=Mon, ..., 6=Sat
+        trigger = FixedTimeTrigger(time="06:30", days_of_week=[0, 1, 2, 3, 4])  # Mon-Fri ISO
+        entries = fixed_time_trigger_to_cron(trigger, command="cmd")
+        assert len(entries) == 1
+        # In cron: Mon=1, Tue=2, ..., Fri=5
+        assert entries[0].expression == "30 6 * * 1,2,3,4,5"
+
+    def test_midnight_time(self):
+        """00:00 becomes '0 0 * * *'."""
+        trigger = FixedTimeTrigger(time="00:00", days_of_week=None)
+        entries = fixed_time_trigger_to_cron(trigger, command="cmd")
+        assert entries[0].expression == "0 0 * * *"
+
+    def test_weekend_only(self):
+        """Saturday and Sunday only (ISO 5,6 -> cron 0,6)."""
+        trigger = FixedTimeTrigger(time="09:00", days_of_week=[5, 6])  # Sat, Sun in ISO
+        entries = fixed_time_trigger_to_cron(trigger, command="cmd")
+        # Cron: Sat=6, Sun=0
+        assert entries[0].expression == "0 9 * * 0,6"
+
+    def test_single_day(self):
+        """Single day (Wednesday only)."""
+        trigger = FixedTimeTrigger(time="14:30", days_of_week=[2])  # Wed in ISO
+        entries = fixed_time_trigger_to_cron(trigger, command="cmd")
+        # Cron: Wed=3
+        assert entries[0].expression == "30 14 * * 3"
+
+    def test_custom_comment_prefix(self):
+        """Custom comment prefix is used."""
+        trigger = FixedTimeTrigger(time="12:00", days_of_week=None)
+        entries = fixed_time_trigger_to_cron(trigger, command="cmd", comment_prefix="Custom:")
+        assert "Custom:" in entries[0].comment
+        assert "Fixed time 12:00" in entries[0].comment
+
+    def test_cron_entry_properties(self):
+        """CronEntry has correct properties (enabled, comment, command)."""
+        trigger = FixedTimeTrigger(time="15:45", days_of_week=[0, 2, 4])  # Mon, Wed, Fri
+        entries = fixed_time_trigger_to_cron(trigger, command="/usr/bin/test.py")
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry.enabled is True
+        assert "Mothbox:" in entry.comment
+        assert entry.command == "/usr/bin/test.py"
+        assert entry.expression == "45 15 * * 1,3,5"
+
+    def test_unsorted_days_are_sorted(self):
+        """Days of week are sorted in output."""
+        # Provide unsorted days
+        trigger = FixedTimeTrigger(time="10:00", days_of_week=[4, 1, 3])  # Fri, Tue, Thu (unsorted)
+        entries = fixed_time_trigger_to_cron(trigger, command="cmd")
+        # Should output sorted: Tue=2, Thu=4, Fri=5
+        assert entries[0].expression == "0 10 * * 2,4,5"
+
+
+class TestIntervalTriggerConversion:
+    """Test interval_trigger_to_cron function."""
+
+    def test_hourly_interval_within_window(self):
+        """60-minute interval within 21:00-05:00 window generates multiple entries."""
+        window = TimeWindow(start_time="21:00", end_time="05:00")
+        trigger = IntervalTrigger(interval_minutes=60, time_window=window)
+        entries = interval_trigger_to_cron(trigger, command="cmd")
+        # Should generate entries at 21:00, 22:00, 23:00, 00:00, 01:00, 02:00, 03:00, 04:00, 05:00
+        assert len(entries) == 9
+        hours = [int(e.expression.split()[1]) for e in entries]
+        assert set(hours) == {21, 22, 23, 0, 1, 2, 3, 4, 5}
+
+    def test_30_minute_interval_short_window(self):
+        """30-minute interval in 2-hour window."""
+        window = TimeWindow(start_time="20:00", end_time="22:00")
+        trigger = IntervalTrigger(interval_minutes=30, time_window=window)
+        entries = interval_trigger_to_cron(trigger, command="cmd")
+        # 20:00, 20:30, 21:00, 21:30, 22:00 = 5 entries
+        assert len(entries) == 5
+        # Check times are correct
+        expressions = [e.expression for e in entries]
+        assert "0 20 * * *" in expressions
+        assert "30 20 * * *" in expressions
+        assert "0 21 * * *" in expressions
+        assert "30 21 * * *" in expressions
+        assert "0 22 * * *" in expressions
+
+    def test_interval_with_days_of_week(self):
+        """Interval restricted to specific days."""
+        window = TimeWindow(start_time="21:00", end_time="23:00")
+        trigger = IntervalTrigger(
+            interval_minutes=60,
+            time_window=window,
+            days_of_week=[0, 1, 2, 3, 4],  # Mon-Fri ISO
+        )
+        entries = interval_trigger_to_cron(trigger, command="cmd")
+        # Should have 3 entries (21:00, 22:00, 23:00), each with days_of_week
+        assert len(entries) == 3
+        for entry in entries:
+            assert "1,2,3,4,5" in entry.expression  # Mon-Fri in cron format
+
+    def test_overnight_window(self):
+        """Window spanning midnight (22:00-02:00) handled correctly."""
+        window = TimeWindow(start_time="22:00", end_time="02:00")
+        trigger = IntervalTrigger(interval_minutes=60, time_window=window)
+        entries = interval_trigger_to_cron(trigger, command="cmd")
+        # 22:00, 23:00, 00:00, 01:00, 02:00 = 5 entries
+        assert len(entries) == 5
+        hours = [int(e.expression.split()[1]) for e in entries]
+        assert 22 in hours
+        assert 23 in hours
+        assert 0 in hours
+        assert 1 in hours
+        assert 2 in hours
+
+    def test_15_minute_interval(self):
+        """15-minute interval within single hour."""
+        window = TimeWindow(start_time="21:00", end_time="22:00")
+        trigger = IntervalTrigger(interval_minutes=15, time_window=window)
+        entries = interval_trigger_to_cron(trigger, command="cmd")
+        # 21:00, 21:15, 21:30, 21:45, 22:00 = 5 entries
+        assert len(entries) == 5
+        expressions = [e.expression for e in entries]
+        assert "0 21 * * *" in expressions
+        assert "15 21 * * *" in expressions
+        assert "30 21 * * *" in expressions
+        assert "45 21 * * *" in expressions
+        assert "0 22 * * *" in expressions
+
+    def test_single_execution_when_interval_equals_window(self):
+        """When interval equals window size, only start time executes."""
+        window = TimeWindow(start_time="21:00", end_time="21:00")
+        trigger = IntervalTrigger(interval_minutes=60, time_window=window)
+        entries = interval_trigger_to_cron(trigger, command="cmd")
+        # Only one execution at start
+        assert len(entries) == 1
+        assert entries[0].expression == "0 21 * * *"
+
+
+class TestSolarTriggerConversion:
+    """Test solar_trigger_to_cron function."""
+
+    def test_get_solar_execution_time_sunset(self):
+        """get_solar_execution_time returns datetime for sunset on specific date."""
+        trigger = SolarTrigger(solar_event="sunset", offset_minutes=0)
+        exec_time = get_solar_execution_time(
+            trigger,
+            target_date=date(2024, 6, 21),  # Summer solstice
+            latitude=35.96,
+            longitude=-83.92,
+            timezone_name="America/New_York"
+        )
+        assert exec_time is not None
+        # Summer sunset in Eastern US (Oak Ridge, TN) is around 21:00 local
+        assert exec_time.hour >= 20  # Should be evening
+
+    def test_get_solar_execution_time_with_offset(self):
+        """Positive and negative offsets work correctly."""
+        trigger_plus = SolarTrigger(solar_event="sunset", offset_minutes=30)
+        trigger_minus = SolarTrigger(solar_event="sunset", offset_minutes=-30)
+
+        base = get_solar_execution_time(
+            SolarTrigger(solar_event="sunset", offset_minutes=0),
+            target_date=date(2024, 6, 21),
+            latitude=35.96, longitude=-83.92, timezone_name="America/New_York"
+        )
+        plus30 = get_solar_execution_time(
+            trigger_plus,
+            target_date=date(2024, 6, 21),
+            latitude=35.96, longitude=-83.92, timezone_name="America/New_York"
+        )
+        minus30 = get_solar_execution_time(
+            trigger_minus,
+            target_date=date(2024, 6, 21),
+            latitude=35.96, longitude=-83.92, timezone_name="America/New_York"
+        )
+
+        # plus30 should be 30 minutes after base
+        assert (plus30 - base).total_seconds() == 30 * 60
+        # minus30 should be 30 minutes before base
+        assert (base - minus30).total_seconds() == 30 * 60
+
+    def test_solar_trigger_to_cron_generates_entries_for_days(self):
+        """solar_trigger_to_cron generates entries for specified number of days."""
+        trigger = SolarTrigger(solar_event="sunset", offset_minutes=30)
+        entries = solar_trigger_to_cron(
+            trigger,
+            command="cmd",
+            latitude=35.96,
+            longitude=-83.92,
+            timezone_name="America/New_York",
+            days_ahead=7
+        )
+        # Should generate 7 entries (one per day)
+        assert len(entries) == 7
+        # Each entry should have a valid cron expression
+        for entry in entries:
+            assert CronEntry.is_valid_expression(entry.expression)
+
+    def test_solar_trigger_with_days_of_week(self):
+        """Solar trigger respects days_of_week restriction."""
+        trigger = SolarTrigger(
+            solar_event="sunset",
+            offset_minutes=0,
+            days_of_week=[0, 2, 4]  # Mon, Wed, Fri (ISO)
+        )
+        entries = solar_trigger_to_cron(
+            trigger,
+            command="cmd",
+            latitude=35.96,
+            longitude=-83.92,
+            timezone_name="America/New_York",
+            days_ahead=14,  # Two weeks
+            from_date=date(2024, 6, 17)  # Monday
+        )
+        # Should have entries only for Mon, Wed, Fri
+        # Week 1: Mon 17, Wed 19, Fri 21 = 3
+        # Week 2: Mon 24, Wed 26, Fri 28 = 3
+        # Total = 6 entries
+        assert len(entries) == 6
+
+    def test_solar_trigger_sunrise(self):
+        """Sunrise trigger works correctly."""
+        trigger = SolarTrigger(solar_event="sunrise", offset_minutes=-15)
+        exec_time = get_solar_execution_time(
+            trigger,
+            target_date=date(2024, 6, 21),
+            latitude=35.96, longitude=-83.92, timezone_name="America/New_York"
+        )
+        # Summer sunrise in Eastern US is around 6:00-6:30 AM
+        assert exec_time.hour <= 7
+
+    def test_solar_trigger_entries_have_correct_day_field(self):
+        """Each cron entry specifies the exact day of month."""
+        trigger = SolarTrigger(solar_event="sunset", offset_minutes=0)
+        entries = solar_trigger_to_cron(
+            trigger,
+            command="cmd",
+            latitude=35.96,
+            longitude=-83.92,
+            timezone_name="America/New_York",
+            days_ahead=3,
+            from_date=date(2024, 6, 15)
+        )
+        # Entries should be for June 15, 16, 17
+        expressions = [e.expression for e in entries]
+        # Each expression should have day-of-month field set
+        # Format: minute hour day month weekday
+        for expr in expressions:
+            parts = expr.split()
+            day = parts[2]
+            month = parts[3]
+            assert day != "*"  # Day should be specific
+            assert month != "*"  # Month should be specific
+
+
+class TestMoonPhaseTriggerConversion:
+    """Test moon_phase_trigger_to_cron function."""
+
+    def test_is_moon_phase_active_full_moon(self):
+        """is_moon_phase_active returns True on full moon date."""
+        trigger = MoonPhaseTrigger(phases=["full"], offset_days=0)
+        # Full moon on 2024-01-27 (verified via astral library)
+        assert is_moon_phase_active(trigger, date(2024, 1, 27)) is True
+        # Not full moon on 2024-01-15
+        assert is_moon_phase_active(trigger, date(2024, 1, 15)) is False
+
+    def test_is_moon_phase_active_with_offset(self):
+        """offset_days expands the active window."""
+        trigger = MoonPhaseTrigger(phases=["full"], offset_days=2)
+        # Full moon on 2024-01-27, offset_days=2 means 25-29 should be active
+        assert is_moon_phase_active(trigger, date(2024, 1, 25)) is True
+        assert is_moon_phase_active(trigger, date(2024, 1, 29)) is True
+        # Outside range
+        assert is_moon_phase_active(trigger, date(2024, 1, 20)) is False
+
+    def test_is_moon_phase_active_multiple_phases(self):
+        """Multiple phases (full AND new) both match."""
+        trigger = MoonPhaseTrigger(phases=["full", "new"], offset_days=0)
+        # Full moon on 2024-01-27, new moon on 2024-01-12
+        assert is_moon_phase_active(trigger, date(2024, 1, 27)) is True  # Full
+        assert is_moon_phase_active(trigger, date(2024, 1, 12)) is True  # New
+        # Neither (2024-01-18 is between phases)
+        assert is_moon_phase_active(trigger, date(2024, 1, 18)) is False
+
+    def test_moon_phase_trigger_to_cron_generates_entries(self):
+        """moon_phase_trigger_to_cron generates entries for matching days."""
+        window = TimeWindow(start_time="21:00", end_time="21:00")
+        trigger = MoonPhaseTrigger(phases=["full"], offset_days=0, time_window=window)
+        entries = moon_phase_trigger_to_cron(
+            trigger,
+            command="cmd",
+            days_ahead=60,  # Two lunar cycles
+            from_date=date(2024, 1, 1)
+        )
+        # Should have at least 2 full moons in 60 days
+        assert len(entries) >= 2
+        # Each entry should be valid
+        for entry in entries:
+            assert CronEntry.is_valid_expression(entry.expression)
+
+    def test_moon_phase_trigger_with_time_window(self):
+        """Moon trigger respects time window for cron expression."""
+        window = TimeWindow(start_time="20:30", end_time="20:30")
+        trigger = MoonPhaseTrigger(phases=["full"], offset_days=0, time_window=window)
+        entries = moon_phase_trigger_to_cron(
+            trigger,
+            command="cmd",
+            days_ahead=30,
+            from_date=date(2024, 1, 1)
+        )
+        # At least 1 full moon in 30 days
+        assert len(entries) >= 1
+        # Check time is from window
+        for entry in entries:
+            parts = entry.expression.split()
+            assert parts[0] == "30"  # minute
+            assert parts[1] == "20"  # hour
+
+    def test_moon_phase_trigger_no_time_window_uses_midnight(self):
+        """Without time_window, defaults to midnight."""
+        trigger = MoonPhaseTrigger(phases=["new"], offset_days=0, time_window=None)
+        entries = moon_phase_trigger_to_cron(
+            trigger,
+            command="cmd",
+            days_ahead=30,
+            from_date=date(2024, 1, 1)
+        )
+        if entries:  # If there's a new moon in range
+            parts = entries[0].expression.split()
+            assert parts[0] == "0"  # minute = 0
+            assert parts[1] == "0"  # hour = 0
+
+    def test_moon_phase_trigger_with_offset_generates_more_entries(self):
+        """Larger offset_days generates more matching dates."""
+        trigger_no_offset = MoonPhaseTrigger(phases=["full"], offset_days=0)
+        trigger_with_offset = MoonPhaseTrigger(phases=["full"], offset_days=2)
+
+        entries_no_offset = moon_phase_trigger_to_cron(
+            trigger_no_offset,
+            command="cmd",
+            days_ahead=60,
+            from_date=date(2024, 1, 1)
+        )
+        entries_with_offset = moon_phase_trigger_to_cron(
+            trigger_with_offset,
+            command="cmd",
+            days_ahead=60,
+            from_date=date(2024, 1, 1)
+        )
+
+        # With offset should have more entries (each phase spans more days)
+        assert len(entries_with_offset) > len(entries_no_offset)
+
+    def test_moon_phase_trigger_entries_have_correct_day_field(self):
+        """Each cron entry specifies the exact day of month."""
+        trigger = MoonPhaseTrigger(phases=["full"], offset_days=0)
+        entries = moon_phase_trigger_to_cron(
+            trigger,
+            command="cmd",
+            days_ahead=30,
+            from_date=date(2024, 1, 1)
+        )
+        # Each expression should have day-of-month field set
+        # Format: minute hour day month weekday
+        for entry in entries:
+            parts = entry.expression.split()
+            day = parts[2]
+            month = parts[3]
+            assert day != "*"  # Day should be specific
+            assert month != "*"  # Month should be specific
+
+
+class TestActionSequencing:
+    """Test event pattern action sequencing."""
+
+    def test_single_action_at_offset_zero(self):
+        """Single action at offset=0 executes at base time."""
+        action = PatternAction(action_type="gpio", action_name="attract_on", offset_minutes=0)
+        pattern = EventPattern(pattern_id="p1", name="Test", description="", actions=[action])
+        entries = pattern_to_cron_entries(pattern, base_time="21:00")
+        assert len(entries) == 1
+        # Should be at 21:00
+        assert "0 21" in entries[0].expression
+
+    def test_multiple_actions_with_offsets(self):
+        """Multiple actions execute at base_time + offset."""
+        actions = [
+            PatternAction(action_type="gpio", action_name="attract_on", offset_minutes=0),
+            PatternAction(action_type="camera", action_name="takephoto", offset_minutes=5),
+            PatternAction(action_type="gpio", action_name="attract_off", offset_minutes=15),
+        ]
+        pattern = EventPattern(pattern_id="p1", name="UV Capture", description="", actions=actions)
+        entries = pattern_to_cron_entries(pattern, base_time="21:00")
+        # UV on at 21:00, photo at 21:05, UV off at 21:15
+        assert len(entries) == 3
+        expressions = [e.expression for e in entries]
+        assert "0 21 * * *" in expressions   # 21:00
+        assert "5 21 * * *" in expressions   # 21:05
+        assert "15 21 * * *" in expressions  # 21:15
+
+    def test_offset_crosses_hour_boundary(self):
+        """Offset pushing into next hour handled correctly."""
+        actions = [
+            PatternAction(action_type="gpio", action_name="attract_on", offset_minutes=0),
+            PatternAction(action_type="gpio", action_name="attract_off", offset_minutes=45),
+        ]
+        pattern = EventPattern(pattern_id="p1", name="Test", description="", actions=actions)
+        entries = pattern_to_cron_entries(pattern, base_time="21:30")
+        # attract_on at 21:30, attract_off at 22:15
+        expressions = [e.expression for e in entries]
+        assert "30 21 * * *" in expressions  # 21:30
+        assert "15 22 * * *" in expressions  # 22:15
+
+    def test_offset_crosses_midnight(self):
+        """Offset pushing into next day handled correctly."""
+        action = PatternAction(action_type="gpio", action_name="attract_off", offset_minutes=90)
+        pattern = EventPattern(pattern_id="p1", name="Test", description="", actions=[action])
+        entries = pattern_to_cron_entries(pattern, base_time="23:00")
+        # 23:00 + 90 = 00:30 (next day, but cron is day-agnostic for repeating schedules)
+        assert "30 0 * * *" in entries[0].expression
+
+    def test_action_with_days_of_week(self):
+        """Actions respect days_of_week constraint."""
+        action = PatternAction(action_type="gpio", action_name="attract_on", offset_minutes=0)
+        pattern = EventPattern(pattern_id="p1", name="Test", description="", actions=[action])
+        entries = pattern_to_cron_entries(pattern, base_time="21:00", days_of_week=[0, 1, 2])  # Mon-Wed ISO
+        # Cron days should be 1,2,3 (Mon-Wed in cron)
+        assert "1,2,3" in entries[0].expression
+
+    def test_action_command_from_cron_security(self):
+        """Action commands are built using cron_security module."""
+        action = PatternAction(action_type="gpio", action_name="attract_on", offset_minutes=0)
+        pattern = EventPattern(pattern_id="p1", name="Test", description="", actions=[action])
+        entries = pattern_to_cron_entries(pattern, base_time="21:00")
+        # Command should be from get_validated_command
+        assert "/usr/bin/python3" in entries[0].command
+        assert "Attract_On.py" in entries[0].command
+
+    def test_entries_have_descriptive_comments(self):
+        """Generated entries have meaningful comments."""
+        action = PatternAction(action_type="camera", action_name="takephoto", offset_minutes=5)
+        pattern = EventPattern(pattern_id="p1", name="UV Capture", description="", actions=[action])
+        entries = pattern_to_cron_entries(pattern, base_time="21:00")
+        # Comment should mention pattern name and action
+        assert "UV Capture" in entries[0].comment
+        assert "takephoto" in entries[0].comment.lower() or "camera" in entries[0].comment.lower()
+
+
+class TestRTCWakealarm:
+    """Test RTC wakealarm functions."""
+
+    def test_calculate_next_waketime_same_day(self):
+        """calculate_next_waketime returns next execution when time is later today."""
+        cron_expr = "0 21 * * *"  # 21:00 daily
+        now = datetime(2024, 6, 15, 20, 0, 0)  # 20:00
+        next_wake = calculate_next_waketime(cron_expr, from_time=now)
+        # Should be 21:00 same day
+        assert next_wake > int(now.timestamp())
+        # Should be about 1 hour later
+        expected = int(datetime(2024, 6, 15, 21, 0, 0).timestamp())
+        assert abs(next_wake - expected) < 60  # Within 1 minute tolerance
+
+    def test_calculate_next_waketime_next_day(self):
+        """If time passed today, calculate for tomorrow."""
+        cron_expr = "0 21 * * *"  # 21:00 daily
+        now = datetime(2024, 6, 15, 22, 0, 0)  # 22:00 (after 21:00)
+        next_wake = calculate_next_waketime(cron_expr, from_time=now)
+        # Should be 21:00 next day
+        expected = int(datetime(2024, 6, 16, 21, 0, 0).timestamp())
+        assert abs(next_wake - expected) < 60
+
+    def test_calculate_next_from_multiple_entries(self):
+        """calculate_next_from_entries returns earliest of multiple crons."""
+        entries = [
+            CronEntry(expression="0 23 * * *", command="cmd"),  # 23:00
+            CronEntry(expression="0 21 * * *", command="cmd"),  # 21:00
+            CronEntry(expression="0 22 * * *", command="cmd"),  # 22:00
+        ]
+        now = datetime(2024, 6, 15, 20, 0, 0)  # 20:00
+        next_wake = calculate_next_from_entries(entries, from_time=now)
+        # Should be 21:00 (earliest)
+        expected = int(datetime(2024, 6, 15, 21, 0, 0).timestamp())
+        assert abs(next_wake - expected) < 60
+
+    def test_calculate_next_from_empty_entries(self):
+        """calculate_next_from_entries returns None for empty list."""
+        next_wake = calculate_next_from_entries([], from_time=datetime.now())
+        assert next_wake is None
+
+    def test_set_rtc_wakealarm_writes_to_sysfs(self):
+        """set_rtc_wakealarm writes epoch to /sys/class/rtc/rtc0/wakealarm."""
+        m = mock_open()
+        with patch("builtins.open", m):
+            epoch = 1718463600
+            result = set_rtc_wakealarm(epoch)
+            assert result is True
+            m.assert_called_with("/sys/class/rtc/rtc0/wakealarm", "w")
+            m().write.assert_called_with(str(epoch))
+
+    def test_clear_rtc_wakealarm_writes_zero(self):
+        """clear_rtc_wakealarm writes 0 to clear existing alarm."""
+        m = mock_open()
+        with patch("builtins.open", m):
+            result = clear_rtc_wakealarm()
+            assert result is True
+            m().write.assert_called_with("0")
+
+    def test_set_rtc_wakealarm_handles_permission_error(self):
+        """set_rtc_wakealarm returns False on permission error."""
+        with patch("builtins.open", side_effect=PermissionError("No permission")):
+            result = set_rtc_wakealarm(1718463600)
+            assert result is False
+
+    def test_calculate_next_waketime_with_day_of_week(self):
+        """calculate_next_waketime handles day-of-week restrictions."""
+        cron_expr = "0 21 * * 1"  # Monday only
+        # June 15, 2024 is Saturday
+        now = datetime(2024, 6, 15, 20, 0, 0)
+        next_wake = calculate_next_waketime(cron_expr, from_time=now)
+        # Should be next Monday (June 17, 2024)
+        expected = int(datetime(2024, 6, 17, 21, 0, 0).timestamp())
+        assert abs(next_wake - expected) < 60
+
+    def test_calculate_next_from_entries_filters_disabled(self):
+        """calculate_next_from_entries skips disabled entries."""
+        entries = [
+            CronEntry(expression="0 23 * * *", command="cmd", enabled=False),  # Disabled
+            CronEntry(expression="0 21 * * *", command="cmd", enabled=True),   # Enabled
+            CronEntry(expression="0 22 * * *", command="cmd", enabled=False),  # Disabled
+        ]
+        now = datetime(2024, 6, 15, 20, 0, 0)
+        next_wake = calculate_next_from_entries(entries, from_time=now)
+        # Should only use enabled entry (21:00)
+        expected = int(datetime(2024, 6, 15, 21, 0, 0).timestamp())
+        assert abs(next_wake - expected) < 60
+
+    def test_clear_rtc_wakealarm_handles_file_not_found(self):
+        """clear_rtc_wakealarm returns False on file not found error."""
+        with patch("builtins.open", side_effect=FileNotFoundError("File not found")):
+            result = clear_rtc_wakealarm()
+            assert result is False
+
+    def test_calculate_next_waketime_handles_complex_expression(self):
+        """calculate_next_waketime handles complex cron expressions."""
+        cron_expr = "0,30 9-17 * * 1-5"  # Every 30 min during business hours on weekdays
+        now = datetime(2024, 6, 17, 9, 15, 0)  # Monday 9:15 AM
+        next_wake = calculate_next_waketime(cron_expr, from_time=now)
+        # Should be 9:30 same day
+        expected = int(datetime(2024, 6, 17, 9, 30, 0).timestamp())
+        assert abs(next_wake - expected) < 60
+
+
+class TestApplyToSystem:
+    """Test apply_to_system function."""
+
+    def test_apply_writes_cron_entries(self):
+        """apply_to_system writes entries to user crontab."""
+        from unittest.mock import MagicMock, patch
+
+        entries = [
+            CronEntry(expression="0 21 * * *", command="cmd1", comment="Test 1"),
+            CronEntry(expression="0 22 * * *", command="cmd2", comment="Test 2"),
+        ]
+        with patch("webui.backend.lib.cron_bridge.CronTab") as mock_crontab_class:
+            mock_cron = MagicMock()
+            mock_crontab_class.return_value = mock_cron
+            # Mock iteration to return empty list (no existing jobs)
+            mock_cron.__iter__ = MagicMock(return_value=iter([]))
+
+            result = apply_to_system(entries, schedule_id="test-123")
+
+            assert result is True
+            # Should have created new jobs
+            assert mock_cron.new.call_count >= 2
+            mock_cron.write.assert_called_once()
+
+    def test_apply_removes_existing_mothbox_jobs_first(self):
+        """apply_to_system removes old Mothbox jobs before adding new."""
+        from unittest.mock import MagicMock, patch
+
+        entries = [CronEntry(expression="0 21 * * *", command="cmd")]
+        with patch("webui.backend.lib.cron_bridge.CronTab") as mock_crontab_class:
+            mock_cron = MagicMock()
+            mock_crontab_class.return_value = mock_cron
+
+            # Simulate existing Mothbox job
+            existing_job = MagicMock()
+            existing_job.command = "/usr/bin/python3 /opt/mothbox/TakePhoto.py"
+            mock_cron.__iter__ = MagicMock(return_value=iter([existing_job]))
+
+            apply_to_system(entries, schedule_id="test-123")
+
+            # Old job should be removed
+            mock_cron.remove.assert_called_with(existing_job)
+
+    def test_apply_sets_rtc_alarm_when_enabled(self):
+        """apply_to_system sets RTC wakealarm when set_rtc=True."""
+        from unittest.mock import MagicMock, patch
+
+
+
+        entries = [CronEntry(expression="0 21 * * *", command="cmd")]
+        with patch("webui.backend.lib.cron_bridge.CronTab") as mock_crontab_class:
+            mock_cron = MagicMock()
+            mock_crontab_class.return_value = mock_cron
+            mock_cron.__iter__ = MagicMock(return_value=iter([]))
+
+            with (
+                patch("webui.backend.lib.cron_bridge.set_rtc_wakealarm") as mock_rtc,
+                patch("webui.backend.lib.cron_bridge.calculate_next_from_entries") as mock_calc,
+            ):
+                mock_calc.return_value = 1718463600
+                apply_to_system(entries, schedule_id="test-123", set_rtc=True)
+                mock_rtc.assert_called_once_with(1718463600)
+
+    def test_apply_preserves_non_mothbox_jobs(self):
+        """apply_to_system preserves system (non-Mothbox) jobs."""
+        from unittest.mock import MagicMock, patch
+
+
+
+        entries = [CronEntry(expression="0 21 * * *", command="cmd")]
+        with patch("webui.backend.lib.cron_bridge.CronTab") as mock_crontab_class:
+            mock_cron = MagicMock()
+            mock_crontab_class.return_value = mock_cron
+
+            # System job (should NOT be removed)
+            system_job = MagicMock()
+            system_job.command = "/usr/bin/logrotate /etc/logrotate.conf"
+
+            # Mothbox job (SHOULD be removed)
+            mothbox_job = MagicMock()
+            mothbox_job.command = "/usr/bin/python3 /opt/mothbox/TakePhoto.py"
+
+            mock_cron.__iter__ = MagicMock(return_value=iter([system_job, mothbox_job]))
+
+            apply_to_system(entries, schedule_id="test-123")
+
+            # Only Mothbox job should be removed
+            mock_cron.remove.assert_called_once_with(mothbox_job)
+
+    def test_apply_handles_disabled_entries(self):
+        """apply_to_system skips disabled entries."""
+        from unittest.mock import MagicMock, patch
+
+
+
+        entries = [
+            CronEntry(expression="0 21 * * *", command="cmd1", enabled=True),
+            CronEntry(expression="0 22 * * *", command="cmd2", enabled=False),  # Disabled
+        ]
+        with patch("webui.backend.lib.cron_bridge.CronTab") as mock_crontab_class:
+            mock_cron = MagicMock()
+            mock_crontab_class.return_value = mock_cron
+            mock_cron.__iter__ = MagicMock(return_value=iter([]))
+
+            with (
+                patch("webui.backend.lib.cron_bridge.set_rtc_wakealarm"),
+                patch("webui.backend.lib.cron_bridge.calculate_next_from_entries") as mock_calc,
+            ):
+                mock_calc.return_value = 1718463600
+                result = apply_to_system(entries, schedule_id="test-123")
+
+            assert result is True
+            # Should only create one job (the enabled one)
+            assert mock_cron.new.call_count == 1
+
+    def test_apply_skips_rtc_when_disabled(self):
+        """apply_to_system skips RTC wakealarm when set_rtc=False."""
+        from unittest.mock import MagicMock, patch
+
+
+
+        entries = [CronEntry(expression="0 21 * * *", command="cmd")]
+        with patch("webui.backend.lib.cron_bridge.CronTab") as mock_crontab_class:
+            mock_cron = MagicMock()
+            mock_crontab_class.return_value = mock_cron
+            mock_cron.__iter__ = MagicMock(return_value=iter([]))
+
+            with patch("webui.backend.lib.cron_bridge.set_rtc_wakealarm") as mock_rtc:
+                apply_to_system(entries, schedule_id="test-123", set_rtc=False)
+                mock_rtc.assert_not_called()
+
+    def test_apply_handles_errors(self):
+        """apply_to_system returns False on error."""
+        from unittest.mock import patch
+
+
+
+        entries = [CronEntry(expression="0 21 * * *", command="cmd")]
+        with patch("webui.backend.lib.cron_bridge.CronTab") as mock_crontab_class:
+            mock_crontab_class.side_effect = Exception("Cron error")
+
+            result = apply_to_system(entries, schedule_id="test-123")
+
+            assert result is False
+
+
+class TestRemoveFromSystem:
+    """Test remove_from_system function."""
+
+    def test_remove_clears_mothbox_jobs(self):
+        """remove_from_system removes all Mothbox cron jobs."""
+        from unittest.mock import MagicMock, patch
+
+
+
+        with patch("webui.backend.lib.cron_bridge.CronTab") as mock_crontab_class:
+            mock_cron = MagicMock()
+            mock_crontab_class.return_value = mock_cron
+
+            # Simulate Mothbox job
+            mothbox_job = MagicMock()
+            mothbox_job.command = "/usr/bin/python3 /opt/mothbox/TakePhoto.py"
+            mock_cron.__iter__ = MagicMock(return_value=iter([mothbox_job]))
+
+            result = remove_from_system()
+
+            assert result is True
+            mock_cron.remove.assert_called_with(mothbox_job)
+            mock_cron.write.assert_called_once()
+
+    def test_remove_clears_rtc_alarm_when_enabled(self):
+        """remove_from_system clears RTC wakealarm when clear_rtc=True."""
+        from unittest.mock import MagicMock, patch
+
+
+
+        with patch("webui.backend.lib.cron_bridge.CronTab") as mock_crontab_class:
+            mock_cron = MagicMock()
+            mock_crontab_class.return_value = mock_cron
+            mock_cron.__iter__ = MagicMock(return_value=iter([]))
+
+            with patch("webui.backend.lib.cron_bridge.clear_rtc_wakealarm") as mock_clear:
+                remove_from_system(clear_rtc=True)
+                mock_clear.assert_called_once()
+
+    def test_remove_preserves_non_mothbox_jobs(self):
+        """remove_from_system preserves system (non-Mothbox) jobs."""
+        from unittest.mock import MagicMock, patch
+
+
+
+        with patch("webui.backend.lib.cron_bridge.CronTab") as mock_crontab_class:
+            mock_cron = MagicMock()
+            mock_crontab_class.return_value = mock_cron
+
+            # System job (should NOT be removed)
+            system_job = MagicMock()
+            system_job.command = "/usr/bin/logrotate /etc/logrotate.conf"
+
+            mock_cron.__iter__ = MagicMock(return_value=iter([system_job]))
+
+            remove_from_system()
+
+            # System job should NOT be removed
+            mock_cron.remove.assert_not_called()
+
+    def test_remove_skips_rtc_when_disabled(self):
+        """remove_from_system skips RTC clear when clear_rtc=False."""
+        from unittest.mock import MagicMock, patch
+
+
+
+        with patch("webui.backend.lib.cron_bridge.CronTab") as mock_crontab_class:
+            mock_cron = MagicMock()
+            mock_crontab_class.return_value = mock_cron
+            mock_cron.__iter__ = MagicMock(return_value=iter([]))
+
+            with patch("webui.backend.lib.cron_bridge.clear_rtc_wakealarm") as mock_clear:
+                remove_from_system(clear_rtc=False)
+                mock_clear.assert_not_called()
+
+    def test_remove_handles_errors(self):
+        """remove_from_system returns False on error."""
+        from unittest.mock import patch
+
+
+
+        with patch("webui.backend.lib.cron_bridge.CronTab") as mock_crontab_class:
+            mock_crontab_class.side_effect = Exception("Cron error")
+
+            result = remove_from_system()
+
+            assert result is False
+
+    def test_remove_with_user_parameter(self):
+        """remove_from_system uses specified user when provided."""
+        from unittest.mock import MagicMock, patch
+
+
+
+        with patch("webui.backend.lib.cron_bridge.CronTab") as mock_crontab_class:
+            mock_cron = MagicMock()
+            mock_crontab_class.return_value = mock_cron
+            mock_cron.__iter__ = MagicMock(return_value=iter([]))
+
+            remove_from_system(user="testuser")
+
+            # Should be called with user parameter
+            mock_crontab_class.assert_called_once_with(user="testuser")
+
+
+class TestGetNextEvents:
+    """Test get_next_events function."""
+
+    def test_returns_list_of_events(self):
+        """get_next_events returns list of event dicts."""
+        from webui.backend.lib.schedule_schema import Schedule
+
+        # Create simple schedule with interval trigger
+        action = PatternAction(action_type="camera", action_name="takephoto", offset_minutes=0)
+        pattern = EventPattern(pattern_id="p1", name="Photo", description="", actions=[action])
+        window = TimeWindow(start_time="21:00", end_time="22:00")
+        trigger = IntervalTrigger(interval_minutes=60, time_window=window)
+        schedule = Schedule(
+            schedule_id="s1",
+            name="Test Schedule",
+            description="",
+            event_patterns=[pattern],
+            trigger_type="interval",
+            interval_trigger=trigger,
+        )
+
+        events = get_next_events(schedule, count=10, from_time=datetime(2024, 6, 15, 20, 0, 0))
+        assert isinstance(events, list)
+        assert len(events) <= 10
+
+    def test_event_contains_required_fields(self):
+        """Each event has datetime, action_type, action_name, pattern_name."""
+        from webui.backend.lib.schedule_schema import Schedule
+
+        action = PatternAction(action_type="gpio", action_name="attract_on", offset_minutes=0)
+        pattern = EventPattern(pattern_id="p1", name="UV Light", description="", actions=[action])
+        trigger = FixedTimeTrigger(time="21:00", days_of_week=None)
+        schedule = Schedule(
+            schedule_id="s1",
+            name="Test",
+            description="",
+            event_patterns=[pattern],
+            trigger_type="fixed_time",
+            fixed_time_trigger=trigger,
+        )
+
+        events = get_next_events(schedule, count=5, from_time=datetime(2024, 6, 15, 20, 0, 0))
+        assert len(events) >= 1
+        event = events[0]
+        assert "datetime" in event
+        assert "action_type" in event
+        assert "action_name" in event
+        assert "pattern_name" in event
+
+    def test_events_are_sorted_chronologically(self):
+        """Events are returned in chronological order."""
+        from webui.backend.lib.schedule_schema import Schedule
+
+        actions = [
+            PatternAction(action_type="gpio", action_name="attract_on", offset_minutes=0),
+            PatternAction(action_type="camera", action_name="takephoto", offset_minutes=5),
+            PatternAction(action_type="gpio", action_name="attract_off", offset_minutes=10),
+        ]
+        pattern = EventPattern(pattern_id="p1", name="UV Capture", description="", actions=actions)
+        trigger = FixedTimeTrigger(time="21:00", days_of_week=None)
+        schedule = Schedule(
+            schedule_id="s1",
+            name="Test",
+            description="",
+            event_patterns=[pattern],
+            trigger_type="fixed_time",
+            fixed_time_trigger=trigger,
+        )
+
+        events = get_next_events(schedule, count=10, from_time=datetime(2024, 6, 15, 20, 0, 0))
+        datetimes = [e["datetime"] for e in events]
+        assert datetimes == sorted(datetimes)
+
+    def test_events_include_all_pattern_actions(self):
+        """Events include actions from all patterns in schedule."""
+        from webui.backend.lib.schedule_schema import Schedule
+
+        action1 = PatternAction(action_type="gpio", action_name="attract_on", offset_minutes=0)
+        action2 = PatternAction(action_type="camera", action_name="takephoto", offset_minutes=5)
+        pattern = EventPattern(pattern_id="p1", name="UV Capture", description="", actions=[action1, action2])
+        trigger = FixedTimeTrigger(time="21:00", days_of_week=None)
+        schedule = Schedule(
+            schedule_id="s1",
+            name="Test",
+            description="",
+            event_patterns=[pattern],
+            trigger_type="fixed_time",
+            fixed_time_trigger=trigger,
+        )
+
+        events = get_next_events(schedule, count=20, from_time=datetime(2024, 6, 15, 20, 0, 0))
+        action_names = {e["action_name"] for e in events}
+        assert "attract_on" in action_names
+        assert "takephoto" in action_names
+
+    def test_respects_date_constraints(self):
+        """Events respect schedule start_date/end_date."""
+        from webui.backend.lib.schedule_schema import Schedule
+
+        action = PatternAction(action_type="camera", action_name="takephoto", offset_minutes=0)
+        pattern = EventPattern(pattern_id="p1", name="Photo", description="", actions=[action])
+        trigger = FixedTimeTrigger(time="21:00", days_of_week=None)
+        schedule = Schedule(
+            schedule_id="s1",
+            name="Test",
+            description="",
+            event_patterns=[pattern],
+            trigger_type="fixed_time",
+            fixed_time_trigger=trigger,
+            start_date="2024-06-15",
+            end_date="2024-06-20",
+        )
+
+        events = get_next_events(schedule, count=100, from_time=datetime(2024, 6, 1, 0, 0, 0))
+        for event in events:
+            event_date = datetime.fromisoformat(event["datetime"]).date()
+            assert event_date >= date(2024, 6, 15)
+            assert event_date <= date(2024, 6, 20)
+
+    def test_returns_empty_for_disabled_schedule(self):
+        """Disabled schedule returns no events."""
+        from webui.backend.lib.schedule_schema import Schedule
+
+        action = PatternAction(action_type="camera", action_name="takephoto", offset_minutes=0)
+        pattern = EventPattern(pattern_id="p1", name="Photo", description="", actions=[action])
+        trigger = FixedTimeTrigger(time="21:00", days_of_week=None)
+        schedule = Schedule(
+            schedule_id="s1",
+            name="Test",
+            description="",
+            event_patterns=[pattern],
+            trigger_type="fixed_time",
+            fixed_time_trigger=trigger,
+            enabled=False,
+        )
+
+        events = get_next_events(schedule, count=10)
+        assert events == []
+
+    def test_respects_count_limit(self):
+        """get_next_events respects count parameter."""
+        from webui.backend.lib.schedule_schema import Schedule
+
+        action = PatternAction(action_type="camera", action_name="takephoto", offset_minutes=0)
+        pattern = EventPattern(pattern_id="p1", name="Photo", description="", actions=[action])
+        trigger = FixedTimeTrigger(time="21:00", days_of_week=None)
+        schedule = Schedule(
+            schedule_id="s1",
+            name="Test",
+            description="",
+            event_patterns=[pattern],
+            trigger_type="fixed_time",
+            fixed_time_trigger=trigger,
+        )
+
+        events5 = get_next_events(schedule, count=5, from_time=datetime(2024, 6, 15, 20, 0, 0))
+        events10 = get_next_events(schedule, count=10, from_time=datetime(2024, 6, 15, 20, 0, 0))
+        assert len(events5) == 5
+        assert len(events10) == 10
+
+
+class TestScheduleToCron:
+    """Test main schedule_to_cron function."""
+
+    def test_fixed_time_schedule_to_cron(self):
+        """Convert fixed-time schedule to cron entries."""
+        action = PatternAction(action_type="camera", action_name="takephoto", offset_minutes=0)
+        pattern = EventPattern(pattern_id="p1", name="Photo", description="", actions=[action])
+        trigger = FixedTimeTrigger(time="21:00", days_of_week=None)
+        schedule = Schedule(
+            schedule_id="s1",
+            name="Test Schedule",
+            description="",
+            event_patterns=[pattern],
+            trigger_type="fixed_time",
+            fixed_time_trigger=trigger,
+        )
+
+        result = schedule_to_cron(schedule)
+        assert isinstance(result, CronBridgeResult)
+        assert result.schedule_id == "s1"
+        assert len(result.entries) > 0
+        assert len(result.errors) == 0
+
+    def test_interval_schedule_to_cron(self):
+        """Convert interval-based schedule to cron entries."""
+        action = PatternAction(action_type="camera", action_name="takephoto", offset_minutes=0)
+        pattern = EventPattern(pattern_id="p1", name="Photo", description="", actions=[action])
+        window = TimeWindow(start_time="21:00", end_time="23:00")
+        trigger = IntervalTrigger(interval_minutes=60, time_window=window)
+        schedule = Schedule(
+            schedule_id="s2",
+            name="Interval Schedule",
+            description="",
+            event_patterns=[pattern],
+            trigger_type="interval",
+            interval_trigger=trigger,
+        )
+
+        result = schedule_to_cron(schedule)
+        assert isinstance(result, CronBridgeResult)
+        assert len(result.entries) >= 3  # 21:00, 22:00, 23:00
+
+    def test_solar_schedule_to_cron(self):
+        """Convert solar-based schedule to cron entries."""
+        action = PatternAction(action_type="gpio", action_name="attract_on", offset_minutes=0)
+        pattern = EventPattern(pattern_id="p1", name="UV Light", description="", actions=[action])
+        trigger = SolarTrigger(solar_event="sunset", offset_minutes=30)
+        schedule = Schedule(
+            schedule_id="s3",
+            name="Solar Schedule",
+            description="",
+            event_patterns=[pattern],
+            trigger_type="solar",
+            solar_trigger=trigger,
+        )
+
+        result = schedule_to_cron(schedule, latitude=35.96, longitude=-83.92)
+        assert isinstance(result, CronBridgeResult)
+        assert len(result.entries) > 0
+
+    def test_moon_phase_schedule_to_cron(self):
+        """Convert moon-phase schedule to cron entries."""
+        action = PatternAction(action_type="camera", action_name="takephoto", offset_minutes=0)
+        pattern = EventPattern(pattern_id="p1", name="Full Moon Photo", description="", actions=[action])
+        window = TimeWindow(start_time="21:00", end_time="21:00")
+        trigger = MoonPhaseTrigger(phases=["full"], offset_days=0, time_window=window)
+        schedule = Schedule(
+            schedule_id="s4",
+            name="Moon Phase Schedule",
+            description="",
+            event_patterns=[pattern],
+            trigger_type="moon_phase",
+            moon_phase_trigger=trigger,
+        )
+
+        result = schedule_to_cron(schedule)
+        assert isinstance(result, CronBridgeResult)
+        # At least one full moon in 30 days
+        assert len(result.entries) >= 1
+
+    def test_disabled_schedule_returns_empty(self):
+        """Disabled schedule returns empty entries list."""
+        action = PatternAction(action_type="camera", action_name="takephoto", offset_minutes=0)
+        pattern = EventPattern(pattern_id="p1", name="Photo", description="", actions=[action])
+        trigger = FixedTimeTrigger(time="21:00", days_of_week=None)
+        schedule = Schedule(
+            schedule_id="s5",
+            name="Disabled Schedule",
+            description="",
+            event_patterns=[pattern],
+            trigger_type="fixed_time",
+            fixed_time_trigger=trigger,
+            enabled=False,
+        )
+
+        result = schedule_to_cron(schedule)
+        assert len(result.entries) == 0
+
+    def test_invalid_trigger_type_returns_error(self):
+        """Invalid trigger type returns error in result."""
+        action = PatternAction(action_type="camera", action_name="takephoto", offset_minutes=0)
+        pattern = EventPattern(pattern_id="p1", name="Photo", description="", actions=[action])
+        schedule = Schedule(
+            schedule_id="s6",
+            name="Invalid Schedule",
+            description="",
+            event_patterns=[pattern],
+            trigger_type="invalid_type",
+        )
+
+        result = schedule_to_cron(schedule)
+        assert len(result.errors) > 0
+        assert "invalid" in result.errors[0].lower() or "unsupported" in result.errors[0].lower()
+
+    def test_empty_event_patterns_returns_empty(self):
+        """Schedule with no patterns returns empty entries."""
+        trigger = FixedTimeTrigger(time="21:00", days_of_week=None)
+        schedule = Schedule(
+            schedule_id="s7",
+            name="Empty Schedule",
+            description="",
+            event_patterns=[],
+            trigger_type="fixed_time",
+            fixed_time_trigger=trigger,
+        )
+
+        result = schedule_to_cron(schedule)
+        assert len(result.entries) == 0
+
+
+class TestSensorTriggerStub:
+    """Test sensor trigger stub (returns empty with warning)."""
+
+    def test_sensor_trigger_returns_empty_entries(self):
+        """Sensor trigger returns empty list (not yet implemented)."""
+        trigger = SensorTrigger(
+            sensor_type="motion",
+            threshold=0.0,
+            comparison="gt",
+            cooldown_minutes=5,
+        )
+        entries = sensor_trigger_to_cron(trigger, command="cmd")
+        assert entries == []
+
+    def test_sensor_trigger_to_cron_returns_warning(self):
+        """Sensor trigger returns warning about not being implemented."""
+        action = PatternAction(action_type="camera", action_name="takephoto", offset_minutes=0)
+        pattern = EventPattern(pattern_id="p1", name="Motion Photo", description="", actions=[action])
+        trigger = SensorTrigger(sensor_type="motion", threshold=0.0)
+        schedule = Schedule(
+            schedule_id="s8",
+            name="Sensor Schedule",
+            description="",
+            event_patterns=[pattern],
+            trigger_type="sensor",
+            sensor_trigger=trigger,
+        )
+
+        result = schedule_to_cron(schedule)
+        assert len(result.entries) == 0
+        assert len(result.errors) > 0
+        assert "sensor" in result.errors[0].lower()
+
+
+class TestEdgeCases:
+    """Test edge cases and boundary conditions."""
+
+    def test_schedule_with_multiple_patterns(self):
+        """Schedule with multiple event patterns generates entries for all."""
+        action1 = PatternAction(action_type="gpio", action_name="attract_on", offset_minutes=0)
+        action2 = PatternAction(action_type="gpio", action_name="attract_off", offset_minutes=15)
+        pattern1 = EventPattern(pattern_id="p1", name="UV On", description="", actions=[action1])
+        pattern2 = EventPattern(pattern_id="p2", name="UV Off", description="", actions=[action2])
+        trigger = FixedTimeTrigger(time="21:00", days_of_week=None)
+        schedule = Schedule(
+            schedule_id="s9",
+            name="Multi Pattern",
+            description="",
+            event_patterns=[pattern1, pattern2],
+            trigger_type="fixed_time",
+            fixed_time_trigger=trigger,
+        )
+
+        result = schedule_to_cron(schedule)
+        # Should have entries for both patterns
+        assert len(result.entries) >= 2
+
+    def test_schedule_with_action_offsets(self):
+        """Schedule correctly applies action offsets."""
+        actions = [
+            PatternAction(action_type="gpio", action_name="attract_on", offset_minutes=0),
+            PatternAction(action_type="camera", action_name="takephoto", offset_minutes=5),
+            PatternAction(action_type="gpio", action_name="attract_off", offset_minutes=15),
+        ]
+        pattern = EventPattern(pattern_id="p1", name="UV Capture", description="", actions=actions)
+        trigger = FixedTimeTrigger(time="21:00", days_of_week=None)
+        schedule = Schedule(
+            schedule_id="s10",
+            name="With Offsets",
+            description="",
+            event_patterns=[pattern],
+            trigger_type="fixed_time",
+            fixed_time_trigger=trigger,
+        )
+
+        result = schedule_to_cron(schedule)
+        assert len(result.entries) >= 3
+        expressions = [e.expression for e in result.entries]
+        # Should have entries at 21:00, 21:05, 21:15
+        assert "0 21 * * *" in expressions
+        assert "5 21 * * *" in expressions
+        assert "15 21 * * *" in expressions
+
+    def test_rtc_waketime_calculated(self):
+        """schedule_to_cron calculates rtc_waketime."""
+        action = PatternAction(action_type="camera", action_name="takephoto", offset_minutes=0)
+        pattern = EventPattern(pattern_id="p1", name="Photo", description="", actions=[action])
+        trigger = FixedTimeTrigger(time="21:00", days_of_week=None)
+        schedule = Schedule(
+            schedule_id="s11",
+            name="Test",
+            description="",
+            event_patterns=[pattern],
+            trigger_type="fixed_time",
+            fixed_time_trigger=trigger,
+        )
+
+        result = schedule_to_cron(schedule)
+        # rtc_waketime should be set
+        assert result.rtc_waketime is not None
+        assert result.rtc_waketime > 0

--- a/Firmware/webui/backend/lib/cron_bridge.py
+++ b/Firmware/webui/backend/lib/cron_bridge.py
@@ -47,6 +47,15 @@ _CRON_FIELD_PATTERNS: Final[tuple[re.Pattern, ...]] = (
     re.compile(r'^(\*|[0-7](,[0-7])*|[0-7]-[0-7]|\*/[0-7])$'),  # weekday
 )
 
+# Cron field range validation constants
+_CRON_FIELD_RANGES: Final[dict[str, tuple[int, int]]] = {
+    "minute": (0, 59),
+    "hour": (0, 23),
+    "day": (1, 31),
+    "month": (1, 12),
+    "weekday": (0, 7),  # 0 and 7 both represent Sunday
+}
+
 
 @dataclass
 class CronEntry:
@@ -72,9 +81,11 @@ class CronEntry:
         """
         lines = []
 
-        # Add comment if present
+        # Add comment if present (sanitize to prevent injection)
         if self.comment:
-            lines.append(f"# {self.comment}")
+            # Remove newlines and additional # to prevent comment injection
+            clean_comment = self.comment.replace('\n', ' ').replace('#', '')
+            lines.append(f"# {clean_comment}")
 
         # Add cron expression and command
         cron_line = f"{self.expression} {self.command}"
@@ -113,7 +124,7 @@ class CronEntry:
                 if len(parts) == 2:
                     try:
                         start, end = int(parts[0]), int(parts[1])
-                        if start >= end:
+                        if start > end:
                             return False
                     except ValueError:
                         return False
@@ -140,35 +151,20 @@ class CronEntry:
             if not pattern.match(field_value):
                 return False
 
-        # Additional validation: check numeric ranges
+        # Additional validation: check numeric ranges using constants
         try:
-            minute, hour, day, month, weekday = fields
+            field_names = ("minute", "hour", "day", "month", "weekday")
+            for field_value, field_name in zip(fields, field_names, strict=True):
+                # Skip wildcards, steps, lists, and ranges
+                if field_value == '*' or field_value.startswith('*/') or ',' in field_value or '-' in field_value:
+                    continue
 
-            # Check minute range (0-59)
-            if minute != '*' and not minute.startswith('*/') and ',' not in minute and '-' not in minute and int(minute) > 59:
-                return False
-
-            # Check hour range (0-23)
-            if hour != '*' and not hour.startswith('*/') and ',' not in hour and '-' not in hour and int(hour) > 23:
-                return False
-
-            # Check day range (1-31)
-            if day != '*' and not day.startswith('*/') and ',' not in day and '-' not in day:
-                day_val = int(day)
-                if day_val < 1 or day_val > 31:
+                min_val, max_val = _CRON_FIELD_RANGES[field_name]
+                val = int(field_value)
+                if val < min_val or val > max_val:
                     return False
 
-            # Check month range (1-12)
-            if month != '*' and not month.startswith('*/') and ',' not in month and '-' not in month:
-                month_val = int(month)
-                if month_val < 1 or month_val > 12:
-                    return False
-
-            # Check weekday range (0-7)
-            if weekday != '*' and not weekday.startswith('*/') and ',' not in weekday and '-' not in weekday and int(weekday) > 7:
-                return False
-
-        except (ValueError, IndexError):
+        except (ValueError, IndexError, KeyError):
             return False
 
         return True
@@ -700,6 +696,10 @@ def pattern_to_cron_entries(
             command = get_validated_command(script_key)
         else:
             # Fallback for unknown actions (shouldn't happen with proper validation)
+            logger.warning(
+                f"Unknown action type '{action.action_type}/{action.action_name}' "
+                f"in pattern - skipping cron entry"
+            )
             command = f"# Unknown action: {action.action_type}/{action.action_name}"
 
         # Build cron expression
@@ -1275,8 +1275,9 @@ def apply_to_system(
         cron.write()
         logger.info(f"Applied {added_count} cron entries for schedule {schedule_id}")
 
-        # Set RTC wakealarm
+        # Set RTC wakealarm (clear existing first to avoid conflicts)
         if set_rtc and entries:
+            clear_rtc_wakealarm()  # Clear any existing alarm before setting new
             next_wake = calculate_next_from_entries(entries)
             if next_wake:
                 set_rtc_wakealarm(next_wake)

--- a/Firmware/webui/backend/lib/cron_bridge.py
+++ b/Firmware/webui/backend/lib/cron_bridge.py
@@ -38,6 +38,15 @@ logger = logging.getLogger(__name__)
 CRON_COMMENT_PREFIX: Final[str] = "Mothbox:"
 RTC_WAKEALARM_PATH: Final[str] = "/sys/class/rtc/rtc0/wakealarm"
 
+# Pre-compiled regex patterns for cron field validation (performance optimization)
+_CRON_FIELD_PATTERNS: Final[tuple[re.Pattern, ...]] = (
+    re.compile(r'^(\*|([0-5]?\d)(,([0-5]?\d))*|([0-5]?\d)-([0-5]?\d)|\*/([1-5]?\d))$'),  # minute
+    re.compile(r'^(\*|([01]?\d|2[0-3])(,([01]?\d|2[0-3]))*|([01]?\d|2[0-3])-([01]?\d|2[0-3])|\*/([01]?\d|2[0-3]))$'),  # hour
+    re.compile(r'^(\*|([1-9]|[12]\d|3[01])(,([1-9]|[12]\d|3[01]))*|([1-9]|[12]\d|3[01])-([1-9]|[12]\d|3[01])|\*/([1-9]|[12]\d|3[01]))$'),  # day
+    re.compile(r'^(\*|([1-9]|1[0-2])(,([1-9]|1[0-2]))*|([1-9]|1[0-2])-([1-9]|1[0-2])|\*/([1-9]|1[0-2]))$'),  # month
+    re.compile(r'^(\*|[0-7](,[0-7])*|[0-7]-[0-7]|\*/[0-7])$'),  # weekday
+)
+
 
 @dataclass
 class CronEntry:
@@ -96,18 +105,8 @@ class CronEntry:
         if len(fields) != 5:
             return False
 
-        # Define validation patterns for each field
-        # minute (0-59), hour (0-23), day (1-31), month (1-12), weekday (0-7)
-        patterns = [
-            r'^(\*|([0-5]?\d)(,([0-5]?\d))*|([0-5]?\d)-([0-5]?\d)|\*/([1-5]?\d))$',  # minute
-            r'^(\*|([01]?\d|2[0-3])(,([01]?\d|2[0-3]))*|([01]?\d|2[0-3])-([01]?\d|2[0-3])|\*/([01]?\d|2[0-3]))$',  # hour
-            r'^(\*|([1-9]|[12]\d|3[01])(,([1-9]|[12]\d|3[01]))*|([1-9]|[12]\d|3[01])-([1-9]|[12]\d|3[01])|\*/([1-9]|[12]\d|3[01]))$',  # day
-            r'^(\*|([1-9]|1[0-2])(,([1-9]|1[0-2]))*|([1-9]|1[0-2])-([1-9]|1[0-2])|\*/([1-9]|1[0-2]))$',  # month
-            r'^(\*|[0-7](,[0-7])*|[0-7]-[0-7]|\*/[0-7])$',  # weekday
-        ]
-
-        # Validate each field
-        for field_value, pattern in zip(fields, patterns, strict=True):
+        # Validate each field using pre-compiled patterns
+        for field_value, pattern in zip(fields, _CRON_FIELD_PATTERNS, strict=True):
             # Handle range expressions (e.g., 9-17)
             if '-' in field_value and not field_value.startswith('*/'):
                 parts = field_value.split('-')
@@ -137,8 +136,8 @@ class CronEntry:
                         return False
                 continue
 
-            # Validate against pattern
-            if not re.match(pattern, field_value):
+            # Validate against pre-compiled pattern
+            if not pattern.match(field_value):
                 return False
 
         # Additional validation: check numeric ranges
@@ -347,20 +346,26 @@ def calculate_next_waketime(
 
     Returns:
         Unix timestamp of next execution
+
+    Raises:
+        ValueError: If cron expression is invalid or calculation fails
     """
     if from_time is None:
         from_time = datetime.now()
 
-    # Create a temporary cron job to calculate schedule
-    cron = CronTab(tab="")  # In-memory crontab
-    job = cron.new(command="placeholder")
-    job.setall(cron_expression)
+    try:
+        # Create a temporary cron job to calculate schedule
+        cron = CronTab(tab="")  # In-memory crontab
+        job = cron.new(command="placeholder")
+        job.setall(cron_expression)
 
-    # Get next execution time
-    schedule = job.schedule(date_from=from_time)
-    next_scheduled = schedule.get_next()
+        # Get next execution time
+        schedule = job.schedule(date_from=from_time)
+        next_scheduled = schedule.get_next()
 
-    return int(next_scheduled.timestamp())
+        return int(next_scheduled.timestamp())
+    except (KeyError, AttributeError, TypeError) as e:
+        raise ValueError(f"Invalid cron expression '{cron_expression}': {e}") from e
 
 
 def calculate_next_from_entries(

--- a/Firmware/webui/backend/lib/cron_bridge.py
+++ b/Firmware/webui/backend/lib/cron_bridge.py
@@ -388,7 +388,7 @@ def calculate_next_from_entries(
             try:
                 next_time = calculate_next_waketime(entry.expression, from_time)
                 next_times.append(next_time)
-            except Exception:
+            except (ValueError, KeyError):
                 # Skip invalid expressions
                 continue
 
@@ -500,7 +500,13 @@ def solar_trigger_to_cron(
 
     Returns:
         List of CronEntry objects, one per day the trigger should execute
+
+    Raises:
+        ValueError: If days_ahead is not in range 1-365
     """
+    if not 1 <= days_ahead <= 365:
+        raise ValueError(f"days_ahead must be between 1 and 365, got {days_ahead}")
+
     if from_date is None:
         from_date = date.today()
 
@@ -579,7 +585,13 @@ def moon_phase_trigger_to_cron(
 
     Returns:
         List of CronEntry objects, one per day that matches the moon phase criteria
+
+    Raises:
+        ValueError: If days_ahead is not in range 1-365
     """
+    if not 1 <= days_ahead <= 365:
+        raise ValueError(f"days_ahead must be between 1 and 365, got {days_ahead}")
+
     if from_date is None:
         from_date = date.today()
 
@@ -736,7 +748,7 @@ def _convert_interval_schedule(schedule: Schedule) -> CronBridgeResult:
     for base_entry in base_entries:
         # Extract hour:minute from expression (format: "minute hour * * dow")
         parts = base_entry.expression.split()
-        base_time = f"{parts[1]}:{parts[0]:>02}"  # "HH:MM"
+        base_time = f"{int(parts[1]):02d}:{int(parts[0]):02d}"  # "HH:MM"
 
         for pattern in schedule.event_patterns:
             pattern_entries = pattern_to_cron_entries(
@@ -1266,7 +1278,7 @@ def apply_to_system(
 
         return True
 
-    except Exception as e:
+    except (OSError, ValueError) as e:
         logger.error(f"Failed to apply cron entries: {e}")
         return False
 
@@ -1310,6 +1322,6 @@ def remove_from_system(
 
         return True
 
-    except Exception as e:
+    except (OSError, ValueError) as e:
         logger.error(f"Failed to remove cron jobs: {e}")
         return False

--- a/Firmware/webui/backend/lib/cron_bridge.py
+++ b/Firmware/webui/backend/lib/cron_bridge.py
@@ -37,6 +37,7 @@ logger = logging.getLogger(__name__)
 # Constants
 CRON_COMMENT_PREFIX: Final[str] = "Mothbox:"
 RTC_WAKEALARM_PATH: Final[str] = "/sys/class/rtc/rtc0/wakealarm"
+LUNAR_CYCLE_DAYS: Final[int] = 30  # Minimum days to look ahead for moon phase schedules
 
 # Pre-compiled regex patterns for cron field validation (performance optimization)
 _CRON_FIELD_PATTERNS: Final[tuple[re.Pattern, ...]] = (
@@ -506,7 +507,10 @@ def solar_trigger_to_cron(
         ValueError: If days_ahead is not in range 1-365
     """
     if not 1 <= days_ahead <= 365:
-        raise ValueError(f"days_ahead must be between 1 and 365, got {days_ahead}")
+        raise ValueError(
+            f"days_ahead must be between 1 and 365, got {days_ahead}. "
+            "Values beyond 365 days lead to excessive computation and memory usage."
+        )
 
     if from_date is None:
         from_date = date.today()
@@ -591,7 +595,10 @@ def moon_phase_trigger_to_cron(
         ValueError: If days_ahead is not in range 1-365
     """
     if not 1 <= days_ahead <= 365:
-        raise ValueError(f"days_ahead must be between 1 and 365, got {days_ahead}")
+        raise ValueError(
+            f"days_ahead must be between 1 and 365, got {days_ahead}. "
+            "Values beyond 365 days lead to excessive computation and memory usage."
+        )
 
     if from_date is None:
         from_date = date.today()
@@ -915,8 +922,8 @@ def schedule_to_cron(
             result = _convert_solar_schedule(schedule, latitude, longitude, timezone_name, days_ahead)
 
     elif schedule.trigger_type == "moon_phase" and schedule.moon_phase_trigger:
-        # Use 30 days for moon phase schedules to capture at least one full moon cycle
-        moon_days_ahead = 30 if days_ahead == 7 else days_ahead
+        # Ensure we look far enough ahead to capture at least one full moon cycle
+        moon_days_ahead = LUNAR_CYCLE_DAYS if days_ahead == 7 else days_ahead
         result = _convert_moon_phase_schedule(schedule, moon_days_ahead)
 
     elif schedule.trigger_type == "sensor" and schedule.sensor_trigger:
@@ -1275,12 +1282,15 @@ def apply_to_system(
         cron.write()
         logger.info(f"Applied {added_count} cron entries for schedule {schedule_id}")
 
-        # Set RTC wakealarm (clear existing first to avoid conflicts)
+        # Set RTC wakealarm (set new alarm first to avoid race condition)
         if set_rtc and entries:
-            clear_rtc_wakealarm()  # Clear any existing alarm before setting new
             next_wake = calculate_next_from_entries(entries)
             if next_wake:
+                # Setting overwrites any existing alarm atomically
                 set_rtc_wakealarm(next_wake)
+            else:
+                # Only clear if no new alarm to set
+                clear_rtc_wakealarm()
 
         return True
 

--- a/Firmware/webui/backend/lib/cron_bridge.py
+++ b/Firmware/webui/backend/lib/cron_bridge.py
@@ -1,0 +1,1315 @@
+"""
+Cron Bridge - Translates schedule configurations to cron expressions.
+
+This module converts Schedule objects from schedule_schema.py into
+system cron expressions and RTC wakealarm settings.
+
+Issue: #215
+"""
+
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta
+from typing import Final
+
+from crontab import CronTab
+
+from webui.backend.lib.cron_security import (
+    get_script_key_for_action,
+    get_validated_command,
+    is_mothbox_command,
+)
+from webui.backend.lib.moon_phase import get_moon_phase, is_within_moon_phase
+from webui.backend.lib.schedule_schema import (
+    EventPattern,
+    FixedTimeTrigger,
+    IntervalTrigger,
+    MoonPhaseTrigger,
+    Schedule,
+    SensorTrigger,
+    SolarTrigger,
+)
+from webui.backend.lib.solar_time import parse_time_spec
+
+logger = logging.getLogger(__name__)
+
+# Constants
+CRON_COMMENT_PREFIX: Final[str] = "Mothbox:"
+RTC_WAKEALARM_PATH: Final[str] = "/sys/class/rtc/rtc0/wakealarm"
+
+
+@dataclass
+class CronEntry:
+    """Represents a single cron job entry.
+
+    Attributes:
+        expression: Cron expression (e.g., "0 21 * * *")
+        command: Full command to execute
+        comment: Optional comment for the job
+        enabled: Whether the entry is enabled
+    """
+    expression: str  # e.g., "0 21 * * *"
+    command: str     # e.g., "/usr/bin/python3 /opt/mothbox/TakePhoto.py"
+    comment: str = ""
+    enabled: bool = True
+
+    def to_cron_line(self) -> str:
+        """Convert entry to crontab line format.
+
+        Returns:
+            String in crontab format with optional comment line.
+            Disabled entries are commented out with #.
+        """
+        lines = []
+
+        # Add comment if present
+        if self.comment:
+            lines.append(f"# {self.comment}")
+
+        # Add cron expression and command
+        cron_line = f"{self.expression} {self.command}"
+        if not self.enabled:
+            cron_line = f"# {cron_line}"
+
+        lines.append(cron_line)
+
+        return "\n".join(lines)
+
+    @staticmethod
+    def is_valid_expression(expr: str) -> bool:
+        """Validate cron expression syntax.
+
+        Args:
+            expr: Cron expression string to validate
+
+        Returns:
+            True if expression is valid cron syntax, False otherwise
+        """
+        if not expr or not isinstance(expr, str):
+            return False
+
+        # Split expression into fields
+        fields = expr.split()
+
+        # Cron expression must have exactly 5 fields (minute hour day month weekday)
+        if len(fields) != 5:
+            return False
+
+        # Define validation patterns for each field
+        # minute (0-59), hour (0-23), day (1-31), month (1-12), weekday (0-7)
+        patterns = [
+            r'^(\*|([0-5]?\d)(,([0-5]?\d))*|([0-5]?\d)-([0-5]?\d)|\*/([1-5]?\d))$',  # minute
+            r'^(\*|([01]?\d|2[0-3])(,([01]?\d|2[0-3]))*|([01]?\d|2[0-3])-([01]?\d|2[0-3])|\*/([01]?\d|2[0-3]))$',  # hour
+            r'^(\*|([1-9]|[12]\d|3[01])(,([1-9]|[12]\d|3[01]))*|([1-9]|[12]\d|3[01])-([1-9]|[12]\d|3[01])|\*/([1-9]|[12]\d|3[01]))$',  # day
+            r'^(\*|([1-9]|1[0-2])(,([1-9]|1[0-2]))*|([1-9]|1[0-2])-([1-9]|1[0-2])|\*/([1-9]|1[0-2]))$',  # month
+            r'^(\*|[0-7](,[0-7])*|[0-7]-[0-7]|\*/[0-7])$',  # weekday
+        ]
+
+        # Validate each field
+        for field_value, pattern in zip(fields, patterns, strict=True):
+            # Handle range expressions (e.g., 9-17)
+            if '-' in field_value and not field_value.startswith('*/'):
+                parts = field_value.split('-')
+                if len(parts) == 2:
+                    try:
+                        start, end = int(parts[0]), int(parts[1])
+                        if start >= end:
+                            return False
+                    except ValueError:
+                        return False
+
+            # Handle step expressions (e.g., */5)
+            if field_value.startswith('*/'):
+                try:
+                    step = int(field_value[2:])
+                    if step <= 0:
+                        return False
+                except ValueError:
+                    return False
+                continue
+
+            # Handle comma-separated lists (e.g., 0,30)
+            if ',' in field_value:
+                values = field_value.split(',')
+                for val in values:
+                    if not val.strip():
+                        return False
+                continue
+
+            # Validate against pattern
+            if not re.match(pattern, field_value):
+                return False
+
+        # Additional validation: check numeric ranges
+        try:
+            minute, hour, day, month, weekday = fields
+
+            # Check minute range (0-59)
+            if minute != '*' and not minute.startswith('*/') and ',' not in minute and '-' not in minute and int(minute) > 59:
+                return False
+
+            # Check hour range (0-23)
+            if hour != '*' and not hour.startswith('*/') and ',' not in hour and '-' not in hour and int(hour) > 23:
+                return False
+
+            # Check day range (1-31)
+            if day != '*' and not day.startswith('*/') and ',' not in day and '-' not in day:
+                day_val = int(day)
+                if day_val < 1 or day_val > 31:
+                    return False
+
+            # Check month range (1-12)
+            if month != '*' and not month.startswith('*/') and ',' not in month and '-' not in month:
+                month_val = int(month)
+                if month_val < 1 or month_val > 12:
+                    return False
+
+            # Check weekday range (0-7)
+            if weekday != '*' and not weekday.startswith('*/') and ',' not in weekday and '-' not in weekday and int(weekday) > 7:
+                return False
+
+        except (ValueError, IndexError):
+            return False
+
+        return True
+
+
+@dataclass
+class CronBridgeResult:
+    """Result of schedule-to-cron conversion.
+
+    Attributes:
+        entries: List of cron entries generated
+        rtc_waketime: Unix timestamp for RTC alarm (None if not applicable)
+        schedule_id: ID of the schedule converted
+        errors: List of warnings/errors encountered
+    """
+    entries: list[CronEntry]
+    rtc_waketime: int | None
+    schedule_id: str
+    errors: list[str] = field(default_factory=list)
+
+
+# =============================================================================
+# TRIGGER CONVERSION FUNCTIONS
+# =============================================================================
+
+
+def _iso_to_cron_weekday(iso_days: list[int] | None) -> str:
+    """Convert ISO weekday list to cron weekday string.
+
+    Args:
+        iso_days: List of ISO weekdays (0=Mon..6=Sun) or None for all days
+
+    Returns:
+        Cron weekday string (e.g., "1,2,3,4,5" for weekdays or "*" for all)
+    """
+    if iso_days is None:
+        return "*"
+    # ISO: 0=Mon..6=Sun -> Cron: 0=Sun..6=Sat
+    # Formula: (iso_day + 1) % 7
+    cron_days = sorted([(d + 1) % 7 for d in iso_days])
+    return ",".join(str(d) for d in cron_days)
+
+
+def _generate_execution_times(
+    start_hour: int,
+    start_minute: int,
+    end_hour: int,
+    end_minute: int,
+    interval_minutes: int,
+) -> list[tuple[int, int]]:
+    """Generate (hour, minute) tuples for execution times within window.
+
+    Handles overnight windows (end < start).
+
+    Args:
+        start_hour: Starting hour (0-23)
+        start_minute: Starting minute (0-59)
+        end_hour: Ending hour (0-23)
+        end_minute: Ending minute (0-59)
+        interval_minutes: Interval between executions in minutes
+
+    Returns:
+        List of (hour, minute) tuples representing execution times
+    """
+    times = []
+
+    # Convert to minutes since midnight for easier arithmetic
+    start_mins = start_hour * 60 + start_minute
+    end_mins = end_hour * 60 + end_minute
+
+    # Handle overnight window (e.g., 22:00 to 02:00)
+    if end_mins < start_mins:
+        end_mins += 24 * 60  # Add 24 hours to end
+
+    current = start_mins
+    while current <= end_mins:
+        # Normalize to 24-hour format
+        normalized = current % (24 * 60)
+        hour = normalized // 60
+        minute = normalized % 60
+        times.append((hour, minute))
+        current += interval_minutes
+
+    return times
+
+
+def fixed_time_trigger_to_cron(
+    trigger: FixedTimeTrigger,
+    command: str,
+    comment_prefix: str = CRON_COMMENT_PREFIX,
+) -> list[CronEntry]:
+    """Convert FixedTimeTrigger to cron entries.
+
+    Args:
+        trigger: FixedTimeTrigger with time (HH:MM) and optional days_of_week
+        command: Full command string to execute
+        comment_prefix: Prefix for cron comment
+
+    Returns:
+        List containing single CronEntry
+
+    Note:
+        ISO weekday (0=Mon..6=Sun) is converted to cron weekday (0=Sun..6=Sat)
+    """
+    # Parse HH:MM
+    hour, minute = map(int, trigger.time.split(":"))
+
+    # Convert ISO weekday to cron weekday using helper function
+    dow_str = _iso_to_cron_weekday(trigger.days_of_week)
+
+    expression = f"{minute} {hour} * * {dow_str}"
+
+    comment = f"{comment_prefix} Fixed time {trigger.time}"
+    if trigger.days_of_week:
+        comment += f" on days {trigger.days_of_week}"
+
+    return [CronEntry(expression=expression, command=command, comment=comment)]
+
+
+def interval_trigger_to_cron(
+    trigger: IntervalTrigger,
+    command: str,
+    comment_prefix: str = CRON_COMMENT_PREFIX,
+) -> list[CronEntry]:
+    """Convert IntervalTrigger to cron entries.
+
+    Args:
+        trigger: IntervalTrigger with interval_minutes, time_window, optional days_of_week
+        command: Full command string to execute
+        comment_prefix: Prefix for cron comment
+
+    Returns:
+        List of CronEntry objects, one per execution time within the window
+    """
+    # Parse time window
+    start_hour, start_minute = map(int, trigger.time_window.start_time.split(":"))
+    end_hour, end_minute = map(int, trigger.time_window.end_time.split(":"))
+
+    # Generate execution times
+    exec_times = _generate_execution_times(
+        start_hour, start_minute,
+        end_hour, end_minute,
+        trigger.interval_minutes
+    )
+
+    # Convert days of week
+    dow_str = _iso_to_cron_weekday(trigger.days_of_week)
+
+    # Create cron entries
+    entries = []
+    for hour, minute in exec_times:
+        expression = f"{minute} {hour} * * {dow_str}"
+        comment = f"{comment_prefix} Interval {trigger.interval_minutes}min at {hour:02d}:{minute:02d}"
+        entries.append(CronEntry(expression=expression, command=command, comment=comment))
+
+    return entries
+
+
+# =============================================================================
+# RTC WAKEALARM FUNCTIONS
+# =============================================================================
+
+
+def calculate_next_waketime(
+    cron_expression: str,
+    from_time: datetime | None = None,
+) -> int:
+    """Calculate next execution time as Unix epoch.
+
+    Uses python-crontab library (same pattern as Scheduler.py).
+
+    Args:
+        cron_expression: Cron expression (e.g., "0 21 * * *")
+        from_time: Calculate from this time (defaults to now)
+
+    Returns:
+        Unix timestamp of next execution
+    """
+    if from_time is None:
+        from_time = datetime.now()
+
+    # Create a temporary cron job to calculate schedule
+    cron = CronTab(tab="")  # In-memory crontab
+    job = cron.new(command="placeholder")
+    job.setall(cron_expression)
+
+    # Get next execution time
+    schedule = job.schedule(date_from=from_time)
+    next_scheduled = schedule.get_next()
+
+    return int(next_scheduled.timestamp())
+
+
+def calculate_next_from_entries(
+    entries: list[CronEntry],
+    from_time: datetime | None = None,
+) -> int | None:
+    """Return earliest next execution from multiple cron entries.
+
+    Args:
+        entries: List of CronEntry objects
+        from_time: Calculate from this time (defaults to now)
+
+    Returns:
+        Unix timestamp of earliest next execution, or None if no entries
+    """
+    if not entries:
+        return None
+
+    if from_time is None:
+        from_time = datetime.now()
+
+    next_times = []
+    for entry in entries:
+        if entry.enabled:
+            try:
+                next_time = calculate_next_waketime(entry.expression, from_time)
+                next_times.append(next_time)
+            except Exception:
+                # Skip invalid expressions
+                continue
+
+    return min(next_times) if next_times else None
+
+
+def set_rtc_wakealarm(epoch_time: int) -> bool:
+    """Set RTC wakealarm (Pi5).
+
+    Reference: Scheduler.py lines 702-716
+
+    Args:
+        epoch_time: Unix timestamp for wakeup
+
+    Returns:
+        True if successful, False on error
+    """
+    try:
+        with open(RTC_WAKEALARM_PATH, "w") as f:
+            f.write(str(epoch_time))
+        logger.info(f"Set RTC wakealarm to {epoch_time}")
+        return True
+    except (PermissionError, FileNotFoundError, OSError) as e:
+        logger.error(f"Failed to set RTC wakealarm: {e}")
+        return False
+
+
+def clear_rtc_wakealarm() -> bool:
+    """Clear existing RTC wakealarm.
+
+    Writes "0" to clear the alarm.
+
+    Returns:
+        True if successful, False on error
+    """
+    try:
+        with open(RTC_WAKEALARM_PATH, "w") as f:
+            f.write("0")
+        logger.info("Cleared RTC wakealarm")
+        return True
+    except (PermissionError, FileNotFoundError, OSError) as e:
+        logger.error(f"Failed to clear RTC wakealarm: {e}")
+        return False
+
+
+def get_solar_execution_time(
+    trigger: SolarTrigger,
+    target_date: date,
+    latitude: float,
+    longitude: float,
+    timezone_name: str = "UTC",
+) -> datetime | None:
+    """Calculate execution time for a solar trigger on a specific date.
+
+    Args:
+        trigger: SolarTrigger with solar_event and offset_minutes
+        target_date: Date to calculate for
+        latitude: Observer latitude
+        longitude: Observer longitude
+        timezone_name: Timezone for calculations
+
+    Returns:
+        Datetime of execution, or None if event doesn't occur (polar regions)
+    """
+    # Build time_spec string (e.g., "sunset+30" or "sunrise-15")
+    if trigger.offset_minutes >= 0:
+        time_spec = f"{trigger.solar_event}+{trigger.offset_minutes}"
+    else:
+        time_spec = f"{trigger.solar_event}{trigger.offset_minutes}"
+
+    try:
+        return parse_time_spec(
+            time_spec,
+            target_date,
+            latitude,
+            longitude,
+            timezone_name
+        )
+    except ValueError:
+        # Solar event doesn't occur on this date (e.g., polar regions)
+        return None
+
+
+def solar_trigger_to_cron(
+    trigger: SolarTrigger,
+    command: str,
+    latitude: float,
+    longitude: float,
+    timezone_name: str = "UTC",
+    days_ahead: int = 7,
+    from_date: date | None = None,
+    comment_prefix: str = CRON_COMMENT_PREFIX,
+) -> list[CronEntry]:
+    """Convert SolarTrigger to cron entries for upcoming days.
+
+    Pre-calculates solar times for the next N days and generates fixed
+    cron entries for each day. Requires regeneration when approaching
+    the end of the pre-calculated period.
+
+    Args:
+        trigger: SolarTrigger with solar_event, offset_minutes, optional days_of_week
+        command: Full command string to execute
+        latitude: Observer latitude
+        longitude: Observer longitude
+        timezone_name: Timezone for calculations
+        days_ahead: Number of days to pre-calculate (default 7)
+        from_date: Start date (defaults to today)
+        comment_prefix: Prefix for cron comment
+
+    Returns:
+        List of CronEntry objects, one per day the trigger should execute
+    """
+    if from_date is None:
+        from_date = date.today()
+
+    entries = []
+
+    for day_offset in range(days_ahead):
+        target_date = from_date + timedelta(days=day_offset)
+
+        # Check day-of-week restriction (ISO: 0=Mon..6=Sun)
+        if trigger.days_of_week is not None and target_date.weekday() not in trigger.days_of_week:
+            continue
+
+        # Calculate execution time for this date
+        exec_time = get_solar_execution_time(
+            trigger, target_date, latitude, longitude, timezone_name
+        )
+
+        if exec_time is None:
+            # Solar event doesn't occur (polar region handling)
+            continue
+
+        # Build cron expression with specific day and month
+        # Format: minute hour day month weekday
+        expression = f"{exec_time.minute} {exec_time.hour} {target_date.day} {target_date.month} *"
+
+        comment = (
+            f"{comment_prefix} {trigger.solar_event}"
+            f"{'+' if trigger.offset_minutes >= 0 else ''}{trigger.offset_minutes}min "
+            f"on {target_date.isoformat()}"
+        )
+
+        entries.append(CronEntry(expression=expression, command=command, comment=comment))
+
+    return entries
+
+
+
+
+def is_moon_phase_active(
+    trigger: MoonPhaseTrigger,
+    target_date: date,
+) -> bool:
+    """Check if moon phase trigger should be active on target_date.
+
+    Args:
+        trigger: MoonPhaseTrigger with phases and offset_days
+        target_date: Date to check
+
+    Returns:
+        True if date matches any of the trigger's phases within offset tolerance
+    """
+    for phase in trigger.phases:
+        if is_within_moon_phase(target_date, phase, trigger.offset_days):
+            return True
+    return False
+
+
+def moon_phase_trigger_to_cron(
+    trigger: MoonPhaseTrigger,
+    command: str,
+    days_ahead: int = 30,
+    from_date: date | None = None,
+    comment_prefix: str = CRON_COMMENT_PREFIX,
+) -> list[CronEntry]:
+    """Convert MoonPhaseTrigger to cron entries for upcoming matching days.
+
+    Pre-calculates which days match the moon phase criteria and generates
+    fixed cron entries for each matching day.
+
+    Args:
+        trigger: MoonPhaseTrigger with phases, offset_days, optional time_window
+        command: Full command string to execute
+        days_ahead: Number of days to pre-calculate (default 30)
+        from_date: Start date (defaults to today)
+        comment_prefix: Prefix for cron comment
+
+    Returns:
+        List of CronEntry objects, one per day that matches the moon phase criteria
+    """
+    if from_date is None:
+        from_date = date.today()
+
+    # Determine execution time from time_window or default to midnight
+    if trigger.time_window:
+        hour, minute = map(int, trigger.time_window.start_time.split(":"))
+    else:
+        hour, minute = 0, 0
+
+    entries = []
+
+    for day_offset in range(days_ahead):
+        target_date = from_date + timedelta(days=day_offset)
+
+        # Check if this date matches the moon phase criteria
+        if not is_moon_phase_active(trigger, target_date):
+            continue
+
+        # Build cron expression with specific day and month
+        expression = f"{minute} {hour} {target_date.day} {target_date.month} *"
+
+        # Get current moon phase for comment
+        phase_info = get_moon_phase(target_date)
+        comment = (
+            f"{comment_prefix} Moon phase ({phase_info['phase']}) "
+            f"on {target_date.isoformat()}"
+        )
+
+        entries.append(CronEntry(expression=expression, command=command, comment=comment))
+
+    return entries
+
+
+def sensor_trigger_to_cron(
+    trigger: SensorTrigger,
+    command: str,
+    comment_prefix: str = CRON_COMMENT_PREFIX,
+) -> list[CronEntry]:
+    """Convert SensorTrigger to cron entries.
+
+    NOTE: Sensor triggers are not yet implemented. They require
+    GPIO interrupt handling which is beyond traditional cron scheduling.
+    This function returns an empty list with a warning logged.
+
+    Args:
+        trigger: SensorTrigger with sensor_type and threshold
+        command: Full command string to execute
+        comment_prefix: Prefix for cron comment
+
+    Returns:
+        Empty list (sensor triggers not implemented via cron)
+    """
+    logger.warning(
+        f"Sensor triggers not yet implemented for cron scheduling. "
+        f"Sensor type: {trigger.sensor_type}"
+    )
+    return []
+
+
+def pattern_to_cron_entries(
+    pattern: EventPattern,
+    base_time: str,  # "HH:MM" format
+    days_of_week: list[int] | None = None,
+    comment_prefix: str = CRON_COMMENT_PREFIX,
+) -> list[CronEntry]:
+    """Convert EventPattern actions to cron entries.
+
+    Each action in the pattern becomes a separate cron entry with:
+    - Execution time = base_time + action.offset_minutes
+    - Command from cron_security.get_validated_command()
+
+    Args:
+        pattern: EventPattern with actions list
+        base_time: Base execution time in "HH:MM" format
+        days_of_week: Optional ISO weekday restrictions (0=Mon..6=Sun)
+        comment_prefix: Prefix for cron comments
+
+    Returns:
+        List of CronEntry objects, one per action in the pattern
+    """
+    base_hour, base_minute = map(int, base_time.split(":"))
+    base_total_minutes = base_hour * 60 + base_minute
+
+    # Convert days_of_week to cron format
+    dow_str = _iso_to_cron_weekday(days_of_week)
+
+    entries = []
+
+    for action in pattern.actions:
+        # Calculate execution time
+        exec_total_minutes = base_total_minutes + action.offset_minutes
+
+        # Normalize to 24-hour format (handle midnight crossing)
+        exec_total_minutes = exec_total_minutes % (24 * 60)
+        exec_hour = exec_total_minutes // 60
+        exec_minute = exec_total_minutes % 60
+
+        # Get validated command from cron_security
+        script_key = get_script_key_for_action(action.action_type, action.action_name)
+        if script_key:
+            command = get_validated_command(script_key)
+        else:
+            # Fallback for unknown actions (shouldn't happen with proper validation)
+            command = f"# Unknown action: {action.action_type}/{action.action_name}"
+
+        # Build cron expression
+        expression = f"{exec_minute} {exec_hour} * * {dow_str}"
+
+        # Build comment
+        comment = (
+            f"{comment_prefix} {pattern.name}: {action.action_type}/{action.action_name} "
+            f"at offset +{action.offset_minutes}min"
+        )
+
+        entries.append(CronEntry(expression=expression, command=command, comment=comment))
+
+    return entries
+
+
+# =============================================================================
+# SCHEDULE-TO-CRON CONVERSION
+# =============================================================================
+
+
+def _convert_fixed_time_schedule(schedule: Schedule, days_ahead: int = 7) -> CronBridgeResult:
+    """Convert fixed-time schedule to cron entries."""
+    trigger = schedule.fixed_time_trigger
+    entries = []
+
+    for pattern in schedule.event_patterns:
+        pattern_entries = pattern_to_cron_entries(
+            pattern,
+            base_time=trigger.time,
+            days_of_week=trigger.days_of_week,
+        )
+        entries.extend(pattern_entries)
+
+    return CronBridgeResult(
+        entries=entries,
+        rtc_waketime=calculate_next_from_entries(entries) if entries else None,
+        schedule_id=schedule.schedule_id,
+    )
+
+
+def _convert_interval_schedule(schedule: Schedule) -> CronBridgeResult:
+    """Convert interval schedule to cron entries."""
+    trigger = schedule.interval_trigger
+    entries = []
+
+    # Generate base execution times from interval trigger
+    base_entries = interval_trigger_to_cron(trigger, command="placeholder")
+
+    # For each base time, generate pattern actions
+    for base_entry in base_entries:
+        # Extract hour:minute from expression (format: "minute hour * * dow")
+        parts = base_entry.expression.split()
+        base_time = f"{parts[1]}:{parts[0]:>02}"  # "HH:MM"
+
+        for pattern in schedule.event_patterns:
+            pattern_entries = pattern_to_cron_entries(
+                pattern,
+                base_time=base_time,
+                days_of_week=trigger.days_of_week,
+            )
+            entries.extend(pattern_entries)
+
+    return CronBridgeResult(
+        entries=entries,
+        rtc_waketime=calculate_next_from_entries(entries) if entries else None,
+        schedule_id=schedule.schedule_id,
+    )
+
+
+def _convert_solar_schedule(
+    schedule: Schedule,
+    latitude: float,
+    longitude: float,
+    timezone_name: str,
+    days_ahead: int,
+) -> CronBridgeResult:
+    """Convert solar schedule to cron entries."""
+    entries = []
+
+    # Generate base entries from solar trigger
+    for pattern in schedule.event_patterns:
+        # For each action in pattern, generate solar-timed entries
+        for action in pattern.actions:
+            script_key = get_script_key_for_action(action.action_type, action.action_name)
+            command = get_validated_command(script_key) if script_key else f"# Unknown: {action.action_type}/{action.action_name}"
+
+            # Create modified trigger with action offset
+            modified_trigger = SolarTrigger(
+                solar_event=schedule.solar_trigger.solar_event,
+                offset_minutes=schedule.solar_trigger.offset_minutes + action.offset_minutes,
+                days_of_week=schedule.solar_trigger.days_of_week,
+            )
+
+            solar_entries = solar_trigger_to_cron(
+                modified_trigger,
+                command=command,
+                latitude=latitude,
+                longitude=longitude,
+                timezone_name=timezone_name,
+                days_ahead=days_ahead,
+            )
+            entries.extend(solar_entries)
+
+    return CronBridgeResult(
+        entries=entries,
+        rtc_waketime=calculate_next_from_entries(entries) if entries else None,
+        schedule_id=schedule.schedule_id,
+    )
+
+
+def _convert_moon_phase_schedule(schedule: Schedule, days_ahead: int) -> CronBridgeResult:
+    """Convert moon phase schedule to cron entries."""
+    entries = []
+
+    # Get base execution time from time_window
+    trigger = schedule.moon_phase_trigger
+    if trigger.time_window:
+        base_hour, base_minute = map(int, trigger.time_window.start_time.split(":"))
+    else:
+        base_hour, base_minute = 0, 0
+
+    # Get dates matching moon phases
+    from_date = date.today()
+    matching_dates = []
+
+    for day_offset in range(days_ahead):
+        target_date = from_date + timedelta(days=day_offset)
+        if is_moon_phase_active(trigger, target_date):
+            matching_dates.append(target_date)
+
+    # For each matching date, generate entries for all pattern actions
+    for target_date in matching_dates:
+        for pattern in schedule.event_patterns:
+            for action in pattern.actions:
+                # Calculate execution time with action offset
+                exec_total_minutes = base_hour * 60 + base_minute + action.offset_minutes
+                exec_total_minutes = exec_total_minutes % (24 * 60)
+                exec_hour = exec_total_minutes // 60
+                exec_minute = exec_total_minutes % 60
+
+                # Get validated command
+                script_key = get_script_key_for_action(action.action_type, action.action_name)
+                command = get_validated_command(script_key) if script_key else f"# Unknown: {action.action_type}/{action.action_name}"
+
+                # Build cron expression with specific day and month
+                expression = f"{exec_minute} {exec_hour} {target_date.day} {target_date.month} *"
+
+                # Get current moon phase for comment
+                phase_info = get_moon_phase(target_date)
+                comment = (
+                    f"{CRON_COMMENT_PREFIX} {pattern.name}: {action.action_type}/{action.action_name} "
+                    f"Moon phase ({phase_info['phase']}) on {target_date.isoformat()}"
+                )
+
+                entries.append(CronEntry(expression=expression, command=command, comment=comment))
+
+    return CronBridgeResult(
+        entries=entries,
+        rtc_waketime=calculate_next_from_entries(entries) if entries else None,
+        schedule_id=schedule.schedule_id,
+    )
+
+
+def schedule_to_cron(
+    schedule: Schedule,
+    latitude: float | None = None,
+    longitude: float | None = None,
+    timezone_name: str = "UTC",
+    days_ahead: int = 7,
+) -> CronBridgeResult:
+    """Convert Schedule to cron entries.
+
+    Main entry point for the cron bridge. Routes to appropriate
+    trigger converter based on schedule.trigger_type.
+
+    Args:
+        schedule: Schedule object to convert
+        latitude: Observer latitude (required for solar triggers)
+        longitude: Observer longitude (required for solar triggers)
+        timezone_name: Timezone for calculations
+        days_ahead: Number of days to pre-calculate (for solar/moon triggers)
+
+    Returns:
+        CronBridgeResult with entries, rtc_waketime, and any errors
+    """
+    result = CronBridgeResult(
+        entries=[],
+        rtc_waketime=None,
+        schedule_id=schedule.schedule_id,
+        errors=[],
+    )
+
+    # Check if schedule is enabled
+    if not schedule.enabled:
+        return result
+
+    # Check for event patterns
+    if not schedule.event_patterns:
+        return result
+
+    # Route to appropriate trigger converter
+    if schedule.trigger_type == "fixed_time" and schedule.fixed_time_trigger:
+        result = _convert_fixed_time_schedule(schedule, days_ahead)
+
+    elif schedule.trigger_type == "interval" and schedule.interval_trigger:
+        result = _convert_interval_schedule(schedule)
+
+    elif schedule.trigger_type == "solar" and schedule.solar_trigger:
+        if latitude is None or longitude is None:
+            result.errors.append("Solar triggers require latitude and longitude")
+        else:
+            result = _convert_solar_schedule(schedule, latitude, longitude, timezone_name, days_ahead)
+
+    elif schedule.trigger_type == "moon_phase" and schedule.moon_phase_trigger:
+        # Use 30 days for moon phase schedules to capture at least one full moon cycle
+        moon_days_ahead = 30 if days_ahead == 7 else days_ahead
+        result = _convert_moon_phase_schedule(schedule, moon_days_ahead)
+
+    elif schedule.trigger_type == "sensor" and schedule.sensor_trigger:
+        # Sensor triggers are stubbed
+        result.errors.append("Sensor triggers not yet implemented for cron scheduling")
+
+    else:
+        result.errors.append(f"Unsupported or invalid trigger type: {schedule.trigger_type}")
+
+    # Calculate RTC waketime if we have entries
+    if result.entries:
+        result.rtc_waketime = calculate_next_from_entries(result.entries)
+
+    return result
+
+
+# =============================================================================
+# EVENT PREVIEW
+# =============================================================================
+
+
+def get_next_events(
+    schedule: Schedule,
+    count: int = 10,
+    from_time: datetime | None = None,
+    latitude: float | None = None,
+    longitude: float | None = None,
+    timezone_name: str = "UTC",
+) -> list[dict]:
+    """Preview next N scheduled events without modifying system.
+
+    Calculates upcoming event execution times based on the schedule's
+    trigger type and event patterns.
+
+    Args:
+        schedule: Schedule object to preview
+        count: Maximum number of events to return (default 10)
+        from_time: Calculate events from this time (defaults to now)
+        latitude: Observer latitude (required for solar triggers)
+        longitude: Observer longitude (required for solar triggers)
+        timezone_name: Timezone for calculations
+
+    Returns:
+        List of event dicts with:
+        - datetime: ISO 8601 string
+        - action_type: str (gpio, camera, etc.)
+        - action_name: str (attract_on, takephoto, etc.)
+        - pattern_name: str
+        - pattern_id: str
+    """
+    if not schedule.enabled:
+        return []
+
+    if from_time is None:
+        from_time = datetime.now()
+
+    events = []
+
+    # Get date constraints
+    start_date = date.fromisoformat(schedule.start_date) if schedule.start_date else None
+    end_date = date.fromisoformat(schedule.end_date) if schedule.end_date else None
+
+    # Calculate trigger times based on type
+    if schedule.trigger_type == "fixed_time" and schedule.fixed_time_trigger:
+        events = _get_events_fixed_time(
+            schedule, count * 2, from_time, start_date, end_date
+        )
+    elif schedule.trigger_type == "interval" and schedule.interval_trigger:
+        events = _get_events_interval(
+            schedule, count * 2, from_time, start_date, end_date
+        )
+    elif schedule.trigger_type == "solar" and schedule.solar_trigger:
+        events = _get_events_solar(
+            schedule, count * 2, from_time, start_date, end_date,
+            latitude, longitude, timezone_name
+        )
+    elif schedule.trigger_type == "moon_phase" and schedule.moon_phase_trigger:
+        events = _get_events_moon_phase(
+            schedule, count * 2, from_time, start_date, end_date
+        )
+
+    # Sort chronologically and trim to count
+    events.sort(key=lambda e: e["datetime"])
+    return events[:count]
+
+
+def _get_events_fixed_time(
+    schedule: Schedule,
+    max_events: int,
+    from_time: datetime,
+    start_date: date | None,
+    end_date: date | None,
+) -> list[dict]:
+    """Generate events for fixed time trigger."""
+    events = []
+    trigger = schedule.fixed_time_trigger
+    hour, minute = map(int, trigger.time.split(":"))
+
+    current_date = from_time.date()
+    days_checked = 0
+    max_days = max_events * 7  # Check up to max_events weeks
+
+    while len(events) < max_events and days_checked < max_days:
+        # Check date constraints
+        if start_date and current_date < start_date:
+            current_date += timedelta(days=1)
+            days_checked += 1
+            continue
+        if end_date and current_date > end_date:
+            break
+
+        # Check day of week restriction
+        if trigger.days_of_week is not None and current_date.weekday() not in trigger.days_of_week:
+            current_date += timedelta(days=1)
+            days_checked += 1
+            continue
+
+        # Generate events for this day
+        trigger_time = datetime.combine(current_date, datetime.min.time().replace(hour=hour, minute=minute))
+
+        if trigger_time > from_time:
+            for pattern in schedule.event_patterns:
+                for action in pattern.actions:
+                    event_time = trigger_time + timedelta(minutes=action.offset_minutes)
+                    events.append({
+                        "datetime": event_time.isoformat(),
+                        "action_type": action.action_type,
+                        "action_name": action.action_name,
+                        "pattern_name": pattern.name,
+                        "pattern_id": pattern.pattern_id,
+                    })
+
+        current_date += timedelta(days=1)
+        days_checked += 1
+
+    return events
+
+
+def _get_events_interval(
+    schedule: Schedule,
+    max_events: int,
+    from_time: datetime,
+    start_date: date | None,
+    end_date: date | None,
+) -> list[dict]:
+    """Generate events for interval trigger."""
+    events = []
+    trigger = schedule.interval_trigger
+
+    # Parse time window
+    start_hour, start_min = map(int, trigger.time_window.start_time.split(":"))
+    end_hour, end_min = map(int, trigger.time_window.end_time.split(":"))
+
+    current_date = from_time.date()
+    days_checked = 0
+    max_days = max_events * 2
+
+    while len(events) < max_events and days_checked < max_days:
+        # Check date constraints
+        if start_date and current_date < start_date:
+            current_date += timedelta(days=1)
+            days_checked += 1
+            continue
+        if end_date and current_date > end_date:
+            break
+
+        # Check day of week restriction
+        if trigger.days_of_week is not None and current_date.weekday() not in trigger.days_of_week:
+            current_date += timedelta(days=1)
+            days_checked += 1
+            continue
+
+        # Generate execution times for this day
+        exec_times = _generate_execution_times(start_hour, start_min, end_hour, end_min, trigger.interval_minutes)
+
+        for exec_hour, exec_min in exec_times:
+            trigger_time = datetime.combine(current_date, datetime.min.time().replace(hour=exec_hour, minute=exec_min))
+
+            if trigger_time > from_time:
+                for pattern in schedule.event_patterns:
+                    for action in pattern.actions:
+                        event_time = trigger_time + timedelta(minutes=action.offset_minutes)
+                        events.append({
+                            "datetime": event_time.isoformat(),
+                            "action_type": action.action_type,
+                            "action_name": action.action_name,
+                            "pattern_name": pattern.name,
+                            "pattern_id": pattern.pattern_id,
+                        })
+
+        current_date += timedelta(days=1)
+        days_checked += 1
+
+    return events
+
+
+def _get_events_solar(
+    schedule: Schedule,
+    max_events: int,
+    from_time: datetime,
+    start_date: date | None,
+    end_date: date | None,
+    latitude: float | None,
+    longitude: float | None,
+    timezone_name: str,
+) -> list[dict]:
+    """Generate events for solar trigger."""
+    events = []
+
+    if latitude is None or longitude is None:
+        return events  # Cannot calculate without coordinates
+
+    trigger = schedule.solar_trigger
+    current_date = from_time.date()
+    days_checked = 0
+    max_days = max_events * 2
+
+    while len(events) < max_events and days_checked < max_days:
+        # Check date constraints
+        if start_date and current_date < start_date:
+            current_date += timedelta(days=1)
+            days_checked += 1
+            continue
+        if end_date and current_date > end_date:
+            break
+
+        # Check day of week restriction
+        if trigger.days_of_week is not None and current_date.weekday() not in trigger.days_of_week:
+            current_date += timedelta(days=1)
+            days_checked += 1
+            continue
+
+        # Calculate solar time
+        exec_time = get_solar_execution_time(trigger, current_date, latitude, longitude, timezone_name)
+
+        if exec_time and exec_time > from_time:
+            for pattern in schedule.event_patterns:
+                for action in pattern.actions:
+                    event_time = exec_time + timedelta(minutes=action.offset_minutes)
+                    events.append({
+                        "datetime": event_time.isoformat(),
+                        "action_type": action.action_type,
+                        "action_name": action.action_name,
+                        "pattern_name": pattern.name,
+                        "pattern_id": pattern.pattern_id,
+                    })
+
+        current_date += timedelta(days=1)
+        days_checked += 1
+
+    return events
+
+
+def _get_events_moon_phase(
+    schedule: Schedule,
+    max_events: int,
+    from_time: datetime,
+    start_date: date | None,
+    end_date: date | None,
+) -> list[dict]:
+    """Generate events for moon phase trigger."""
+    events = []
+    trigger = schedule.moon_phase_trigger
+
+    # Get execution time from time window
+    if trigger.time_window:
+        hour, minute = map(int, trigger.time_window.start_time.split(":"))
+    else:
+        hour, minute = 0, 0
+
+    current_date = from_time.date()
+    days_checked = 0
+    max_days = max_events * 30  # Check up to 30x max_events days
+
+    while len(events) < max_events and days_checked < max_days:
+        # Check date constraints
+        if start_date and current_date < start_date:
+            current_date += timedelta(days=1)
+            days_checked += 1
+            continue
+        if end_date and current_date > end_date:
+            break
+
+        # Check moon phase
+        if is_moon_phase_active(trigger, current_date):
+            trigger_time = datetime.combine(current_date, datetime.min.time().replace(hour=hour, minute=minute))
+
+            if trigger_time > from_time:
+                for pattern in schedule.event_patterns:
+                    for action in pattern.actions:
+                        event_time = trigger_time + timedelta(minutes=action.offset_minutes)
+                        events.append({
+                            "datetime": event_time.isoformat(),
+                            "action_type": action.action_type,
+                            "action_name": action.action_name,
+                            "pattern_name": pattern.name,
+                            "pattern_id": pattern.pattern_id,
+                        })
+
+        current_date += timedelta(days=1)
+        days_checked += 1
+
+    return events
+
+
+# =============================================================================
+# SYSTEM CRON MANAGEMENT
+# =============================================================================
+
+
+def apply_to_system(
+    entries: list[CronEntry],
+    schedule_id: str,
+    set_rtc: bool = True,
+    user: str | None = None,
+) -> bool:
+    """Apply cron entries to system crontab.
+
+    1. Remove existing Mothbox jobs (preserves system jobs)
+    2. Add new entries
+    3. Optionally set RTC wakealarm
+
+    Args:
+        entries: List of CronEntry objects to add
+        schedule_id: ID of the schedule being applied
+        set_rtc: Whether to set RTC wakealarm (default True)
+        user: Username for crontab (None for current user)
+
+    Returns:
+        True if successful, False on error
+    """
+    try:
+        # Open user crontab
+        cron = CronTab(user=user) if user else CronTab(user=True)
+
+        # Remove existing Mothbox jobs
+        jobs_to_remove = []
+        for job in cron:
+            if is_mothbox_command(job.command):
+                jobs_to_remove.append(job)
+
+        for job in jobs_to_remove:
+            cron.remove(job)
+
+        logger.info(f"Removed {len(jobs_to_remove)} existing Mothbox cron jobs")
+
+        # Add new entries
+        added_count = 0
+        for entry in entries:
+            if entry.enabled:
+                job = cron.new(command=entry.command, comment=entry.comment)
+                job.setall(entry.expression)
+                added_count += 1
+
+        # Write changes
+        cron.write()
+        logger.info(f"Applied {added_count} cron entries for schedule {schedule_id}")
+
+        # Set RTC wakealarm
+        if set_rtc and entries:
+            next_wake = calculate_next_from_entries(entries)
+            if next_wake:
+                set_rtc_wakealarm(next_wake)
+
+        return True
+
+    except Exception as e:
+        logger.error(f"Failed to apply cron entries: {e}")
+        return False
+
+
+def remove_from_system(
+    clear_rtc: bool = True,
+    user: str | None = None,
+) -> bool:
+    """Remove all Mothbox cron jobs from system.
+
+    Uses is_mothbox_command() from cron_security to identify jobs safely.
+    Preserves non-Mothbox system jobs.
+
+    Args:
+        clear_rtc: Whether to clear RTC wakealarm (default True)
+        user: Username for crontab (None for current user)
+
+    Returns:
+        True if successful, False on error
+    """
+    try:
+        # Open user crontab
+        cron = CronTab(user=user) if user else CronTab(user=True)
+
+        # Find and remove Mothbox jobs
+        jobs_to_remove = []
+        for job in cron:
+            if is_mothbox_command(job.command):
+                jobs_to_remove.append(job)
+
+        for job in jobs_to_remove:
+            cron.remove(job)
+
+        # Write changes
+        cron.write()
+        logger.info(f"Removed {len(jobs_to_remove)} Mothbox cron jobs")
+
+        # Clear RTC wakealarm
+        if clear_rtc:
+            clear_rtc_wakealarm()
+
+        return True
+
+    except Exception as e:
+        logger.error(f"Failed to remove cron jobs: {e}")
+        return False

--- a/Firmware/webui/backend/requirements.txt
+++ b/Firmware/webui/backend/requirements.txt
@@ -16,3 +16,4 @@ geopip>=2.0.0
 
 # Astronomical calculations for scheduler (Issue #210)
 astral>=3.2
+pytz

--- a/Firmware/webui/backend/requirements.txt
+++ b/Firmware/webui/backend/requirements.txt
@@ -17,3 +17,4 @@ geopip>=2.0.0
 # Astronomical calculations for scheduler (Issue #210)
 astral>=3.2
 pytz
+croniter  # Cron expression iteration for RTC wakealarm


### PR DESCRIPTION
## Summary

Implements the cron bridge library (`webui/backend/lib/cron_bridge.py`) that translates schedule configurations to system cron expressions and RTC wakealarm settings.

### Core Features
- **CronEntry dataclass**: Manages cron expression format, validation, and serialization
- **Fixed time trigger conversion**: Supports specific times with day-of-week constraints
- **Interval trigger conversion**: Handles minutely through yearly patterns
- **Solar trigger conversion**: Pre-calculates fixed times for N days ahead (user chose "fixed upfront" strategy)
- **Moon phase trigger conversion**: Matches target phases with configurable tolerance
- **Action sequencing**: Each EventPattern action becomes separate cron entry with offset applied
- **RTC wakealarm integration**: Read/write `/sys/class/rtc/rtc0/wakealarm` for low-power wake
- **System cron management**: `apply_to_system()` and `remove_from_system()` using python-crontab
- **Event preview**: `get_next_events()` for schedule visualization

### Design Decisions
- Solar triggers use "fixed upfront" strategy (pre-calculate N days of solar times)
- Sensor triggers return empty list with warning (stub only - per user decision)
- ISO weekday (0=Mon..6=Sun) to cron weekday (0=Sun..6=Sat) conversion handled
- Polar region edge cases handled gracefully (skip days without solar events)

### Dependencies
- Builds on existing scheduler libraries: `schedule_schema.py`, `solar_time.py`, `moon_phase.py`, `cron_security.py`
- Uses `python-crontab` library for cron manipulation

## Test Plan
- [x] 87 unit tests covering all functionality (TDD approach)
- [x] CronEntry dataclass tests (9 tests)
- [x] Fixed time trigger conversion tests (8 tests)
- [x] Interval trigger conversion tests (6 tests)
- [x] Solar trigger conversion tests (6 tests)
- [x] Moon phase trigger conversion tests (8 tests)
- [x] Action sequencing tests (7 tests)
- [x] RTC wakealarm tests (11 tests)
- [x] apply_to_system/remove_from_system tests (13 tests)
- [x] get_next_events preview tests (7 tests)
- [x] Main schedule_to_cron tests (7 tests)
- [x] Sensor trigger stub tests (2 tests)
- [x] Edge case tests (3 tests)
- [x] All ruff linting checks pass

Closes #215