### PR TITLE
feat(scheduler): Add SchedulerService with LRU cache (#212)

### DIFF
--- a/Firmware/Tests/unit/test_scheduler_service.py
+++ b/Firmware/Tests/unit/test_scheduler_service.py
@@ -1,0 +1,1619 @@
+"""
+Unit tests for Scheduler Service with LRU Cache (Issue #212 - Subtask 1)
+
+Tests SchedulerService with in-memory LRU cache, TTL expiration, and statistics tracking.
+Follows the same pattern as DeploymentService for consistency.
+
+Coverage Target: 85%+
+"""
+
+import pytest
+from pathlib import Path
+from datetime import datetime
+
+# Import scheduler service and schema
+try:
+    from webui.backend.services.scheduler_service import SchedulerService
+    from webui.backend.lib.schedule_schema import Schedule
+    IMPLEMENTATION_EXISTS = True
+except ImportError:
+    IMPLEMENTATION_EXISTS = False
+    SchedulerService = None
+    Schedule = None
+
+# Skip all tests if implementation doesn't exist
+pytestmark = pytest.mark.skipif(
+    not IMPLEMENTATION_EXISTS,
+    reason="Implementation not yet created"
+)
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+@pytest.fixture
+def temp_schedules_dir(tmp_path, monkeypatch):
+    """Create temp directory and mock USER_SCHEDULES_DIR."""
+    schedules = tmp_path / "schedules"
+    schedules.mkdir()
+    # Mock USER_SCHEDULES_DIR in storage module (service uses storage functions)
+    monkeypatch.setattr('webui.backend.lib.schedule_storage.USER_SCHEDULES_DIR', schedules)
+    return schedules
+
+
+@pytest.fixture
+def sample_schedule():
+    """Create a valid Schedule object for testing."""
+    from webui.backend.lib.schedule_schema import (
+        Schedule,
+        EventPattern,
+        PatternAction,
+        IntervalTrigger,
+        TimeWindow,
+    )
+
+    # Create a simple pattern: Turn on UV, take photo, turn off UV
+    actions = [
+        PatternAction(
+            action_type="gpio",
+            action_name="attract_on",
+            offset_minutes=0,
+            description="Turn on UV attract lights"
+        ),
+        PatternAction(
+            action_type="camera",
+            action_name="takephoto",
+            offset_minutes=5,
+            description="Capture photo"
+        ),
+        PatternAction(
+            action_type="gpio",
+            action_name="attract_off",
+            offset_minutes=15,
+            description="Turn off UV lights"
+        ),
+    ]
+
+    pattern = EventPattern(
+        pattern_id="",
+        name="UV Capture Cycle",
+        description="Standard UV light photo capture sequence",
+        actions=actions,
+        category="user",
+    )
+
+    time_window = TimeWindow(
+        start_time="21:00",
+        end_time="05:00",
+    )
+
+    trigger = IntervalTrigger(
+        interval_minutes=60,
+        time_window=time_window,
+    )
+
+    schedule = Schedule(
+        schedule_id="",
+        name="Nightly Moth Survey",
+        description="Hourly captures from 9 PM to 5 AM",
+        event_patterns=[pattern],
+        trigger_type="interval",
+        interval_trigger=trigger,
+        enabled=True,
+    )
+
+    return schedule
+
+
+@pytest.fixture
+def sample_event_pattern():
+    """Create a valid EventPattern for testing."""
+    from webui.backend.lib.schedule_schema import (
+        EventPattern,
+        PatternAction,
+    )
+
+    actions = [
+        PatternAction(
+            action_type="gpio",
+            action_name="attract_on",
+            offset_minutes=0,
+        ),
+        PatternAction(
+            action_type="camera",
+            action_name="takephoto",
+            offset_minutes=5,
+        ),
+        PatternAction(
+            action_type="gpio",
+            action_name="attract_off",
+            offset_minutes=10,
+        ),
+    ]
+
+    return EventPattern(
+        pattern_id="",
+        name="Simple Capture",
+        actions=actions,
+    )
+
+
+@pytest.fixture
+def scheduler_service(temp_schedules_dir):
+    """Create a fresh SchedulerService for each test."""
+    return SchedulerService(cache_ttl=300, max_cache_size=100)
+
+
+@pytest.fixture
+def multiple_schedules(temp_schedules_dir, sample_schedule):
+    """Create 5 test schedules in storage."""
+    from webui.backend.lib.schedule_storage import create_schedule
+    from webui.backend.lib.schedule_schema import (
+        Schedule,
+        IntervalTrigger,
+        TimeWindow,
+    )
+
+    schedules = []
+    for i in range(5):
+        # Create schedule with unique name and ID
+        # Use modulo to keep hours valid (0-23)
+        start_hour = (20 + i) % 24
+        end_hour = (4 + i) % 24
+
+        time_window = TimeWindow(
+            start_time=f"{start_hour:02d}:00",
+            end_time=f"{end_hour:02d}:00",
+        )
+
+        trigger = IntervalTrigger(
+            interval_minutes=30 + (i * 10),
+            time_window=time_window,
+        )
+
+        schedule = Schedule(
+            schedule_id=f"test-schedule-{i}",
+            name=f"Test Schedule {i}",
+            description=f"Test description {i}",
+            event_patterns=sample_schedule.event_patterns,
+            trigger_type="interval",
+            interval_trigger=trigger,
+            enabled=(i % 2 == 0),  # Alternate enabled/disabled
+        )
+
+        create_schedule(schedule)
+        schedules.append(schedule)
+
+    return schedules
+
+
+# ============================================================================
+# Test Service Initialization
+# ============================================================================
+
+class TestSchedulerServiceInit:
+    """Tests for SchedulerService initialization."""
+
+    def test_default_cache_ttl(self):
+        """SchedulerService should use default cache TTL."""
+        service = SchedulerService()
+        assert service.cache_ttl == 300
+
+    def test_custom_cache_ttl(self):
+        """SchedulerService should accept custom cache TTL."""
+        service = SchedulerService(cache_ttl=600)
+        assert service.cache_ttl == 600
+
+    def test_custom_max_cache_size(self):
+        """SchedulerService should accept custom max cache size."""
+        service = SchedulerService(max_cache_size=50)
+        assert service.max_cache_size == 50
+
+    def test_statistics_initialized(self, scheduler_service):
+        """SchedulerService should initialize statistics to zero."""
+        stats = scheduler_service.get_statistics()
+        assert stats['cache_hits'] == 0
+        assert stats['cache_misses'] == 0
+        assert stats['cache_evictions'] == 0
+        assert stats['total_reads'] == 0
+        assert stats['total_writes'] == 0
+        assert stats['total_deletes'] == 0
+
+    def test_cache_starts_empty(self, scheduler_service):
+        """Cache should start with no entries."""
+        stats = scheduler_service.get_statistics()
+        assert stats['cache_size'] == 0
+
+    def test_locks_initialized(self, scheduler_service):
+        """RLock instances should be created for thread safety."""
+        # Verify locks exist (RLock objects)
+        assert hasattr(scheduler_service, '_cache_lock')
+        assert hasattr(scheduler_service, '_stats_lock')
+        # RLock objects are callable for context manager
+        assert callable(scheduler_service._cache_lock.__enter__)
+        assert callable(scheduler_service._stats_lock.__enter__)
+
+
+# ============================================================================
+# Test Service Imports
+# ============================================================================
+
+class TestServiceImports:
+    """Tests for required imports and availability."""
+
+    def test_scheduler_service_importable(self):
+        """SchedulerService should be importable."""
+        from webui.backend.services.scheduler_service import SchedulerService
+        assert SchedulerService is not None
+
+    def test_schedule_schema_available(self):
+        """Schedule dataclass should be available."""
+        from webui.backend.lib.schedule_schema import Schedule
+        assert Schedule is not None
+
+    def test_schedule_storage_available(self):
+        """Storage functions should be available."""
+        from webui.backend.lib.schedule_storage import (
+            create_schedule,
+            read_schedule,
+            update_schedule,
+            delete_schedule,
+            list_schedules,
+        )
+        assert create_schedule is not None
+        assert read_schedule is not None
+        assert update_schedule is not None
+        assert delete_schedule is not None
+        assert list_schedules is not None
+
+    def test_event_pattern_available(self):
+        """EventPattern dataclass should be available."""
+        from webui.backend.lib.schedule_schema import EventPattern
+        assert EventPattern is not None
+
+    def test_pattern_action_available(self):
+        """PatternAction dataclass should be available."""
+        from webui.backend.lib.schedule_schema import PatternAction
+        assert PatternAction is not None
+
+    def test_interval_trigger_available(self):
+        """IntervalTrigger dataclass should be available."""
+        from webui.backend.lib.schedule_schema import IntervalTrigger
+        assert IntervalTrigger is not None
+
+
+# ============================================================================
+# Test Get Schedule
+# ============================================================================
+
+class TestGetSchedule:
+    """Tests for get_schedule() method."""
+
+    def test_get_schedule_existing(self, scheduler_service, temp_schedules_dir, sample_schedule):
+        """get_schedule should return Schedule from storage."""
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        # Create schedule in storage
+        sample_schedule.schedule_id = "test-existing"
+        create_schedule(sample_schedule)
+
+        # Get schedule
+        schedule = scheduler_service.get_schedule("test-existing")
+        assert schedule is not None
+        assert schedule.schedule_id == "test-existing"
+        assert schedule.name == sample_schedule.name
+
+    def test_get_schedule_nonexistent(self, scheduler_service, temp_schedules_dir):
+        """get_schedule should return None for missing schedule."""
+        schedule = scheduler_service.get_schedule("nonexistent-schedule")
+        assert schedule is None
+
+    def test_get_schedule_cache_hit(self, scheduler_service, temp_schedules_dir, sample_schedule):
+        """Second call should use cache (hits incremented)."""
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        sample_schedule.schedule_id = "test-cache-hit"
+        create_schedule(sample_schedule)
+
+        # First call - cache miss
+        scheduler_service.get_schedule("test-cache-hit")
+        stats_after_first = scheduler_service.get_statistics()
+        assert stats_after_first['cache_misses'] == 1
+        assert stats_after_first['cache_hits'] == 0
+
+        # Second call - cache hit
+        scheduler_service.get_schedule("test-cache-hit")
+        stats_after_second = scheduler_service.get_statistics()
+        assert stats_after_second['cache_hits'] == 1
+        assert stats_after_second['cache_misses'] == 1  # Still 1
+
+    def test_get_schedule_cache_miss_tracked(self, scheduler_service, temp_schedules_dir, sample_schedule):
+        """Miss increments counter."""
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        sample_schedule.schedule_id = "test-miss"
+        create_schedule(sample_schedule)
+
+        stats_before = scheduler_service.get_statistics()
+        assert stats_before['cache_misses'] == 0
+
+        scheduler_service.get_schedule("test-miss")
+
+        stats_after = scheduler_service.get_statistics()
+        assert stats_after['cache_misses'] == 1
+
+    def test_get_schedule_cache_hit_tracked(self, scheduler_service, temp_schedules_dir, sample_schedule):
+        """Hit increments counter."""
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        sample_schedule.schedule_id = "test-hit-tracked"
+        create_schedule(sample_schedule)
+
+        # First call - cache miss
+        scheduler_service.get_schedule("test-hit-tracked")
+        stats_before = scheduler_service.get_statistics()
+        assert stats_before['cache_hits'] == 0
+
+        # Second call - cache hit
+        scheduler_service.get_schedule("test-hit-tracked")
+        stats_after = scheduler_service.get_statistics()
+        assert stats_after['cache_hits'] == 1
+
+    def test_get_schedule_reads_tracked(self, scheduler_service, temp_schedules_dir, sample_schedule):
+        """Total reads incremented."""
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        sample_schedule.schedule_id = "test-reads"
+        create_schedule(sample_schedule)
+
+        stats_before = scheduler_service.get_statistics()
+        assert stats_before['total_reads'] == 0
+
+        # Call twice
+        scheduler_service.get_schedule("test-reads")
+        scheduler_service.get_schedule("test-reads")
+
+        stats_after = scheduler_service.get_statistics()
+        assert stats_after['total_reads'] == 2
+
+    def test_cache_ttl_expiration(self, temp_schedules_dir, sample_schedule):
+        """Entry expires after TTL (use time.sleep)."""
+        import time
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        # Create service with very short TTL
+        service = SchedulerService(cache_ttl=0.1, max_cache_size=100)
+
+        sample_schedule.schedule_id = "test-ttl"
+        create_schedule(sample_schedule)
+
+        # First call - cache miss
+        service.get_schedule("test-ttl")
+        stats_after_first = service.get_statistics()
+        assert stats_after_first['cache_misses'] == 1
+        assert stats_after_first['cache_size'] == 1
+
+        # Wait for TTL to expire
+        time.sleep(0.15)
+
+        # Second call - cache miss (TTL expired)
+        service.get_schedule("test-ttl")
+        stats_after_second = service.get_statistics()
+        assert stats_after_second['cache_misses'] == 2
+        assert stats_after_second['cache_hits'] == 0
+
+
+# ============================================================================
+# Test List Schedules
+# ============================================================================
+
+class TestListSchedules:
+    """Tests for list_schedules() method."""
+
+    def test_list_schedules_empty(self, scheduler_service, temp_schedules_dir):
+        """Empty list when no schedules."""
+        schedules = scheduler_service.list_schedules(include_builtin=False)
+        assert schedules == []
+
+    def test_list_schedules_returns_all(self, scheduler_service, temp_schedules_dir, multiple_schedules):
+        """Returns all schedules."""
+        schedules = scheduler_service.list_schedules(include_builtin=False)
+        assert len(schedules) == 5
+        # Check all IDs present
+        schedule_ids = [s.schedule_id for s in schedules]
+        for i in range(5):
+            assert f"test-schedule-{i}" in schedule_ids
+
+    def test_list_schedules_includes_builtin(self, scheduler_service, temp_schedules_dir):
+        """Includes built-in schedules by default."""
+        # This test verifies that include_builtin=True is the default
+        # Built-in schedules may or may not exist in the test environment
+        # We just verify the call succeeds and returns a list
+        schedules = scheduler_service.list_schedules()
+        assert isinstance(schedules, list)
+
+    def test_list_schedules_from_storage(self, scheduler_service, temp_schedules_dir, multiple_schedules):
+        """Delegates to storage layer."""
+        # Verify that list_schedules returns schedules created in storage
+        schedules = scheduler_service.list_schedules(include_builtin=False)
+        assert len(schedules) == 5
+        # Verify schedule objects are valid
+        for schedule in schedules:
+            assert hasattr(schedule, 'schedule_id')
+            assert hasattr(schedule, 'name')
+            assert hasattr(schedule, 'event_patterns')
+
+    def test_list_schedules_caches_individual(self, scheduler_service, temp_schedules_dir, multiple_schedules):
+        """Individual schedules cached after listing."""
+        # List schedules
+        scheduler_service.list_schedules(include_builtin=False)
+
+        # Check cache statistics
+        stats = scheduler_service.get_statistics()
+        assert stats['cache_size'] == 5  # All 5 schedules should be cached
+
+        # Now get_schedule should be a cache hit
+        schedule = scheduler_service.get_schedule("test-schedule-0")
+        assert schedule is not None
+
+        stats_after = scheduler_service.get_statistics()
+        assert stats_after['cache_hits'] == 1  # Cache hit from get_schedule
+
+
+# ============================================================================
+# Test Cache Behavior
+# ============================================================================
+
+class TestCacheBehavior:
+    """Tests for LRU cache behavior."""
+
+    def test_cache_lru_eviction(self, temp_schedules_dir, sample_schedule):
+        """Evicts LRU when full."""
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        # Create service with small cache
+        service = SchedulerService(cache_ttl=300, max_cache_size=3)
+
+        # Create 4 schedules
+        for i in range(4):
+            schedule = Schedule(
+                schedule_id=f"evict-test-{i}",
+                name=f"Evict Test {i}",
+                description="Test schedule",
+                event_patterns=sample_schedule.event_patterns,
+                trigger_type="interval",
+                interval_trigger=sample_schedule.interval_trigger,
+                enabled=True,
+            )
+            create_schedule(schedule)
+
+        # Get first 3 schedules - cache fills up
+        service.get_schedule("evict-test-0")
+        service.get_schedule("evict-test-1")
+        service.get_schedule("evict-test-2")
+
+        stats = service.get_statistics()
+        assert stats['cache_size'] == 3
+        assert stats['cache_evictions'] == 0
+
+        # Get 4th schedule - triggers eviction
+        service.get_schedule("evict-test-3")
+
+        stats_after = service.get_statistics()
+        assert stats_after['cache_size'] == 3  # Still 3 (max)
+        assert stats_after['cache_evictions'] == 1  # One eviction
+
+        # Verify LRU was evicted (evict-test-0)
+        # Next get_schedule for evict-test-0 should be cache miss
+        service.get_schedule("evict-test-0")
+        stats_final = service.get_statistics()
+        # Total misses: 4 (initial loads) + 1 (evicted item) = 5
+        assert stats_final['cache_misses'] == 5
+
+    def test_cache_size_tracked(self, scheduler_service, temp_schedules_dir, multiple_schedules):
+        """Statistics track cache size."""
+        stats_before = scheduler_service.get_statistics()
+        assert stats_before['cache_size'] == 0
+
+        # Get a schedule
+        scheduler_service.get_schedule("test-schedule-0")
+
+        stats_after = scheduler_service.get_statistics()
+        assert stats_after['cache_size'] == 1
+
+        # Get another schedule
+        scheduler_service.get_schedule("test-schedule-1")
+
+        stats_final = scheduler_service.get_statistics()
+        assert stats_final['cache_size'] == 2
+
+    def test_cache_evictions_tracked(self, temp_schedules_dir, sample_schedule):
+        """Evictions counter increments."""
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        # Create service with max_cache_size=2
+        service = SchedulerService(cache_ttl=300, max_cache_size=2)
+
+        # Create 3 schedules
+        for i in range(3):
+            schedule = Schedule(
+                schedule_id=f"track-evict-{i}",
+                name=f"Track Evict {i}",
+                description="Test schedule",
+                event_patterns=sample_schedule.event_patterns,
+                trigger_type="interval",
+                interval_trigger=sample_schedule.interval_trigger,
+                enabled=True,
+            )
+            create_schedule(schedule)
+
+        stats_before = service.get_statistics()
+        assert stats_before['cache_evictions'] == 0
+
+        # Fill cache
+        service.get_schedule("track-evict-0")
+        service.get_schedule("track-evict-1")
+
+        stats_after_fill = service.get_statistics()
+        assert stats_after_fill['cache_evictions'] == 0
+
+        # Trigger eviction
+        service.get_schedule("track-evict-2")
+
+        stats_after_evict = service.get_statistics()
+        assert stats_after_evict['cache_evictions'] == 1
+
+
+# ============================================================================
+# Test Create Schedule
+# ============================================================================
+
+class TestCreateSchedule:
+    """Tests for create_schedule() method."""
+
+    def test_create_schedule_success(self, scheduler_service, temp_schedules_dir, sample_schedule):
+        """create_schedule should create and cache schedule."""
+        sample_schedule.schedule_id = "test-create-success"
+
+        result = scheduler_service.create_schedule(sample_schedule)
+
+        assert result is True
+
+        # Verify schedule was created on disk
+        schedule_path = temp_schedules_dir / "test-create-success.json"
+        assert schedule_path.exists()
+
+        # Verify schedule is in cache
+        stats = scheduler_service.get_statistics()
+        assert stats['cache_size'] == 1
+
+    def test_create_schedule_validation_error(self, scheduler_service, sample_schedule):
+        """create_schedule should raise on invalid schedule."""
+        from webui.backend.lib.schedule_schema import ScheduleValidationError
+
+        # Create invalid schedule (empty name)
+        sample_schedule.schedule_id = "test-create-invalid"
+        sample_schedule.name = ""
+
+        with pytest.raises(ScheduleValidationError):
+            scheduler_service.create_schedule(sample_schedule)
+
+    def test_create_schedule_updates_cache(self, scheduler_service, temp_schedules_dir, sample_schedule):
+        """New schedule should be in cache after creation."""
+        sample_schedule.schedule_id = "test-create-cache"
+
+        scheduler_service.create_schedule(sample_schedule)
+
+        # Verify we can retrieve it from cache (cache hit)
+        stats_before = scheduler_service.get_statistics()
+        retrieved = scheduler_service.get_schedule("test-create-cache")
+        stats_after = scheduler_service.get_statistics()
+
+        assert retrieved is not None
+        assert retrieved.schedule_id == "test-create-cache"
+        assert stats_after['cache_hits'] == stats_before['cache_hits'] + 1
+
+    def test_create_schedule_writes_tracked(self, scheduler_service, temp_schedules_dir, sample_schedule):
+        """Total writes should be incremented."""
+        sample_schedule.schedule_id = "test-create-writes"
+
+        stats_before = scheduler_service.get_statistics()
+        assert stats_before['total_writes'] == 0
+
+        scheduler_service.create_schedule(sample_schedule)
+
+        stats_after = scheduler_service.get_statistics()
+        assert stats_after['total_writes'] == 1
+
+    def test_create_schedule_returns_bool(self, scheduler_service, temp_schedules_dir, sample_schedule):
+        """create_schedule should return True on success."""
+        sample_schedule.schedule_id = "test-create-bool"
+
+        result = scheduler_service.create_schedule(sample_schedule)
+
+        assert isinstance(result, bool)
+        assert result is True
+
+
+# ============================================================================
+# Test Update Schedule
+# ============================================================================
+
+class TestUpdateSchedule:
+    """Tests for update_schedule() method."""
+
+    def test_update_schedule_success(self, scheduler_service, temp_schedules_dir, sample_schedule):
+        """update_schedule should update and return Schedule."""
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        # Create schedule first
+        sample_schedule.schedule_id = "test-update-success"
+        create_schedule(sample_schedule)
+
+        # Update it
+        updated = scheduler_service.update_schedule(
+            "test-update-success",
+            {"name": "Updated Name"}
+        )
+
+        assert updated is not None
+        assert isinstance(updated, Schedule)
+        assert updated.name == "Updated Name"
+        assert updated.schedule_id == "test-update-success"
+
+    def test_update_schedule_nonexistent(self, scheduler_service, temp_schedules_dir):
+        """update_schedule should return None for missing schedule."""
+        result = scheduler_service.update_schedule(
+            "nonexistent-schedule",
+            {"name": "New Name"}
+        )
+
+        assert result is None
+
+    def test_update_schedule_partial_fields(self, scheduler_service, temp_schedules_dir, sample_schedule):
+        """update_schedule should only update specified fields."""
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        # Create schedule first
+        sample_schedule.schedule_id = "test-update-partial"
+        sample_schedule.name = "Original Name"
+        sample_schedule.description = "Original Description"
+        create_schedule(sample_schedule)
+
+        # Update only name
+        updated = scheduler_service.update_schedule(
+            "test-update-partial",
+            {"name": "Updated Name"}
+        )
+
+        assert updated is not None
+        assert updated.name == "Updated Name"
+        assert updated.description == "Original Description"
+
+    def test_update_schedule_cache_updated(self, scheduler_service, temp_schedules_dir, sample_schedule):
+        """Cache should reflect changes after update."""
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        # Create schedule
+        sample_schedule.schedule_id = "test-update-cache"
+        sample_schedule.name = "Original Name"
+        create_schedule(sample_schedule)
+
+        # Get it to populate cache
+        scheduler_service.get_schedule("test-update-cache")
+
+        # Update it
+        scheduler_service.update_schedule(
+            "test-update-cache",
+            {"name": "Updated Name"}
+        )
+
+        # Get from cache (should be cache hit with updated value)
+        retrieved = scheduler_service.get_schedule("test-update-cache")
+
+        assert retrieved is not None
+        assert retrieved.name == "Updated Name"
+
+    def test_update_schedule_builtin_protected(self, scheduler_service, temp_schedules_dir):
+        """update_schedule should raise ValueError for built-in schedule."""
+        # This test assumes a built-in schedule exists
+        # For now, we'll create a mock by patching is_builtin_schedule
+        from unittest.mock import patch
+
+        with patch('webui.backend.services.scheduler_service.is_builtin_schedule', return_value=True):
+            with pytest.raises(ValueError, match="Cannot modify built-in schedule"):
+                scheduler_service.update_schedule(
+                    "builtin-schedule",
+                    {"name": "New Name"}
+                )
+
+
+# ============================================================================
+# Test Delete Schedule
+# ============================================================================
+
+class TestDeleteSchedule:
+    """Tests for delete_schedule() method."""
+
+    def test_delete_schedule_success(self, scheduler_service, temp_schedules_dir, sample_schedule):
+        """delete_schedule should delete and return True."""
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        # Create schedule first
+        sample_schedule.schedule_id = "test-delete-success"
+        create_schedule(sample_schedule)
+
+        # Verify it exists
+        schedule_path = temp_schedules_dir / "test-delete-success.json"
+        assert schedule_path.exists()
+
+        # Delete it
+        result = scheduler_service.delete_schedule("test-delete-success")
+
+        assert result is True
+        assert not schedule_path.exists()
+
+    def test_delete_schedule_nonexistent(self, scheduler_service, temp_schedules_dir):
+        """delete_schedule should return False for missing schedule."""
+        result = scheduler_service.delete_schedule("nonexistent-schedule")
+
+        assert result is False
+
+    def test_delete_schedule_cache_invalidated(self, scheduler_service, temp_schedules_dir, sample_schedule):
+        """Cache entry should be removed after delete."""
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        # Create schedule
+        sample_schedule.schedule_id = "test-delete-cache"
+        create_schedule(sample_schedule)
+
+        # Get it to populate cache
+        scheduler_service.get_schedule("test-delete-cache")
+        stats_after_get = scheduler_service.get_statistics()
+        assert stats_after_get['cache_size'] == 1
+
+        # Delete it
+        scheduler_service.delete_schedule("test-delete-cache")
+
+        # Cache should be empty
+        stats_after_delete = scheduler_service.get_statistics()
+        assert stats_after_delete['cache_size'] == 0
+
+    def test_delete_schedule_builtin_protected(self, scheduler_service, temp_schedules_dir):
+        """delete_schedule should raise ValueError for built-in schedule."""
+        from unittest.mock import patch
+
+        with patch('webui.backend.services.scheduler_service.is_builtin_schedule', return_value=True):
+            with pytest.raises(ValueError, match="Cannot delete built-in schedule"):
+                scheduler_service.delete_schedule("builtin-schedule")
+
+    def test_delete_schedule_clears_active(self, scheduler_service, temp_schedules_dir, sample_schedule):
+        """delete_schedule should clear active schedule ID if deleted."""
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        # Create schedule
+        sample_schedule.schedule_id = "test-delete-active"
+        sample_schedule.is_active = True
+        create_schedule(sample_schedule)
+
+        # Set as active
+        scheduler_service._active_schedule_id = "test-delete-active"
+
+        # Delete it
+        scheduler_service.delete_schedule("test-delete-active")
+
+        # Active schedule should be cleared
+        assert scheduler_service._active_schedule_id is None
+
+
+# ============================================================================
+# Test Get Active Schedule
+# ============================================================================
+
+class TestGetActiveSchedule:
+    """Tests for get_active_schedule() method."""
+
+    def test_get_active_schedule_none(self, scheduler_service, temp_schedules_dir):
+        """get_active_schedule should return None when no active schedule."""
+        active = scheduler_service.get_active_schedule()
+        assert active is None
+
+    def test_get_active_schedule_returns_active(self, scheduler_service, temp_schedules_dir, sample_schedule):
+        """get_active_schedule should return active schedule."""
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        # Create schedule
+        sample_schedule.schedule_id = "test-active-schedule"
+        sample_schedule.is_active = True
+        create_schedule(sample_schedule)
+
+        # Set as active
+        scheduler_service._active_schedule_id = "test-active-schedule"
+
+        # Get active schedule
+        active = scheduler_service.get_active_schedule()
+        assert active is not None
+        assert active.schedule_id == "test-active-schedule"
+
+    def test_get_active_schedule_from_cache(self, scheduler_service, temp_schedules_dir, sample_schedule):
+        """get_active_schedule should use _active_schedule_id for O(1) lookup."""
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        # Create schedule
+        sample_schedule.schedule_id = "test-active-cache"
+        sample_schedule.is_active = True
+        create_schedule(sample_schedule)
+
+        # Set as active
+        scheduler_service._active_schedule_id = "test-active-cache"
+
+        # Get active schedule (should use cached ID)
+        active = scheduler_service.get_active_schedule()
+        assert active is not None
+        assert active.schedule_id == "test-active-cache"
+
+
+# ============================================================================
+# Test Activate Schedule
+# ============================================================================
+
+class TestActivateSchedule:
+    """Tests for activate_schedule() method."""
+
+    def test_activate_schedule_success(self, scheduler_service, temp_schedules_dir, sample_schedule):
+        """activate_schedule should activate and return (True, '')."""
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        # Create enabled schedule
+        sample_schedule.schedule_id = "test-activate-success"
+        sample_schedule.enabled = True
+        create_schedule(sample_schedule)
+
+        # Activate it
+        success, error = scheduler_service.activate_schedule("test-activate-success")
+
+        assert success is True
+        assert error == ""
+        assert scheduler_service._active_schedule_id == "test-activate-success"
+
+    def test_activate_schedule_nonexistent(self, scheduler_service, temp_schedules_dir):
+        """activate_schedule should return (False, error_msg) for nonexistent schedule."""
+        success, error = scheduler_service.activate_schedule("nonexistent-schedule")
+
+        assert success is False
+        assert "not found" in error.lower()
+
+    def test_activate_schedule_disabled(self, scheduler_service, temp_schedules_dir, sample_schedule):
+        """activate_schedule should return (False, error) for disabled schedule."""
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        # Create disabled schedule
+        sample_schedule.schedule_id = "test-activate-disabled"
+        sample_schedule.enabled = False
+        create_schedule(sample_schedule)
+
+        # Try to activate
+        success, error = scheduler_service.activate_schedule("test-activate-disabled")
+
+        assert success is False
+        assert "disabled" in error.lower()
+
+    def test_activate_deactivates_previous(self, scheduler_service, temp_schedules_dir, sample_schedule):
+        """activate_schedule should deactivate previous active schedule."""
+        from webui.backend.lib.schedule_storage import create_schedule
+        from webui.backend.lib.schedule_schema import Schedule
+
+        # Create two enabled schedules
+        sample_schedule.schedule_id = "test-activate-first"
+        sample_schedule.enabled = True
+        create_schedule(sample_schedule)
+
+        second_schedule = Schedule(
+            schedule_id="test-activate-second",
+            name="Second Schedule",
+            description="Second test schedule",
+            event_patterns=sample_schedule.event_patterns,
+            trigger_type="interval",
+            interval_trigger=sample_schedule.interval_trigger,
+            enabled=True,
+        )
+        create_schedule(second_schedule)
+
+        # Activate first
+        scheduler_service.activate_schedule("test-activate-first")
+        assert scheduler_service._active_schedule_id == "test-activate-first"
+
+        # Activate second
+        scheduler_service.activate_schedule("test-activate-second")
+        assert scheduler_service._active_schedule_id == "test-activate-second"
+
+        # First should be deactivated
+        first = scheduler_service.get_schedule("test-activate-first")
+        assert first is not None
+        assert first.is_active is False
+
+    def test_activate_updates_is_active_flag(self, scheduler_service, temp_schedules_dir, sample_schedule):
+        """activate_schedule should set is_active=True in storage."""
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        # Create enabled schedule
+        sample_schedule.schedule_id = "test-activate-flag"
+        sample_schedule.enabled = True
+        sample_schedule.is_active = False
+        create_schedule(sample_schedule)
+
+        # Activate it
+        scheduler_service.activate_schedule("test-activate-flag")
+
+        # Verify is_active is True
+        schedule = scheduler_service.get_schedule("test-activate-flag")
+        assert schedule is not None
+        assert schedule.is_active is True
+
+    def test_activate_same_schedule_idempotent(self, scheduler_service, temp_schedules_dir, sample_schedule):
+        """activate_schedule should be idempotent for already active schedule."""
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        # Create enabled schedule
+        sample_schedule.schedule_id = "test-activate-idempotent"
+        sample_schedule.enabled = True
+        create_schedule(sample_schedule)
+
+        # Activate it twice
+        success1, error1 = scheduler_service.activate_schedule("test-activate-idempotent")
+        success2, error2 = scheduler_service.activate_schedule("test-activate-idempotent")
+
+        assert success1 is True
+        assert success2 is True
+        assert error1 == ""
+        assert error2 == ""
+        assert scheduler_service._active_schedule_id == "test-activate-idempotent"
+
+    def test_activate_builtin_allowed(self, scheduler_service, temp_schedules_dir, sample_schedule):
+        """activate_schedule should allow activating built-in schedules."""
+        from webui.backend.lib.schedule_storage import create_schedule
+        from unittest.mock import patch
+
+        # Create schedule
+        sample_schedule.schedule_id = "builtin-schedule"
+        sample_schedule.enabled = True
+        create_schedule(sample_schedule)
+
+        # Mock is_builtin_schedule to return True
+        with patch('webui.backend.services.scheduler_service.is_builtin_schedule', return_value=True):
+            success, error = scheduler_service.activate_schedule("builtin-schedule")
+
+            assert success is True
+            assert error == ""
+            assert scheduler_service._active_schedule_id == "builtin-schedule"
+
+
+# ============================================================================
+# Test Deactivate Schedule
+# ============================================================================
+
+class TestDeactivateSchedule:
+    """Tests for deactivate_schedule() method."""
+
+    def test_deactivate_schedule_success(self, scheduler_service, temp_schedules_dir, sample_schedule):
+        """deactivate_schedule should deactivate current active schedule."""
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        # Create and activate schedule
+        sample_schedule.schedule_id = "test-deactivate-success"
+        sample_schedule.enabled = True
+        create_schedule(sample_schedule)
+        scheduler_service.activate_schedule("test-deactivate-success")
+
+        # Verify it's active
+        assert scheduler_service._active_schedule_id == "test-deactivate-success"
+
+        # Deactivate it
+        result = scheduler_service.deactivate_schedule()
+
+        assert result is True
+        assert scheduler_service._active_schedule_id is None
+
+        # Verify is_active is False
+        schedule = scheduler_service.get_schedule("test-deactivate-success")
+        assert schedule is not None
+        assert schedule.is_active is False
+
+    def test_deactivate_schedule_none_active(self, scheduler_service, temp_schedules_dir):
+        """deactivate_schedule should return True (no-op) when no active schedule."""
+        # No active schedule
+        assert scheduler_service._active_schedule_id is None
+
+        # Deactivate (no-op)
+        result = scheduler_service.deactivate_schedule()
+
+        assert result is True
+        assert scheduler_service._active_schedule_id is None
+
+
+# ============================================================================
+# Test Cache Invalidation
+# ============================================================================
+
+class TestInvalidateCache:
+    """Tests for invalidate_cache() method."""
+
+    def test_invalidate_cache_all(self, scheduler_service, temp_schedules_dir, multiple_schedules):
+        """invalidate_cache should clear entire cache when schedule_id=None."""
+        # Populate cache by getting all schedules
+        for i in range(5):
+            scheduler_service.get_schedule(f"test-schedule-{i}")
+
+        stats_before = scheduler_service.get_statistics()
+        assert stats_before['cache_size'] == 5
+
+        # Invalidate entire cache
+        scheduler_service.invalidate_cache()
+
+        stats_after = scheduler_service.get_statistics()
+        assert stats_after['cache_size'] == 0
+
+    def test_invalidate_cache_specific(self, scheduler_service, temp_schedules_dir, multiple_schedules):
+        """invalidate_cache should clear single entry when schedule_id is provided."""
+        # Populate cache with 3 schedules
+        scheduler_service.get_schedule("test-schedule-0")
+        scheduler_service.get_schedule("test-schedule-1")
+        scheduler_service.get_schedule("test-schedule-2")
+
+        stats_before = scheduler_service.get_statistics()
+        assert stats_before['cache_size'] == 3
+
+        # Invalidate only test-schedule-1
+        scheduler_service.invalidate_cache("test-schedule-1")
+
+        stats_after = scheduler_service.get_statistics()
+        assert stats_after['cache_size'] == 2
+
+        # Verify test-schedule-0 and test-schedule-2 still in cache
+        # (cache hits should increment)
+        stats_before_hits = stats_after['cache_hits']
+        scheduler_service.get_schedule("test-schedule-0")
+        scheduler_service.get_schedule("test-schedule-2")
+        stats_final = scheduler_service.get_statistics()
+        assert stats_final['cache_hits'] == stats_before_hits + 2
+
+        # Verify test-schedule-1 is cache miss
+        stats_before_misses = stats_final['cache_misses']
+        scheduler_service.get_schedule("test-schedule-1")
+        stats_after_miss = scheduler_service.get_statistics()
+        assert stats_after_miss['cache_misses'] == stats_before_misses + 1
+
+    def test_invalidate_cache_nonexistent(self, scheduler_service, temp_schedules_dir):
+        """invalidate_cache should not error for missing key."""
+        # Cache is empty
+        stats_before = scheduler_service.get_statistics()
+        assert stats_before['cache_size'] == 0
+
+        # Invalidate nonexistent entry (should not raise)
+        scheduler_service.invalidate_cache("nonexistent-schedule")
+
+        # No change in cache size
+        stats_after = scheduler_service.get_statistics()
+        assert stats_after['cache_size'] == 0
+
+    def test_invalidate_updates_size(self, scheduler_service, temp_schedules_dir, multiple_schedules):
+        """invalidate_cache should correctly decrement cache size."""
+        # Populate cache with 5 schedules
+        for i in range(5):
+            scheduler_service.get_schedule(f"test-schedule-{i}")
+
+        stats_initial = scheduler_service.get_statistics()
+        assert stats_initial['cache_size'] == 5
+
+        # Invalidate 3 schedules one by one
+        scheduler_service.invalidate_cache("test-schedule-0")
+        stats_after_1 = scheduler_service.get_statistics()
+        assert stats_after_1['cache_size'] == 4
+
+        scheduler_service.invalidate_cache("test-schedule-1")
+        stats_after_2 = scheduler_service.get_statistics()
+        assert stats_after_2['cache_size'] == 3
+
+        scheduler_service.invalidate_cache("test-schedule-2")
+        stats_after_3 = scheduler_service.get_statistics()
+        assert stats_after_3['cache_size'] == 2
+
+    def test_invalidate_cache_preserves_stats(self, scheduler_service, temp_schedules_dir, multiple_schedules):
+        """invalidate_cache should preserve statistics counters."""
+        # Perform some operations
+        scheduler_service.get_schedule("test-schedule-0")  # Miss
+        scheduler_service.get_schedule("test-schedule-0")  # Hit
+        scheduler_service.get_schedule("test-schedule-1")  # Miss
+
+        stats_before = scheduler_service.get_statistics()
+        cache_hits_before = stats_before['cache_hits']
+        cache_misses_before = stats_before['cache_misses']
+        total_reads_before = stats_before['total_reads']
+
+        # Invalidate cache
+        scheduler_service.invalidate_cache()
+
+        stats_after = scheduler_service.get_statistics()
+        assert stats_after['cache_hits'] == cache_hits_before
+        assert stats_after['cache_misses'] == cache_misses_before
+        assert stats_after['total_reads'] == total_reads_before
+
+
+# ============================================================================
+# Test Statistics
+# ============================================================================
+
+class TestGetStatistics:
+    """Tests for get_statistics() method."""
+
+    def test_statistics_structure(self, scheduler_service):
+        """get_statistics should return dict with all expected fields."""
+        stats = scheduler_service.get_statistics()
+
+        # Verify all expected keys present
+        expected_keys = {
+            "cache_hits",
+            "cache_misses",
+            "cache_evictions",
+            "cache_size",
+            "max_cache_size",
+            "cache_ttl",
+            "hit_ratio",
+            "total_reads",
+            "total_writes",
+            "total_deletes",
+            "active_schedule_id",
+        }
+        assert set(stats.keys()) == expected_keys
+
+        # Verify types
+        assert isinstance(stats["cache_hits"], int)
+        assert isinstance(stats["cache_misses"], int)
+        assert isinstance(stats["cache_evictions"], int)
+        assert isinstance(stats["cache_size"], int)
+        assert isinstance(stats["max_cache_size"], int)
+        assert isinstance(stats["cache_ttl"], int)
+        assert isinstance(stats["hit_ratio"], float)
+        assert isinstance(stats["total_reads"], int)
+        assert isinstance(stats["total_writes"], int)
+        assert isinstance(stats["total_deletes"], int)
+        assert stats["active_schedule_id"] is None or isinstance(stats["active_schedule_id"], str)
+
+    def test_hit_ratio_calculation(self, scheduler_service, temp_schedules_dir, sample_schedule):
+        """get_statistics should calculate hit ratio correctly."""
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        # Create schedule
+        sample_schedule.schedule_id = "test-hit-ratio"
+        create_schedule(sample_schedule)
+
+        # Read 3 times: 1 miss + 2 hits
+        scheduler_service.get_schedule("test-hit-ratio")  # Miss
+        scheduler_service.get_schedule("test-hit-ratio")  # Hit
+        scheduler_service.get_schedule("test-hit-ratio")  # Hit
+
+        stats = scheduler_service.get_statistics()
+        assert stats['cache_hits'] == 2
+        assert stats['cache_misses'] == 1
+
+        # Hit ratio = 2 / (2 + 1) = 2/3 = 0.666...
+        expected_ratio = 2.0 / 3.0
+        assert abs(stats['hit_ratio'] - expected_ratio) < 0.0001
+
+    def test_hit_ratio_zero_requests(self, scheduler_service):
+        """get_statistics should return 0.0 hit ratio when no requests."""
+        stats = scheduler_service.get_statistics()
+        assert stats['hit_ratio'] == 0.0
+
+    def test_statistics_after_operations(self, scheduler_service, temp_schedules_dir, sample_schedule):
+        """get_statistics should reflect actual operations correctly."""
+        from webui.backend.lib.schedule_storage import create_schedule
+        from webui.backend.lib.schedule_schema import Schedule
+
+        # Create a schedule
+        sample_schedule.schedule_id = "test-stats-ops"
+        create_schedule(sample_schedule)
+
+        # Read it twice (1 miss + 1 hit)
+        scheduler_service.get_schedule("test-stats-ops")
+        scheduler_service.get_schedule("test-stats-ops")
+
+        # Update it
+        scheduler_service.update_schedule("test-stats-ops", {"name": "Updated Name"})
+
+        # Create another schedule
+        another_schedule = Schedule(
+            schedule_id="test-stats-ops-2",
+            name="Another Schedule",
+            description="Test schedule",
+            event_patterns=sample_schedule.event_patterns,
+            trigger_type="interval",
+            interval_trigger=sample_schedule.interval_trigger,
+            enabled=True,
+        )
+        create_schedule(another_schedule)
+
+        # Delete it
+        scheduler_service.delete_schedule("test-stats-ops-2")
+
+        # Verify statistics
+        stats = scheduler_service.get_statistics()
+        assert stats['total_reads'] == 2  # 2 get_schedule calls
+        assert stats['total_writes'] == 1  # 1 update
+        assert stats['total_deletes'] == 1  # 1 delete
+        assert stats['cache_misses'] == 1  # First read
+        assert stats['cache_hits'] == 1  # Second read
+
+    def test_statistics_includes_active_schedule(self, scheduler_service, temp_schedules_dir, sample_schedule):
+        """get_statistics should include active_schedule_id field."""
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        # Initially, no active schedule
+        stats_before = scheduler_service.get_statistics()
+        assert stats_before['active_schedule_id'] is None
+
+        # Create and activate a schedule
+        sample_schedule.schedule_id = "test-active-in-stats"
+        sample_schedule.enabled = True
+        create_schedule(sample_schedule)
+        scheduler_service.activate_schedule("test-active-in-stats")
+
+        # Verify active_schedule_id in statistics
+        stats_after = scheduler_service.get_statistics()
+        assert stats_after['active_schedule_id'] == "test-active-in-stats"
+
+
+# ============================================================================
+# Test Thread Safety
+# ============================================================================
+
+def _create_test_schedule(schedule_id: str, sample_schedule) -> Schedule:
+    """Helper to create test schedules for concurrent tests."""
+    from webui.backend.lib.schedule_schema import Schedule
+
+    return Schedule(
+        schedule_id=schedule_id,
+        name=f"Concurrent Test {schedule_id}",
+        description=f"Schedule for concurrent testing - {schedule_id}",
+        event_patterns=sample_schedule.event_patterns,
+        trigger_type="interval",
+        interval_trigger=sample_schedule.interval_trigger,
+        enabled=True,
+    )
+
+
+class TestThreadSafety:
+    """Tests for thread safety under concurrent access."""
+
+    def test_concurrent_reads(self, scheduler_service, sample_schedule, temp_schedules_dir):
+        """10 threads reading the same schedule should all succeed."""
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+
+        # Create schedule first
+        sample_schedule.schedule_id = "concurrent-reads"
+        scheduler_service.create_schedule(sample_schedule)
+
+        results = []
+        errors = []
+
+        def read_schedule():
+            try:
+                schedule = scheduler_service.get_schedule("concurrent-reads")
+                return schedule is not None
+            except Exception as e:
+                return str(e)
+
+        with ThreadPoolExecutor(max_workers=10) as executor:
+            futures = [executor.submit(read_schedule) for _ in range(10)]
+            for future in as_completed(futures):
+                result = future.result()
+                if isinstance(result, bool):
+                    results.append(result)
+                else:
+                    errors.append(result)
+
+        assert len(errors) == 0, f"Errors occurred: {errors}"
+        assert all(results), "All reads should succeed"
+        assert len(results) == 10
+
+    def test_concurrent_writes(self, scheduler_service, sample_schedule, temp_schedules_dir):
+        """5 threads creating different schedules should all succeed."""
+        import threading
+
+        results = []
+        errors = []
+
+        def create_schedule(schedule_id):
+            try:
+                schedule = _create_test_schedule(schedule_id, sample_schedule)
+                success = scheduler_service.create_schedule(schedule)
+                return (schedule_id, success)
+            except Exception as e:
+                return (schedule_id, str(e))
+
+        threads = []
+        for i in range(5):
+            schedule_id = f"concurrent-write-{i}"
+            t = threading.Thread(target=lambda sid=schedule_id: results.append(create_schedule(sid)))
+            threads.append(t)
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Verify all succeeded
+        for schedule_id, result in results:
+            if isinstance(result, bool):
+                assert result is True, f"Schedule {schedule_id} creation failed"
+            else:
+                errors.append(f"{schedule_id}: {result}")
+
+        assert len(errors) == 0, f"Errors occurred: {errors}"
+        assert len(results) == 5
+
+    def test_concurrent_mixed_operations(self, scheduler_service, sample_schedule, temp_schedules_dir):
+        """Read/write/delete mix across threads should work correctly."""
+        import threading
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        # Create 3 schedules initially
+        for i in range(3):
+            schedule = _create_test_schedule(f"mixed-{i}", sample_schedule)
+            create_schedule(schedule)
+
+        results = []
+        errors = []
+
+        def read_op():
+            try:
+                scheduler_service.get_schedule("mixed-0")
+                return ("read", True)
+            except Exception as e:
+                return ("read", str(e))
+
+        def write_op():
+            try:
+                success = scheduler_service.update_schedule("mixed-1", {"name": "Updated Mixed 1"})
+                return ("write", success is not None)
+            except Exception as e:
+                return ("write", str(e))
+
+        def delete_op():
+            try:
+                success = scheduler_service.delete_schedule("mixed-2")
+                return ("delete", success)
+            except Exception as e:
+                return ("delete", str(e))
+
+        # Run operations concurrently
+        ops = [read_op, write_op, delete_op, read_op, write_op, read_op]
+        threads = []
+        for op in ops:
+            t = threading.Thread(target=lambda o=op: results.append(o()))
+            threads.append(t)
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Verify no errors occurred
+        for op_type, result in results:
+            if isinstance(result, str):
+                errors.append(f"{op_type}: {result}")
+
+        assert len(errors) == 0, f"Errors occurred: {errors}"
+
+    def test_concurrent_activation(self, scheduler_service, sample_schedule, temp_schedules_dir):
+        """Multiple threads activating different schedules - service should track one active ID."""
+        import threading
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        # Create 5 enabled schedules
+        schedules = []
+        for i in range(5):
+            schedule = _create_test_schedule(f"activation-{i}", sample_schedule)
+            schedule.enabled = True
+            create_schedule(schedule)
+            schedules.append(schedule)
+
+        results = []
+        errors = []
+
+        def activate(schedule_id):
+            try:
+                success, error = scheduler_service.activate_schedule(schedule_id)
+                return (schedule_id, success, error)
+            except Exception as e:
+                return (schedule_id, False, str(e))
+
+        threads = []
+        for schedule in schedules:
+            t = threading.Thread(target=lambda s=schedule: results.append(activate(s.schedule_id)))
+            threads.append(t)
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Verify no exceptions occurred
+        for schedule_id, success, error in results:
+            if not success and error:
+                errors.append(f"{schedule_id}: {error}")
+
+        # Thread-safe property: service should have exactly one active schedule ID
+        active = scheduler_service.get_active_schedule()
+        assert active is not None, "One schedule should be active"
+        assert scheduler_service._active_schedule_id is not None, "Active schedule ID should be set"
+
+        # Verify all activations completed without exceptions
+        assert len(errors) == 0, f"Activation errors occurred: {errors}"
+
+    def test_concurrent_cache_invalidation(self, scheduler_service, sample_schedule, temp_schedules_dir):
+        """Invalidation during concurrent reads should not cause errors."""
+        import threading
+        import time
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        # Create schedule
+        sample_schedule.schedule_id = "invalidation-test"
+        create_schedule(sample_schedule)
+
+        # Populate cache
+        scheduler_service.get_schedule("invalidation-test")
+
+        errors = []
+        stop_flag = [False]
+
+        def read_continuously():
+            try:
+                while not stop_flag[0]:
+                    scheduler_service.get_schedule("invalidation-test")
+                    time.sleep(0.001)
+            except Exception as e:
+                errors.append(f"read: {str(e)}")
+
+        def invalidate_continuously():
+            try:
+                while not stop_flag[0]:
+                    scheduler_service.invalidate_cache("invalidation-test")
+                    time.sleep(0.001)
+            except Exception as e:
+                errors.append(f"invalidate: {str(e)}")
+
+        # Start threads
+        readers = [threading.Thread(target=read_continuously) for _ in range(3)]
+        invalidators = [threading.Thread(target=invalidate_continuously) for _ in range(2)]
+
+        for t in readers + invalidators:
+            t.start()
+
+        # Run for 0.5 seconds
+        time.sleep(0.5)
+        stop_flag[0] = True
+
+        for t in readers + invalidators:
+            t.join(timeout=2)
+
+        assert len(errors) == 0, f"Errors occurred: {errors}"
+
+    def test_no_deadlock_nested_operations(self, scheduler_service, sample_schedule, temp_schedules_dir):
+        """Complex operation chains should not deadlock.
+
+        This test verifies that lock ordering is correct. The get_statistics() method
+        must acquire cache_lock before stats_lock to prevent deadlock when:
+        - Thread A: get_schedule() holds cache_lock, waits for stats_lock
+        - Thread B: get_statistics() holds stats_lock, waits for cache_lock
+        """
+        import threading
+        import time
+
+        scheduler_service.create_schedule(sample_schedule)
+        completed_count = [0]
+        lock = threading.Lock()
+
+        def complex_ops():
+            try:
+                # Fewer iterations to avoid timeout
+                for _ in range(10):
+                    scheduler_service.get_schedule(sample_schedule.schedule_id)
+                    stats = scheduler_service.get_statistics()
+                    scheduler_service.invalidate_cache(sample_schedule.schedule_id)
+                    scheduler_service.get_schedule(sample_schedule.schedule_id)
+                with lock:
+                    completed_count[0] += 1
+            except Exception:
+                pass  # Swallow exceptions, just check completion
+
+        threads = [threading.Thread(target=complex_ops) for _ in range(3)]
+        start_time = time.time()
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=15)  # Longer timeout to account for slow operations
+
+        elapsed = time.time() - start_time
+
+        # At least one thread should complete (no complete deadlock)
+        assert completed_count[0] > 0, f"No threads completed in {elapsed:.2f}s - possible deadlock"
+
+        # Ideally all threads complete
+        if completed_count[0] < 3:
+            logger.warning(f"Only {completed_count[0]}/3 threads completed in {elapsed:.2f}s")
+
+    def test_statistics_thread_safe(self, scheduler_service, sample_schedule, temp_schedules_dir):
+        """Statistics should remain consistent after concurrent operations."""
+        import threading
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        # Create 5 schedules
+        schedules = []
+        for i in range(5):
+            schedule = _create_test_schedule(f"stats-concurrent-{i}", sample_schedule)
+            create_schedule(schedule)
+            schedules.append(schedule)
+
+        operation_count = [0]
+        lock = threading.Lock()
+
+        def do_operations():
+            for _ in range(10):
+                for s in schedules:
+                    scheduler_service.get_schedule(s.schedule_id)
+                    with lock:
+                        operation_count[0] += 1
+
+        threads = [threading.Thread(target=do_operations) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        stats = scheduler_service.get_statistics()
+
+        # Verify total reads matches operations
+        # 5 threads * 10 iterations * 5 schedules = 250 operations
+        expected_total = 250
+        assert stats['total_reads'] >= expected_total, f"Expected at least {expected_total} reads, got {stats['total_reads']}"
+        assert operation_count[0] == expected_total, f"Expected {expected_total} operations, got {operation_count[0]}"
+
+    def test_cache_eviction_thread_safe(self, scheduler_service, sample_schedule, temp_schedules_dir):
+        """LRU eviction under contention should not corrupt cache."""
+        import threading
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        # Create service with small cache (max 5 items)
+        service = SchedulerService(cache_ttl=300, max_cache_size=5)
+
+        # Create 10 schedules
+        for i in range(10):
+            schedule = _create_test_schedule(f"eviction-{i}", sample_schedule)
+            create_schedule(schedule)
+
+        errors = []
+
+        def access_schedules():
+            try:
+                for i in range(10):
+                    service.get_schedule(f"eviction-{i}")
+            except Exception as e:
+                errors.append(str(e))
+
+        # 5 threads accessing all schedules concurrently
+        threads = [threading.Thread(target=access_schedules) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Verify no errors
+        assert len(errors) == 0, f"Errors occurred: {errors}"
+
+        # Verify cache size is at max (not corrupted)
+        stats = service.get_statistics()
+        assert stats['cache_size'] <= 5, f"Cache size should be <= 5, got {stats['cache_size']}"
+        assert stats['cache_evictions'] > 0, "Evictions should have occurred"

--- a/Firmware/Tests/unit/test_scheduler_service.py
+++ b/Firmware/Tests/unit/test_scheduler_service.py
@@ -7,14 +7,13 @@ Follows the same pattern as DeploymentService for consistency.
 Coverage Target: 85%+
 """
 
+
 import pytest
-from pathlib import Path
-from datetime import datetime
 
 # Import scheduler service and schema
 try:
-    from webui.backend.services.scheduler_service import SchedulerService
     from webui.backend.lib.schedule_schema import Schedule
+    from webui.backend.services.scheduler_service import SchedulerService
     IMPLEMENTATION_EXISTS = True
 except ImportError:
     IMPLEMENTATION_EXISTS = False
@@ -46,10 +45,10 @@ def temp_schedules_dir(tmp_path, monkeypatch):
 def sample_schedule():
     """Create a valid Schedule object for testing."""
     from webui.backend.lib.schedule_schema import (
-        Schedule,
         EventPattern,
-        PatternAction,
         IntervalTrigger,
+        PatternAction,
+        Schedule,
         TimeWindow,
     )
 
@@ -148,12 +147,12 @@ def scheduler_service(temp_schedules_dir):
 @pytest.fixture
 def multiple_schedules(temp_schedules_dir, sample_schedule):
     """Create 5 test schedules in storage."""
-    from webui.backend.lib.schedule_storage import create_schedule
     from webui.backend.lib.schedule_schema import (
-        Schedule,
         IntervalTrigger,
+        Schedule,
         TimeWindow,
     )
+    from webui.backend.lib.schedule_storage import create_schedule
 
     schedules = []
     for i in range(5):
@@ -256,10 +255,10 @@ class TestServiceImports:
         """Storage functions should be available."""
         from webui.backend.lib.schedule_storage import (
             create_schedule,
-            read_schedule,
-            update_schedule,
             delete_schedule,
             list_schedules,
+            read_schedule,
+            update_schedule,
         )
         assert create_schedule is not None
         assert read_schedule is not None
@@ -380,6 +379,7 @@ class TestGetSchedule:
     def test_cache_ttl_expiration(self, temp_schedules_dir, sample_schedule):
         """Entry expires after TTL (use time.sleep)."""
         import time
+
         from webui.backend.lib.schedule_storage import create_schedule
 
         # Create service with very short TTL
@@ -721,12 +721,14 @@ class TestUpdateSchedule:
         # For now, we'll create a mock by patching is_builtin_schedule
         from unittest.mock import patch
 
-        with patch('webui.backend.services.scheduler_service.is_builtin_schedule', return_value=True):
-            with pytest.raises(ValueError, match="Cannot modify built-in schedule"):
-                scheduler_service.update_schedule(
-                    "builtin-schedule",
-                    {"name": "New Name"}
-                )
+        with (
+            patch('webui.backend.services.scheduler_service.is_builtin_schedule', return_value=True),
+            pytest.raises(ValueError, match="Cannot modify built-in schedule"),
+        ):
+            scheduler_service.update_schedule(
+                "builtin-schedule",
+                {"name": "New Name"}
+            )
 
 
 # ============================================================================
@@ -784,9 +786,11 @@ class TestDeleteSchedule:
         """delete_schedule should raise ValueError for built-in schedule."""
         from unittest.mock import patch
 
-        with patch('webui.backend.services.scheduler_service.is_builtin_schedule', return_value=True):
-            with pytest.raises(ValueError, match="Cannot delete built-in schedule"):
-                scheduler_service.delete_schedule("builtin-schedule")
+        with (
+            patch('webui.backend.services.scheduler_service.is_builtin_schedule', return_value=True),
+            pytest.raises(ValueError, match="Cannot delete built-in schedule"),
+        ):
+            scheduler_service.delete_schedule("builtin-schedule")
 
     def test_delete_schedule_clears_active(self, scheduler_service, temp_schedules_dir, sample_schedule):
         """delete_schedule should clear active schedule ID if deleted."""
@@ -901,8 +905,8 @@ class TestActivateSchedule:
 
     def test_activate_deactivates_previous(self, scheduler_service, temp_schedules_dir, sample_schedule):
         """activate_schedule should deactivate previous active schedule."""
-        from webui.backend.lib.schedule_storage import create_schedule
         from webui.backend.lib.schedule_schema import Schedule
+        from webui.backend.lib.schedule_storage import create_schedule
 
         # Create two enabled schedules
         sample_schedule.schedule_id = "test-activate-first"
@@ -972,8 +976,9 @@ class TestActivateSchedule:
 
     def test_activate_builtin_allowed(self, scheduler_service, temp_schedules_dir, sample_schedule):
         """activate_schedule should allow activating built-in schedules."""
-        from webui.backend.lib.schedule_storage import create_schedule
         from unittest.mock import patch
+
+        from webui.backend.lib.schedule_storage import create_schedule
 
         # Create schedule
         sample_schedule.schedule_id = "builtin-schedule"
@@ -1208,8 +1213,8 @@ class TestGetStatistics:
 
     def test_statistics_after_operations(self, scheduler_service, temp_schedules_dir, sample_schedule):
         """get_statistics should reflect actual operations correctly."""
-        from webui.backend.lib.schedule_storage import create_schedule
         from webui.backend.lib.schedule_schema import Schedule
+        from webui.backend.lib.schedule_storage import create_schedule
 
         # Create a schedule
         sample_schedule.schedule_id = "test-stats-ops"
@@ -1356,6 +1361,7 @@ class TestThreadSafety:
     def test_concurrent_mixed_operations(self, scheduler_service, sample_schedule, temp_schedules_dir):
         """Read/write/delete mix across threads should work correctly."""
         import threading
+
         from webui.backend.lib.schedule_storage import create_schedule
 
         # Create 3 schedules initially
@@ -1409,6 +1415,7 @@ class TestThreadSafety:
     def test_concurrent_activation(self, scheduler_service, sample_schedule, temp_schedules_dir):
         """Multiple threads activating different schedules - service should track one active ID."""
         import threading
+
         from webui.backend.lib.schedule_storage import create_schedule
 
         # Create 5 enabled schedules
@@ -1456,6 +1463,7 @@ class TestThreadSafety:
         """Invalidation during concurrent reads should not cause errors."""
         import threading
         import time
+
         from webui.backend.lib.schedule_storage import create_schedule
 
         # Create schedule
@@ -1520,7 +1528,7 @@ class TestThreadSafety:
                 # Fewer iterations to avoid timeout
                 for _ in range(10):
                     scheduler_service.get_schedule(sample_schedule.schedule_id)
-                    stats = scheduler_service.get_statistics()
+                    scheduler_service.get_statistics()  # Exercise nested lock acquisition
                     scheduler_service.invalidate_cache(sample_schedule.schedule_id)
                     scheduler_service.get_schedule(sample_schedule.schedule_id)
                 with lock:
@@ -1542,12 +1550,12 @@ class TestThreadSafety:
         assert completed_count[0] > 0, f"No threads completed in {elapsed:.2f}s - possible deadlock"
 
         # Ideally all threads complete
-        if completed_count[0] < 3:
-            logger.warning(f"Only {completed_count[0]}/3 threads completed in {elapsed:.2f}s")
+        # Note: We just check for no deadlock, not all completions
 
     def test_statistics_thread_safe(self, scheduler_service, sample_schedule, temp_schedules_dir):
         """Statistics should remain consistent after concurrent operations."""
         import threading
+
         from webui.backend.lib.schedule_storage import create_schedule
 
         # Create 5 schedules
@@ -1584,6 +1592,7 @@ class TestThreadSafety:
     def test_cache_eviction_thread_safe(self, scheduler_service, sample_schedule, temp_schedules_dir):
         """LRU eviction under contention should not corrupt cache."""
         import threading
+
         from webui.backend.lib.schedule_storage import create_schedule
 
         # Create service with small cache (max 5 items)
@@ -1617,3 +1626,385 @@ class TestThreadSafety:
         stats = service.get_statistics()
         assert stats['cache_size'] <= 5, f"Cache size should be <= 5, got {stats['cache_size']}"
         assert stats['cache_evictions'] > 0, "Evictions should have occurred"
+
+
+# ============================================================================
+# Test Concurrent Modifications (Issue #212 - Code Review Fix 5)
+# ============================================================================
+
+
+class TestConcurrentModifications:
+    """
+    Tests for concurrent write operations.
+
+    These tests verify thread safety for concurrent modifications that were
+    previously under-tested. They focus on:
+    1. Concurrent create_schedule() calls with cache eviction
+    2. Concurrent activate_schedule() calls (race to become active)
+    3. Concurrent cache invalidation during reads
+    """
+
+    def test_concurrent_create_with_eviction(self, temp_schedules_dir, sample_schedule):
+        """Multiple threads creating schedules when cache is near capacity.
+
+        This tests the interaction between create_schedule() and LRU eviction
+        when multiple threads are creating schedules simultaneously.
+        """
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+
+        # Create service with small cache (max 5 items)
+        service = SchedulerService(cache_ttl=300, max_cache_size=5)
+
+        results = []
+        errors = []
+
+        def create_schedule_thread(schedule_id: str):
+            try:
+                schedule = _create_test_schedule(schedule_id, sample_schedule)
+                success = service.create_schedule(schedule)
+                return (schedule_id, success, None)
+            except Exception as e:
+                return (schedule_id, False, str(e))
+
+        # Create 10 schedules concurrently (exceeding cache capacity)
+        with ThreadPoolExecutor(max_workers=10) as executor:
+            futures = [
+                executor.submit(create_schedule_thread, f"evict-create-{i}")
+                for i in range(10)
+            ]
+            for future in as_completed(futures):
+                result = future.result()
+                results.append(result)
+                if result[2]:  # error message present
+                    errors.append(result)
+
+        # Verify no errors occurred
+        assert len(errors) == 0, f"Errors occurred: {errors}"
+
+        # Verify all creates succeeded
+        successful = [r for r in results if r[1]]
+        assert len(successful) == 10, f"Expected 10 successful creates, got {len(successful)}"
+
+        # Verify cache evictions occurred (created 10 items, max 5)
+        stats = service.get_statistics()
+        assert stats['cache_size'] <= 5, f"Cache size should be <= 5, got {stats['cache_size']}"
+        assert stats['cache_evictions'] >= 5, f"Should have at least 5 evictions, got {stats['cache_evictions']}"
+
+        # Verify all schedules exist on disk
+        for i in range(10):
+            schedule_path = temp_schedules_dir / f"evict-create-{i}.json"
+            assert schedule_path.exists(), f"Schedule file {schedule_path} should exist"
+
+    def test_concurrent_activate_race(self, temp_schedules_dir, sample_schedule):
+        """Multiple threads racing to activate different schedules.
+
+        Only one schedule should end up active. This tests the thread-safe
+        handling of _active_schedule_id and the deactivation of previously
+        active schedules during concurrent activation attempts.
+        """
+        import threading
+
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        service = SchedulerService(cache_ttl=300, max_cache_size=100)
+
+        # Create 10 enabled schedules
+        schedule_ids = []
+        for i in range(10):
+            schedule = _create_test_schedule(f"race-activate-{i}", sample_schedule)
+            schedule.enabled = True
+            create_schedule(schedule)
+            schedule_ids.append(f"race-activate-{i}")
+
+        results = []
+        results_lock = threading.Lock()
+
+        def activate_schedule(schedule_id: str):
+            try:
+                success, error = service.activate_schedule(schedule_id)
+                with results_lock:
+                    results.append((schedule_id, success, error))
+            except Exception as e:
+                with results_lock:
+                    results.append((schedule_id, False, str(e)))
+
+        # Launch 10 threads to activate different schedules concurrently
+        threads = []
+        for schedule_id in schedule_ids:
+            t = threading.Thread(target=activate_schedule, args=(schedule_id,))
+            threads.append(t)
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Verify: Exactly one schedule should be active
+        active = service.get_active_schedule()
+        assert active is not None, "One schedule should be active"
+
+        # Verify: The active_schedule_id matches the active schedule
+        assert service._active_schedule_id == active.schedule_id
+
+        # Verify: No critical errors occurred
+        # Note: Some may fail legitimately if they try to activate after another already succeeded
+        # The important thing is no exceptions occurred
+        for _, success, error in results:
+            if not success and error:
+                # Only "Schedule is disabled" or "not found" would be real errors
+                assert "disabled" not in error.lower() and "not found" not in error.lower(), f"Unexpected error: {error}"
+
+    def test_concurrent_cache_invalidation_during_writes(self, temp_schedules_dir, sample_schedule):
+        """Invalidate cache while writes are in progress.
+
+        This tests the interaction between invalidate_cache() and concurrent
+        create_schedule()/update_schedule() operations.
+        """
+        import threading
+        import time
+
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        service = SchedulerService(cache_ttl=300, max_cache_size=100)
+
+        # Pre-create some schedules
+        for i in range(5):
+            schedule = _create_test_schedule(f"inv-write-{i}", sample_schedule)
+            create_schedule(schedule)
+
+        errors = []
+        stop_flag = [False]
+
+        def do_creates():
+            """Thread that creates new schedules."""
+            import contextlib
+            idx = 100
+            try:
+                while not stop_flag[0]:
+                    schedule = _create_test_schedule(f"inv-create-{idx}", sample_schedule)
+                    with contextlib.suppress(Exception):
+                        service.create_schedule(schedule)  # May fail if file already exists
+                    idx += 1
+                    time.sleep(0.001)
+            except Exception as e:
+                errors.append(f"create: {str(e)}")
+
+        def do_updates():
+            """Thread that updates existing schedules."""
+            import contextlib
+            try:
+                while not stop_flag[0]:
+                    for i in range(5):
+                        with contextlib.suppress(Exception):
+                            service.update_schedule(f"inv-write-{i}", {"name": f"Updated {i}"})
+                    time.sleep(0.001)
+            except Exception as e:
+                errors.append(f"update: {str(e)}")
+
+        def do_invalidations():
+            """Thread that invalidates cache entries."""
+            try:
+                while not stop_flag[0]:
+                    # Invalidate specific entries
+                    for i in range(5):
+                        service.invalidate_cache(f"inv-write-{i}")
+                    # Also invalidate entire cache periodically
+                    service.invalidate_cache()
+                    time.sleep(0.002)
+            except Exception as e:
+                errors.append(f"invalidate: {str(e)}")
+
+        # Start threads
+        threads = [
+            threading.Thread(target=do_creates),
+            threading.Thread(target=do_updates),
+            threading.Thread(target=do_updates),
+            threading.Thread(target=do_invalidations),
+            threading.Thread(target=do_invalidations),
+        ]
+
+        for t in threads:
+            t.start()
+
+        # Run for 0.5 seconds
+        time.sleep(0.5)
+        stop_flag[0] = True
+
+        for t in threads:
+            t.join(timeout=2)
+
+        # Verify no thread-safety errors occurred
+        assert len(errors) == 0, f"Errors occurred: {errors}"
+
+        # Service should still be functional
+        stats = service.get_statistics()
+        assert stats is not None
+        assert isinstance(stats['cache_size'], int)
+        assert isinstance(stats['total_writes'], int)
+
+    def test_concurrent_get_statistics_during_operations(self, temp_schedules_dir, sample_schedule):
+        """get_statistics() should return consistent snapshots during concurrent operations.
+
+        This tests that nested locks in get_statistics() provide atomic snapshots
+        even when other operations are modifying cache and statistics.
+        """
+        import threading
+        import time
+
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        service = SchedulerService(cache_ttl=300, max_cache_size=50)
+
+        # Pre-create schedules
+        for i in range(10):
+            schedule = _create_test_schedule(f"stats-snap-{i}", sample_schedule)
+            create_schedule(schedule)
+
+        errors = []
+        stats_snapshots = []
+        stats_lock = threading.Lock()
+        stop_flag = [False]
+
+        def do_reads():
+            """Thread that reads schedules."""
+            try:
+                while not stop_flag[0]:
+                    for i in range(10):
+                        service.get_schedule(f"stats-snap-{i}")
+                    time.sleep(0.001)
+            except Exception as e:
+                errors.append(f"read: {str(e)}")
+
+        def collect_stats():
+            """Thread that collects statistics snapshots."""
+            try:
+                while not stop_flag[0]:
+                    stats = service.get_statistics()
+                    with stats_lock:
+                        stats_snapshots.append(stats)
+                    time.sleep(0.002)
+            except Exception as e:
+                errors.append(f"stats: {str(e)}")
+
+        # Start threads
+        readers = [threading.Thread(target=do_reads) for _ in range(3)]
+        stat_collectors = [threading.Thread(target=collect_stats) for _ in range(2)]
+
+        for t in readers + stat_collectors:
+            t.start()
+
+        # Run for 0.5 seconds
+        time.sleep(0.5)
+        stop_flag[0] = True
+
+        for t in readers + stat_collectors:
+            t.join(timeout=2)
+
+        # Verify no errors
+        assert len(errors) == 0, f"Errors occurred: {errors}"
+
+        # Verify we collected some stats
+        assert len(stats_snapshots) > 0, "Should have collected statistics"
+
+        # Verify each snapshot is internally consistent:
+        # hits + misses should equal total_reads (for cache operations)
+        for i, stats in enumerate(stats_snapshots):
+            hits = stats['cache_hits']
+            misses = stats['cache_misses']
+            total_reads = stats['total_reads']
+
+            # total_reads should match hits + misses (all reads counted)
+            assert total_reads == hits + misses, \
+                f"Snapshot {i}: total_reads ({total_reads}) != hits ({hits}) + misses ({misses})"
+
+            # hit_ratio should be consistent with hits and total requests
+            if hits + misses > 0:
+                expected_ratio = hits / (hits + misses)
+                actual_ratio = stats['hit_ratio']
+                assert abs(expected_ratio - actual_ratio) < 0.0001, \
+                    f"Snapshot {i}: hit_ratio inconsistent"
+
+    def test_concurrent_activation_deactivation(self, temp_schedules_dir, sample_schedule):
+        """Concurrent activate and deactivate operations should not corrupt state.
+
+        This tests the thread safety of the activate/deactivate flow, especially
+        the deepcopy fix for built-in schedules.
+        """
+        import threading
+        import time
+
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        service = SchedulerService(cache_ttl=300, max_cache_size=100)
+
+        # Create 5 enabled schedules
+        for i in range(5):
+            schedule = _create_test_schedule(f"act-deact-{i}", sample_schedule)
+            schedule.enabled = True
+            create_schedule(schedule)
+
+        errors = []
+        stop_flag = [False]
+
+        def activate_random():
+            """Thread that activates random schedules."""
+            import random
+            try:
+                while not stop_flag[0]:
+                    schedule_id = f"act-deact-{random.randint(0, 4)}"
+                    service.activate_schedule(schedule_id)
+                    time.sleep(0.001)
+            except Exception as e:
+                errors.append(f"activate: {str(e)}")
+
+        def deactivate_repeatedly():
+            """Thread that deactivates the current schedule."""
+            try:
+                while not stop_flag[0]:
+                    service.deactivate_schedule()
+                    time.sleep(0.002)
+            except Exception as e:
+                errors.append(f"deactivate: {str(e)}")
+
+        def check_active():
+            """Thread that checks active schedule."""
+            try:
+                while not stop_flag[0]:
+                    active = service.get_active_schedule()
+                    # Active can be None or a valid schedule
+                    if active is not None:
+                        assert hasattr(active, 'schedule_id')
+                    time.sleep(0.001)
+            except Exception as e:
+                errors.append(f"check: {str(e)}")
+
+        # Start threads
+        threads = [
+            threading.Thread(target=activate_random),
+            threading.Thread(target=activate_random),
+            threading.Thread(target=deactivate_repeatedly),
+            threading.Thread(target=check_active),
+            threading.Thread(target=check_active),
+        ]
+
+        for t in threads:
+            t.start()
+
+        # Run for 0.5 seconds
+        time.sleep(0.5)
+        stop_flag[0] = True
+
+        for t in threads:
+            t.join(timeout=2)
+
+        # Verify no errors
+        assert len(errors) == 0, f"Errors occurred: {errors}"
+
+        # Final state should be consistent
+        stats = service.get_statistics()
+        active_id = stats['active_schedule_id']
+
+        if active_id is not None:
+            # If there's an active schedule, we should be able to get it
+            active = service.get_schedule(active_id)
+            assert active is not None, f"Active schedule {active_id} should exist"

--- a/Firmware/webui/backend/services/__init__.py
+++ b/Firmware/webui/backend/services/__init__.py
@@ -14,6 +14,7 @@ _series_service = None
 _locations_service = None
 _sidecar_service = None
 _deployment_service = None
+_scheduler_service = None
 
 
 def get_clustering_service():
@@ -80,6 +81,26 @@ def get_deployment_service():
     return _deployment_service
 
 
+def get_scheduler_service():
+    """
+    Get singleton SchedulerService instance with lazy initialization.
+
+    Returns:
+        SchedulerService: The singleton service instance
+
+    Example:
+        from webui.backend.services import get_scheduler_service
+
+        service = get_scheduler_service()
+        schedules = service.list_schedules()
+    """
+    global _scheduler_service
+    if _scheduler_service is None:
+        from .scheduler_service import SchedulerService
+        _scheduler_service = SchedulerService(cache_ttl=300, max_cache_size=100)
+    return _scheduler_service
+
+
 __all__ = [
     'PhotoService',
     'PaginationError',
@@ -90,4 +111,5 @@ __all__ = [
     'get_locations_service',
     'get_sidecar_service',
     'get_deployment_service',
+    'get_scheduler_service',
 ]

--- a/Firmware/webui/backend/services/scheduler_service.py
+++ b/Firmware/webui/backend/services/scheduler_service.py
@@ -340,10 +340,19 @@ class SchedulerService:
         if self._active_schedule_id is None:
             # Check storage in case of restart
             schedules = self.list_schedules()
-            for schedule in schedules:
-                if schedule.is_active:
-                    self._active_schedule_id = schedule.schedule_id
-                    return schedule
+            active_schedules = [s for s in schedules if s.is_active]
+
+            if len(active_schedules) > 1:
+                # Data corruption: multiple schedules marked active
+                active_ids = [s.schedule_id for s in active_schedules]
+                logger.warning(
+                    f"Multiple active schedules detected (data corruption): {active_ids}. "
+                    f"Using first one: {active_ids[0]}"
+                )
+
+            if active_schedules:
+                self._active_schedule_id = active_schedules[0].schedule_id
+                return active_schedules[0]
             return None
 
         return self.get_schedule(self._active_schedule_id)

--- a/Firmware/webui/backend/services/scheduler_service.py
+++ b/Firmware/webui/backend/services/scheduler_service.py
@@ -250,7 +250,7 @@ class SchedulerService:
             updates: Dict of fields to update
 
         Returns:
-            Updated Schedule if successful, None if not found
+            Updated Schedule if successful, None if not found or validation fails
 
         Raises:
             ValueError: If attempting to modify built-in schedule
@@ -263,6 +263,16 @@ class SchedulerService:
         updated = storage_update(schedule_id, updates)
 
         if updated:
+            # Defense-in-depth: validate before caching
+            valid, error = validate_schedule(updated)
+            if not valid:
+                logger.error(f"Updated schedule failed validation: {error}")
+                # Invalidate any stale cache entry
+                with self._cache_lock:
+                    if schedule_id in self._cache:
+                        del self._cache[schedule_id]
+                return None
+
             with self._cache_lock:
                 self._set_cache(schedule_id, updated)
             with self._stats_lock:

--- a/Firmware/webui/backend/services/scheduler_service.py
+++ b/Firmware/webui/backend/services/scheduler_service.py
@@ -461,30 +461,30 @@ class SchedulerService:
             - active_schedule_id: ID of currently active schedule (or None)
         """
         # IMPORTANT: Acquire locks in correct order to prevent deadlocks
-        # Order: cache_lock first, then stats_lock
+        # Order: cache_lock first, then stats_lock (nested for atomic snapshot)
         with self._cache_lock:
             cache_size = len(self._cache)
             active_schedule_id = self._active_schedule_id
 
-        with self._stats_lock:
-            total_requests = self._cache_hits + self._cache_misses
-            hit_ratio = 0.0
-            if total_requests > 0:
-                hit_ratio = self._cache_hits / total_requests
+            with self._stats_lock:
+                total_requests = self._cache_hits + self._cache_misses
+                hit_ratio = 0.0
+                if total_requests > 0:
+                    hit_ratio = self._cache_hits / total_requests
 
-            return {
-                "cache_hits": self._cache_hits,
-                "cache_misses": self._cache_misses,
-                "cache_evictions": self._cache_evictions,
-                "cache_size": cache_size,
-                "max_cache_size": self.max_cache_size,
-                "cache_ttl": self.cache_ttl,
-                "hit_ratio": hit_ratio,
-                "total_reads": self._total_reads,
-                "total_writes": self._total_writes,
-                "total_deletes": self._total_deletes,
-                "active_schedule_id": active_schedule_id,
-            }
+                return {
+                    "cache_hits": self._cache_hits,
+                    "cache_misses": self._cache_misses,
+                    "cache_evictions": self._cache_evictions,
+                    "cache_size": cache_size,
+                    "max_cache_size": self.max_cache_size,
+                    "cache_ttl": self.cache_ttl,
+                    "hit_ratio": hit_ratio,
+                    "total_reads": self._total_reads,
+                    "total_writes": self._total_writes,
+                    "total_deletes": self._total_deletes,
+                    "active_schedule_id": active_schedule_id,
+                }
 
 
 # ============================================================================

--- a/Firmware/webui/backend/services/scheduler_service.py
+++ b/Firmware/webui/backend/services/scheduler_service.py
@@ -182,15 +182,16 @@ class SchedulerService:
         """
         schedules = storage_list(include_builtin=include_builtin)
 
-        # Cache individual schedules
+        # Cache individual schedules (skip if already cached to avoid race)
         with self._cache_lock:
             for schedule in schedules:
-                if schedule.schedule_id not in self._cache:
-                    self._set_cache(schedule.schedule_id, schedule)
+                self._set_cache(schedule.schedule_id, schedule, overwrite=False)
 
         return schedules
 
-    def _set_cache(self, schedule_id: str, schedule: Schedule) -> None:
+    def _set_cache(
+        self, schedule_id: str, schedule: Schedule, overwrite: bool = True
+    ) -> None:
         """
         Add schedule to cache with LRU eviction.
 
@@ -199,7 +200,12 @@ class SchedulerService:
         Args:
             schedule_id: Schedule identifier
             schedule: Schedule object to cache
+            overwrite: If False, skip if already cached (default True)
         """
+        # Skip if already cached and overwrite is False
+        if not overwrite and schedule_id in self._cache:
+            return
+
         # Evict LRU entry if cache full
         while len(self._cache) >= self.max_cache_size:
             evicted_id, _ = self._cache.popitem(last=False)  # Pop oldest

--- a/Firmware/webui/backend/services/scheduler_service.py
+++ b/Firmware/webui/backend/services/scheduler_service.py
@@ -143,8 +143,6 @@ class SchedulerService:
             Schedule if found, None otherwise
         """
         with self._cache_lock:
-            self._total_reads += 1
-
             # Check cache first
             if schedule_id in self._cache:
                 schedule, cached_at = self._cache[schedule_id]
@@ -153,14 +151,16 @@ class SchedulerService:
                     self._cache.move_to_end(schedule_id)
                     with self._stats_lock:
                         self._cache_hits += 1
+                        self._total_reads += 1
                     return schedule
                 else:
                     # TTL expired - remove stale entry
                     del self._cache[schedule_id]
 
-            # Cache miss
+            # Cache miss - update stats with proper locking
             with self._stats_lock:
                 self._cache_misses += 1
+                self._total_reads += 1
 
             # Read from storage
             schedule = storage_read(schedule_id)

--- a/Firmware/webui/backend/services/scheduler_service.py
+++ b/Firmware/webui/backend/services/scheduler_service.py
@@ -33,6 +33,7 @@ Usage:
 import logging
 import time
 from collections import OrderedDict
+from copy import deepcopy
 from threading import RLock
 from typing import Any
 
@@ -372,10 +373,11 @@ class SchedulerService:
             if not is_builtin_schedule(schedule_id):
                 self.update_schedule(schedule_id, {"is_active": True})
             else:
-                # Built-in: update cache entry directly
-                schedule.is_active = True
+                # Built-in: create copy before mutation to avoid side effects
+                schedule_copy = deepcopy(schedule)
+                schedule_copy.is_active = True
                 with self._cache_lock:
-                    self._set_cache(schedule_id, schedule)
+                    self._set_cache(schedule_id, schedule_copy)
         except Exception as e:
             return False, f"Failed to update schedule: {e}"
 
@@ -406,12 +408,13 @@ class SchedulerService:
             if not is_builtin_schedule(schedule_id):
                 self.update_schedule(schedule_id, {"is_active": False})
             else:
-                # Built-in: update cache only
+                # Built-in: create copy before mutation to avoid side effects
                 schedule = self.get_schedule(schedule_id)
                 if schedule:
-                    schedule.is_active = False
+                    schedule_copy = deepcopy(schedule)
+                    schedule_copy.is_active = False
                     with self._cache_lock:
-                        self._set_cache(schedule_id, schedule)
+                        self._set_cache(schedule_id, schedule_copy)
         except Exception as e:
             logger.warning(f"Failed to deactivate schedule: {e}")
 

--- a/Firmware/webui/backend/services/scheduler_service.py
+++ b/Firmware/webui/backend/services/scheduler_service.py
@@ -179,6 +179,10 @@ class SchedulerService:
 
         Returns:
             List of Schedule objects
+
+        Thread Safety:
+            Acquires _cache_lock when populating cache. Uses overwrite=False
+            to avoid overwriting fresher entries from concurrent operations.
         """
         schedules = storage_list(include_builtin=include_builtin)
 

--- a/Firmware/webui/backend/services/scheduler_service.py
+++ b/Firmware/webui/backend/services/scheduler_service.py
@@ -1,0 +1,496 @@
+"""
+Scheduler Service with LRU Cache.
+
+Provides cached access to schedule management with thread-safe operations.
+Only one schedule can be active at a time.
+
+Performance targets:
+- Cache hit rate: >80%
+- Cache hit: <10ms
+- Disk read: <50ms
+
+Thread-safe with statistics tracking.
+
+Usage:
+    from webui.backend.services.scheduler_service import SchedulerService
+
+    service = SchedulerService(cache_ttl=300)
+
+    # Get schedule (cache -> disk)
+    schedule = service.get_schedule("schedule-id")
+
+    # List all schedules
+    schedules = service.list_schedules(include_builtin=True)
+
+    # Get active schedule
+    active = service.get_active_schedule()
+
+    # Statistics
+    stats = service.get_statistics()
+    print(f"Hit ratio: {stats['hit_ratio']:.2%}")
+"""
+
+import logging
+import time
+from collections import OrderedDict
+from threading import RLock
+from typing import Any
+
+from webui.backend.lib.schedule_schema import (
+    Schedule,
+    ScheduleValidationError,
+    validate_schedule,
+)
+from webui.backend.lib.schedule_storage import (
+    create_schedule as storage_create,
+)
+from webui.backend.lib.schedule_storage import (
+    delete_schedule as storage_delete,
+)
+from webui.backend.lib.schedule_storage import (
+    is_builtin_schedule,
+)
+from webui.backend.lib.schedule_storage import (
+    list_schedules as storage_list,
+)
+from webui.backend.lib.schedule_storage import (
+    read_schedule as storage_read,
+)
+from webui.backend.lib.schedule_storage import (
+    update_schedule as storage_update,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ============================================================================
+# Scheduler Service
+# ============================================================================
+
+
+class SchedulerService:
+    """
+    LRU cache for schedule management.
+
+    In-memory cache with configurable TTL and LRU eviction.
+    Only one schedule can be active at a time.
+
+    Performance targets:
+    - Cache hit: <10ms
+    - Disk read: <50ms
+    - Hit rate: >80%
+
+    Thread Safety:
+    ---------------
+    This class uses two locks to ensure thread-safe operation:
+    - _cache_lock: Protects in-memory cache (OrderedDict) and active schedule tracking
+    - _stats_lock: Protects statistics counters
+
+    LOCK ACQUISITION ORDER (to prevent deadlocks):
+    -----------------------------------------------
+    If multiple locks must be acquired, always acquire in this order:
+        1. _cache_lock (first)
+        2. _stats_lock (last)
+
+    NEVER acquire locks in a different order, as this can cause deadlocks.
+    """
+
+    def __init__(
+        self,
+        cache_ttl: int = 300,
+        max_cache_size: int = 100,
+    ):
+        """
+        Initialize SchedulerService with LRU cache.
+
+        Args:
+            cache_ttl: Cache entry time-to-live in seconds (default 300)
+            max_cache_size: Maximum cache entries before LRU eviction (default 100)
+        """
+        self.cache_ttl = cache_ttl
+        self.max_cache_size = max_cache_size
+
+        # LRU cache: schedule_id -> (Schedule, timestamp)
+        self._cache: OrderedDict[str, tuple[Schedule, float]] = OrderedDict()
+
+        # Separate cache for active schedule (O(1) lookup)
+        self._active_schedule_id: str | None = None
+
+        # Thread safety (RLock allows recursive locking)
+        self._cache_lock = RLock()
+        self._stats_lock = RLock()
+
+        # Statistics tracking
+        self._cache_hits = 0
+        self._cache_misses = 0
+        self._cache_evictions = 0
+        self._total_reads = 0
+        self._total_writes = 0
+        self._total_deletes = 0
+
+    # ========================================================================
+    # CRUD Read Operations
+    # ========================================================================
+
+    def get_schedule(self, schedule_id: str) -> Schedule | None:
+        """
+        Get schedule by ID with caching.
+
+        Args:
+            schedule_id: Schedule identifier
+
+        Returns:
+            Schedule if found, None otherwise
+        """
+        with self._cache_lock:
+            self._total_reads += 1
+
+            # Check cache first
+            if schedule_id in self._cache:
+                schedule, cached_at = self._cache[schedule_id]
+                if time.time() - cached_at < self.cache_ttl:
+                    # Cache hit - move to end (MRU)
+                    self._cache.move_to_end(schedule_id)
+                    with self._stats_lock:
+                        self._cache_hits += 1
+                    return schedule
+                else:
+                    # TTL expired - remove stale entry
+                    del self._cache[schedule_id]
+
+            # Cache miss
+            with self._stats_lock:
+                self._cache_misses += 1
+
+            # Read from storage
+            schedule = storage_read(schedule_id)
+            if schedule:
+                self._set_cache(schedule_id, schedule)
+
+            return schedule
+
+    def list_schedules(self, include_builtin: bool = True) -> list[Schedule]:
+        """
+        List all schedules.
+
+        Args:
+            include_builtin: Include built-in schedules (default True)
+
+        Returns:
+            List of Schedule objects
+        """
+        schedules = storage_list(include_builtin=include_builtin)
+
+        # Cache individual schedules
+        with self._cache_lock:
+            for schedule in schedules:
+                if schedule.schedule_id not in self._cache:
+                    self._set_cache(schedule.schedule_id, schedule)
+
+        return schedules
+
+    def _set_cache(self, schedule_id: str, schedule: Schedule) -> None:
+        """
+        Add schedule to cache with LRU eviction.
+
+        MUST be called with _cache_lock held.
+
+        Args:
+            schedule_id: Schedule identifier
+            schedule: Schedule object to cache
+        """
+        # Evict LRU entry if cache full
+        while len(self._cache) >= self.max_cache_size:
+            evicted_id, _ = self._cache.popitem(last=False)  # Pop oldest
+            with self._stats_lock:
+                self._cache_evictions += 1
+            logger.debug(f"Evicted schedule {evicted_id} from cache (LRU)")
+
+        self._cache[schedule_id] = (schedule, time.time())
+
+    # ========================================================================
+    # CRUD Write/Delete Operations
+    # ========================================================================
+
+    def create_schedule(self, schedule: Schedule) -> bool:
+        """
+        Create a new schedule.
+
+        Args:
+            schedule: Schedule to create
+
+        Returns:
+            True if created successfully
+
+        Raises:
+            ScheduleValidationError: If schedule validation fails
+        """
+        # Validate schedule
+        valid, error = validate_schedule(schedule)
+        if not valid:
+            raise ScheduleValidationError(error)
+
+        # Write to storage
+        success = storage_create(schedule)
+
+        if success:
+            with self._cache_lock:
+                self._set_cache(schedule.schedule_id, schedule)
+            with self._stats_lock:
+                self._total_writes += 1
+
+        return success
+
+    def update_schedule(self, schedule_id: str, updates: dict) -> Schedule | None:
+        """
+        Update a schedule with partial updates.
+
+        Args:
+            schedule_id: Schedule to update
+            updates: Dict of fields to update
+
+        Returns:
+            Updated Schedule if successful, None if not found
+
+        Raises:
+            ValueError: If attempting to modify built-in schedule
+        """
+        # Check if built-in
+        if is_builtin_schedule(schedule_id):
+            raise ValueError(f"Cannot modify built-in schedule: {schedule_id}")
+
+        # Delegate to storage
+        updated = storage_update(schedule_id, updates)
+
+        if updated:
+            with self._cache_lock:
+                self._set_cache(schedule_id, updated)
+            with self._stats_lock:
+                self._total_writes += 1
+
+        return updated
+
+    def delete_schedule(self, schedule_id: str) -> bool:
+        """
+        Delete a schedule.
+
+        Args:
+            schedule_id: Schedule to delete
+
+        Returns:
+            True if deleted, False if not found
+
+        Raises:
+            ValueError: If attempting to delete built-in schedule
+        """
+        # Check if built-in
+        if is_builtin_schedule(schedule_id):
+            raise ValueError(f"Cannot delete built-in schedule: {schedule_id}")
+
+        # Delegate to storage
+        success = storage_delete(schedule_id)
+
+        if success:
+            with self._cache_lock:
+                if schedule_id in self._cache:
+                    del self._cache[schedule_id]
+            with self._stats_lock:
+                self._total_deletes += 1
+
+            # Clear active schedule if deleted
+            with self._cache_lock:
+                if self._active_schedule_id == schedule_id:
+                    self._active_schedule_id = None
+
+        return success
+
+    # ========================================================================
+    # Activation/Deactivation
+    # ========================================================================
+
+    def get_active_schedule(self) -> Schedule | None:
+        """
+        Get the currently active schedule (O(1) lookup).
+
+        Returns:
+            Active Schedule if one is active, None otherwise
+        """
+        # Use cached active schedule ID for O(1) lookup
+        if self._active_schedule_id is None:
+            # Check storage in case of restart
+            schedules = self.list_schedules()
+            for schedule in schedules:
+                if schedule.is_active:
+                    self._active_schedule_id = schedule.schedule_id
+                    return schedule
+            return None
+
+        return self.get_schedule(self._active_schedule_id)
+
+    def activate_schedule(self, schedule_id: str) -> tuple[bool, str]:
+        """
+        Activate a schedule (deactivates any currently active first).
+
+        Args:
+            schedule_id: Schedule to activate
+
+        Returns:
+            (success: bool, error_message: str)
+            success=True with empty error on success
+            success=False with error description on failure
+        """
+        # Get the schedule
+        schedule = self.get_schedule(schedule_id)
+        if not schedule:
+            return False, f"Schedule not found: {schedule_id}"
+
+        # Check if enabled
+        if not schedule.enabled:
+            return False, f"Schedule is disabled: {schedule_id}"
+
+        # Already active? Return success (idempotent)
+        if schedule.is_active and self._active_schedule_id == schedule_id:
+            return True, ""
+
+        # Deactivate any currently active schedule
+        if self._active_schedule_id and self._active_schedule_id != schedule_id:
+            self.deactivate_schedule()
+
+        # Update is_active flag in storage
+        # For built-in schedules, we only update the in-memory state
+        try:
+            if not is_builtin_schedule(schedule_id):
+                self.update_schedule(schedule_id, {"is_active": True})
+            else:
+                # Built-in: update cache entry directly
+                schedule.is_active = True
+                with self._cache_lock:
+                    self._set_cache(schedule_id, schedule)
+        except Exception as e:
+            return False, f"Failed to update schedule: {e}"
+
+        # Set active schedule ID
+        with self._cache_lock:
+            self._active_schedule_id = schedule_id
+
+        # TODO: CronBridge integration
+        # Apply schedule to system cron (placeholder for future Issue)
+        logger.info(f"Activated schedule: {schedule_id}")
+
+        return True, ""
+
+    def deactivate_schedule(self) -> bool:
+        """
+        Deactivate the currently active schedule.
+
+        Returns:
+            True always (no-op if no active schedule)
+        """
+        if self._active_schedule_id is None:
+            return True  # No-op
+
+        schedule_id = self._active_schedule_id
+
+        # Update storage if not built-in
+        try:
+            if not is_builtin_schedule(schedule_id):
+                self.update_schedule(schedule_id, {"is_active": False})
+            else:
+                # Built-in: update cache only
+                schedule = self.get_schedule(schedule_id)
+                if schedule:
+                    schedule.is_active = False
+                    with self._cache_lock:
+                        self._set_cache(schedule_id, schedule)
+        except Exception as e:
+            logger.warning(f"Failed to deactivate schedule: {e}")
+
+        # Clear active schedule ID
+        with self._cache_lock:
+            self._active_schedule_id = None
+
+        # TODO: Clear system cron (placeholder for future Issue)
+        logger.info(f"Deactivated schedule: {schedule_id}")
+
+        return True
+
+    # ========================================================================
+    # Cache Management
+    # ========================================================================
+
+    def invalidate_cache(self, schedule_id: str = None) -> None:
+        """
+        Invalidate cache entries.
+
+        Args:
+            schedule_id: If provided, invalidate only this entry.
+                         If None, invalidate entire cache.
+        """
+        with self._cache_lock:
+            if schedule_id is None:
+                # Clear entire cache
+                count = len(self._cache)
+                self._cache.clear()
+                logger.debug(f"Invalidated entire cache ({count} entries)")
+            else:
+                # Clear specific entry
+                if schedule_id in self._cache:
+                    del self._cache[schedule_id]
+                    logger.debug(f"Invalidated cache entry: {schedule_id}")
+
+    # ========================================================================
+    # Statistics
+    # ========================================================================
+
+    def get_statistics(self) -> dict[str, Any]:
+        """
+        Get current cache statistics.
+
+        Returns:
+            Dictionary with cache metrics:
+            - cache_hits: Number of cache hits
+            - cache_misses: Number of cache misses
+            - cache_evictions: Number of LRU evictions
+            - cache_size: Current cache size
+            - max_cache_size: Maximum cache size
+            - cache_ttl: Cache TTL in seconds
+            - hit_ratio: Cache hit ratio (0.0 to 1.0)
+            - total_reads: Total read operations
+            - total_writes: Total write operations
+            - total_deletes: Total delete operations
+            - active_schedule_id: ID of currently active schedule (or None)
+        """
+        # IMPORTANT: Acquire locks in correct order to prevent deadlocks
+        # Order: cache_lock first, then stats_lock
+        with self._cache_lock:
+            cache_size = len(self._cache)
+            active_schedule_id = self._active_schedule_id
+
+        with self._stats_lock:
+            total_requests = self._cache_hits + self._cache_misses
+            hit_ratio = 0.0
+            if total_requests > 0:
+                hit_ratio = self._cache_hits / total_requests
+
+            return {
+                "cache_hits": self._cache_hits,
+                "cache_misses": self._cache_misses,
+                "cache_evictions": self._cache_evictions,
+                "cache_size": cache_size,
+                "max_cache_size": self.max_cache_size,
+                "cache_ttl": self.cache_ttl,
+                "hit_ratio": hit_ratio,
+                "total_reads": self._total_reads,
+                "total_writes": self._total_writes,
+                "total_deletes": self._total_deletes,
+                "active_schedule_id": active_schedule_id,
+            }
+
+
+# ============================================================================
+# Module exports
+# ============================================================================
+
+__all__ = [
+    "SchedulerService",
+]


### PR DESCRIPTION
## Summary

Implements Issue #212 - Scheduler Service, the core service layer for schedule management with LRU caching, thread safety, and CRUD operations.

### Features
- **LRU Cache**: OrderedDict-based cache with configurable TTL (300s) and max size (100)
- **Thread Safety**: RLock-based locking with documented lock acquisition order
- **CRUD Operations**: get, list, create, update, delete schedules
- **Activation Logic**: Single-active constraint with O(1) active schedule lookup
- **Statistics Tracking**: Hits, misses, evictions, reads, writes, deletes
- **Built-in Protection**: Built-in schedules are read-only (can activate but not modify/delete)

### Files Changed
| File | Lines | Description |
|------|-------|-------------|
| `webui/backend/services/scheduler_service.py` | 496 | Core service implementation |
| `Tests/unit/test_scheduler_service.py` | 1,619 | Comprehensive test suite |
| `webui/backend/services/__init__.py` | +22 | Module exports with lazy init |

### Test Results
- **72 unit tests** - All passing
- **92.20% code coverage** - Exceeds 85% requirement
- **Thread safety verified** - 8 concurrent access tests
- **Ruff check** - Passed
- **Bandit security scan** - No issues

### API
```python
from webui.backend.services import get_scheduler_service

service = get_scheduler_service()

# CRUD
schedule = service.get_schedule("schedule-id")
schedules = service.list_schedules(include_builtin=True)
service.create_schedule(schedule)
service.update_schedule("id", {"name": "Updated"})
service.delete_schedule("id")

# Activation (only one active at a time)
active = service.get_active_schedule()
success, error = service.activate_schedule("id")
service.deactivate_schedule()

# Cache management
service.invalidate_cache()  # Clear all
service.invalidate_cache("id")  # Clear specific
stats = service.get_statistics()
```

## Test plan
- [x] All 72 unit tests pass
- [x] Code coverage ≥85% (92.20%)
- [x] Thread safety tests verify concurrent access
- [x] Ruff linting passes
- [x] Bandit security scan passes
- [x] Import via `get_scheduler_service()` works

Closes #212