### PR TITLE
feat(scheduler): Add schedule preview generator with moon phases (#214)

### DIFF
--- a/Firmware/Tests/unit/test_schedule_preview.py
+++ b/Firmware/Tests/unit/test_schedule_preview.py
@@ -29,6 +29,7 @@ try:
         validate_preview_days,
         validate_timezone,
     )
+
     IMPLEMENTATION_EXISTS = True
 except ImportError:
     IMPLEMENTATION_EXISTS = False
@@ -61,10 +62,7 @@ except ImportError:
 
 
 # Skip all tests if implementation doesn't exist
-pytestmark = pytest.mark.skipif(
-    not IMPLEMENTATION_EXISTS,
-    reason="Implementation not yet created"
-)
+pytestmark = pytest.mark.skipif(not IMPLEMENTATION_EXISTS, reason="Implementation not yet created")
 
 
 # ============================================================================
@@ -726,9 +724,7 @@ class TestConflictIntegration:
 
     @patch("webui.backend.lib.schedule_preview.detect_conflicts")
     @patch("webui.backend.lib.schedule_preview.generate_pattern_executions")
-    def test_no_conflicts_empty_list(
-        self, mock_gen_exec, mock_detect, sample_interval_schedule
-    ):
+    def test_no_conflicts_empty_list(self, mock_gen_exec, mock_detect, sample_interval_schedule):
         """Test empty conflict list when no conflicts."""
         mock_gen_exec.return_value = []
 
@@ -861,6 +857,41 @@ class TestEdgeCases:
         valid, error = validate_timezone("not-a-timezone")
         assert valid is False
         assert "Invalid timezone" in error
+
+    @patch.dict("sys.modules", {"pytz": None})
+    def test_timezone_validation_pytz_not_installed(self):
+        """Test graceful handling when pytz is not installed."""
+        # We need to patch the import inside the function
+        import sys
+
+        # Save original pytz module
+        original_pytz = sys.modules.get("pytz")
+
+        # Remove pytz from modules to simulate it not being installed
+        if "pytz" in sys.modules:
+            del sys.modules["pytz"]
+
+        # Also need to patch builtins to make import fail
+        import builtins
+
+        original_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "pytz":
+                raise ImportError("No module named 'pytz'")
+            return original_import(name, *args, **kwargs)
+
+        builtins.__import__ = mock_import
+
+        try:
+            valid, error = validate_timezone("America/New_York")
+            assert valid is False
+            assert "pytz library required" in error
+        finally:
+            # Restore original import and pytz module
+            builtins.__import__ = original_import
+            if original_pytz is not None:
+                sys.modules["pytz"] = original_pytz
 
 
 # ============================================================================

--- a/Firmware/Tests/unit/test_schedule_preview.py
+++ b/Firmware/Tests/unit/test_schedule_preview.py
@@ -357,6 +357,31 @@ class TestPreviewResult:
         assert output["total_executions"] == 0
         assert "moon_phases" in output
         assert "generated_at" in output
+        assert "warnings" in output
+        assert output["warnings"] == []
+
+    def test_preview_result_with_warnings(self):
+        """Test PreviewResult with warnings list."""
+        result = PreviewResult(
+            schedule_id="test-schedule",
+            schedule_name="Test Schedule",
+            preview_start=datetime(2025, 6, 15, 0, 0, 0, tzinfo=UTC),
+            preview_end=datetime(2025, 6, 21, 23, 59, 59, tzinfo=UTC),
+            executions=[],
+            conflicts=[],
+            moon_phases={},
+            total_actions=0,
+            total_executions=0,
+            warnings=["Warning 1", "Warning 2"],
+        )
+
+        output = result.to_dict()
+
+        assert output["warnings"] == ["Warning 1", "Warning 2"]
+
+        # Test roundtrip
+        restored = PreviewResult.from_dict(output)
+        assert restored.warnings == ["Warning 1", "Warning 2"]
 
     def test_preview_result_empty_executions(self):
         """Test PreviewResult with no executions."""
@@ -894,6 +919,75 @@ class TestLocationFallback:
         call_args = mock_gen_exec.call_args
         assert call_args.kwargs["latitude"] == 10.0
         assert call_args.kwargs["longitude"] == 20.0
+
+    @patch("webui.backend.lib.schedule_preview._get_default_location")
+    @patch("webui.backend.lib.schedule_preview.detect_conflicts")
+    @patch("webui.backend.lib.schedule_preview.generate_pattern_executions")
+    def test_default_location_warning_included(
+        self, mock_gen_exec, mock_detect, mock_default_loc, sample_interval_schedule
+    ):
+        """Test that default location (0, 0) generates a warning in result."""
+        # Simulate no GPS data available - returns None
+        mock_default_loc.return_value = (None, None)
+        mock_gen_exec.return_value = []
+
+        mock_report = MagicMock()
+        mock_report.conflicts = []
+        mock_detect.return_value = mock_report
+
+        # Call without explicit params - should use (0, 0) default
+        result = generate_preview(sample_interval_schedule, days=1)
+
+        # Should have warning about default location
+        assert len(result.warnings) == 1
+        assert "default location (0, 0)" in result.warnings[0]
+        assert "Solar-based triggers may be inaccurate" in result.warnings[0]
+
+    @patch("webui.backend.lib.schedule_preview._get_default_location")
+    @patch("webui.backend.lib.schedule_preview.detect_conflicts")
+    @patch("webui.backend.lib.schedule_preview.generate_pattern_executions")
+    def test_explicit_location_no_warning(
+        self, mock_gen_exec, mock_detect, mock_default_loc, sample_interval_schedule
+    ):
+        """Test that explicit coordinates don't generate warning."""
+        mock_default_loc.return_value = (None, None)
+        mock_gen_exec.return_value = []
+
+        mock_report = MagicMock()
+        mock_report.conflicts = []
+        mock_detect.return_value = mock_report
+
+        # Call with explicit coordinates
+        result = generate_preview(
+            sample_interval_schedule,
+            days=1,
+            latitude=35.0,
+            longitude=-80.0,
+        )
+
+        # Should have no warnings
+        assert result.warnings == []
+
+    @patch("webui.backend.lib.schedule_preview._get_default_location")
+    @patch("webui.backend.lib.schedule_preview.detect_conflicts")
+    @patch("webui.backend.lib.schedule_preview.generate_pattern_executions")
+    def test_controls_location_no_warning(
+        self, mock_gen_exec, mock_detect, mock_default_loc, sample_interval_schedule
+    ):
+        """Test that valid GPS from controls.txt doesn't generate warning."""
+        # Simulate valid GPS data from controls.txt
+        mock_default_loc.return_value = (35.9606, -83.9207)
+        mock_gen_exec.return_value = []
+
+        mock_report = MagicMock()
+        mock_report.conflicts = []
+        mock_detect.return_value = mock_report
+
+        # Call without explicit params - should use GPS from controls.txt
+        result = generate_preview(sample_interval_schedule, days=1)
+
+        # Should have no warnings
+        assert result.warnings == []
 
 
 # ============================================================================

--- a/Firmware/Tests/unit/test_schedule_preview.py
+++ b/Firmware/Tests/unit/test_schedule_preview.py
@@ -27,6 +27,7 @@ try:
         generate_preview,
         validate_coordinates,
         validate_preview_days,
+        validate_timezone,
     )
     IMPLEMENTATION_EXISTS = True
 except ImportError:
@@ -798,6 +799,43 @@ class TestEdgeCases:
         valid, error = validate_coordinates(35.0, 181.0)
         assert valid is False
         assert "Longitude" in error
+
+    def test_timezone_validation_valid_utc(self):
+        """Test valid UTC timezone passes validation."""
+        valid, error = validate_timezone("UTC")
+        assert valid is True
+        assert error is None
+
+    def test_timezone_validation_valid_iana(self):
+        """Test valid IANA timezone passes validation."""
+        valid, error = validate_timezone("America/New_York")
+        assert valid is True
+        assert error is None
+
+    def test_timezone_validation_valid_europe(self):
+        """Test valid European timezone passes validation."""
+        valid, error = validate_timezone("Europe/London")
+        assert valid is True
+        assert error is None
+
+    def test_timezone_validation_invalid_name(self):
+        """Test invalid timezone name rejected."""
+        valid, error = validate_timezone("Invalid/Timezone")
+        assert valid is False
+        assert "Invalid timezone" in error
+        assert "IANA" in error
+
+    def test_timezone_validation_empty_string(self):
+        """Test empty timezone string rejected."""
+        valid, error = validate_timezone("")
+        assert valid is False
+        assert "empty" in error
+
+    def test_timezone_validation_gibberish(self):
+        """Test gibberish timezone rejected."""
+        valid, error = validate_timezone("not-a-timezone")
+        assert valid is False
+        assert "Invalid timezone" in error
 
 
 # ============================================================================

--- a/Firmware/Tests/unit/test_schedule_preview.py
+++ b/Firmware/Tests/unit/test_schedule_preview.py
@@ -1,0 +1,922 @@
+"""
+Unit tests for Schedule Preview Library (Issue #214)
+
+Tests preview generation, action expansion, moon phase integration,
+and conflict detection for the scheduler preview system.
+
+Coverage Target: 85%+
+Test Count Target: 20+ tests
+"""
+
+from datetime import UTC, date, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Import schedule preview library
+try:
+    from webui.backend.lib.schedule_preview import (
+        MAX_PREVIEW_DAYS,
+        MIN_PREVIEW_DAYS,
+        ActionExecution,
+        PreviewExecution,
+        PreviewResult,
+        _expand_actions,
+        _get_moon_phases_dict,
+        _get_trigger_info,
+        generate_preview,
+        validate_coordinates,
+        validate_preview_days,
+    )
+    IMPLEMENTATION_EXISTS = True
+except ImportError:
+    IMPLEMENTATION_EXISTS = False
+    ActionExecution = None
+    PreviewExecution = None
+    PreviewResult = None
+
+# Import schema classes
+try:
+    from webui.backend.lib.schedule_schema import (
+        EventPattern,
+        FixedTimeTrigger,
+        IntervalTrigger,
+        MoonPhaseTrigger,
+        PatternAction,
+        Schedule,
+        SensorTrigger,
+        SolarTrigger,
+        TimeWindow,
+    )
+except ImportError:
+    EventPattern = None
+    Schedule = None
+
+# Import conflict types
+try:
+    from webui.backend.lib.schedule_conflict import Conflict
+except ImportError:
+    Conflict = None
+
+
+# Skip all tests if implementation doesn't exist
+pytestmark = pytest.mark.skipif(
+    not IMPLEMENTATION_EXISTS,
+    reason="Implementation not yet created"
+)
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def sample_action():
+    """Create a sample PatternAction."""
+    return PatternAction(
+        action_type="gpio",
+        action_name="attract_on",
+        offset_minutes=0,
+        description="Turn on UV attract lights",
+    )
+
+
+@pytest.fixture
+def sample_pattern():
+    """Create a sample EventPattern with multiple actions."""
+    actions = [
+        PatternAction(
+            action_type="gpio",
+            action_name="attract_on",
+            offset_minutes=0,
+            description="Turn on UV attract lights",
+        ),
+        PatternAction(
+            action_type="camera",
+            action_name="takephoto",
+            offset_minutes=5,
+            description="Capture photo",
+        ),
+        PatternAction(
+            action_type="gpio",
+            action_name="attract_off",
+            offset_minutes=15,
+            description="Turn off UV lights",
+        ),
+    ]
+
+    return EventPattern(
+        pattern_id="uv-capture-cycle",
+        name="UV Capture Cycle",
+        description="Standard UV light photo capture sequence",
+        actions=actions,
+        category="user",
+    )
+
+
+@pytest.fixture
+def sample_interval_schedule(sample_pattern):
+    """Create a schedule with interval trigger."""
+    time_window = TimeWindow(
+        start_time="21:00",
+        end_time="05:00",
+    )
+
+    trigger = IntervalTrigger(
+        interval_minutes=60,
+        time_window=time_window,
+    )
+
+    return Schedule(
+        schedule_id="nightly-survey",
+        name="Nightly Moth Survey",
+        description="Hourly captures from 9 PM to 5 AM",
+        event_patterns=[sample_pattern],
+        trigger_type="interval",
+        interval_trigger=trigger,
+        enabled=True,
+    )
+
+
+@pytest.fixture
+def sample_solar_schedule(sample_pattern):
+    """Create a schedule with solar trigger."""
+    trigger = SolarTrigger(
+        solar_event="sunset",
+        offset_minutes=30,
+        days_of_week=None,
+    )
+
+    return Schedule(
+        schedule_id="sunset-survey",
+        name="Sunset Survey",
+        description="Capture 30 minutes after sunset",
+        event_patterns=[sample_pattern],
+        trigger_type="solar",
+        solar_trigger=trigger,
+        enabled=True,
+    )
+
+
+@pytest.fixture
+def sample_moon_schedule(sample_pattern):
+    """Create a schedule with moon phase trigger."""
+    trigger = MoonPhaseTrigger(
+        phases=["full"],
+        offset_days=2,
+        time_window=None,
+    )
+
+    return Schedule(
+        schedule_id="fullmoon-survey",
+        name="Full Moon Survey",
+        description="Capture around full moon",
+        event_patterns=[sample_pattern],
+        trigger_type="moon_phase",
+        moon_phase_trigger=trigger,
+        enabled=True,
+    )
+
+
+@pytest.fixture
+def sample_fixed_time_schedule(sample_pattern):
+    """Create a schedule with fixed time trigger."""
+    trigger = FixedTimeTrigger(
+        time="21:00",
+        days_of_week=None,
+    )
+
+    return Schedule(
+        schedule_id="nightly-fixed",
+        name="Nightly Fixed Time",
+        description="Capture every night at 9 PM",
+        event_patterns=[sample_pattern],
+        trigger_type="fixed_time",
+        fixed_time_trigger=trigger,
+        enabled=True,
+    )
+
+
+@pytest.fixture
+def sample_sensor_schedule(sample_pattern):
+    """Create a schedule with sensor trigger."""
+    trigger = SensorTrigger(
+        sensor_type="motion",
+        threshold=1.0,
+        comparison="gt",
+        cooldown_minutes=5,
+        time_window=None,
+    )
+
+    return Schedule(
+        schedule_id="motion-triggered",
+        name="Motion Triggered",
+        description="Capture on motion detection",
+        event_patterns=[sample_pattern],
+        trigger_type="sensor",
+        sensor_trigger=trigger,
+        enabled=True,
+    )
+
+
+# ============================================================================
+# A. Data Structure Tests (5 tests)
+# ============================================================================
+
+
+class TestActionExecution:
+    """Tests for ActionExecution dataclass."""
+
+    def test_action_execution_to_dict(self):
+        """Test ActionExecution serialization."""
+        action = ActionExecution(
+            time=datetime(2025, 6, 15, 21, 0, 0, tzinfo=UTC),
+            action_name="attract_on",
+            action_type="gpio",
+            offset_minutes=0,
+            description="Turn on UV lights",
+        )
+
+        result = action.to_dict()
+
+        assert result["time"] == "2025-06-15T21:00:00+00:00"
+        assert result["action_name"] == "attract_on"
+        assert result["action_type"] == "gpio"
+        assert result["offset_minutes"] == 0
+        assert result["description"] == "Turn on UV lights"
+
+    def test_action_execution_from_dict(self):
+        """Test ActionExecution deserialization."""
+        data = {
+            "time": "2025-06-15T21:00:00+00:00",
+            "action_name": "takephoto",
+            "action_type": "camera",
+            "offset_minutes": 5,
+            "description": "Capture photo",
+        }
+
+        action = ActionExecution.from_dict(data)
+
+        assert action.time == datetime(2025, 6, 15, 21, 0, 0, tzinfo=UTC)
+        assert action.action_name == "takephoto"
+        assert action.action_type == "camera"
+        assert action.offset_minutes == 5
+        assert action.description == "Capture photo"
+
+    def test_action_execution_roundtrip(self):
+        """Test ActionExecution serialization roundtrip."""
+        original = ActionExecution(
+            time=datetime(2025, 6, 15, 21, 5, 0, tzinfo=UTC),
+            action_name="attract_off",
+            action_type="gpio",
+            offset_minutes=15,
+            description="Turn off UV lights",
+        )
+
+        restored = ActionExecution.from_dict(original.to_dict())
+
+        assert restored.time == original.time
+        assert restored.action_name == original.action_name
+        assert restored.action_type == original.action_type
+        assert restored.offset_minutes == original.offset_minutes
+        assert restored.description == original.description
+
+
+class TestPreviewExecution:
+    """Tests for PreviewExecution dataclass."""
+
+    def test_preview_execution_to_dict(self):
+        """Test PreviewExecution serialization."""
+        actions = [
+            ActionExecution(
+                time=datetime(2025, 6, 15, 21, 0, 0, tzinfo=UTC),
+                action_name="attract_on",
+                action_type="gpio",
+                offset_minutes=0,
+            ),
+        ]
+
+        execution = PreviewExecution(
+            start_time=datetime(2025, 6, 15, 21, 0, 0, tzinfo=UTC),
+            end_time=datetime(2025, 6, 15, 21, 15, 0, tzinfo=UTC),
+            pattern_id="uv-cycle",
+            pattern_name="UV Capture Cycle",
+            trigger_info="interval:60m",
+            actions=actions,
+        )
+
+        result = execution.to_dict()
+
+        assert result["start_time"] == "2025-06-15T21:00:00+00:00"
+        assert result["end_time"] == "2025-06-15T21:15:00+00:00"
+        assert result["pattern_id"] == "uv-cycle"
+        assert result["pattern_name"] == "UV Capture Cycle"
+        assert result["trigger_info"] == "interval:60m"
+        assert len(result["actions"]) == 1
+
+    def test_preview_execution_empty_actions(self):
+        """Test PreviewExecution with empty actions list."""
+        execution = PreviewExecution(
+            start_time=datetime(2025, 6, 15, 21, 0, 0, tzinfo=UTC),
+            end_time=datetime(2025, 6, 15, 21, 0, 0, tzinfo=UTC),
+            pattern_id="empty",
+            pattern_name="Empty Pattern",
+            trigger_info="fixed",
+            actions=[],
+        )
+
+        result = execution.to_dict()
+
+        assert result["actions"] == []
+
+
+class TestPreviewResult:
+    """Tests for PreviewResult dataclass."""
+
+    def test_preview_result_to_dict(self):
+        """Test PreviewResult serialization."""
+        result = PreviewResult(
+            schedule_id="test-schedule",
+            schedule_name="Test Schedule",
+            preview_start=datetime(2025, 6, 15, 0, 0, 0, tzinfo=UTC),
+            preview_end=datetime(2025, 6, 21, 23, 59, 59, tzinfo=UTC),
+            executions=[],
+            conflicts=[],
+            moon_phases={"2025-06-15": {"phase": "full", "illumination": 1.0}},
+            total_actions=0,
+            total_executions=0,
+        )
+
+        output = result.to_dict()
+
+        assert output["schedule_id"] == "test-schedule"
+        assert output["schedule_name"] == "Test Schedule"
+        assert output["total_actions"] == 0
+        assert output["total_executions"] == 0
+        assert "moon_phases" in output
+        assert "generated_at" in output
+
+    def test_preview_result_empty_executions(self):
+        """Test PreviewResult with no executions."""
+        result = PreviewResult(
+            schedule_id="empty",
+            schedule_name="Empty Schedule",
+            preview_start=datetime(2025, 6, 15, 0, 0, 0, tzinfo=UTC),
+            preview_end=datetime(2025, 6, 21, 23, 59, 59, tzinfo=UTC),
+            executions=[],
+            conflicts=[],
+            moon_phases={},
+            total_actions=0,
+            total_executions=0,
+        )
+
+        output = result.to_dict()
+
+        assert output["executions"] == []
+        assert output["conflicts"] == []
+        assert output["moon_phases"] == {}
+
+    def test_preview_result_from_dict(self):
+        """Test PreviewResult deserialization."""
+        data = {
+            "schedule_id": "test-schedule",
+            "schedule_name": "Test Schedule",
+            "preview_start": "2025-06-15T00:00:00+00:00",
+            "preview_end": "2025-06-21T23:59:59+00:00",
+            "executions": [
+                {
+                    "start_time": "2025-06-15T21:00:00+00:00",
+                    "end_time": "2025-06-15T21:15:00+00:00",
+                    "pattern_id": "uv-cycle",
+                    "pattern_name": "UV Capture Cycle",
+                    "trigger_info": "interval:60m",
+                    "actions": [
+                        {
+                            "time": "2025-06-15T21:00:00+00:00",
+                            "action_name": "attract_on",
+                            "action_type": "gpio",
+                            "offset_minutes": 0,
+                            "description": "Turn on UV lights",
+                        }
+                    ],
+                }
+            ],
+            "conflicts": [],
+            "moon_phases": {"2025-06-15": {"phase": "full", "illumination": 1.0}},
+            "total_actions": 1,
+            "total_executions": 1,
+            "generated_at": "2025-06-15T12:00:00+00:00",
+        }
+
+        result = PreviewResult.from_dict(data)
+
+        assert result.schedule_id == "test-schedule"
+        assert result.schedule_name == "Test Schedule"
+        assert result.preview_start == datetime(2025, 6, 15, 0, 0, 0, tzinfo=UTC)
+        assert result.preview_end == datetime(2025, 6, 21, 23, 59, 59, tzinfo=UTC)
+        assert result.total_actions == 1
+        assert result.total_executions == 1
+        assert len(result.executions) == 1
+        assert result.executions[0].pattern_id == "uv-cycle"
+        assert len(result.executions[0].actions) == 1
+        assert result.executions[0].actions[0].action_name == "attract_on"
+        assert result.moon_phases == {"2025-06-15": {"phase": "full", "illumination": 1.0}}
+
+    def test_preview_result_roundtrip(self):
+        """Test PreviewResult serialization roundtrip."""
+        original = PreviewResult(
+            schedule_id="roundtrip-test",
+            schedule_name="Roundtrip Test Schedule",
+            preview_start=datetime(2025, 6, 15, 0, 0, 0, tzinfo=UTC),
+            preview_end=datetime(2025, 6, 21, 23, 59, 59, tzinfo=UTC),
+            executions=[
+                PreviewExecution(
+                    start_time=datetime(2025, 6, 15, 21, 0, 0, tzinfo=UTC),
+                    end_time=datetime(2025, 6, 15, 21, 15, 0, tzinfo=UTC),
+                    pattern_id="test-pattern",
+                    pattern_name="Test Pattern",
+                    trigger_info="interval:30m",
+                    actions=[
+                        ActionExecution(
+                            time=datetime(2025, 6, 15, 21, 0, 0, tzinfo=UTC),
+                            action_name="takephoto",
+                            action_type="camera",
+                            offset_minutes=0,
+                            description="Capture photo",
+                        )
+                    ],
+                )
+            ],
+            conflicts=[],
+            moon_phases={"2025-06-15": {"phase": "waxing_gibbous", "illumination": 0.75}},
+            total_actions=1,
+            total_executions=1,
+            generated_at=datetime(2025, 6, 15, 12, 0, 0, tzinfo=UTC),
+        )
+
+        restored = PreviewResult.from_dict(original.to_dict())
+
+        assert restored.schedule_id == original.schedule_id
+        assert restored.schedule_name == original.schedule_name
+        assert restored.preview_start == original.preview_start
+        assert restored.preview_end == original.preview_end
+        assert restored.total_actions == original.total_actions
+        assert restored.total_executions == original.total_executions
+        assert restored.generated_at == original.generated_at
+        assert len(restored.executions) == len(original.executions)
+        assert restored.executions[0].pattern_id == original.executions[0].pattern_id
+        assert len(restored.executions[0].actions) == len(original.executions[0].actions)
+
+
+# ============================================================================
+# B. Trigger Type Tests (5 tests)
+# ============================================================================
+
+
+class TestTriggerInfo:
+    """Tests for trigger info generation."""
+
+    def test_interval_trigger_info(self, sample_interval_schedule):
+        """Test interval trigger info generation."""
+        info = _get_trigger_info(sample_interval_schedule)
+
+        assert "interval:60m" in info
+        assert "21:00" in info
+        assert "05:00" in info
+
+    def test_solar_trigger_info_positive_offset(self, sample_solar_schedule):
+        """Test solar trigger info with positive offset."""
+        info = _get_trigger_info(sample_solar_schedule)
+
+        assert info == "sunset+30"
+
+    def test_solar_trigger_info_negative_offset(self, sample_pattern):
+        """Test solar trigger info with negative offset."""
+        trigger = SolarTrigger(
+            solar_event="sunrise",
+            offset_minutes=-15,
+        )
+        schedule = Schedule(
+            schedule_id="test",
+            name="Test",
+            event_patterns=[sample_pattern],
+            trigger_type="solar",
+            solar_trigger=trigger,
+        )
+
+        info = _get_trigger_info(schedule)
+
+        assert info == "sunrise-15"
+
+    def test_moon_phase_trigger_info(self, sample_moon_schedule):
+        """Test moon phase trigger info generation."""
+        info = _get_trigger_info(sample_moon_schedule)
+
+        assert "moon:full" in info
+        assert "+2d" in info
+
+    def test_fixed_time_trigger_info(self, sample_fixed_time_schedule):
+        """Test fixed time trigger info generation."""
+        info = _get_trigger_info(sample_fixed_time_schedule)
+
+        assert info == "daily:21:00"
+
+    def test_sensor_trigger_info(self, sample_sensor_schedule):
+        """Test sensor trigger info generation."""
+        info = _get_trigger_info(sample_sensor_schedule)
+
+        assert info == "sensor:motion"
+
+
+# ============================================================================
+# C. Action Expansion Tests (4 tests)
+# ============================================================================
+
+
+class TestActionExpansion:
+    """Tests for action expansion."""
+
+    def test_expand_single_action(self):
+        """Test expanding single action pattern."""
+        pattern = EventPattern(
+            pattern_id="single",
+            name="Single Action",
+            actions=[
+                PatternAction(
+                    action_type="camera",
+                    action_name="takephoto",
+                    offset_minutes=0,
+                ),
+            ],
+        )
+
+        trigger_time = datetime(2025, 6, 15, 21, 0, 0, tzinfo=UTC)
+        actions = _expand_actions(pattern, trigger_time)
+
+        assert len(actions) == 1
+        assert actions[0].time == trigger_time
+        assert actions[0].action_name == "takephoto"
+        assert actions[0].offset_minutes == 0
+
+    def test_expand_multiple_actions(self, sample_pattern):
+        """Test expanding multi-action pattern."""
+        trigger_time = datetime(2025, 6, 15, 21, 0, 0, tzinfo=UTC)
+        actions = _expand_actions(sample_pattern, trigger_time)
+
+        assert len(actions) == 3
+
+        # First action at t+0
+        assert actions[0].time == trigger_time
+        assert actions[0].action_name == "attract_on"
+
+        # Second action at t+5
+        assert actions[1].time == trigger_time + timedelta(minutes=5)
+        assert actions[1].action_name == "takephoto"
+
+        # Third action at t+15
+        assert actions[2].time == trigger_time + timedelta(minutes=15)
+        assert actions[2].action_name == "attract_off"
+
+    def test_expand_actions_sorted_by_time(self):
+        """Test that expanded actions are sorted by time."""
+        # Create pattern with unsorted offsets
+        pattern = EventPattern(
+            pattern_id="unsorted",
+            name="Unsorted",
+            actions=[
+                PatternAction(
+                    action_type="gpio",
+                    action_name="action_c",
+                    offset_minutes=15,
+                ),
+                PatternAction(
+                    action_type="gpio",
+                    action_name="action_a",
+                    offset_minutes=0,
+                ),
+                PatternAction(
+                    action_type="gpio",
+                    action_name="action_b",
+                    offset_minutes=5,
+                ),
+            ],
+        )
+
+        trigger_time = datetime(2025, 6, 15, 21, 0, 0, tzinfo=UTC)
+        actions = _expand_actions(pattern, trigger_time)
+
+        # Should be sorted by time
+        assert actions[0].action_name == "action_a"
+        assert actions[1].action_name == "action_b"
+        assert actions[2].action_name == "action_c"
+
+    def test_expand_actions_preserves_metadata(self, sample_pattern):
+        """Test that action expansion preserves description."""
+        trigger_time = datetime(2025, 6, 15, 21, 0, 0, tzinfo=UTC)
+        actions = _expand_actions(sample_pattern, trigger_time)
+
+        # Check first action has description
+        assert actions[0].description == "Turn on UV attract lights"
+        assert actions[0].action_type == "gpio"
+
+
+# ============================================================================
+# D. Moon Phase Integration Tests (3 tests)
+# ============================================================================
+
+
+class TestMoonPhaseIntegration:
+    """Tests for moon phase integration."""
+
+    def test_moon_phases_dict_structure(self):
+        """Test moon phases dictionary structure."""
+        start = date(2025, 6, 15)
+        end = date(2025, 6, 17)
+
+        phases = _get_moon_phases_dict(start, end)
+
+        # Should have 3 days
+        assert len(phases) == 3
+        assert "2025-06-15" in phases
+        assert "2025-06-16" in phases
+        assert "2025-06-17" in phases
+
+    def test_moon_phases_contain_required_fields(self):
+        """Test moon phase entries contain required fields."""
+        start = date(2025, 6, 15)
+        end = date(2025, 6, 15)
+
+        phases = _get_moon_phases_dict(start, end)
+        phase_info = phases["2025-06-15"]
+
+        assert "date" in phase_info
+        assert "phase" in phase_info
+        assert "illumination" in phase_info
+
+    def test_moon_phases_illumination_range(self):
+        """Test illumination values are in valid range."""
+        start = date(2025, 6, 1)
+        end = date(2025, 6, 30)
+
+        phases = _get_moon_phases_dict(start, end)
+
+        for date_str, phase_info in phases.items():
+            illumination = phase_info["illumination"]
+            assert 0.0 <= illumination <= 1.0, f"Invalid illumination for {date_str}"
+
+
+# ============================================================================
+# E. Conflict Integration Tests (3 tests)
+# ============================================================================
+
+
+class TestConflictIntegration:
+    """Tests for conflict detection integration."""
+
+    @patch("webui.backend.lib.schedule_preview.detect_conflicts")
+    @patch("webui.backend.lib.schedule_preview.generate_pattern_executions")
+    def test_conflicts_included_in_result(
+        self, mock_gen_exec, mock_detect, sample_interval_schedule
+    ):
+        """Test conflicts are included in preview result."""
+        # Mock execution generation
+        mock_gen_exec.return_value = []
+
+        # Mock conflict detection with a conflict
+        mock_conflict = MagicMock()
+        mock_conflict.to_dict.return_value = {
+            "conflict_type": "time_overlap",
+            "severity": "warning",
+        }
+
+        mock_report = MagicMock()
+        mock_report.conflicts = [mock_conflict]
+        mock_detect.return_value = mock_report
+
+        result = generate_preview(sample_interval_schedule, days=1)
+
+        assert len(result.conflicts) == 1
+
+    @patch("webui.backend.lib.schedule_preview.detect_conflicts")
+    @patch("webui.backend.lib.schedule_preview.generate_pattern_executions")
+    def test_no_conflicts_empty_list(
+        self, mock_gen_exec, mock_detect, sample_interval_schedule
+    ):
+        """Test empty conflict list when no conflicts."""
+        mock_gen_exec.return_value = []
+
+        mock_report = MagicMock()
+        mock_report.conflicts = []
+        mock_detect.return_value = mock_report
+
+        result = generate_preview(sample_interval_schedule, days=1)
+
+        assert result.conflicts == []
+
+    @patch("webui.backend.lib.schedule_preview.detect_conflicts")
+    @patch("webui.backend.lib.schedule_preview.generate_pattern_executions")
+    def test_conflict_report_called_with_correct_params(
+        self, mock_gen_exec, mock_detect, sample_interval_schedule
+    ):
+        """Test detect_conflicts called with correct parameters."""
+        mock_gen_exec.return_value = []
+
+        mock_report = MagicMock()
+        mock_report.conflicts = []
+        mock_detect.return_value = mock_report
+
+        generate_preview(
+            sample_interval_schedule,
+            days=14,
+            latitude=35.0,
+            longitude=-80.0,
+            timezone_name="America/New_York",
+        )
+
+        mock_detect.assert_called_once()
+        call_args = mock_detect.call_args
+        assert call_args.kwargs["preview_days"] == 14
+        assert call_args.kwargs["latitude"] == 35.0
+        assert call_args.kwargs["longitude"] == -80.0
+        assert call_args.kwargs["timezone_name"] == "America/New_York"
+
+
+# ============================================================================
+# F. Edge Case Tests (5 tests)
+# ============================================================================
+
+
+class TestEdgeCases:
+    """Tests for edge cases."""
+
+    def test_preview_days_validation_min(self):
+        """Test minimum preview days validation."""
+        valid, error = validate_preview_days(MIN_PREVIEW_DAYS)
+        assert valid is True
+        assert error is None
+
+    def test_preview_days_validation_max(self):
+        """Test maximum preview days validation."""
+        valid, error = validate_preview_days(MAX_PREVIEW_DAYS)
+        assert valid is True
+        assert error is None
+
+    def test_preview_days_validation_below_min(self):
+        """Test below minimum preview days rejected."""
+        valid, error = validate_preview_days(0)
+        assert valid is False
+        assert "at least" in error
+
+    def test_preview_days_validation_above_max(self):
+        """Test above maximum preview days rejected."""
+        valid, error = validate_preview_days(91)
+        assert valid is False
+        assert "at most" in error
+
+    def test_generate_preview_invalid_days_raises(self, sample_interval_schedule):
+        """Test generate_preview raises for invalid days."""
+        with pytest.raises(ValueError) as excinfo:
+            generate_preview(sample_interval_schedule, days=0)
+
+        assert "between" in str(excinfo.value)
+
+    def test_coordinates_validation_valid(self):
+        """Test valid coordinates pass validation."""
+        valid, error = validate_coordinates(35.0, -80.0)
+        assert valid is True
+        assert error is None
+
+    def test_coordinates_validation_invalid_latitude(self):
+        """Test invalid latitude rejected."""
+        valid, error = validate_coordinates(91.0, -80.0)
+        assert valid is False
+        assert "Latitude" in error
+
+    def test_coordinates_validation_invalid_longitude(self):
+        """Test invalid longitude rejected."""
+        valid, error = validate_coordinates(35.0, 181.0)
+        assert valid is False
+        assert "Longitude" in error
+
+
+# ============================================================================
+# G. Location Fallback Tests (2 tests)
+# ============================================================================
+
+
+class TestLocationFallback:
+    """Tests for location fallback behavior."""
+
+    @patch("webui.backend.lib.schedule_preview._get_default_location")
+    @patch("webui.backend.lib.schedule_preview.detect_conflicts")
+    @patch("webui.backend.lib.schedule_preview.generate_pattern_executions")
+    def test_location_from_params_priority(
+        self, mock_gen_exec, mock_detect, mock_default_loc, sample_interval_schedule
+    ):
+        """Test explicit params override controls.txt location."""
+        mock_default_loc.return_value = (10.0, 20.0)  # Default location
+        mock_gen_exec.return_value = []
+
+        mock_report = MagicMock()
+        mock_report.conflicts = []
+        mock_detect.return_value = mock_report
+
+        # Call with explicit params
+        generate_preview(
+            sample_interval_schedule,
+            days=1,
+            latitude=35.0,
+            longitude=-80.0,
+        )
+
+        # generate_pattern_executions should be called with explicit params
+        call_args = mock_gen_exec.call_args
+        assert call_args.kwargs["latitude"] == 35.0
+        assert call_args.kwargs["longitude"] == -80.0
+
+    @patch("webui.backend.lib.schedule_preview._get_default_location")
+    @patch("webui.backend.lib.schedule_preview.detect_conflicts")
+    @patch("webui.backend.lib.schedule_preview.generate_pattern_executions")
+    def test_location_from_controls_fallback(
+        self, mock_gen_exec, mock_detect, mock_default_loc, sample_interval_schedule
+    ):
+        """Test controls.txt location used when params None."""
+        mock_default_loc.return_value = (10.0, 20.0)  # From controls.txt
+        mock_gen_exec.return_value = []
+
+        mock_report = MagicMock()
+        mock_report.conflicts = []
+        mock_detect.return_value = mock_report
+
+        # Call without explicit params
+        generate_preview(sample_interval_schedule, days=1)
+
+        # generate_pattern_executions should be called with default location
+        call_args = mock_gen_exec.call_args
+        assert call_args.kwargs["latitude"] == 10.0
+        assert call_args.kwargs["longitude"] == 20.0
+
+
+# ============================================================================
+# H. Integration Tests (2 tests)
+# ============================================================================
+
+
+class TestPreviewGeneration:
+    """Integration tests for full preview generation."""
+
+    @patch("webui.backend.lib.schedule_preview.detect_conflicts")
+    @patch("webui.backend.lib.schedule_preview.generate_pattern_executions")
+    def test_generate_preview_returns_result(
+        self, mock_gen_exec, mock_detect, sample_interval_schedule
+    ):
+        """Test generate_preview returns valid PreviewResult."""
+        mock_gen_exec.return_value = []
+
+        mock_report = MagicMock()
+        mock_report.conflicts = []
+        mock_detect.return_value = mock_report
+
+        result = generate_preview(sample_interval_schedule, days=7)
+
+        assert isinstance(result, PreviewResult)
+        assert result.schedule_id == sample_interval_schedule.schedule_id
+        assert result.schedule_name == sample_interval_schedule.name
+        assert result.total_executions == 0
+        assert result.total_actions == 0
+
+    @patch("webui.backend.lib.schedule_preview.detect_conflicts")
+    @patch("webui.backend.lib.schedule_preview.generate_pattern_executions")
+    def test_generate_preview_counts_actions(
+        self, mock_gen_exec, mock_detect, sample_interval_schedule, sample_pattern
+    ):
+        """Test generate_preview correctly counts actions."""
+        from webui.backend.lib.schedule_conflict import PatternExecution
+
+        # Mock 2 pattern executions
+        mock_exec_1 = PatternExecution(
+            pattern_id="uv-capture-cycle",
+            pattern_name="UV Capture Cycle",
+            start_time=datetime(2025, 6, 15, 21, 0, 0, tzinfo=UTC),
+            end_time=datetime(2025, 6, 15, 21, 15, 0, tzinfo=UTC),
+            resource_usages=[],
+        )
+        mock_exec_2 = PatternExecution(
+            pattern_id="uv-capture-cycle",
+            pattern_name="UV Capture Cycle",
+            start_time=datetime(2025, 6, 15, 22, 0, 0, tzinfo=UTC),
+            end_time=datetime(2025, 6, 15, 22, 15, 0, tzinfo=UTC),
+            resource_usages=[],
+        )
+        mock_gen_exec.return_value = [mock_exec_1, mock_exec_2]
+
+        mock_report = MagicMock()
+        mock_report.conflicts = []
+        mock_detect.return_value = mock_report
+
+        result = generate_preview(sample_interval_schedule, days=1)
+
+        assert result.total_executions == 2
+        # Each execution has 3 actions (from sample_pattern)
+        assert result.total_actions == 6

--- a/Firmware/Tests/unit/test_scheduler_ui_routes.py
+++ b/Firmware/Tests/unit/test_scheduler_ui_routes.py
@@ -253,6 +253,25 @@ class TestSchedulePreviewEndpoint:
         data = response.get_json()
         assert "lat" in data["error"].lower()
 
+    def test_preview_invalid_timezone(self, client):
+        """Test preview with invalid timezone name."""
+        response = client.get('/api/scheduler/ui/schedules/test/preview?tz=Invalid/Timezone')
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "error" in data
+        assert "timezone" in data["error"].lower()
+        assert "Invalid timezone" in data["message"]
+
+    def test_preview_empty_timezone(self, client):
+        """Test preview with empty timezone."""
+        response = client.get('/api/scheduler/ui/schedules/test/preview?tz=')
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "error" in data
+        assert "timezone" in data["error"].lower()
+
 
 # ============================================================================
 # List Schedules Endpoint Tests

--- a/Firmware/Tests/unit/test_scheduler_ui_routes.py
+++ b/Firmware/Tests/unit/test_scheduler_ui_routes.py
@@ -1,0 +1,371 @@
+"""
+Unit tests for Scheduler UI API Routes (Issue #214)
+
+Tests the REST API endpoints for schedule preview and management.
+
+Coverage Target: 85%+
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Try to import Flask app for testing
+try:
+    from webui.backend.app import app
+
+    # Import scheduler_ui_bp to ensure it exists (used for skip condition)
+    from webui.backend.routes.scheduler_ui import scheduler_ui_bp  # noqa: F401
+    IMPLEMENTATION_EXISTS = True
+except ImportError:
+    IMPLEMENTATION_EXISTS = False
+    app = None
+
+# Skip all tests if implementation doesn't exist
+pytestmark = pytest.mark.skipif(
+    not IMPLEMENTATION_EXISTS,
+    reason="Implementation not yet created"
+)
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture(autouse=True)
+def reset_scheduler_service():
+    """Reset the scheduler service singleton before each test.
+
+    Note: app.py uses relative import 'routes.scheduler_ui' which creates a
+    different module object than 'webui.backend.routes.scheduler_ui'. We need
+    to patch both to handle all cases.
+    """
+    import sys
+    # Get the module that app.py actually uses (relative import creates this)
+    module = sys.modules.get('routes.scheduler_ui')
+    if module is None:
+        # Fallback to full path if relative import module not found
+        import webui.backend.routes.scheduler_ui as module
+
+    original = getattr(module, '_scheduler_service', None)
+    module._scheduler_service = None
+    yield
+    module._scheduler_service = original
+
+
+@pytest.fixture
+def client():
+    """Create Flask test client."""
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    with app.test_client() as client:
+        yield client
+
+
+def _get_scheduler_ui_module():
+    """Get the scheduler_ui module as used by app.py.
+
+    app.py uses relative import 'routes.scheduler_ui' which creates a
+    different module entry than 'webui.backend.routes.scheduler_ui'.
+    This function returns the actual module reference used at runtime.
+    """
+    import sys
+    module = sys.modules.get('routes.scheduler_ui')
+    if module is None:
+        import webui.backend.routes.scheduler_ui as module
+    return module
+
+
+@pytest.fixture
+def mock_scheduler_service():
+    """Mock SchedulerService by directly setting the module variable.
+
+    Uses sys.modules to find the actual module reference used by app.py's
+    relative import pattern.
+    """
+    module = _get_scheduler_ui_module()
+    mock_service = MagicMock()
+    module._scheduler_service = mock_service
+    yield mock_service
+
+
+@pytest.fixture
+def sample_schedule():
+    """Create a mock schedule object."""
+    schedule = MagicMock()
+    schedule.schedule_id = "test-schedule"
+    schedule.name = "Test Schedule"
+    schedule.description = "A test schedule"
+    schedule.trigger_type = "interval"
+    schedule.enabled = True
+    schedule.is_active = False
+    schedule.created_at = "2025-06-15T00:00:00Z"
+    schedule.modified_at = "2025-06-15T00:00:00Z"
+    schedule.to_dict.return_value = {
+        "schedule_id": "test-schedule",
+        "name": "Test Schedule",
+        "trigger_type": "interval",
+    }
+    return schedule
+
+
+@pytest.fixture
+def mock_preview_result():
+    """Create a mock PreviewResult."""
+    result = MagicMock()
+    result.to_dict.return_value = {
+        "schedule_id": "test-schedule",
+        "schedule_name": "Test Schedule",
+        "preview_start": "2025-06-15T00:00:00Z",
+        "preview_end": "2025-06-21T23:59:59Z",
+        "executions": [],
+        "conflicts": [],
+        "moon_phases": {},
+        "total_actions": 0,
+        "total_executions": 0,
+        "generated_at": "2025-06-15T12:00:00Z",
+    }
+    return result
+
+
+# ============================================================================
+# Preview Endpoint Tests
+# ============================================================================
+
+
+class TestSchedulePreviewEndpoint:
+    """Tests for GET /api/scheduler/ui/schedules/{id}/preview."""
+
+    def test_preview_success(self, client, mock_scheduler_service, mock_preview_result):
+        """Test successful preview generation."""
+        # Configure mock to return a schedule
+        schedule = MagicMock()
+        schedule.schedule_id = "test-schedule"
+        schedule.name = "Test Schedule"
+        mock_scheduler_service.get_schedule.return_value = schedule
+
+        module = _get_scheduler_ui_module()
+        with patch.object(module, 'generate_preview') as mock_gen:
+            mock_gen.return_value = mock_preview_result
+
+            response = client.get('/api/scheduler/ui/schedules/test-schedule/preview')
+
+            assert response.status_code == 200, f"Response: {response.get_json()}"
+            data = response.get_json()
+            assert data["schedule_id"] == "test-schedule"
+            assert "executions" in data
+            assert "moon_phases" in data
+
+    def test_preview_with_custom_days(self, client, mock_scheduler_service, mock_preview_result):
+        """Test preview with custom days parameter."""
+        schedule = MagicMock()
+        mock_scheduler_service.get_schedule.return_value = schedule
+
+        module = _get_scheduler_ui_module()
+        with patch.object(module, 'generate_preview') as mock_gen:
+            mock_gen.return_value = mock_preview_result
+
+            response = client.get('/api/scheduler/ui/schedules/test-schedule/preview?days=14')
+
+            assert response.status_code == 200
+            mock_gen.assert_called_once()
+            call_kwargs = mock_gen.call_args.kwargs
+            assert call_kwargs['days'] == 14
+
+    def test_preview_with_coordinates(self, client, mock_scheduler_service, mock_preview_result):
+        """Test preview with lat/lon parameters."""
+        schedule = MagicMock()
+        mock_scheduler_service.get_schedule.return_value = schedule
+
+        module = _get_scheduler_ui_module()
+        with patch.object(module, 'generate_preview') as mock_gen:
+            mock_gen.return_value = mock_preview_result
+
+            response = client.get(
+                '/api/scheduler/ui/schedules/test-schedule/preview?lat=35.0&lon=-80.0'
+            )
+
+            assert response.status_code == 200
+            call_kwargs = mock_gen.call_args.kwargs
+            assert call_kwargs['latitude'] == 35.0
+            assert call_kwargs['longitude'] == -80.0
+
+    def test_preview_schedule_not_found(self, client, mock_scheduler_service):
+        """Test preview with non-existent schedule."""
+        mock_scheduler_service.get_schedule.return_value = None
+
+        response = client.get('/api/scheduler/ui/schedules/nonexistent/preview')
+
+        assert response.status_code == 404
+        data = response.get_json()
+        assert "error" in data
+        assert "not found" in data["error"].lower()
+
+    def test_preview_invalid_days_not_integer(self, client):
+        """Test preview with non-integer days."""
+        response = client.get('/api/scheduler/ui/schedules/test/preview?days=abc')
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "error" in data
+        assert "days" in data["error"].lower()
+
+    def test_preview_invalid_days_below_min(self, client):
+        """Test preview with days below minimum."""
+        response = client.get('/api/scheduler/ui/schedules/test/preview?days=0')
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "error" in data
+
+    def test_preview_invalid_days_above_max(self, client):
+        """Test preview with days above maximum."""
+        response = client.get('/api/scheduler/ui/schedules/test/preview?days=100')
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "error" in data
+
+    def test_preview_invalid_latitude(self, client):
+        """Test preview with invalid latitude."""
+        response = client.get('/api/scheduler/ui/schedules/test/preview?lat=100')
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "error" in data
+        assert "Latitude" in data["message"]
+
+    def test_preview_invalid_longitude(self, client):
+        """Test preview with invalid longitude."""
+        response = client.get('/api/scheduler/ui/schedules/test/preview?lon=200')
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "error" in data
+        assert "Longitude" in data["message"]
+
+    def test_preview_invalid_lat_format(self, client):
+        """Test preview with non-numeric latitude."""
+        response = client.get('/api/scheduler/ui/schedules/test/preview?lat=abc')
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "lat" in data["error"].lower()
+
+
+# ============================================================================
+# List Schedules Endpoint Tests
+# ============================================================================
+
+
+class TestListSchedulesEndpoint:
+    """Tests for GET /api/scheduler/ui/schedules."""
+
+    def test_list_schedules_empty(self, client, mock_scheduler_service):
+        """Test listing with no schedules."""
+        mock_scheduler_service.list_schedules.return_value = []
+
+        response = client.get('/api/scheduler/ui/schedules')
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["schedules"] == []
+        assert data["total"] == 0
+
+    def test_list_schedules_with_data(self, client, mock_scheduler_service):
+        """Test listing with schedules."""
+        schedule = MagicMock()
+        schedule.schedule_id = "test-schedule"
+        schedule.name = "Test Schedule"
+        schedule.description = "A test schedule"
+        schedule.trigger_type = "interval"
+        schedule.enabled = True
+        schedule.is_active = False
+        schedule.created_at = "2025-06-15T00:00:00Z"
+        schedule.modified_at = "2025-06-15T00:00:00Z"
+        mock_scheduler_service.list_schedules.return_value = [schedule]
+
+        response = client.get('/api/scheduler/ui/schedules')
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["total"] == 1
+        assert len(data["schedules"]) == 1
+        assert data["schedules"][0]["schedule_id"] == "test-schedule"
+
+    def test_list_schedules_include_builtin(self, client, mock_scheduler_service):
+        """Test include_builtin parameter."""
+        mock_scheduler_service.list_schedules.return_value = []
+
+        response = client.get('/api/scheduler/ui/schedules?include_builtin=true')
+
+        assert response.status_code == 200
+        mock_scheduler_service.list_schedules.assert_called_with(include_builtin=True)
+
+    def test_list_schedules_active_only(self, client, mock_scheduler_service):
+        """Test active_only filter."""
+        # One active, one inactive
+        active_schedule = MagicMock()
+        active_schedule.schedule_id = "active"
+        active_schedule.name = "Active"
+        active_schedule.description = ""
+        active_schedule.trigger_type = "interval"
+        active_schedule.enabled = True
+        active_schedule.is_active = True
+        active_schedule.created_at = "2025-06-15T00:00:00Z"
+        active_schedule.modified_at = "2025-06-15T00:00:00Z"
+
+        inactive_schedule = MagicMock()
+        inactive_schedule.schedule_id = "inactive"
+        inactive_schedule.name = "Inactive"
+        inactive_schedule.description = ""
+        inactive_schedule.trigger_type = "interval"
+        inactive_schedule.enabled = True
+        inactive_schedule.is_active = False
+        inactive_schedule.created_at = "2025-06-15T00:00:00Z"
+        inactive_schedule.modified_at = "2025-06-15T00:00:00Z"
+
+        mock_scheduler_service.list_schedules.return_value = [inactive_schedule, active_schedule]
+
+        response = client.get('/api/scheduler/ui/schedules?active_only=true')
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["total"] == 1
+        assert data["schedules"][0]["schedule_id"] == "active"
+
+
+# ============================================================================
+# Get Schedule Endpoint Tests
+# ============================================================================
+
+
+class TestGetScheduleEndpoint:
+    """Tests for GET /api/scheduler/ui/schedules/{id}."""
+
+    def test_get_schedule_success(self, client, mock_scheduler_service):
+        """Test successful schedule retrieval."""
+        schedule = MagicMock()
+        schedule.to_dict.return_value = {
+            "schedule_id": "test-schedule",
+            "name": "Test Schedule",
+        }
+        mock_scheduler_service.get_schedule.return_value = schedule
+
+        response = client.get('/api/scheduler/ui/schedules/test-schedule')
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["schedule_id"] == "test-schedule"
+
+    def test_get_schedule_not_found(self, client, mock_scheduler_service):
+        """Test schedule not found."""
+        mock_scheduler_service.get_schedule.return_value = None
+
+        response = client.get('/api/scheduler/ui/schedules/nonexistent')
+
+        assert response.status_code == 404
+        data = response.get_json()
+        assert "error" in data
+        assert "not found" in data["error"].lower()

--- a/Firmware/webui/backend/app.py
+++ b/Firmware/webui/backend/app.py
@@ -347,6 +347,7 @@ from routes.metadata import metadata_bp
 from routes.preferences import preferences_bp
 from routes.presets import presets_bp
 from routes.scheduler import scheduler_bp
+from routes.scheduler_ui import scheduler_ui_bp
 from routes.search import search_bp
 from routes.sidecar import sidecar_bp
 from routes.system import system_bp
@@ -361,6 +362,7 @@ app.register_blueprint(gallery_bp, url_prefix="/api/gallery")
 app.register_blueprint(config_bp, url_prefix="/api/config")
 app.register_blueprint(gpio_bp, url_prefix="/api/gpio")
 app.register_blueprint(scheduler_bp, url_prefix="/api/scheduler")
+app.register_blueprint(scheduler_ui_bp, url_prefix="/api/scheduler/ui")
 app.register_blueprint(presets_bp, url_prefix="/api/presets")
 app.register_blueprint(preferences_bp, url_prefix="/api/preferences")
 app.register_blueprint(gps_bp, url_prefix="/api/gps")

--- a/Firmware/webui/backend/lib/schedule_preview.py
+++ b/Firmware/webui/backend/lib/schedule_preview.py
@@ -549,3 +549,32 @@ def validate_coordinates(
             return False, f"Longitude must be between -180 and 180, got {longitude}"
 
     return True, None
+
+
+def validate_timezone(timezone_name: str) -> tuple[bool, str | None]:
+    """
+    Validate timezone name parameter.
+
+    Args:
+        timezone_name: IANA timezone name to validate (e.g., "America/New_York", "UTC")
+
+    Returns:
+        (True, None) if valid, (False, error_message) if invalid
+    """
+    if not isinstance(timezone_name, str):
+        return False, f"Timezone must be a string, got {type(timezone_name).__name__}"
+
+    if not timezone_name:
+        return False, "Timezone cannot be empty"
+
+    try:
+        import pytz
+
+        pytz.timezone(timezone_name)
+        return True, None
+    except pytz.UnknownTimeZoneError:
+        return (
+            False,
+            f"Invalid timezone '{timezone_name}'. "
+            "Use IANA timezone names (e.g., 'America/New_York', 'Europe/London', 'UTC')",
+        )

--- a/Firmware/webui/backend/lib/schedule_preview.py
+++ b/Firmware/webui/backend/lib/schedule_preview.py
@@ -153,6 +153,7 @@ class PreviewResult:
     - Conflicts detected over preview period
     - Moon phases for calendar display
     - Summary statistics
+    - Warnings about potential issues
 
     Attributes:
         schedule_id: Source schedule identifier
@@ -164,6 +165,7 @@ class PreviewResult:
         moon_phases: Moon phase by date {ISO date string: phase dict}
         total_actions: Total count of individual actions
         total_executions: Total count of pattern executions
+        warnings: List of warning messages (e.g., default location used)
         generated_at: Timestamp when preview was generated
     """
 
@@ -176,6 +178,7 @@ class PreviewResult:
     moon_phases: dict[str, dict]
     total_actions: int
     total_executions: int
+    warnings: list[str] = field(default_factory=list)
     generated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
 
     def to_dict(self) -> dict:
@@ -190,6 +193,7 @@ class PreviewResult:
             "moon_phases": self.moon_phases,
             "total_actions": self.total_actions,
             "total_executions": self.total_executions,
+            "warnings": self.warnings,
             "generated_at": self.generated_at.isoformat(),
         }
 
@@ -206,6 +210,7 @@ class PreviewResult:
             moon_phases=data.get("moon_phases", {}),
             total_actions=data["total_actions"],
             total_executions=data["total_executions"],
+            warnings=data.get("warnings", []),
             generated_at=datetime.fromisoformat(data["generated_at"]),
         )
 
@@ -426,6 +431,9 @@ def generate_preview(
             f"Preview days must be between {MIN_PREVIEW_DAYS} and {MAX_PREVIEW_DAYS}, got {days}"
         )
 
+    # Collect warnings for API response
+    warnings: list[str] = []
+
     # Resolve location
     if latitude is None or longitude is None:
         default_lat, default_lon = _get_default_location()
@@ -435,9 +443,11 @@ def generate_preview(
             longitude = default_lon if default_lon is not None else DEFAULT_LONGITUDE
 
         if latitude == DEFAULT_LATITUDE and longitude == DEFAULT_LONGITUDE:
-            logger.warning(
+            warning_msg = (
                 "Using default location (0, 0). Solar-based triggers may be inaccurate."
             )
+            logger.warning(warning_msg)
+            warnings.append(warning_msg)
 
     # Calculate date range
     start_date = date.today()
@@ -492,6 +502,7 @@ def generate_preview(
         moon_phases=moon_phases,
         total_actions=total_actions,
         total_executions=total_executions,
+        warnings=warnings,
     )
 
 

--- a/Firmware/webui/backend/lib/schedule_preview.py
+++ b/Firmware/webui/backend/lib/schedule_preview.py
@@ -443,9 +443,7 @@ def generate_preview(
             longitude = default_lon if default_lon is not None else DEFAULT_LONGITUDE
 
         if latitude == DEFAULT_LATITUDE and longitude == DEFAULT_LONGITUDE:
-            warning_msg = (
-                "Using default location (0, 0). Solar-based triggers may be inaccurate."
-            )
+            warning_msg = "Using default location (0, 0). Solar-based triggers may be inaccurate."
             logger.warning(warning_msg)
             warnings.append(warning_msg)
 
@@ -467,10 +465,7 @@ def generate_preview(
     )
 
     # Convert to preview executions with expanded actions
-    executions = [
-        _convert_execution(exec, schedule, trigger_info)
-        for exec in raw_executions
-    ]
+    executions = [_convert_execution(exec, schedule, trigger_info) for exec in raw_executions]
 
     # Detect conflicts
     conflict_report = detect_conflicts(
@@ -583,6 +578,8 @@ def validate_timezone(timezone_name: str) -> tuple[bool, str | None]:
 
         pytz.timezone(timezone_name)
         return True, None
+    except ImportError:
+        return False, "pytz library required for timezone validation"
     except pytz.UnknownTimeZoneError:
         return (
             False,

--- a/Firmware/webui/backend/lib/schedule_preview.py
+++ b/Firmware/webui/backend/lib/schedule_preview.py
@@ -1,0 +1,551 @@
+"""
+Schedule preview generation library.
+
+Generates execution timelines for schedules, showing:
+- Pattern executions with absolute action times
+- Moon phase information for calendar display
+- Conflicts detected over the preview period
+
+This module builds on schedule_conflict.py for execution generation
+and adds action-level expansion plus moon phase data.
+
+Issue #214 - Scheduler Phase 3: Schedule Preview
+"""
+
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, date, datetime, timedelta
+from typing import Final
+
+from webui.backend.lib.moon_phase import get_moon_phases_for_range
+from webui.backend.lib.schedule_conflict import (
+    Conflict,
+    PatternExecution,
+    detect_conflicts,
+    generate_pattern_executions,
+)
+from webui.backend.lib.schedule_schema import (
+    EventPattern,
+    Schedule,
+)
+
+# ============================================================================
+# Constants
+# ============================================================================
+
+# Maximum preview days
+MAX_PREVIEW_DAYS: Final[int] = 90
+MIN_PREVIEW_DAYS: Final[int] = 1
+DEFAULT_PREVIEW_DAYS: Final[int] = 7
+
+# Default location (equator) when GPS unavailable
+DEFAULT_LATITUDE: Final[float] = 0.0
+DEFAULT_LONGITUDE: Final[float] = 0.0
+
+# Logger
+logger = logging.getLogger(__name__)
+
+
+# ============================================================================
+# Data Structures
+# ============================================================================
+
+
+@dataclass
+class ActionExecution:
+    """
+    A single action within a pattern execution.
+
+    Represents an instantiated action with absolute execution time.
+
+    Attributes:
+        time: Absolute execution time
+        action_name: Action identifier (e.g., "attract_on", "takephoto")
+        action_type: Action category (e.g., "gpio", "camera", "gps_sync", "service")
+        offset_minutes: Offset from pattern start
+        description: Human-readable description
+    """
+
+    time: datetime
+    action_name: str
+    action_type: str
+    offset_minutes: int
+    description: str = ""
+
+    def to_dict(self) -> dict:
+        """Serialize to dictionary."""
+        return {
+            "time": self.time.isoformat(),
+            "action_name": self.action_name,
+            "action_type": self.action_type,
+            "offset_minutes": self.offset_minutes,
+            "description": self.description,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "ActionExecution":
+        """Deserialize from dictionary."""
+        return cls(
+            time=datetime.fromisoformat(data["time"]),
+            action_name=data["action_name"],
+            action_type=data["action_type"],
+            offset_minutes=data["offset_minutes"],
+            description=data.get("description", ""),
+        )
+
+
+@dataclass
+class PreviewExecution:
+    """
+    A single pattern execution with expanded actions.
+
+    Wraps PatternExecution from schedule_conflict.py, adding:
+    - Expanded action list with absolute times
+    - Trigger description for display
+
+    Attributes:
+        start_time: When pattern execution begins
+        end_time: When pattern execution completes
+        pattern_id: Source pattern identifier
+        pattern_name: Human-readable pattern name
+        trigger_info: Trigger description (e.g., "interval:60m", "sunset+30")
+        actions: Expanded actions with absolute times
+    """
+
+    start_time: datetime
+    end_time: datetime
+    pattern_id: str
+    pattern_name: str
+    trigger_info: str
+    actions: list[ActionExecution] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        """Serialize to dictionary."""
+        return {
+            "start_time": self.start_time.isoformat(),
+            "end_time": self.end_time.isoformat(),
+            "pattern_id": self.pattern_id,
+            "pattern_name": self.pattern_name,
+            "trigger_info": self.trigger_info,
+            "actions": [a.to_dict() for a in self.actions],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "PreviewExecution":
+        """Deserialize from dictionary."""
+        return cls(
+            start_time=datetime.fromisoformat(data["start_time"]),
+            end_time=datetime.fromisoformat(data["end_time"]),
+            pattern_id=data["pattern_id"],
+            pattern_name=data["pattern_name"],
+            trigger_info=data["trigger_info"],
+            actions=[ActionExecution.from_dict(a) for a in data.get("actions", [])],
+        )
+
+
+@dataclass
+class PreviewResult:
+    """
+    Complete preview result for a schedule.
+
+    Contains:
+    - All pattern executions with expanded actions
+    - Conflicts detected over preview period
+    - Moon phases for calendar display
+    - Summary statistics
+
+    Attributes:
+        schedule_id: Source schedule identifier
+        schedule_name: Human-readable schedule name
+        preview_start: Preview period start (midnight UTC)
+        preview_end: Preview period end (midnight UTC)
+        executions: List of pattern executions
+        conflicts: List of detected conflicts
+        moon_phases: Moon phase by date {ISO date string: phase dict}
+        total_actions: Total count of individual actions
+        total_executions: Total count of pattern executions
+        generated_at: Timestamp when preview was generated
+    """
+
+    schedule_id: str
+    schedule_name: str
+    preview_start: datetime
+    preview_end: datetime
+    executions: list[PreviewExecution]
+    conflicts: list[Conflict]
+    moon_phases: dict[str, dict]
+    total_actions: int
+    total_executions: int
+    generated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    def to_dict(self) -> dict:
+        """Serialize to dictionary."""
+        return {
+            "schedule_id": self.schedule_id,
+            "schedule_name": self.schedule_name,
+            "preview_start": self.preview_start.isoformat(),
+            "preview_end": self.preview_end.isoformat(),
+            "executions": [e.to_dict() for e in self.executions],
+            "conflicts": [c.to_dict() for c in self.conflicts],
+            "moon_phases": self.moon_phases,
+            "total_actions": self.total_actions,
+            "total_executions": self.total_executions,
+            "generated_at": self.generated_at.isoformat(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "PreviewResult":
+        """Deserialize from dictionary."""
+        return cls(
+            schedule_id=data["schedule_id"],
+            schedule_name=data["schedule_name"],
+            preview_start=datetime.fromisoformat(data["preview_start"]),
+            preview_end=datetime.fromisoformat(data["preview_end"]),
+            executions=[PreviewExecution.from_dict(e) for e in data.get("executions", [])],
+            conflicts=[Conflict.from_dict(c) for c in data.get("conflicts", [])],
+            moon_phases=data.get("moon_phases", {}),
+            total_actions=data["total_actions"],
+            total_executions=data["total_executions"],
+            generated_at=datetime.fromisoformat(data["generated_at"]),
+        )
+
+
+# ============================================================================
+# Helper Functions
+# ============================================================================
+
+
+def _get_default_location() -> tuple[float | None, float | None]:
+    """
+    Get default location from controls.txt GPS data.
+
+    Returns:
+        (latitude, longitude) tuple, or (None, None) if GPS unavailable
+    """
+    try:
+        from mothbox_paths import CONTROLS_FILE, get_control_values
+
+        controls = get_control_values(CONTROLS_FILE)
+        lat_str = controls.get("lat", "n/a")
+        lon_str = controls.get("lon", "n/a")
+
+        if lat_str != "n/a" and lon_str != "n/a":
+            lat = float(lat_str)
+            lon = float(lon_str)
+            logger.debug(f"Using GPS location from controls.txt: {lat}, {lon}")
+            return lat, lon
+    except Exception as e:
+        logger.warning(f"Could not read GPS coordinates from controls.txt: {e}")
+
+    return None, None
+
+
+def _get_trigger_info(schedule: Schedule) -> str:
+    """
+    Generate human-readable trigger description.
+
+    Args:
+        schedule: Schedule to describe
+
+    Returns:
+        Trigger description string (e.g., "interval:60m", "sunset+30", "moon:full")
+    """
+    trigger_type = schedule.trigger_type
+
+    if trigger_type == "interval" and schedule.interval_trigger:
+        interval = schedule.interval_trigger.interval_minutes
+        window = schedule.interval_trigger.time_window
+        return f"interval:{interval}m ({window.start_time}-{window.end_time})"
+
+    elif trigger_type == "solar" and schedule.solar_trigger:
+        event = schedule.solar_trigger.solar_event
+        offset = schedule.solar_trigger.offset_minutes
+        if offset > 0:
+            return f"{event}+{offset}"
+        elif offset < 0:
+            return f"{event}{offset}"
+        else:
+            return event
+
+    elif trigger_type == "moon_phase" and schedule.moon_phase_trigger:
+        phases = schedule.moon_phase_trigger.phases
+        offset = schedule.moon_phase_trigger.offset_days
+        phases_str = ",".join(phases)
+        if offset > 0:
+            return f"moon:{phases_str}+{offset}d"
+        elif offset < 0:
+            return f"moon:{phases_str}{offset}d"
+        else:
+            return f"moon:{phases_str}"
+
+    elif trigger_type == "fixed_time" and schedule.fixed_time_trigger:
+        time_str = schedule.fixed_time_trigger.time
+        return f"daily:{time_str}"
+
+    elif trigger_type == "sensor" and schedule.sensor_trigger:
+        sensor = schedule.sensor_trigger.sensor_type
+        return f"sensor:{sensor}"
+
+    return trigger_type
+
+
+def _expand_actions(
+    pattern: EventPattern,
+    trigger_time: datetime,
+) -> list[ActionExecution]:
+    """
+    Expand pattern actions to absolute times.
+
+    Args:
+        pattern: EventPattern with actions to expand
+        trigger_time: Pattern execution start time
+
+    Returns:
+        List of ActionExecution with absolute times
+    """
+    actions = []
+
+    for action in pattern.actions:
+        action_time = trigger_time + timedelta(minutes=action.offset_minutes)
+        actions.append(
+            ActionExecution(
+                time=action_time,
+                action_name=action.action_name,
+                action_type=action.action_type,
+                offset_minutes=action.offset_minutes,
+                description=action.description,
+            )
+        )
+
+    # Sort by time
+    actions.sort(key=lambda a: a.time)
+
+    return actions
+
+
+def _find_pattern_by_id(schedule: Schedule, pattern_id: str) -> EventPattern | None:
+    """
+    Find an EventPattern in schedule by ID.
+
+    Args:
+        schedule: Schedule containing patterns
+        pattern_id: Pattern ID to find
+
+    Returns:
+        EventPattern if found, None otherwise
+    """
+    for pattern in schedule.event_patterns:
+        if pattern.pattern_id == pattern_id:
+            return pattern
+    return None
+
+
+def _convert_execution(
+    execution: PatternExecution,
+    schedule: Schedule,
+    trigger_info: str,
+) -> PreviewExecution:
+    """
+    Convert PatternExecution to PreviewExecution with expanded actions.
+
+    Args:
+        execution: PatternExecution from schedule_conflict.py
+        schedule: Source schedule (for pattern lookup)
+        trigger_info: Trigger description string
+
+    Returns:
+        PreviewExecution with expanded actions
+    """
+    # Find the pattern to get action details
+    pattern = _find_pattern_by_id(schedule, execution.pattern_id)
+
+    actions = []
+    if pattern:
+        actions = _expand_actions(pattern, execution.start_time)
+
+    return PreviewExecution(
+        start_time=execution.start_time,
+        end_time=execution.end_time,
+        pattern_id=execution.pattern_id,
+        pattern_name=execution.pattern_name,
+        trigger_info=trigger_info,
+        actions=actions,
+    )
+
+
+def _get_moon_phases_dict(start_date: date, end_date: date) -> dict[str, dict]:
+    """
+    Get moon phases as dictionary keyed by ISO date string.
+
+    Args:
+        start_date: Start of range
+        end_date: End of range
+
+    Returns:
+        Dict mapping ISO date strings to phase info dicts
+    """
+    phases_list = get_moon_phases_for_range(start_date, end_date)
+
+    return {phase["date"]: phase for phase in phases_list}
+
+
+# ============================================================================
+# Main Preview Function
+# ============================================================================
+
+
+def generate_preview(
+    schedule: Schedule,
+    days: int = DEFAULT_PREVIEW_DAYS,
+    latitude: float | None = None,
+    longitude: float | None = None,
+    timezone_name: str = "UTC",
+) -> PreviewResult:
+    """
+    Generate execution preview for a schedule.
+
+    Creates a timeline of all pattern executions over the specified period,
+    with expanded actions, conflicts, and moon phases.
+
+    Args:
+        schedule: Schedule to preview
+        days: Number of days to preview (1-90, default 7)
+        latitude: Location latitude (uses GPS from controls.txt if None)
+        longitude: Location longitude (uses GPS from controls.txt if None)
+        timezone_name: Timezone for time resolution
+
+    Returns:
+        PreviewResult with executions, conflicts, and moon phases
+
+    Raises:
+        ValueError: If days is out of range (1-90)
+    """
+    # Validate days
+    if days < MIN_PREVIEW_DAYS or days > MAX_PREVIEW_DAYS:
+        raise ValueError(
+            f"Preview days must be between {MIN_PREVIEW_DAYS} and {MAX_PREVIEW_DAYS}, got {days}"
+        )
+
+    # Resolve location
+    if latitude is None or longitude is None:
+        default_lat, default_lon = _get_default_location()
+        if latitude is None:
+            latitude = default_lat if default_lat is not None else DEFAULT_LATITUDE
+        if longitude is None:
+            longitude = default_lon if default_lon is not None else DEFAULT_LONGITUDE
+
+        if latitude == DEFAULT_LATITUDE and longitude == DEFAULT_LONGITUDE:
+            logger.warning(
+                "Using default location (0, 0). Solar-based triggers may be inaccurate."
+            )
+
+    # Calculate date range
+    start_date = date.today()
+    end_date = start_date + timedelta(days=days - 1)
+
+    # Generate trigger info once (shared by all executions)
+    trigger_info = _get_trigger_info(schedule)
+
+    # Generate pattern executions using schedule_conflict.py
+    raw_executions = generate_pattern_executions(
+        schedule=schedule,
+        start_date=start_date,
+        end_date=end_date,
+        latitude=latitude,
+        longitude=longitude,
+        timezone_name=timezone_name,
+    )
+
+    # Convert to preview executions with expanded actions
+    executions = [
+        _convert_execution(exec, schedule, trigger_info)
+        for exec in raw_executions
+    ]
+
+    # Detect conflicts
+    conflict_report = detect_conflicts(
+        schedule=schedule,
+        preview_days=days,
+        latitude=latitude,
+        longitude=longitude,
+        timezone_name=timezone_name,
+    )
+
+    # Get moon phases for the period
+    moon_phases = _get_moon_phases_dict(start_date, end_date)
+
+    # Calculate totals
+    total_actions = sum(len(e.actions) for e in executions)
+    total_executions = len(executions)
+
+    # Build preview start/end as datetimes
+    preview_start = datetime.combine(start_date, datetime.min.time(), tzinfo=UTC)
+    preview_end = datetime.combine(end_date, datetime.max.time(), tzinfo=UTC)
+
+    return PreviewResult(
+        schedule_id=schedule.schedule_id,
+        schedule_name=schedule.name,
+        preview_start=preview_start,
+        preview_end=preview_end,
+        executions=executions,
+        conflicts=conflict_report.conflicts,
+        moon_phases=moon_phases,
+        total_actions=total_actions,
+        total_executions=total_executions,
+    )
+
+
+# ============================================================================
+# Validation Functions
+# ============================================================================
+
+
+def validate_preview_days(days: int) -> tuple[bool, str | None]:
+    """
+    Validate preview days parameter.
+
+    Args:
+        days: Number of days to validate
+
+    Returns:
+        (True, None) if valid, (False, error_message) if invalid
+    """
+    if not isinstance(days, int):
+        return False, f"Preview days must be an integer, got {type(days).__name__}"
+
+    if days < MIN_PREVIEW_DAYS:
+        return False, f"Preview days must be at least {MIN_PREVIEW_DAYS}, got {days}"
+
+    if days > MAX_PREVIEW_DAYS:
+        return False, f"Preview days must be at most {MAX_PREVIEW_DAYS}, got {days}"
+
+    return True, None
+
+
+def validate_coordinates(
+    latitude: float | None,
+    longitude: float | None,
+) -> tuple[bool, str | None]:
+    """
+    Validate geographic coordinates.
+
+    Args:
+        latitude: Latitude to validate (-90 to 90)
+        longitude: Longitude to validate (-180 to 180)
+
+    Returns:
+        (True, None) if valid, (False, error_message) if invalid
+    """
+    if latitude is not None:
+        if not isinstance(latitude, (int, float)):
+            return False, f"Latitude must be a number, got {type(latitude).__name__}"
+        if latitude < -90 or latitude > 90:
+            return False, f"Latitude must be between -90 and 90, got {latitude}"
+
+    if longitude is not None:
+        if not isinstance(longitude, (int, float)):
+            return False, f"Longitude must be a number, got {type(longitude).__name__}"
+        if longitude < -180 or longitude > 180:
+            return False, f"Longitude must be between -180 and 180, got {longitude}"
+
+    return True, None

--- a/Firmware/webui/backend/routes/scheduler_ui.py
+++ b/Firmware/webui/backend/routes/scheduler_ui.py
@@ -1,0 +1,278 @@
+"""
+High-level Scheduler UI API routes.
+
+Provides REST endpoints for the visual scheduler UI, including:
+- Schedule preview generation
+- Future: Schedule CRUD operations
+- Future: Pattern management
+
+Issue #214 - Scheduler Phase 3: Schedule Preview
+"""
+
+import logging
+
+from flask import Blueprint, jsonify, request
+
+from webui.backend.lib.schedule_preview import (
+    DEFAULT_PREVIEW_DAYS,
+    generate_preview,
+    validate_coordinates,
+    validate_preview_days,
+)
+from webui.backend.services.scheduler_service import SchedulerService
+
+# Logger
+logger = logging.getLogger(__name__)
+
+# Blueprint
+scheduler_ui_bp = Blueprint("scheduler_ui", __name__)
+
+# Service instance (lazy initialization)
+_scheduler_service = None
+
+
+def get_scheduler_service() -> SchedulerService:
+    """Get or create SchedulerService singleton."""
+    global _scheduler_service
+    if _scheduler_service is None:
+        _scheduler_service = SchedulerService()
+    return _scheduler_service
+
+
+# ============================================================================
+# Preview Endpoints
+# ============================================================================
+
+
+@scheduler_ui_bp.route("/schedules/<schedule_id>/preview", methods=["GET"])
+def get_schedule_preview(schedule_id: str):
+    """
+    Generate execution preview for a schedule.
+
+    GET /api/scheduler/ui/schedules/{id}/preview
+
+    Query Parameters:
+        days: Number of days to preview (default: 7, min: 1, max: 90)
+        lat: Override latitude (-90 to 90)
+        lon: Override longitude (-180 to 180)
+        tz: Timezone name (default: UTC)
+
+    Returns:
+        200 OK: PreviewResult as JSON
+        400 Bad Request: Invalid parameters
+        404 Not Found: Schedule not found
+
+    Response Schema:
+    {
+        "schedule_id": "string",
+        "schedule_name": "string",
+        "preview_start": "ISO 8601 datetime",
+        "preview_end": "ISO 8601 datetime",
+        "executions": [
+            {
+                "start_time": "ISO 8601 datetime",
+                "end_time": "ISO 8601 datetime",
+                "pattern_id": "string",
+                "pattern_name": "string",
+                "trigger_info": "string",
+                "actions": [
+                    {
+                        "time": "ISO 8601 datetime",
+                        "action_name": "string",
+                        "action_type": "string",
+                        "offset_minutes": number,
+                        "description": "string"
+                    }
+                ]
+            }
+        ],
+        "conflicts": [...],
+        "moon_phases": {
+            "YYYY-MM-DD": {
+                "date": "YYYY-MM-DD",
+                "phase": "string",
+                "phase_name": "string",
+                "illumination": number
+            }
+        },
+        "total_actions": number,
+        "total_executions": number,
+        "generated_at": "ISO 8601 datetime"
+    }
+    """
+    try:
+        # Parse query parameters
+        days_str = request.args.get("days", str(DEFAULT_PREVIEW_DAYS))
+        lat_str = request.args.get("lat")
+        lon_str = request.args.get("lon")
+        timezone_name = request.args.get("tz", "UTC")
+
+        # Validate and parse days
+        try:
+            days = int(days_str)
+        except ValueError:
+            return jsonify({
+                "error": "Invalid days parameter",
+                "message": f"Expected integer, got '{days_str}'",
+            }), 400
+
+        valid, error = validate_preview_days(days)
+        if not valid:
+            return jsonify({
+                "error": "Invalid days parameter",
+                "message": error,
+            }), 400
+
+        # Parse latitude
+        latitude = None
+        if lat_str is not None:
+            try:
+                latitude = float(lat_str)
+            except ValueError:
+                return jsonify({
+                    "error": "Invalid lat parameter",
+                    "message": f"Expected number, got '{lat_str}'",
+                }), 400
+
+        # Parse longitude
+        longitude = None
+        if lon_str is not None:
+            try:
+                longitude = float(lon_str)
+            except ValueError:
+                return jsonify({
+                    "error": "Invalid lon parameter",
+                    "message": f"Expected number, got '{lon_str}'",
+                }), 400
+
+        # Validate coordinates
+        valid, error = validate_coordinates(latitude, longitude)
+        if not valid:
+            return jsonify({
+                "error": "Invalid coordinates",
+                "message": error,
+            }), 400
+
+        # Get schedule from service
+        service = get_scheduler_service()
+        schedule = service.get_schedule(schedule_id)
+
+        if schedule is None:
+            return jsonify({
+                "error": "Schedule not found",
+                "message": f"No schedule with ID '{schedule_id}'",
+            }), 404
+
+        # Generate preview
+        result = generate_preview(
+            schedule=schedule,
+            days=days,
+            latitude=latitude,
+            longitude=longitude,
+            timezone_name=timezone_name,
+        )
+
+        return jsonify(result.to_dict()), 200
+
+    except ValueError as e:
+        logger.warning(f"Preview generation error: {e}")
+        return jsonify({
+            "error": "Preview generation failed",
+            "message": str(e),
+        }), 400
+
+    except Exception as e:
+        logger.error(f"Unexpected error in preview generation: {e}", exc_info=True)
+        return jsonify({
+            "error": "Internal server error",
+            "message": "Failed to generate preview",
+        }), 500
+
+
+# ============================================================================
+# Future Endpoints (Placeholders)
+# ============================================================================
+
+
+@scheduler_ui_bp.route("/schedules", methods=["GET"])
+def list_schedules():
+    """
+    List all schedules (summary).
+
+    GET /api/scheduler/ui/schedules
+
+    Query Parameters:
+        include_builtin: Include built-in schedules (default: false)
+        active_only: Filter to active schedule only (default: false)
+
+    Returns:
+        200 OK: List of schedule summaries
+    """
+    try:
+        include_builtin = request.args.get("include_builtin", "false").lower() == "true"
+        active_only = request.args.get("active_only", "false").lower() == "true"
+
+        service = get_scheduler_service()
+        schedules = service.list_schedules(include_builtin=include_builtin)
+
+        # Filter to active only if requested
+        if active_only:
+            schedules = [s for s in schedules if s.is_active]
+
+        # Return summaries (not full schedule objects)
+        summaries = [
+            {
+                "schedule_id": s.schedule_id,
+                "name": s.name,
+                "description": s.description,
+                "trigger_type": s.trigger_type,
+                "enabled": s.enabled,
+                "is_active": s.is_active,
+                "created_at": s.created_at,
+                "modified_at": s.modified_at,
+            }
+            for s in schedules
+        ]
+
+        return jsonify({
+            "schedules": summaries,
+            "total": len(summaries),
+        }), 200
+
+    except Exception as e:
+        logger.error(f"Error listing schedules: {e}", exc_info=True)
+        return jsonify({
+            "error": "Internal server error",
+            "message": "Failed to list schedules",
+        }), 500
+
+
+@scheduler_ui_bp.route("/schedules/<schedule_id>", methods=["GET"])
+def get_schedule(schedule_id: str):
+    """
+    Get full schedule details.
+
+    GET /api/scheduler/ui/schedules/{id}
+
+    Returns:
+        200 OK: Full schedule object
+        404 Not Found: Schedule not found
+    """
+    try:
+        service = get_scheduler_service()
+        schedule = service.get_schedule(schedule_id)
+
+        if schedule is None:
+            return jsonify({
+                "error": "Schedule not found",
+                "message": f"No schedule with ID '{schedule_id}'",
+            }), 404
+
+        return jsonify(schedule.to_dict()), 200
+
+    except Exception as e:
+        logger.error(f"Error getting schedule: {e}", exc_info=True)
+        return jsonify({
+            "error": "Internal server error",
+            "message": "Failed to get schedule",
+        }), 500

--- a/Firmware/webui/backend/routes/scheduler_ui.py
+++ b/Firmware/webui/backend/routes/scheduler_ui.py
@@ -18,8 +18,21 @@ from webui.backend.lib.schedule_preview import (
     generate_preview,
     validate_coordinates,
     validate_preview_days,
+    validate_timezone,
 )
 from webui.backend.services.scheduler_service import SchedulerService
+
+# Rate limiter import with fallback for testing
+try:
+    from webui.backend.app import limiter
+except ImportError:
+    # Stub for testing without full app context
+    class _LimiterStub:
+        def limit(self, *args, **kwargs):
+            def decorator(f):
+                return f
+            return decorator
+    limiter = _LimiterStub()
 
 # Logger
 logger = logging.getLogger(__name__)
@@ -45,6 +58,7 @@ def get_scheduler_service() -> SchedulerService:
 
 
 @scheduler_ui_bp.route("/schedules/<schedule_id>/preview", methods=["GET"])
+@limiter.limit("30 per minute")
 def get_schedule_preview(schedule_id: str):
     """
     Generate execution preview for a schedule.
@@ -150,6 +164,14 @@ def get_schedule_preview(schedule_id: str):
         if not valid:
             return jsonify({
                 "error": "Invalid coordinates",
+                "message": error,
+            }), 400
+
+        # Validate timezone
+        valid, error = validate_timezone(timezone_name)
+        if not valid:
+            return jsonify({
+                "error": "Invalid timezone",
                 "message": error,
             }), 400
 

--- a/Firmware/webui/backend/routes/scheduler_ui.py
+++ b/Firmware/webui/backend/routes/scheduler_ui.py
@@ -200,7 +200,7 @@ def get_schedule_preview(schedule_id: str):
         logger.warning(f"Preview generation error: {e}")
         return jsonify({
             "error": "Preview generation failed",
-            "message": "Invalid preview parameters",
+            "message": str(e),
         }), 400
 
     except Exception as e:

--- a/Firmware/webui/backend/routes/scheduler_ui.py
+++ b/Firmware/webui/backend/routes/scheduler_ui.py
@@ -178,7 +178,7 @@ def get_schedule_preview(schedule_id: str):
         logger.warning(f"Preview generation error: {e}")
         return jsonify({
             "error": "Preview generation failed",
-            "message": str(e),
+            "message": "Invalid preview parameters",
         }), 400
 
     except Exception as e:

--- a/Firmware/webui/docs/dev/api/scheduler-preview.md
+++ b/Firmware/webui/docs/dev/api/scheduler-preview.md
@@ -1,0 +1,234 @@
+# Scheduler Preview API
+
+Schedule preview generation API for the visual scheduler UI.
+
+## Overview
+
+The Scheduler Preview API generates execution timelines for schedules, showing:
+- Pattern executions with absolute action times
+- Moon phase information for calendar display
+- Conflicts detected over the preview period
+
+This API is designed to support the visual scheduler UI calendar view.
+
+## Performance
+
+- **Preview generation**: Scales with `days` parameter
+- **Rate limit**: 30 requests per minute
+
+## Endpoints
+
+### Generate Schedule Preview
+
+```
+GET /api/scheduler/ui/schedules/{id}/preview
+```
+
+Generate an execution preview for a schedule over a specified period.
+
+**Path Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| id | string | Schedule ID |
+
+**Query Parameters:**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| days | integer | No | 7 | Number of days to preview (1-90) |
+| lat | float | No | GPS from controls.txt | Override latitude (-90 to 90) |
+| lon | float | No | GPS from controls.txt | Override longitude (-180 to 180) |
+| tz | string | No | UTC | IANA timezone name (e.g., "America/New_York") |
+
+**Example Request:**
+```bash
+curl "http://localhost:5000/api/scheduler/ui/schedules/nightly-survey/preview?days=7"
+```
+
+**Example Response:**
+```json
+{
+  "schedule_id": "nightly-survey",
+  "schedule_name": "Nightly Moth Survey",
+  "preview_start": "2025-06-15T00:00:00+00:00",
+  "preview_end": "2025-06-21T23:59:59.999999+00:00",
+  "executions": [
+    {
+      "start_time": "2025-06-15T21:00:00+00:00",
+      "end_time": "2025-06-15T21:15:00+00:00",
+      "pattern_id": "uv-capture-cycle",
+      "pattern_name": "UV Capture Cycle",
+      "trigger_info": "interval:60m (21:00-05:00)",
+      "actions": [
+        {
+          "time": "2025-06-15T21:00:00+00:00",
+          "action_name": "attract_on",
+          "action_type": "gpio",
+          "offset_minutes": 0,
+          "description": "Turn on UV attract lights"
+        },
+        {
+          "time": "2025-06-15T21:05:00+00:00",
+          "action_name": "takephoto",
+          "action_type": "camera",
+          "offset_minutes": 5,
+          "description": "Capture photo"
+        },
+        {
+          "time": "2025-06-15T21:15:00+00:00",
+          "action_name": "attract_off",
+          "action_type": "gpio",
+          "offset_minutes": 15,
+          "description": "Turn off UV lights"
+        }
+      ]
+    }
+  ],
+  "conflicts": [],
+  "moon_phases": {
+    "2025-06-15": {
+      "date": "2025-06-15",
+      "phase": "waning_gibbous",
+      "phase_name": "Waning Gibbous",
+      "illumination": 0.72,
+      "age_days": 18.5
+    },
+    "2025-06-16": {
+      "date": "2025-06-16",
+      "phase": "waning_gibbous",
+      "phase_name": "Waning Gibbous",
+      "illumination": 0.63,
+      "age_days": 19.5
+    }
+  },
+  "total_actions": 24,
+  "total_executions": 8,
+  "generated_at": "2025-06-15T12:00:00+00:00"
+}
+```
+
+**Error Responses:**
+
+| Status | Description |
+|--------|-------------|
+| 400 | Invalid parameters (days out of range, invalid coordinates, invalid timezone) |
+| 404 | Schedule not found |
+| 429 | Rate limit exceeded (30/min) |
+| 500 | Internal server error |
+
+---
+
+### List Schedules
+
+```
+GET /api/scheduler/ui/schedules
+```
+
+List all schedules with summary information.
+
+**Query Parameters:**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| include_builtin | boolean | No | false | Include built-in schedules |
+| active_only | boolean | No | false | Filter to active schedule only |
+
+**Example Response:**
+```json
+{
+  "schedules": [
+    {
+      "schedule_id": "nightly-survey",
+      "name": "Nightly Moth Survey",
+      "description": "Hourly captures from 9 PM to 5 AM",
+      "trigger_type": "interval",
+      "enabled": true,
+      "is_active": true,
+      "created_at": "2025-06-01T00:00:00Z",
+      "modified_at": "2025-06-10T12:00:00Z"
+    }
+  ],
+  "total": 1
+}
+```
+
+---
+
+### Get Schedule Details
+
+```
+GET /api/scheduler/ui/schedules/{id}
+```
+
+Get full schedule details including event patterns.
+
+**Path Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| id | string | Schedule ID |
+
+**Example Response:**
+```json
+{
+  "schedule_id": "nightly-survey",
+  "name": "Nightly Moth Survey",
+  "description": "Hourly captures from 9 PM to 5 AM",
+  "trigger_type": "interval",
+  "interval_trigger": {
+    "interval_minutes": 60,
+    "time_window": {
+      "start_time": "21:00",
+      "end_time": "05:00"
+    }
+  },
+  "event_patterns": [
+    {
+      "pattern_id": "uv-capture-cycle",
+      "name": "UV Capture Cycle",
+      "actions": [...]
+    }
+  ],
+  "enabled": true,
+  "is_active": true
+}
+```
+
+**Error Responses:**
+
+| Status | Description |
+|--------|-------------|
+| 404 | Schedule not found |
+
+---
+
+## Trigger Info Formats
+
+The `trigger_info` field in preview executions describes how the pattern was triggered:
+
+| Trigger Type | Format | Example |
+|--------------|--------|---------|
+| Interval | `interval:{minutes}m ({start}-{end})` | `interval:60m (21:00-05:00)` |
+| Solar | `{event}` or `{event}+{offset}` | `sunset+30`, `sunrise-15` |
+| Moon Phase | `moon:{phases}` or `moon:{phases}+{offset}d` | `moon:full`, `moon:full,new+2d` |
+| Fixed Time | `daily:{time}` | `daily:21:00` |
+| Sensor | `sensor:{type}` | `sensor:motion` |
+
+---
+
+## Location Fallback
+
+When latitude/longitude are not provided:
+1. Tries to read from GPS data in `controls.txt`
+2. Falls back to (0, 0) with a warning logged
+
+Solar-based triggers (sunset, sunrise) require valid coordinates for accurate times.
+
+---
+
+## Related Documentation
+
+- [Scheduler Dev Guide](../guides/SCHEDULER_DEV_GUIDE.md) - Complete scheduler architecture
+- [Schedule Schema](../guides/SCHEDULER_DEV_GUIDE.md#data-structures) - JSON file format
+- [Conflict Detection](../guides/SCHEDULER_DEV_GUIDE.md#conflict-detection) - How conflicts are detected


### PR DESCRIPTION
## Summary

Implements the Schedule Preview feature (Issue #214) that generates execution timelines for schedules with moon phase information for calendar display.

### Changes

**Library** (`webui/backend/lib/schedule_preview.py` - 551 lines):
- `ActionExecution`: Single action with absolute execution time
- `PreviewExecution`: Pattern execution with expanded actions  
- `PreviewResult`: Complete preview with executions, conflicts, moon phases
- `generate_preview()`: Main preview generation function (1-90 days)
- Validates days range and coordinate bounds
- Falls back to GPS from controls.txt when location not provided
- Integrates with `schedule_conflict.py` for execution generation
- Includes moon phases via `moon_phase.py`

**API** (`webui/backend/routes/scheduler_ui.py` - 278 lines):
- `GET /api/scheduler/ui/schedules/{id}/preview` - Generate preview
- `GET /api/scheduler/ui/schedules` - List schedules (summary)
- `GET /api/scheduler/ui/schedules/{id}` - Get full schedule

**Tests**:
- 37 unit tests for library (`test_schedule_preview.py`)
- 16 unit tests for API routes (`test_scheduler_ui_routes.py`)
- 53 tests total, all passing
- 85.84% coverage (meets 85% target)

## Test plan

- [x] All 53 unit tests pass
- [x] Coverage meets 85% target (85.84%)
- [x] Ruff linting passes
- [x] API matches SCHEDULER_DEV_GUIDE.md specification

Closes #214