### PR TITLE
feat(scheduler): Add cron bridge for schedule-to-cron conversion (#215)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r Tests/requirements-test.txt
           # Install additional backend dependencies needed for test imports
-          pip install python-crontab timezonefinder==6.5.4
+          pip install python-crontab timezonefinder==6.5.4 croniter
 
       - name: Run unit tests with coverage (shard ${{ matrix.shard }}/3)
         env:
@@ -162,7 +162,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r Tests/requirements-test.txt
           # Install additional backend dependencies needed for test imports
-          pip install python-crontab timezonefinder==6.5.4
+          pip install python-crontab timezonefinder==6.5.4 croniter
 
       - name: Run integration tests (parallel, non-hardware)
         env:

--- a/Firmware/webui/backend/lib/cron_bridge.py
+++ b/Firmware/webui/backend/lib/cron_bridge.py
@@ -1282,7 +1282,11 @@ def apply_to_system(
         cron.write()
         logger.info(f"Applied {added_count} cron entries for schedule {schedule_id}")
 
-        # Set RTC wakealarm (set new alarm first to avoid race condition)
+        # Set RTC wakealarm AFTER cron entries are written.
+        # Ordering rationale: If process crashes between writes:
+        #   - Current order (cron→RTC): Jobs exist but no wake. Recoverable on next activation.
+        #   - Reversed (RTC→cron): Wake set but no jobs. Wastes power waking for nothing.
+        # For battery-powered field devices, the current order is safer.
         if set_rtc and entries:
             next_wake = calculate_next_from_entries(entries)
             if next_wake:


### PR DESCRIPTION
## Summary

Implements the Cron Bridge that translates schedule configurations to system cron expressions and RTC wakealarm settings, enabling automated Mothbox scheduling.

### Changes

- **New library**: `webui/backend/lib/cron_bridge.py` (1,343 lines)
  - `CronEntry` and `CronBridgeResult` dataclasses
  - Trigger converters for all types: fixed_time, interval, solar, moon_phase, sensor (stub)
  - RTC wakealarm management: `set_rtc_wakealarm()`, `clear_rtc_wakealarm()`
  - System cron integration: `apply_to_system()`, `remove_from_system()`
  - Event preview: `get_next_events()`

- **Integration with scheduler_service.py**: Required mode implementation
  - `activate_schedule()` now applies cron entries with rollback on failure
  - `deactivate_schedule()` now removes cron entries

- **New tests**: 96 unit tests with 80% coverage

- **Documentation**: `webui/docs/dev/api/cron-bridge.md` and CLAUDE.md updates

- **New dependency**: `croniter>=1.3.0` for cron expression iteration

### Design Decisions

- **Required mode**: Activation fails if cron conversion fails, with rollback
- **Solar triggers**: Pre-calculate N days of solar times (fixed upfront strategy)
- **Sensor triggers**: Stub only (event-driven, cannot be cron-scheduled)
- **ISO to cron weekday**: 0=Mon..6=Sun → 0=Sun..6=Sat conversion handled

## Test Plan

- [x] 96 unit tests passing
- [x] 80% coverage on cron_bridge.py
- [x] All 249 scheduler tests passing
- [x] Ruff linting clean
- [x] Bandit security scan clean

Closes #215