### PR TITLE
feat(scheduler): Add built-in event patterns (#219)

### DIFF
--- a/Firmware/Tests/conftest.py
+++ b/Firmware/Tests/conftest.py
@@ -1582,6 +1582,7 @@ def pytest_collection_modifyitems(config, items):
             'test_scheduler_workflow',  # Uses mocks/tmp_path, no camera/GPIO (Issue #216)
             'test_scheduler_activation',  # Uses mocks/tmp_path, no camera/GPIO (Issue #216)
             'test_scheduler_api_workflow',  # Uses mocks/tmp_path/Flask test client, no camera/GPIO (Issue #218)
+            'test_builtin_patterns_api',  # Uses Flask test client, no camera/GPIO (Issue #219)
         )
 
         is_non_hardware_test = any(test in fspath_str for test in non_hardware_tests)

--- a/Firmware/Tests/integration/test_builtin_patterns_api.py
+++ b/Firmware/Tests/integration/test_builtin_patterns_api.py
@@ -1,0 +1,346 @@
+"""
+Integration tests for built-in event patterns API (Issue #219).
+
+Tests the patterns/builtin endpoint and validates that:
+1. The API returns all 5 required patterns
+2. Pattern deduplication works correctly
+3. source_schedule and duration_minutes are populated
+4. Pattern validation endpoint accepts all built-in patterns
+
+Requires the Flask app to be running or mocked.
+"""
+
+import pytest
+
+# Try to import Flask app for testing
+try:
+    from webui.backend.app import app
+    from webui.backend.routes.scheduler_ui import scheduler_ui_bp  # noqa: F401
+    IMPLEMENTATION_EXISTS = True
+except ImportError:
+    IMPLEMENTATION_EXISTS = False
+    app = None
+
+# Skip all tests if implementation doesn't exist
+pytestmark = pytest.mark.skipif(
+    not IMPLEMENTATION_EXISTS,
+    reason="Implementation not yet created"
+)
+
+
+# =============================================================================
+# FIXTURES
+# =============================================================================
+
+
+@pytest.fixture(autouse=True)
+def reset_builtin_patterns_cache():
+    """Reset the built-in patterns cache before each test.
+
+    The scheduler_ui module caches patterns at module level.
+    We need to reset it to ensure tests get fresh data.
+    """
+    import webui.backend.routes.scheduler_ui as module
+
+    original = getattr(module, '_builtin_patterns_cache', None)
+    module._builtin_patterns_cache = None
+    yield
+    module._builtin_patterns_cache = original
+
+
+@pytest.fixture
+def client():
+    """Flask test client."""
+    app.config["TESTING"] = True
+    app.config["WTF_CSRF_ENABLED"] = False
+    with app.test_client() as client:
+        yield client
+
+
+# =============================================================================
+# TEST: GET /api/scheduler/ui/patterns/builtin
+# =============================================================================
+
+
+class TestListBuiltinPatternsEndpoint:
+    """Test the patterns/builtin endpoint."""
+
+    def test_endpoint_returns_200(self, client) -> None:
+        """GET /api/scheduler/ui/patterns/builtin returns 200 OK."""
+        response = client.get("/api/scheduler/ui/patterns/builtin")
+        assert response.status_code == 200
+
+    def test_endpoint_returns_list(self, client) -> None:
+        """Response is a JSON list."""
+        response = client.get("/api/scheduler/ui/patterns/builtin")
+        data = response.get_json()
+        assert isinstance(data, list)
+
+    def test_returns_at_least_5_patterns(self, client) -> None:
+        """Should return at least 5 patterns (Issue #219 requirement)."""
+        response = client.get("/api/scheduler/ui/patterns/builtin")
+        data = response.get_json()
+        assert len(data) >= 5, f"Expected at least 5 patterns, got {len(data)}"
+
+    def test_all_required_patterns_present(self, client) -> None:
+        """All 5 required patterns must be present."""
+        response = client.get("/api/scheduler/ui/patterns/builtin")
+        data = response.get_json()
+
+        pattern_names = {p.get("name") for p in data}
+
+        required = [
+            "UV Capture Cycle",
+            "Attract Session",
+            "Flash Capture",
+            "Dawn Transect",
+            "Dusk Transect",
+        ]
+
+        for name in required:
+            assert name in pattern_names, f"Missing pattern: {name}"
+
+    def test_patterns_have_required_fields(self, client) -> None:
+        """Each pattern must have pattern_id, name, actions, category."""
+        response = client.get("/api/scheduler/ui/patterns/builtin")
+        data = response.get_json()
+
+        for pattern in data:
+            pattern_name = pattern.get("name", "unnamed")
+            assert "pattern_id" in pattern, f"{pattern_name}: missing pattern_id"
+            assert "name" in pattern, f"{pattern_name}: missing name"
+            assert "actions" in pattern, f"{pattern_name}: missing actions"
+            assert "category" in pattern, f"{pattern_name}: missing category"
+
+    def test_patterns_have_source_schedule(self, client) -> None:
+        """Each pattern must have source_schedule populated."""
+        response = client.get("/api/scheduler/ui/patterns/builtin")
+        data = response.get_json()
+
+        for pattern in data:
+            pattern_name = pattern.get("name", "unnamed")
+            assert "source_schedule" in pattern, f"{pattern_name}: missing source_schedule"
+            assert pattern["source_schedule"], f"{pattern_name}: empty source_schedule"
+
+    def test_patterns_have_duration_minutes(self, client) -> None:
+        """Each pattern must have duration_minutes computed."""
+        response = client.get("/api/scheduler/ui/patterns/builtin")
+        data = response.get_json()
+
+        for pattern in data:
+            pattern_name = pattern.get("name", "unnamed")
+            assert "duration_minutes" in pattern, f"{pattern_name}: missing duration_minutes"
+            assert isinstance(pattern["duration_minutes"], int), (
+                f"{pattern_name}: duration_minutes must be int"
+            )
+
+    def test_pattern_ids_are_unique(self, client) -> None:
+        """All pattern_ids should be unique (deduplication)."""
+        response = client.get("/api/scheduler/ui/patterns/builtin")
+        data = response.get_json()
+
+        pattern_ids = [p.get("pattern_id") for p in data]
+        unique_ids = set(pattern_ids)
+
+        assert len(pattern_ids) == len(unique_ids), (
+            f"Duplicate pattern_ids found: {len(pattern_ids)} patterns, {len(unique_ids)} unique"
+        )
+
+
+# =============================================================================
+# TEST: PATTERN DURATIONS
+# =============================================================================
+
+
+class TestPatternDurations:
+    """Test that pattern durations are correctly computed."""
+
+    def test_uv_capture_cycle_duration(self, client) -> None:
+        """UV Capture Cycle should have 15-minute duration."""
+        response = client.get("/api/scheduler/ui/patterns/builtin")
+        data = response.get_json()
+
+        pattern = next((p for p in data if p.get("name") == "UV Capture Cycle"), None)
+        assert pattern is not None, "UV Capture Cycle not found"
+        assert pattern["duration_minutes"] == 15, (
+            f"Expected 15 minutes, got {pattern['duration_minutes']}"
+        )
+
+    def test_attract_session_duration(self, client) -> None:
+        """Attract Session should have 60-minute duration."""
+        response = client.get("/api/scheduler/ui/patterns/builtin")
+        data = response.get_json()
+
+        pattern = next((p for p in data if p.get("name") == "Attract Session"), None)
+        assert pattern is not None, "Attract Session not found"
+        assert pattern["duration_minutes"] == 60, (
+            f"Expected 60 minutes, got {pattern['duration_minutes']}"
+        )
+
+    def test_flash_capture_duration(self, client) -> None:
+        """Flash Capture should have 1-minute duration (short flash cycle)."""
+        response = client.get("/api/scheduler/ui/patterns/builtin")
+        data = response.get_json()
+
+        pattern = next((p for p in data if p.get("name") == "Flash Capture"), None)
+        assert pattern is not None, "Flash Capture not found"
+        assert pattern["duration_minutes"] == 1, (
+            f"Expected 1 minute, got {pattern['duration_minutes']}"
+        )
+
+    def test_dawn_transect_duration(self, client) -> None:
+        """Dawn Transect should have 20-minute duration."""
+        response = client.get("/api/scheduler/ui/patterns/builtin")
+        data = response.get_json()
+
+        pattern = next((p for p in data if p.get("name") == "Dawn Transect"), None)
+        assert pattern is not None, "Dawn Transect not found"
+        assert pattern["duration_minutes"] == 20, (
+            f"Expected 20 minutes, got {pattern['duration_minutes']}"
+        )
+
+    def test_dusk_transect_duration(self, client) -> None:
+        """Dusk Transect should have 20-minute duration."""
+        response = client.get("/api/scheduler/ui/patterns/builtin")
+        data = response.get_json()
+
+        pattern = next((p for p in data if p.get("name") == "Dusk Transect"), None)
+        assert pattern is not None, "Dusk Transect not found"
+        assert pattern["duration_minutes"] == 20, (
+            f"Expected 20 minutes, got {pattern['duration_minutes']}"
+        )
+
+
+# =============================================================================
+# TEST: PATTERN VALIDATION ENDPOINT
+# =============================================================================
+
+
+class TestPatternValidationEndpoint:
+    """Test the patterns/validate endpoint with built-in patterns."""
+
+    def test_validate_endpoint_exists(self, client) -> None:
+        """POST /api/scheduler/ui/patterns/validate should exist."""
+        response = client.post(
+            "/api/scheduler/ui/patterns/validate",
+            json={"name": "Test", "actions": []},
+        )
+        # Should not return 404
+        assert response.status_code != 404
+
+    def test_valid_pattern_passes_validation(self, client) -> None:
+        """A valid pattern structure should pass validation."""
+        pattern = {
+            "pattern_id": "test-pattern",
+            "name": "Test Pattern",
+            "description": "A test pattern for validation",
+            "actions": [
+                {
+                    "action_type": "gpio",
+                    "action_name": "attract_on",
+                    "offset_minutes": 0,
+                    "description": "Turn on lights",
+                }
+            ],
+            "category": "user",
+            "tags": ["test"],
+        }
+
+        response = client.post("/api/scheduler/ui/patterns/validate", json=pattern)
+        assert response.status_code == 200
+
+        data = response.get_json()
+        assert data.get("valid") is True, f"Validation failed: {data.get('error')}"
+
+    def test_invalid_pattern_fails_validation(self, client) -> None:
+        """An invalid pattern should fail validation."""
+        pattern = {
+            "name": "",  # Empty name should fail
+            "actions": [],  # No actions should fail
+        }
+
+        response = client.post("/api/scheduler/ui/patterns/validate", json=pattern)
+        # The endpoint may return 400 for malformed input or 200 with valid=False
+        # Both are acceptable behaviors for invalid patterns
+        assert response.status_code in [200, 400]
+
+        data = response.get_json()
+        if response.status_code == 200:
+            assert data.get("valid") is False
+            assert "error" in data
+        else:
+            # 400 response indicates invalid input detected
+            assert "error" in data
+
+    def test_builtin_patterns_all_validate(self, client) -> None:
+        """All built-in patterns should pass validation when submitted."""
+        # Get built-in patterns
+        patterns_response = client.get("/api/scheduler/ui/patterns/builtin")
+        patterns = patterns_response.get_json()
+
+        for pattern in patterns:
+            pattern_name = pattern.get("name", "unnamed")
+
+            # Remove API-added fields
+            pattern_data = {
+                "pattern_id": pattern.get("pattern_id"),
+                "name": pattern.get("name"),
+                "description": pattern.get("description", ""),
+                "actions": pattern.get("actions", []),
+                "category": pattern.get("category", "built-in"),
+                "tags": pattern.get("tags", []),
+            }
+
+            response = client.post("/api/scheduler/ui/patterns/validate", json=pattern_data)
+            assert response.status_code == 200, f"{pattern_name}: HTTP {response.status_code}"
+
+            data = response.get_json()
+            assert data.get("valid") is True, (
+                f"{pattern_name} failed validation: {data.get('error')}"
+            )
+
+
+# =============================================================================
+# TEST: PATTERN SOURCE SCHEDULES
+# =============================================================================
+
+
+class TestPatternSourceSchedules:
+    """Test that patterns correctly report their source schedules."""
+
+    def test_uv_capture_from_nightly_moth_survey(self, client) -> None:
+        """UV Capture Cycle should come from Nightly Moth Survey."""
+        response = client.get("/api/scheduler/ui/patterns/builtin")
+        data = response.get_json()
+
+        pattern = next((p for p in data if p.get("name") == "UV Capture Cycle"), None)
+        assert pattern is not None
+        assert "Nightly" in pattern["source_schedule"] or "nightly" in pattern["source_schedule"].lower()
+
+    def test_flash_capture_from_flash_survey(self, client) -> None:
+        """Flash Capture should come from Flash Capture Survey."""
+        response = client.get("/api/scheduler/ui/patterns/builtin")
+        data = response.get_json()
+
+        pattern = next((p for p in data if p.get("name") == "Flash Capture"), None)
+        assert pattern is not None
+        assert "Flash" in pattern["source_schedule"]
+
+    def test_attract_session_from_extended_attract(self, client) -> None:
+        """Attract Session should come from Extended Attract Session."""
+        response = client.get("/api/scheduler/ui/patterns/builtin")
+        data = response.get_json()
+
+        pattern = next((p for p in data if p.get("name") == "Attract Session"), None)
+        assert pattern is not None
+        assert "Attract" in pattern["source_schedule"] or "Extended" in pattern["source_schedule"]
+
+    def test_transects_from_dawn_dusk_survey(self, client) -> None:
+        """Dawn/Dusk Transect patterns should come from Dawn & Dusk Survey."""
+        response = client.get("/api/scheduler/ui/patterns/builtin")
+        data = response.get_json()
+
+        for pattern_name in ["Dawn Transect", "Dusk Transect"]:
+            pattern = next((p for p in data if p.get("name") == pattern_name), None)
+            assert pattern is not None, f"{pattern_name} not found"
+            assert "Dawn" in pattern["source_schedule"] or "Dusk" in pattern["source_schedule"]

--- a/Firmware/Tests/integration/test_builtin_patterns_api.py
+++ b/Firmware/Tests/integration/test_builtin_patterns_api.py
@@ -35,8 +35,8 @@ pytestmark = pytest.mark.skipif(not IMPLEMENTATION_EXISTS, reason="Implementatio
 def reset_builtin_patterns_cache():
     """Reset the built-in patterns cache before each test.
 
-    The scheduler_ui module caches patterns at module level.
-    We need to reset it to ensure tests get fresh data.
+    The scheduler_ui module caches patterns and warnings at module level.
+    We need to reset both to ensure tests get fresh data.
 
     Note: We acquire the cache lock to prevent race conditions when
     tests run in parallel.
@@ -44,11 +44,14 @@ def reset_builtin_patterns_cache():
     import webui.backend.routes.scheduler_ui as module
 
     with module._builtin_patterns_cache_lock:
-        original = getattr(module, "_builtin_patterns_cache", None)
+        original_patterns = getattr(module, "_builtin_patterns_cache", None)
+        original_warnings = getattr(module, "_builtin_patterns_cache_warnings", [])
         module._builtin_patterns_cache = None
+        module._builtin_patterns_cache_warnings = []
     yield
     with module._builtin_patterns_cache_lock:
-        module._builtin_patterns_cache = original
+        module._builtin_patterns_cache = original_patterns
+        module._builtin_patterns_cache_warnings = original_warnings
 
 
 @pytest.fixture
@@ -73,24 +76,37 @@ class TestListBuiltinPatternsEndpoint:
         response = client.get("/api/scheduler/ui/patterns/builtin")
         assert response.status_code == 200
 
-    def test_endpoint_returns_list(self, client) -> None:
-        """Response is a JSON list."""
+    def test_endpoint_returns_object_with_patterns(self, client) -> None:
+        """Response is a JSON object with patterns list and warnings."""
         response = client.get("/api/scheduler/ui/patterns/builtin")
         data = response.get_json()
-        assert isinstance(data, list)
+        assert isinstance(data, dict)
+        assert "patterns" in data
+        assert "warnings" in data
+        assert isinstance(data["patterns"], list)
+        assert isinstance(data["warnings"], list)
+
+    def test_warnings_empty_when_no_errors(self, client) -> None:
+        """Warnings array should be empty when all files load successfully."""
+        response = client.get("/api/scheduler/ui/patterns/builtin")
+        data = response.get_json()
+        # With valid built-in files, warnings should be empty
+        assert data["warnings"] == [], f"Expected no warnings, got: {data['warnings']}"
 
     def test_returns_at_least_5_patterns(self, client) -> None:
         """Should return at least 5 patterns (Issue #219 requirement)."""
         response = client.get("/api/scheduler/ui/patterns/builtin")
         data = response.get_json()
-        assert len(data) >= 5, f"Expected at least 5 patterns, got {len(data)}"
+        patterns = data["patterns"]
+        assert len(patterns) >= 5, f"Expected at least 5 patterns, got {len(patterns)}"
 
     def test_all_required_patterns_present(self, client) -> None:
         """All 5 required patterns must be present."""
         response = client.get("/api/scheduler/ui/patterns/builtin")
         data = response.get_json()
+        patterns = data["patterns"]
 
-        pattern_names = {p.get("name") for p in data}
+        pattern_names = {p.get("name") for p in patterns}
 
         required = [
             "UV Capture Cycle",
@@ -107,8 +123,9 @@ class TestListBuiltinPatternsEndpoint:
         """Each pattern must have pattern_id, name, actions, category."""
         response = client.get("/api/scheduler/ui/patterns/builtin")
         data = response.get_json()
+        patterns = data["patterns"]
 
-        for pattern in data:
+        for pattern in patterns:
             pattern_name = pattern.get("name", "unnamed")
             assert "pattern_id" in pattern, f"{pattern_name}: missing pattern_id"
             assert "name" in pattern, f"{pattern_name}: missing name"
@@ -119,8 +136,9 @@ class TestListBuiltinPatternsEndpoint:
         """Each pattern must have source_schedule populated."""
         response = client.get("/api/scheduler/ui/patterns/builtin")
         data = response.get_json()
+        patterns = data["patterns"]
 
-        for pattern in data:
+        for pattern in patterns:
             pattern_name = pattern.get("name", "unnamed")
             assert "source_schedule" in pattern, f"{pattern_name}: missing source_schedule"
             assert pattern["source_schedule"], f"{pattern_name}: empty source_schedule"
@@ -129,8 +147,9 @@ class TestListBuiltinPatternsEndpoint:
         """Each pattern must have duration_minutes computed."""
         response = client.get("/api/scheduler/ui/patterns/builtin")
         data = response.get_json()
+        patterns = data["patterns"]
 
-        for pattern in data:
+        for pattern in patterns:
             pattern_name = pattern.get("name", "unnamed")
             assert "duration_minutes" in pattern, f"{pattern_name}: missing duration_minutes"
             assert isinstance(pattern["duration_minutes"], int), (
@@ -141,8 +160,9 @@ class TestListBuiltinPatternsEndpoint:
         """All pattern_ids should be unique (deduplication)."""
         response = client.get("/api/scheduler/ui/patterns/builtin")
         data = response.get_json()
+        patterns = data["patterns"]
 
-        pattern_ids = [p.get("pattern_id") for p in data]
+        pattern_ids = [p.get("pattern_id") for p in patterns]
         unique_ids = set(pattern_ids)
 
         assert len(pattern_ids) == len(unique_ids), (
@@ -162,8 +182,9 @@ class TestPatternDurations:
         """UV Capture Cycle should have 15-minute duration."""
         response = client.get("/api/scheduler/ui/patterns/builtin")
         data = response.get_json()
+        patterns = data["patterns"]
 
-        pattern = next((p for p in data if p.get("name") == "UV Capture Cycle"), None)
+        pattern = next((p for p in patterns if p.get("name") == "UV Capture Cycle"), None)
         assert pattern is not None, "UV Capture Cycle not found"
         assert pattern["duration_minutes"] == 15, (
             f"Expected 15 minutes, got {pattern['duration_minutes']}"
@@ -173,8 +194,9 @@ class TestPatternDurations:
         """Attract Session should have 60-minute duration."""
         response = client.get("/api/scheduler/ui/patterns/builtin")
         data = response.get_json()
+        patterns = data["patterns"]
 
-        pattern = next((p for p in data if p.get("name") == "Attract Session"), None)
+        pattern = next((p for p in patterns if p.get("name") == "Attract Session"), None)
         assert pattern is not None, "Attract Session not found"
         assert pattern["duration_minutes"] == 60, (
             f"Expected 60 minutes, got {pattern['duration_minutes']}"
@@ -184,8 +206,9 @@ class TestPatternDurations:
         """Flash Capture should have 1-minute duration (short flash cycle)."""
         response = client.get("/api/scheduler/ui/patterns/builtin")
         data = response.get_json()
+        patterns = data["patterns"]
 
-        pattern = next((p for p in data if p.get("name") == "Flash Capture"), None)
+        pattern = next((p for p in patterns if p.get("name") == "Flash Capture"), None)
         assert pattern is not None, "Flash Capture not found"
         assert pattern["duration_minutes"] == 1, (
             f"Expected 1 minute, got {pattern['duration_minutes']}"
@@ -195,8 +218,9 @@ class TestPatternDurations:
         """Dawn Transect should have 20-minute duration."""
         response = client.get("/api/scheduler/ui/patterns/builtin")
         data = response.get_json()
+        patterns = data["patterns"]
 
-        pattern = next((p for p in data if p.get("name") == "Dawn Transect"), None)
+        pattern = next((p for p in patterns if p.get("name") == "Dawn Transect"), None)
         assert pattern is not None, "Dawn Transect not found"
         assert pattern["duration_minutes"] == 20, (
             f"Expected 20 minutes, got {pattern['duration_minutes']}"
@@ -206,8 +230,9 @@ class TestPatternDurations:
         """Dusk Transect should have 20-minute duration."""
         response = client.get("/api/scheduler/ui/patterns/builtin")
         data = response.get_json()
+        patterns = data["patterns"]
 
-        pattern = next((p for p in data if p.get("name") == "Dusk Transect"), None)
+        pattern = next((p for p in patterns if p.get("name") == "Dusk Transect"), None)
         assert pattern is not None, "Dusk Transect not found"
         assert pattern["duration_minutes"] == 20, (
             f"Expected 20 minutes, got {pattern['duration_minutes']}"
@@ -279,7 +304,8 @@ class TestPatternValidationEndpoint:
         """All built-in patterns should pass validation when submitted."""
         # Get built-in patterns
         patterns_response = client.get("/api/scheduler/ui/patterns/builtin")
-        patterns = patterns_response.get_json()
+        data = patterns_response.get_json()
+        patterns = data["patterns"]
 
         for pattern in patterns:
             pattern_name = pattern.get("name", "unnamed")
@@ -315,8 +341,9 @@ class TestPatternSourceSchedules:
         """UV Capture Cycle should come from Nightly Moth Survey."""
         response = client.get("/api/scheduler/ui/patterns/builtin")
         data = response.get_json()
+        patterns = data["patterns"]
 
-        pattern = next((p for p in data if p.get("name") == "UV Capture Cycle"), None)
+        pattern = next((p for p in patterns if p.get("name") == "UV Capture Cycle"), None)
         assert pattern is not None
         assert (
             "Nightly" in pattern["source_schedule"]
@@ -327,8 +354,9 @@ class TestPatternSourceSchedules:
         """Flash Capture should come from Flash Capture Survey."""
         response = client.get("/api/scheduler/ui/patterns/builtin")
         data = response.get_json()
+        patterns = data["patterns"]
 
-        pattern = next((p for p in data if p.get("name") == "Flash Capture"), None)
+        pattern = next((p for p in patterns if p.get("name") == "Flash Capture"), None)
         assert pattern is not None
         assert "Flash" in pattern["source_schedule"]
 
@@ -336,8 +364,9 @@ class TestPatternSourceSchedules:
         """Attract Session should come from Extended Attract Session."""
         response = client.get("/api/scheduler/ui/patterns/builtin")
         data = response.get_json()
+        patterns = data["patterns"]
 
-        pattern = next((p for p in data if p.get("name") == "Attract Session"), None)
+        pattern = next((p for p in patterns if p.get("name") == "Attract Session"), None)
         assert pattern is not None
         assert "Attract" in pattern["source_schedule"] or "Extended" in pattern["source_schedule"]
 
@@ -345,8 +374,9 @@ class TestPatternSourceSchedules:
         """Dawn/Dusk Transect patterns should come from Dawn & Dusk Survey."""
         response = client.get("/api/scheduler/ui/patterns/builtin")
         data = response.get_json()
+        patterns = data["patterns"]
 
         for pattern_name in ["Dawn Transect", "Dusk Transect"]:
-            pattern = next((p for p in data if p.get("name") == pattern_name), None)
+            pattern = next((p for p in patterns if p.get("name") == pattern_name), None)
             assert pattern is not None, f"{pattern_name} not found"
             assert "Dawn" in pattern["source_schedule"] or "Dusk" in pattern["source_schedule"]

--- a/Firmware/Tests/integration/test_builtin_patterns_api.py
+++ b/Firmware/Tests/integration/test_builtin_patterns_api.py
@@ -16,16 +16,14 @@ import pytest
 try:
     from webui.backend.app import app
     from webui.backend.routes.scheduler_ui import scheduler_ui_bp  # noqa: F401
+
     IMPLEMENTATION_EXISTS = True
 except ImportError:
     IMPLEMENTATION_EXISTS = False
     app = None
 
 # Skip all tests if implementation doesn't exist
-pytestmark = pytest.mark.skipif(
-    not IMPLEMENTATION_EXISTS,
-    reason="Implementation not yet created"
-)
+pytestmark = pytest.mark.skipif(not IMPLEMENTATION_EXISTS, reason="Implementation not yet created")
 
 
 # =============================================================================
@@ -39,13 +37,18 @@ def reset_builtin_patterns_cache():
 
     The scheduler_ui module caches patterns at module level.
     We need to reset it to ensure tests get fresh data.
+
+    Note: We acquire the cache lock to prevent race conditions when
+    tests run in parallel.
     """
     import webui.backend.routes.scheduler_ui as module
 
-    original = getattr(module, '_builtin_patterns_cache', None)
-    module._builtin_patterns_cache = None
+    with module._builtin_patterns_cache_lock:
+        original = getattr(module, "_builtin_patterns_cache", None)
+        module._builtin_patterns_cache = None
     yield
-    module._builtin_patterns_cache = original
+    with module._builtin_patterns_cache_lock:
+        module._builtin_patterns_cache = original
 
 
 @pytest.fixture
@@ -315,7 +318,10 @@ class TestPatternSourceSchedules:
 
         pattern = next((p for p in data if p.get("name") == "UV Capture Cycle"), None)
         assert pattern is not None
-        assert "Nightly" in pattern["source_schedule"] or "nightly" in pattern["source_schedule"].lower()
+        assert (
+            "Nightly" in pattern["source_schedule"]
+            or "nightly" in pattern["source_schedule"].lower()
+        )
 
     def test_flash_capture_from_flash_survey(self, client) -> None:
         """Flash Capture should come from Flash Capture Survey."""

--- a/Firmware/Tests/unit/test_builtin_event_patterns.py
+++ b/Firmware/Tests/unit/test_builtin_event_patterns.py
@@ -1,0 +1,399 @@
+"""
+Unit tests for built-in event patterns (Issue #219).
+
+Tests that all required built-in event patterns:
+1. Parse as valid JSON
+2. Pass schema validation
+3. Have unique pattern IDs
+4. Use valid action types and names
+5. Meet the Issue #219 acceptance criteria
+
+The 5 required patterns are:
+- UV Capture Cycle (15 min UV + photo)
+- Attract Session (60 min with lights)
+- Flash Capture (instant flash + photo)
+- Dawn Transect
+- Dusk Transect
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from webui.backend.lib.cron_security import ACTION_TYPE_SCRIPTS
+from webui.backend.lib.schedule_schema import (
+    PATTERN_CATEGORIES,
+    EventPattern,
+    PatternAction,
+    Schedule,
+    validate_event_pattern,
+    validate_schedule,
+)
+
+# =============================================================================
+# FIXTURES
+# =============================================================================
+
+
+@pytest.fixture
+def builtin_schedules_dir() -> Path:
+    """Get the built-in schedules directory."""
+    return Path(__file__).parent.parent.parent / "webui" / "backend" / "presets_builtin" / "schedules"
+
+
+@pytest.fixture
+def all_schedule_files(builtin_schedules_dir: Path) -> list[Path]:
+    """Get all JSON schedule files from built-in directory."""
+    if not builtin_schedules_dir.exists():
+        pytest.skip(f"Built-in schedules directory not found: {builtin_schedules_dir}")
+    return list(builtin_schedules_dir.glob("*.json"))
+
+
+@pytest.fixture
+def all_schedules(all_schedule_files: list[Path]) -> list[dict]:
+    """Load and parse all schedule JSON files."""
+    schedules = []
+    for file_path in all_schedule_files:
+        with open(file_path) as f:
+            schedules.append(json.load(f))
+    return schedules
+
+
+@pytest.fixture
+def all_patterns(all_schedules: list[dict]) -> list[dict]:
+    """Extract all event patterns from all schedules."""
+    patterns = []
+    for schedule in all_schedules:
+        for pattern in schedule.get("event_patterns", []):
+            # Add source schedule info for debugging
+            pattern["_source_schedule"] = schedule.get("name", "unknown")
+            patterns.append(pattern)
+    return patterns
+
+
+# =============================================================================
+# TEST: JSON PARSING
+# =============================================================================
+
+
+class TestBuiltinSchedulesParsing:
+    """Test that all built-in schedule files are valid JSON."""
+
+    def test_schedules_directory_exists(self, builtin_schedules_dir: Path) -> None:
+        """Verify the built-in schedules directory exists."""
+        assert builtin_schedules_dir.exists(), f"Directory not found: {builtin_schedules_dir}"
+        assert builtin_schedules_dir.is_dir(), f"Not a directory: {builtin_schedules_dir}"
+
+    def test_schedule_files_exist(self, all_schedule_files: list[Path]) -> None:
+        """Verify at least one schedule file exists."""
+        assert len(all_schedule_files) > 0, "No schedule files found"
+
+    def test_all_files_are_valid_json(self, all_schedule_files: list[Path]) -> None:
+        """All schedule files must parse as valid JSON."""
+        for file_path in all_schedule_files:
+            try:
+                with open(file_path) as f:
+                    data = json.load(f)
+                assert isinstance(data, dict), f"{file_path.name}: Root must be dict"
+            except json.JSONDecodeError as e:
+                pytest.fail(f"{file_path.name}: Invalid JSON - {e}")
+
+    def test_all_schedules_have_event_patterns(self, all_schedules: list[dict]) -> None:
+        """All schedules must have at least one event pattern."""
+        for schedule in all_schedules:
+            name = schedule.get("name", "unknown")
+            patterns = schedule.get("event_patterns", [])
+            assert len(patterns) > 0, f"Schedule '{name}' has no event_patterns"
+
+
+# =============================================================================
+# TEST: SCHEMA VALIDATION
+# =============================================================================
+
+
+class TestPatternSchemaValidation:
+    """Test that all patterns pass schema validation."""
+
+    def test_all_patterns_pass_validation(self, all_patterns: list[dict]) -> None:
+        """All patterns must pass validate_event_pattern()."""
+        for pattern_data in all_patterns:
+            source = pattern_data.get("_source_schedule", "unknown")
+            pattern_name = pattern_data.get("name", "unnamed")
+
+            # Convert dict to EventPattern
+            actions = [
+                PatternAction(**{k: v for k, v in a.items() if k != "_source_schedule"})
+                for a in pattern_data.get("actions", [])
+            ]
+            pattern = EventPattern(
+                pattern_id=pattern_data.get("pattern_id", ""),
+                name=pattern_data.get("name", ""),
+                description=pattern_data.get("description", ""),
+                actions=actions,
+                category=pattern_data.get("category", "user"),
+                tags=pattern_data.get("tags", []),
+            )
+
+            valid, error = validate_event_pattern(pattern)
+            assert valid, f"Pattern '{pattern_name}' from '{source}' failed: {error}"
+
+    def test_all_schedules_pass_validation(self, all_schedules: list[dict]) -> None:
+        """All schedules must pass validate_schedule()."""
+        for schedule_data in all_schedules:
+            schedule_name = schedule_data.get("name", "unnamed")
+
+            schedule = Schedule.from_dict(schedule_data)
+            valid, error = validate_schedule(schedule)
+            assert valid, f"Schedule '{schedule_name}' failed validation: {error}"
+
+
+# =============================================================================
+# TEST: PATTERN UNIQUENESS
+# =============================================================================
+
+
+class TestPatternUniqueness:
+    """Test that pattern IDs are unique across all schedules."""
+
+    def test_pattern_ids_are_unique(self, all_patterns: list[dict]) -> None:
+        """All pattern_ids must be unique."""
+        pattern_ids = [p.get("pattern_id") for p in all_patterns]
+        seen = set()
+        duplicates = []
+        for pid in pattern_ids:
+            if pid in seen:
+                duplicates.append(pid)
+            seen.add(pid)
+
+        assert not duplicates, f"Duplicate pattern IDs: {duplicates}"
+
+    def test_pattern_names_are_descriptive(self, all_patterns: list[dict]) -> None:
+        """All patterns must have non-empty names."""
+        for pattern in all_patterns:
+            name = pattern.get("name", "")
+            assert name, f"Pattern {pattern.get('pattern_id')} has empty name"
+            assert len(name) >= 3, f"Pattern name '{name}' is too short"
+
+
+# =============================================================================
+# TEST: ACTION VALIDATION
+# =============================================================================
+
+
+class TestActionValidation:
+    """Test that all actions use valid types and names."""
+
+    def test_all_action_types_are_valid(self, all_patterns: list[dict]) -> None:
+        """All action_type values must be in ACTION_TYPE_SCRIPTS."""
+        valid_types = set(ACTION_TYPE_SCRIPTS.keys())
+
+        for pattern in all_patterns:
+            pattern_name = pattern.get("name", "unnamed")
+            for action in pattern.get("actions", []):
+                action_type = action.get("action_type")
+                assert action_type in valid_types, (
+                    f"Pattern '{pattern_name}': invalid action_type '{action_type}'. "
+                    f"Valid types: {valid_types}"
+                )
+
+    def test_all_action_names_are_valid(self, all_patterns: list[dict]) -> None:
+        """All action_name values must be valid for their action_type."""
+        for pattern in all_patterns:
+            pattern_name = pattern.get("name", "unnamed")
+            for action in pattern.get("actions", []):
+                action_type = action.get("action_type")
+                action_name = action.get("action_name")
+
+                valid_names = ACTION_TYPE_SCRIPTS.get(action_type, {})
+                assert action_name in valid_names, (
+                    f"Pattern '{pattern_name}': invalid action_name '{action_name}' "
+                    f"for type '{action_type}'. Valid names: {set(valid_names.keys())}"
+                )
+
+    def test_all_offsets_are_valid(self, all_patterns: list[dict]) -> None:
+        """All offset_minutes must be 0-1440."""
+        for pattern in all_patterns:
+            pattern_name = pattern.get("name", "unnamed")
+            for action in pattern.get("actions", []):
+                offset = action.get("offset_minutes", 0)
+                assert 0 <= offset <= 1440, (
+                    f"Pattern '{pattern_name}': offset_minutes {offset} out of range [0, 1440]"
+                )
+
+
+# =============================================================================
+# TEST: CATEGORY VALIDATION
+# =============================================================================
+
+
+class TestCategoryValidation:
+    """Test that all built-in patterns have category 'built-in'."""
+
+    def test_all_patterns_are_builtin_category(self, all_patterns: list[dict]) -> None:
+        """All patterns must have category 'built-in'."""
+        for pattern in all_patterns:
+            pattern_name = pattern.get("name", "unnamed")
+            category = pattern.get("category", "user")
+            assert category == "built-in", (
+                f"Pattern '{pattern_name}' has category '{category}', expected 'built-in'"
+            )
+
+    def test_category_is_valid(self, all_patterns: list[dict]) -> None:
+        """All categories must be in PATTERN_CATEGORIES."""
+        for pattern in all_patterns:
+            category = pattern.get("category", "user")
+            assert category in PATTERN_CATEGORIES, (
+                f"Invalid category '{category}'. Valid: {PATTERN_CATEGORIES}"
+            )
+
+
+# =============================================================================
+# TEST: REQUIRED PATTERNS (Issue #219)
+# =============================================================================
+
+
+class TestRequiredPatterns:
+    """Test that all 5 required patterns exist (Issue #219 acceptance criteria)."""
+
+    REQUIRED_PATTERNS = [
+        "UV Capture Cycle",
+        "Attract Session",
+        "Flash Capture",
+        "Dawn Transect",
+        "Dusk Transect",
+    ]
+
+    def test_all_required_patterns_exist(self, all_patterns: list[dict]) -> None:
+        """All 5 required patterns must exist by name."""
+        pattern_names = {p.get("name") for p in all_patterns}
+
+        missing = []
+        for required in self.REQUIRED_PATTERNS:
+            if required not in pattern_names:
+                missing.append(required)
+
+        assert not missing, f"Missing required patterns: {missing}"
+
+    def test_uv_capture_cycle_exists(self, all_patterns: list[dict]) -> None:
+        """UV Capture Cycle pattern must exist with correct structure."""
+        pattern = next(
+            (p for p in all_patterns if p.get("name") == "UV Capture Cycle"),
+            None
+        )
+        assert pattern is not None, "UV Capture Cycle pattern not found"
+
+        # Check it has attract_on, takephoto, attract_off actions
+        action_names = [a.get("action_name") for a in pattern.get("actions", [])]
+        assert "attract_on" in action_names, "UV Capture Cycle missing attract_on"
+        assert "takephoto" in action_names, "UV Capture Cycle missing takephoto"
+        assert "attract_off" in action_names, "UV Capture Cycle missing attract_off"
+
+    def test_attract_session_exists(self, all_patterns: list[dict]) -> None:
+        """Attract Session pattern must exist with 60-minute duration."""
+        pattern = next(
+            (p for p in all_patterns if p.get("name") == "Attract Session"),
+            None
+        )
+        assert pattern is not None, "Attract Session pattern not found"
+
+        # Check duration is 60 minutes (max offset)
+        max_offset = max(
+            a.get("offset_minutes", 0) for a in pattern.get("actions", [])
+        )
+        assert max_offset == 60, f"Attract Session duration is {max_offset}, expected 60"
+
+    def test_flash_capture_exists(self, all_patterns: list[dict]) -> None:
+        """Flash Capture pattern must exist with flash_on/flash_off actions."""
+        pattern = next(
+            (p for p in all_patterns if p.get("name") == "Flash Capture"),
+            None
+        )
+        assert pattern is not None, "Flash Capture pattern not found"
+
+        # Check it has flash_on, takephoto, flash_off actions
+        action_names = [a.get("action_name") for a in pattern.get("actions", [])]
+        assert "flash_on" in action_names, "Flash Capture missing flash_on"
+        assert "takephoto" in action_names, "Flash Capture missing takephoto"
+        assert "flash_off" in action_names, "Flash Capture missing flash_off"
+
+    def test_dawn_transect_exists(self, all_patterns: list[dict]) -> None:
+        """Dawn Transect pattern must exist."""
+        pattern = next(
+            (p for p in all_patterns if p.get("name") == "Dawn Transect"),
+            None
+        )
+        assert pattern is not None, "Dawn Transect pattern not found"
+        assert "dawn" in pattern.get("tags", []), "Dawn Transect missing 'dawn' tag"
+
+    def test_dusk_transect_exists(self, all_patterns: list[dict]) -> None:
+        """Dusk Transect pattern must exist."""
+        pattern = next(
+            (p for p in all_patterns if p.get("name") == "Dusk Transect"),
+            None
+        )
+        assert pattern is not None, "Dusk Transect pattern not found"
+        assert "dusk" in pattern.get("tags", []), "Dusk Transect missing 'dusk' tag"
+
+
+# =============================================================================
+# TEST: PATTERN STRUCTURE
+# =============================================================================
+
+
+class TestPatternStructure:
+    """Test pattern structural requirements."""
+
+    def test_all_patterns_have_tags(self, all_patterns: list[dict]) -> None:
+        """All patterns should have at least one tag for discoverability."""
+        for pattern in all_patterns:
+            pattern_name = pattern.get("name", "unnamed")
+            tags = pattern.get("tags", [])
+            assert len(tags) >= 1, f"Pattern '{pattern_name}' has no tags"
+
+    def test_all_patterns_have_descriptions(self, all_patterns: list[dict]) -> None:
+        """All patterns should have non-empty descriptions."""
+        for pattern in all_patterns:
+            pattern_name = pattern.get("name", "unnamed")
+            description = pattern.get("description", "")
+            assert description, f"Pattern '{pattern_name}' has no description"
+            assert len(description) >= 20, (
+                f"Pattern '{pattern_name}' description too short: '{description[:30]}...'"
+            )
+
+    def test_all_actions_have_descriptions(self, all_patterns: list[dict]) -> None:
+        """All actions should have descriptions for clarity."""
+        for pattern in all_patterns:
+            pattern_name = pattern.get("name", "unnamed")
+            for i, action in enumerate(pattern.get("actions", [])):
+                description = action.get("description", "")
+                assert description, (
+                    f"Pattern '{pattern_name}' action {i+1} has no description"
+                )
+
+    def test_gpio_patterns_turn_off_lights(self, all_patterns: list[dict]) -> None:
+        """Patterns that turn on lights should also turn them off."""
+        for pattern in all_patterns:
+            pattern_name = pattern.get("name", "unnamed")
+            action_names = [a.get("action_name") for a in pattern.get("actions", [])]
+
+            if "attract_on" in action_names:
+                assert "attract_off" in action_names, (
+                    f"Pattern '{pattern_name}' has attract_on but no attract_off"
+                )
+
+            if "flash_on" in action_names:
+                assert "flash_off" in action_names, (
+                    f"Pattern '{pattern_name}' has flash_on but no flash_off"
+                )
+
+    def test_actions_are_in_offset_order(self, all_patterns: list[dict]) -> None:
+        """Actions should be ordered by offset_minutes for clarity."""
+        for pattern in all_patterns:
+            pattern_name = pattern.get("name", "unnamed")
+            offsets = [a.get("offset_minutes", 0) for a in pattern.get("actions", [])]
+            sorted_offsets = sorted(offsets)
+
+            assert offsets == sorted_offsets, (
+                f"Pattern '{pattern_name}' actions not in offset order: {offsets}"
+            )

--- a/Firmware/Tests/unit/test_builtin_event_patterns.py
+++ b/Firmware/Tests/unit/test_builtin_event_patterns.py
@@ -39,7 +39,9 @@ from webui.backend.lib.schedule_schema import (
 @pytest.fixture
 def builtin_schedules_dir() -> Path:
     """Get the built-in schedules directory."""
-    return Path(__file__).parent.parent.parent / "webui" / "backend" / "presets_builtin" / "schedules"
+    return (
+        Path(__file__).parent.parent.parent / "webui" / "backend" / "presets_builtin" / "schedules"
+    )
 
 
 @pytest.fixture
@@ -275,65 +277,46 @@ class TestRequiredPatterns:
 
         assert not missing, f"Missing required patterns: {missing}"
 
-    def test_uv_capture_cycle_exists(self, all_patterns: list[dict]) -> None:
-        """UV Capture Cycle pattern must exist with correct structure."""
+    @pytest.mark.parametrize(
+        "pattern_name,expected_actions,expected_tags,expected_duration",
+        [
+            ("UV Capture Cycle", ["attract_on", "takephoto", "attract_off"], None, None),
+            ("Attract Session", None, None, 60),
+            ("Flash Capture", ["flash_on", "takephoto", "flash_off"], None, None),
+            ("Dawn Transect", None, ["dawn"], None),
+            ("Dusk Transect", None, ["dusk"], None),
+        ],
+    )
+    def test_required_pattern_configuration(
+        self,
+        all_patterns: list[dict],
+        pattern_name: str,
+        expected_actions: list[str] | None,
+        expected_tags: list[str] | None,
+        expected_duration: int | None,
+    ) -> None:
+        """Required patterns must exist with correct configuration."""
         pattern = next(
-            (p for p in all_patterns if p.get("name") == "UV Capture Cycle"),
-            None
+            (p for p in all_patterns if p.get("name") == pattern_name),
+            None,
         )
-        assert pattern is not None, "UV Capture Cycle pattern not found"
+        assert pattern is not None, f"{pattern_name} pattern not found"
 
-        # Check it has attract_on, takephoto, attract_off actions
-        action_names = [a.get("action_name") for a in pattern.get("actions", [])]
-        assert "attract_on" in action_names, "UV Capture Cycle missing attract_on"
-        assert "takephoto" in action_names, "UV Capture Cycle missing takephoto"
-        assert "attract_off" in action_names, "UV Capture Cycle missing attract_off"
+        if expected_actions:
+            action_names = [a.get("action_name") for a in pattern.get("actions", [])]
+            for action in expected_actions:
+                assert action in action_names, f"{pattern_name} missing {action}"
 
-    def test_attract_session_exists(self, all_patterns: list[dict]) -> None:
-        """Attract Session pattern must exist with 60-minute duration."""
-        pattern = next(
-            (p for p in all_patterns if p.get("name") == "Attract Session"),
-            None
-        )
-        assert pattern is not None, "Attract Session pattern not found"
+        if expected_tags:
+            tags = pattern.get("tags", [])
+            for tag in expected_tags:
+                assert tag in tags, f"{pattern_name} missing '{tag}' tag"
 
-        # Check duration is 60 minutes (max offset)
-        max_offset = max(
-            a.get("offset_minutes", 0) for a in pattern.get("actions", [])
-        )
-        assert max_offset == 60, f"Attract Session duration is {max_offset}, expected 60"
-
-    def test_flash_capture_exists(self, all_patterns: list[dict]) -> None:
-        """Flash Capture pattern must exist with flash_on/flash_off actions."""
-        pattern = next(
-            (p for p in all_patterns if p.get("name") == "Flash Capture"),
-            None
-        )
-        assert pattern is not None, "Flash Capture pattern not found"
-
-        # Check it has flash_on, takephoto, flash_off actions
-        action_names = [a.get("action_name") for a in pattern.get("actions", [])]
-        assert "flash_on" in action_names, "Flash Capture missing flash_on"
-        assert "takephoto" in action_names, "Flash Capture missing takephoto"
-        assert "flash_off" in action_names, "Flash Capture missing flash_off"
-
-    def test_dawn_transect_exists(self, all_patterns: list[dict]) -> None:
-        """Dawn Transect pattern must exist."""
-        pattern = next(
-            (p for p in all_patterns if p.get("name") == "Dawn Transect"),
-            None
-        )
-        assert pattern is not None, "Dawn Transect pattern not found"
-        assert "dawn" in pattern.get("tags", []), "Dawn Transect missing 'dawn' tag"
-
-    def test_dusk_transect_exists(self, all_patterns: list[dict]) -> None:
-        """Dusk Transect pattern must exist."""
-        pattern = next(
-            (p for p in all_patterns if p.get("name") == "Dusk Transect"),
-            None
-        )
-        assert pattern is not None, "Dusk Transect pattern not found"
-        assert "dusk" in pattern.get("tags", []), "Dusk Transect missing 'dusk' tag"
+        if expected_duration is not None:
+            max_offset = max(a.get("offset_minutes", 0) for a in pattern.get("actions", []))
+            assert max_offset == expected_duration, (
+                f"{pattern_name} duration is {max_offset}, expected {expected_duration}"
+            )
 
 
 # =============================================================================
@@ -367,9 +350,7 @@ class TestPatternStructure:
             pattern_name = pattern.get("name", "unnamed")
             for i, action in enumerate(pattern.get("actions", [])):
                 description = action.get("description", "")
-                assert description, (
-                    f"Pattern '{pattern_name}' action {i+1} has no description"
-                )
+                assert description, f"Pattern '{pattern_name}' action {i + 1} has no description"
 
     def test_gpio_patterns_turn_off_lights(self, all_patterns: list[dict]) -> None:
         """Patterns that turn on lights should also turn them off."""

--- a/Firmware/Tests/unit/test_event_pattern_api.py
+++ b/Firmware/Tests/unit/test_event_pattern_api.py
@@ -131,7 +131,10 @@ class TestListBuiltinPatterns:
 
         assert response.status_code == 200
         data = response.get_json()
-        assert isinstance(data, list)
+        assert isinstance(data, dict)
+        assert "patterns" in data
+        assert "warnings" in data
+        assert isinstance(data["patterns"], list)
 
     def test_includes_required_fields(self, client):
         """Test each pattern includes required fields."""
@@ -139,9 +142,10 @@ class TestListBuiltinPatterns:
 
         assert response.status_code == 200
         data = response.get_json()
-        assert len(data) > 0, "Expected at least one pattern"
+        patterns = data["patterns"]
+        assert len(patterns) > 0, "Expected at least one pattern"
 
-        for pattern in data:
+        for pattern in patterns:
             assert "pattern_id" in pattern, "Missing pattern_id field"
             assert "name" in pattern, "Missing name field"
             assert "actions" in pattern, "Missing actions field"
@@ -152,9 +156,10 @@ class TestListBuiltinPatterns:
 
         assert response.status_code == 200
         data = response.get_json()
-        assert len(data) > 0
+        patterns = data["patterns"]
+        assert len(patterns) > 0
 
-        for pattern in data:
+        for pattern in patterns:
             assert "source_schedule" in pattern, "Missing source_schedule field"
             assert isinstance(pattern["source_schedule"], str)
             assert len(pattern["source_schedule"]) > 0
@@ -165,9 +170,10 @@ class TestListBuiltinPatterns:
 
         assert response.status_code == 200
         data = response.get_json()
-        assert len(data) > 0
+        patterns = data["patterns"]
+        assert len(patterns) > 0
 
-        for pattern in data:
+        for pattern in patterns:
             assert "category" in pattern
             assert pattern["category"] == "built-in"
 
@@ -177,7 +183,8 @@ class TestListBuiltinPatterns:
 
         assert response.status_code == 200
         data = response.get_json()
-        assert len(data) >= 3, f"Expected at least 3 patterns, got {len(data)}"
+        patterns = data["patterns"]
+        assert len(patterns) >= 3, f"Expected at least 3 patterns, got {len(patterns)}"
 
     def test_no_duplicate_pattern_ids(self, client):
         """Test no duplicate pattern_ids in response."""
@@ -185,8 +192,9 @@ class TestListBuiltinPatterns:
 
         assert response.status_code == 200
         data = response.get_json()
+        patterns = data["patterns"]
 
-        pattern_ids = [p["pattern_id"] for p in data]
+        pattern_ids = [p["pattern_id"] for p in patterns]
         unique_ids = set(pattern_ids)
         assert len(pattern_ids) == len(unique_ids), "Duplicate pattern_ids found"
 
@@ -196,9 +204,10 @@ class TestListBuiltinPatterns:
 
         assert response.status_code == 200
         data = response.get_json()
-        assert len(data) > 0
+        patterns = data["patterns"]
+        assert len(patterns) > 0
 
-        for pattern in data:
+        for pattern in patterns:
             actions = pattern.get("actions", [])
             assert isinstance(actions, list)
             assert len(actions) > 0, f"Pattern {pattern['name']} has no actions"
@@ -213,9 +222,10 @@ class TestListBuiltinPatterns:
 
         assert response.status_code == 200
         data = response.get_json()
-        assert len(data) > 0
+        patterns = data["patterns"]
+        assert len(patterns) > 0
 
-        for pattern in data:
+        for pattern in patterns:
             assert "tags" in pattern
             assert isinstance(pattern["tags"], list)
 
@@ -225,9 +235,10 @@ class TestListBuiltinPatterns:
 
         assert response.status_code == 200
         data = response.get_json()
-        assert len(data) > 0
+        patterns = data["patterns"]
+        assert len(patterns) > 0
 
-        for pattern in data:
+        for pattern in patterns:
             assert "duration_minutes" in pattern, "Missing duration_minutes field"
             assert isinstance(pattern["duration_minutes"], int)
             assert pattern["duration_minutes"] >= 0
@@ -242,9 +253,10 @@ class TestListBuiltinPatterns:
 
         assert response.status_code == 200
         data = response.get_json()
-        assert len(data) > 0, "Expected at least one pattern"
+        patterns = data["patterns"]
+        assert len(patterns) > 0, "Expected at least one pattern"
 
-        for pattern in data:
+        for pattern in patterns:
             pattern_id = pattern.get("pattern_id")
             assert pattern_id, f"Pattern '{pattern.get('name', 'unknown')}' missing pattern_id"
             assert isinstance(pattern_id, str), "pattern_id should be a string"
@@ -580,16 +592,19 @@ class TestErrorHandling:
         """Test endpoint handles missing builtin directory gracefully."""
         module = _get_scheduler_ui_module()
 
-        # Mock Path to return a non-existent directory
+        # Mock list_builtin_patterns to return empty list (simulates missing directory)
         with patch.object(module, "list_builtin_patterns") as mock_list:
-            mock_list.return_value = []
+            mock_list.return_value = ([], [])  # Returns (patterns, warnings) tuple
 
             response = client.get("/api/scheduler/ui/patterns/builtin")
 
             assert response.status_code == 200
             data = response.get_json()
-            assert isinstance(data, list)
-            assert len(data) == 0
+            assert isinstance(data, dict)
+            assert "patterns" in data
+            assert "warnings" in data
+            assert isinstance(data["patterns"], list)
+            assert len(data["patterns"]) == 0
 
     def test_rate_limiting_decorator_applied(self, client):
         """Test that rate limiting decorator is applied to validate endpoint."""

--- a/Firmware/webui/backend/presets_builtin/schedules/dawn_dusk_survey.json
+++ b/Firmware/webui/backend/presets_builtin/schedules/dawn_dusk_survey.json
@@ -14,7 +14,7 @@
           "action_name": "attract_on",
           "offset_minutes": 0,
           "parameters": {},
-          "description": "Turn on attract lights at dusk"
+          "description": "Turn on UV attract lights at dusk"
         },
         {
           "action_type": "camera",
@@ -42,7 +42,7 @@
           "action_name": "attract_off",
           "offset_minutes": 20,
           "parameters": {},
-          "description": "Turn off attract lights"
+          "description": "Turn off UV attract lights"
         }
       ],
       "category": "built-in",
@@ -58,7 +58,7 @@
           "action_name": "attract_on",
           "offset_minutes": 0,
           "parameters": {},
-          "description": "Turn on attract lights at dawn"
+          "description": "Turn on UV attract lights at dawn"
         },
         {
           "action_type": "camera",
@@ -86,7 +86,7 @@
           "action_name": "attract_off",
           "offset_minutes": 20,
           "parameters": {},
-          "description": "Turn off attract lights"
+          "description": "Turn off UV attract lights"
         }
       ],
       "category": "built-in",

--- a/Firmware/webui/backend/presets_builtin/schedules/dawn_dusk_survey.json
+++ b/Firmware/webui/backend/presets_builtin/schedules/dawn_dusk_survey.json
@@ -2,12 +2,12 @@
   "schema_version": "2.0",
   "schedule_id": "dawn_dusk_survey",
   "name": "Dawn & Dusk Survey",
-  "description": "Solar-triggered schedule for photographing crepuscular species (active at dawn and dusk). Triggers at civil dusk each evening to capture the transition period when many moth species begin activity.",
+  "description": "Solar-triggered schedule for photographing crepuscular species (active at dawn and dusk). Triggers at civil dusk each evening to capture the transition period when many moth species begin activity. Contains both dawn and dusk transect patterns for the pattern library.",
   "event_patterns": [
     {
-      "pattern_id": "dusk_photo_sequence",
-      "name": "Dusk Photo Sequence",
-      "description": "Capture photo sequence at civil dusk to document crepuscular activity",
+      "pattern_id": "dusk_transect",
+      "name": "Dusk Transect",
+      "description": "Dusk transect pattern for capturing crepuscular species active at twilight. Takes multiple photos as light decreases to document species transitioning from diurnal to nocturnal behavior.",
       "actions": [
         {
           "action_type": "gpio",
@@ -21,21 +21,21 @@
           "action_name": "takephoto",
           "offset_minutes": 0,
           "parameters": {},
-          "description": "Capture first photo at civil dusk"
+          "description": "First capture at civil dusk"
         },
         {
           "action_type": "camera",
           "action_name": "takephoto",
           "offset_minutes": 10,
           "parameters": {},
-          "description": "Capture second photo 10 minutes later"
+          "description": "Second capture 10 minutes later"
         },
         {
           "action_type": "camera",
           "action_name": "takephoto",
           "offset_minutes": 20,
           "parameters": {},
-          "description": "Capture third photo 20 minutes later"
+          "description": "Third capture 20 minutes later"
         },
         {
           "action_type": "gpio",
@@ -46,7 +46,51 @@
         }
       ],
       "category": "built-in",
-      "tags": ["dusk", "dawn", "crepuscular", "survey", "solar"]
+      "tags": ["dusk", "crepuscular", "transect", "survey", "solar"]
+    },
+    {
+      "pattern_id": "dawn_transect",
+      "name": "Dawn Transect",
+      "description": "Dawn transect pattern for capturing crepuscular species active at first light. Takes multiple photos as light increases to document species transitioning from nocturnal to diurnal behavior.",
+      "actions": [
+        {
+          "action_type": "gpio",
+          "action_name": "attract_on",
+          "offset_minutes": 0,
+          "parameters": {},
+          "description": "Turn on attract lights at dawn"
+        },
+        {
+          "action_type": "camera",
+          "action_name": "takephoto",
+          "offset_minutes": 0,
+          "parameters": {},
+          "description": "First capture at civil dawn"
+        },
+        {
+          "action_type": "camera",
+          "action_name": "takephoto",
+          "offset_minutes": 10,
+          "parameters": {},
+          "description": "Second capture 10 minutes later"
+        },
+        {
+          "action_type": "camera",
+          "action_name": "takephoto",
+          "offset_minutes": 20,
+          "parameters": {},
+          "description": "Third capture 20 minutes later"
+        },
+        {
+          "action_type": "gpio",
+          "action_name": "attract_off",
+          "offset_minutes": 20,
+          "parameters": {},
+          "description": "Turn off attract lights"
+        }
+      ],
+      "category": "built-in",
+      "tags": ["dawn", "crepuscular", "transect", "survey", "solar"]
     }
   ],
   "trigger_type": "solar",

--- a/Firmware/webui/backend/presets_builtin/schedules/extended_attract_session.json
+++ b/Firmware/webui/backend/presets_builtin/schedules/extended_attract_session.json
@@ -1,0 +1,83 @@
+{
+  "schema_version": "2.0",
+  "schedule_id": "extended_attract_session",
+  "name": "Extended Attract Session",
+  "description": "Extended 60-minute UV attraction sessions for documenting insect accumulation patterns over time. UV attract lights remain on for the full duration with photos captured at 15-minute intervals to show how moth populations build up at the light source.",
+  "event_patterns": [
+    {
+      "pattern_id": "attract_session",
+      "name": "Attract Session",
+      "description": "60-minute UV attraction session with photos at 15-minute intervals. Documents the gradual accumulation of moths at the UV light source over time.",
+      "actions": [
+        {
+          "action_type": "gpio",
+          "action_name": "attract_on",
+          "offset_minutes": 0,
+          "parameters": {},
+          "description": "Turn on UV attract lights for extended session"
+        },
+        {
+          "action_type": "camera",
+          "action_name": "takephoto",
+          "offset_minutes": 15,
+          "parameters": {},
+          "description": "Capture photo at 15 minutes"
+        },
+        {
+          "action_type": "camera",
+          "action_name": "takephoto",
+          "offset_minutes": 30,
+          "parameters": {},
+          "description": "Capture photo at 30 minutes"
+        },
+        {
+          "action_type": "camera",
+          "action_name": "takephoto",
+          "offset_minutes": 45,
+          "parameters": {},
+          "description": "Capture photo at 45 minutes"
+        },
+        {
+          "action_type": "camera",
+          "action_name": "takephoto",
+          "offset_minutes": 60,
+          "parameters": {},
+          "description": "Final capture at 60 minutes"
+        },
+        {
+          "action_type": "gpio",
+          "action_name": "attract_off",
+          "offset_minutes": 60,
+          "parameters": {},
+          "description": "Turn off UV attract lights"
+        }
+      ],
+      "category": "built-in",
+      "tags": ["attract", "extended", "60min", "survey", "accumulation"]
+    }
+  ],
+  "trigger_type": "interval",
+  "interval_trigger": {
+    "interval_minutes": 90,
+    "time_window": {
+      "start_time": "sunset",
+      "end_time": "sunrise",
+      "start_offset_minutes": 30,
+      "end_offset_minutes": 0
+    },
+    "days_of_week": null
+  },
+  "solar_trigger": null,
+  "moon_phase_trigger": null,
+  "fixed_time_trigger": null,
+  "sensor_trigger": null,
+  "start_date": null,
+  "end_date": null,
+  "deployment_id": null,
+  "create_deployment": false,
+  "enabled": true,
+  "is_active": false,
+  "created_at": "2024-12-21T00:00:00Z",
+  "modified_at": "2024-12-21T00:00:00Z",
+  "modified_by": null
+}

--- a/Firmware/webui/backend/presets_builtin/schedules/flash_capture_survey.json
+++ b/Firmware/webui/backend/presets_builtin/schedules/flash_capture_survey.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "2.0",
+  "schedule_id": "flash_capture_survey",
+  "name": "Flash Capture Survey",
+  "description": "Fixed-time flash photography for nocturnal surveys. Uses camera flash for instant illumination without waiting for moths to gather. Ideal for quick sampling at regular intervals.",
+  "event_patterns": [
+    {
+      "pattern_id": "flash_capture",
+      "name": "Flash Capture",
+      "description": "Instant flash photography sequence. Turns on flash, captures photo immediately, then turns off flash after 1 minute to allow for camera processing.",
+      "actions": [
+        {
+          "action_type": "gpio",
+          "action_name": "flash_on",
+          "offset_minutes": 0,
+          "parameters": {},
+          "description": "Turn on camera flash"
+        },
+        {
+          "action_type": "camera",
+          "action_name": "takephoto",
+          "offset_minutes": 0,
+          "parameters": {},
+          "description": "Capture photo with flash"
+        },
+        {
+          "action_type": "gpio",
+          "action_name": "flash_off",
+          "offset_minutes": 1,
+          "parameters": {},
+          "description": "Turn off camera flash"
+        }
+      ],
+      "category": "built-in",
+      "tags": ["flash", "instant", "capture", "nocturnal"]
+    }
+  ],
+  "trigger_type": "interval",
+  "interval_trigger": {
+    "interval_minutes": 30,
+    "time_window": {
+      "start_time": "22:00",
+      "end_time": "04:00",
+      "start_offset_minutes": 0,
+      "end_offset_minutes": 0
+    },
+    "days_of_week": null
+  },
+  "solar_trigger": null,
+  "moon_phase_trigger": null,
+  "fixed_time_trigger": null,
+  "sensor_trigger": null,
+  "start_date": null,
+  "end_date": null,
+  "deployment_id": null,
+  "create_deployment": false,
+  "enabled": true,
+  "is_active": false,
+  "created_at": "2024-12-21T00:00:00Z",
+  "modified_at": "2024-12-21T00:00:00Z",
+  "modified_by": null
+}

--- a/Firmware/webui/backend/routes/scheduler_ui.py
+++ b/Firmware/webui/backend/routes/scheduler_ui.py
@@ -67,6 +67,7 @@ _scheduler_service = None
 
 # Built-in patterns cache (populated on first request)
 _builtin_patterns_cache: list[dict] | None = None
+_builtin_patterns_cache_warnings: list[str] = []
 _builtin_patterns_cache_lock = threading.Lock()
 
 
@@ -973,7 +974,7 @@ def validate_schedule_endpoint(schedule_id: str) -> tuple[Response, int]:
 # ============================================================================
 
 
-def list_builtin_patterns() -> list[dict]:
+def list_builtin_patterns() -> tuple[list[dict], list[str]]:
     """
     Extract unique event patterns from built-in schedules.
 
@@ -988,7 +989,9 @@ def list_builtin_patterns() -> list[dict]:
     - duration_minutes: Computed from max action offset
 
     Returns:
-        List of pattern dictionaries with source_schedule and duration_minutes added
+        Tuple of (patterns, warnings) where:
+        - patterns: List of pattern dictionaries with source_schedule and duration_minutes
+        - warnings: List of warning messages for any files that failed to load
 
     Note:
         Results are cached at module level for performance using thread-safe
@@ -999,37 +1002,43 @@ def list_builtin_patterns() -> list[dict]:
         If built-in schedule files are modified, a service restart is required
         to refresh the cache.
     """
-    global _builtin_patterns_cache
+    global _builtin_patterns_cache, _builtin_patterns_cache_warnings
 
     # Fast path: cache already populated (no lock needed)
     if _builtin_patterns_cache is not None:
-        return _builtin_patterns_cache
+        return _builtin_patterns_cache, _builtin_patterns_cache_warnings
 
     # Slow path: acquire lock and populate cache
     with _builtin_patterns_cache_lock:
         # Double-check after acquiring lock
         if _builtin_patterns_cache is not None:
-            return _builtin_patterns_cache
+            return _builtin_patterns_cache, _builtin_patterns_cache_warnings
 
         patterns = []
+        warnings: list[str] = []
         seen_ids: set[str] = set()
 
         # Path to built-in schedules directory
         builtin_dir = Path(__file__).parent.parent / "presets_builtin" / "schedules"
 
         if not builtin_dir.exists():
-            logger.warning(f"Built-in schedules directory not found: {builtin_dir}")
+            warning_msg = f"Built-in schedules directory not found: {builtin_dir}"
+            logger.warning(warning_msg)
+            warnings.append(warning_msg)
             _builtin_patterns_cache = patterns
-            return patterns
+            _builtin_patterns_cache_warnings = warnings
+            return patterns, warnings
 
         schedule_files = sorted(builtin_dir.glob("*.json"))
 
         # Safety limit on number of files to process
         if len(schedule_files) > MAX_BUILTIN_SCHEDULE_FILES:
-            logger.warning(
+            warning_msg = (
                 f"Found {len(schedule_files)} schedule files in {builtin_dir}, "
                 f"processing only first {MAX_BUILTIN_SCHEDULE_FILES}"
             )
+            logger.warning(warning_msg)
+            warnings.append(warning_msg)
             schedule_files = schedule_files[:MAX_BUILTIN_SCHEDULE_FILES]
 
         for schedule_file in schedule_files:
@@ -1064,20 +1073,27 @@ def list_builtin_patterns() -> list[dict]:
                     patterns.append(pattern_copy)
 
             except json.JSONDecodeError as e:
-                logger.error(f"Failed to parse schedule file {schedule_file}: {e}")
+                warning_msg = f"Failed to parse schedule file {schedule_file.name}: {e}"
+                logger.error(warning_msg)
+                warnings.append(warning_msg)
             except Exception as e:
-                logger.error(f"Error processing schedule file {schedule_file}: {e}")
+                warning_msg = f"Error processing schedule file {schedule_file.name}: {e}"
+                logger.error(warning_msg)
+                warnings.append(warning_msg)
 
         # Log warning if no patterns found (possible misconfiguration)
         if not patterns and builtin_dir.exists():
-            logger.warning(
+            warning_msg = (
                 f"No patterns found in {builtin_dir}. "
                 "Check schedule files for valid event_patterns."
             )
+            logger.warning(warning_msg)
+            warnings.append(warning_msg)
 
         # Cache the result for subsequent calls
         _builtin_patterns_cache = patterns
-        return patterns
+        _builtin_patterns_cache_warnings = warnings
+        return patterns, warnings
 
 
 @scheduler_ui_bp.route("/patterns/builtin", methods=["GET"])
@@ -1088,25 +1104,28 @@ def list_builtin_patterns_endpoint() -> tuple[Response, int]:
     GET /api/scheduler/ui/patterns/builtin
 
     Returns:
-        200 OK: List of built-in pattern objects
+        200 OK: Object with patterns list and any warnings
 
     Response Schema:
-    [
-        {
-            "pattern_id": "string",
-            "name": "string",
-            "description": "string",
-            "actions": [...],
-            "category": "built-in",
-            "tags": [...],
-            "source_schedule": "string",
-            "duration_minutes": number
-        }
-    ]
+    {
+        "patterns": [
+            {
+                "pattern_id": "string",
+                "name": "string",
+                "description": "string",
+                "actions": [...],
+                "category": "built-in",
+                "tags": [...],
+                "source_schedule": "string",
+                "duration_minutes": number
+            }
+        ],
+        "warnings": ["string"]  // Empty if no issues loading files
+    }
     """
     try:
-        patterns = list_builtin_patterns()
-        return jsonify(patterns), 200
+        patterns, warnings = list_builtin_patterns()
+        return jsonify({"patterns": patterns, "warnings": warnings}), 200
 
     except Exception as e:
         logger.error(f"Error listing built-in patterns: {e}", exc_info=True)

--- a/Firmware/webui/backend/routes/scheduler_ui.py
+++ b/Firmware/webui/backend/routes/scheduler_ui.py
@@ -19,7 +19,7 @@ import threading
 from functools import wraps
 from pathlib import Path
 
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, Response, jsonify, request
 from werkzeug.exceptions import BadRequest
 
 from webui.backend.constants import MAX_BUILTIN_SCHEDULE_FILES
@@ -51,7 +51,9 @@ except ImportError:
         def limit(self, *args, **kwargs):
             def decorator(f):
                 return f
+
             return decorator
+
     limiter = _LimiterStub()
 
 # Logger
@@ -83,6 +85,7 @@ def require_json(f):
     Passes the parsed JSON data to the wrapped function as `json_data` kwarg.
     Returns 400 Bad Request if JSON is missing, invalid, or not an object.
     """
+
     @wraps(f)
     def decorated(*args, **kwargs):
         try:
@@ -97,6 +100,7 @@ def require_json(f):
             return jsonify({"error": "Request body must be a JSON object"}), 400
 
         return f(*args, json_data=data, **kwargs)
+
     return decorated
 
 
@@ -107,7 +111,7 @@ def require_json(f):
 
 @scheduler_ui_bp.route("/schedules/<schedule_id>/preview", methods=["GET"])
 @limiter.limit("30 per minute")
-def get_schedule_preview(schedule_id: str):
+def get_schedule_preview(schedule_id: str) -> tuple[Response, int]:
     """
     Generate execution preview for a schedule.
 
@@ -203,9 +207,11 @@ def get_schedule_preview(schedule_id: str):
         schedule = service.get_schedule(schedule_id)
 
         if schedule is None:
-            return jsonify({
-                "error": "Schedule not found",
-            }), 404
+            return jsonify(
+                {
+                    "error": "Schedule not found",
+                }
+            ), 404
 
         # Generate preview
         result = generate_preview(
@@ -220,16 +226,20 @@ def get_schedule_preview(schedule_id: str):
 
     except ValueError as e:
         logger.warning(f"Preview generation error: {e}")
-        return jsonify({
-            "error": "Preview generation failed",
-        }), 400
+        return jsonify(
+            {
+                "error": "Preview generation failed",
+            }
+        ), 400
 
     except Exception as e:
         logger.error(f"Unexpected error in preview generation: {e}", exc_info=True)
-        return jsonify({
-            "error": "Internal server error",
-            "message": "Failed to generate preview",
-        }), 500
+        return jsonify(
+            {
+                "error": "Internal server error",
+                "message": "Failed to generate preview",
+            }
+        ), 500
 
 
 # ============================================================================
@@ -238,7 +248,7 @@ def get_schedule_preview(schedule_id: str):
 
 
 @scheduler_ui_bp.route("/schedules", methods=["GET"])
-def list_schedules():
+def list_schedules() -> tuple[Response, int]:
     """
     List all schedules (summary).
 
@@ -277,21 +287,25 @@ def list_schedules():
             for s in schedules
         ]
 
-        return jsonify({
-            "schedules": summaries,
-            "total": len(summaries),
-        }), 200
+        return jsonify(
+            {
+                "schedules": summaries,
+                "total": len(summaries),
+            }
+        ), 200
 
     except Exception as e:
         logger.error(f"Error listing schedules: {e}", exc_info=True)
-        return jsonify({
-            "error": "Internal server error",
-            "message": "Failed to list schedules",
-        }), 500
+        return jsonify(
+            {
+                "error": "Internal server error",
+                "message": "Failed to list schedules",
+            }
+        ), 500
 
 
 @scheduler_ui_bp.route("/schedules/<schedule_id>", methods=["GET"])
-def get_schedule(schedule_id: str):
+def get_schedule(schedule_id: str) -> tuple[Response, int]:
     """
     Get full schedule details.
 
@@ -306,21 +320,25 @@ def get_schedule(schedule_id: str):
         schedule = service.get_schedule(schedule_id)
 
         if schedule is None:
-            return jsonify({
-                "error": "Schedule not found",
-            }), 404
+            return jsonify(
+                {
+                    "error": "Schedule not found",
+                }
+            ), 404
 
         return jsonify(schedule.to_dict()), 200
 
     except Exception as e:
         logger.error(f"Error getting schedule: {e}", exc_info=True)
-        return jsonify({
-            "error": "Internal server error",
-        }), 500
+        return jsonify(
+            {
+                "error": "Internal server error",
+            }
+        ), 500
 
 
 @scheduler_ui_bp.route("/schedules/active", methods=["GET"])
-def get_active_schedule():
+def get_active_schedule() -> tuple[Response, int]:
     """
     Get the currently active schedule.
 
@@ -337,26 +355,32 @@ def get_active_schedule():
         schedule = service.get_active_schedule()
 
         if schedule is None:
-            return jsonify({
-                "active": False,
-                "schedule": None,
-            }), 200
+            return jsonify(
+                {
+                    "active": False,
+                    "schedule": None,
+                }
+            ), 200
 
-        return jsonify({
-            "active": True,
-            "schedule": schedule.to_dict(),
-        }), 200
+        return jsonify(
+            {
+                "active": True,
+                "schedule": schedule.to_dict(),
+            }
+        ), 200
 
     except Exception as e:
         logger.error(f"Error getting active schedule: {e}", exc_info=True)
-        return jsonify({
-            "error": "Internal server error",
-            "message": "Failed to get active schedule",
-        }), 500
+        return jsonify(
+            {
+                "error": "Internal server error",
+                "message": "Failed to get active schedule",
+            }
+        ), 500
 
 
 @scheduler_ui_bp.route("/schedules/builtin", methods=["GET"])
-def list_builtin_schedules():
+def list_builtin_schedules() -> tuple[Response, int]:
     """
     List all built-in schedules.
 
@@ -394,17 +418,21 @@ def list_builtin_schedules():
             for s in builtin
         ]
 
-        return jsonify({
-            "schedules": summaries,
-            "total": len(summaries),
-        }), 200
+        return jsonify(
+            {
+                "schedules": summaries,
+                "total": len(summaries),
+            }
+        ), 200
 
     except Exception as e:
         logger.error(f"Error listing built-in schedules: {e}", exc_info=True)
-        return jsonify({
-            "error": "Internal server error",
-            "message": "Failed to list built-in schedules",
-        }), 500
+        return jsonify(
+            {
+                "error": "Internal server error",
+                "message": "Failed to list built-in schedules",
+            }
+        ), 500
 
 
 # ============================================================================
@@ -415,7 +443,7 @@ def list_builtin_schedules():
 @scheduler_ui_bp.route("/schedules", methods=["POST"])
 @limiter.limit("30 per minute")
 @require_json
-def create_schedule(json_data: dict):
+def create_schedule(json_data: dict) -> tuple[Response, int]:
     """
     Create a new schedule.
 
@@ -440,14 +468,18 @@ def create_schedule(json_data: dict):
             schedule = Schedule.from_dict(json_data)
         except KeyError as e:
             logger.debug(f"Missing required field in schedule: {e}")
-            return jsonify({
-                "error": f"Missing required field: {e}",
-            }), 400
+            return jsonify(
+                {
+                    "error": f"Missing required field: {e}",
+                }
+            ), 400
         except Exception as e:
             logger.error(f"Invalid schedule format: {e}", exc_info=True)
-            return jsonify({
-                "error": "Invalid schedule format",
-            }), 400
+            return jsonify(
+                {
+                    "error": "Invalid schedule format",
+                }
+            ), 400
 
         # Create via service (validates internally)
         service = get_scheduler_service()
@@ -455,33 +487,41 @@ def create_schedule(json_data: dict):
             success = service.create_schedule(schedule)
         except ScheduleValidationError as e:
             logger.debug(f"Schedule validation failed: {e}")
-            return jsonify({
-                "error": "Schedule validation failed",
-            }), 400
+            return jsonify(
+                {
+                    "error": "Schedule validation failed",
+                }
+            ), 400
 
         if not success:
-            return jsonify({
-                "error": "Failed to create schedule",
-            }), 500
+            return jsonify(
+                {
+                    "error": "Failed to create schedule",
+                }
+            ), 500
 
-        return jsonify({
-            "message": "Schedule created",
-            "schedule_id": schedule.schedule_id,
-            "schedule": schedule.to_dict(),
-        }), 201
+        return jsonify(
+            {
+                "message": "Schedule created",
+                "schedule_id": schedule.schedule_id,
+                "schedule": schedule.to_dict(),
+            }
+        ), 201
 
     except Exception as e:
         logger.error(f"Error creating schedule: {e}", exc_info=True)
-        return jsonify({
-            "error": "Internal server error",
-            "message": "Failed to create schedule",
-        }), 500
+        return jsonify(
+            {
+                "error": "Internal server error",
+                "message": "Failed to create schedule",
+            }
+        ), 500
 
 
 @scheduler_ui_bp.route("/schedules/<schedule_id>", methods=["PUT"])
 @limiter.limit("30 per minute")
 @require_json
-def update_schedule(schedule_id: str, json_data: dict):
+def update_schedule(schedule_id: str, json_data: dict) -> tuple[Response, int]:
     """
     Update a schedule.
 
@@ -506,9 +546,11 @@ def update_schedule(schedule_id: str, json_data: dict):
         # Check if schedule exists
         existing = service.get_schedule(schedule_id)
         if existing is None:
-            return jsonify({
-                "error": "Schedule not found",
-            }), 404
+            return jsonify(
+                {
+                    "error": "Schedule not found",
+                }
+            ), 404
 
         # Update via service (handles built-in check)
         try:
@@ -516,35 +558,45 @@ def update_schedule(schedule_id: str, json_data: dict):
         except ValueError as e:
             # Built-in schedule protection
             logger.warning(f"Update blocked for built-in schedule: {e}")
-            return jsonify({
-                "error": "Cannot modify built-in schedule",
-            }), 403
+            return jsonify(
+                {
+                    "error": "Cannot modify built-in schedule",
+                }
+            ), 403
         except ScheduleValidationError as e:
             logger.warning(f"Schedule validation failed: {e}")
-            return jsonify({
-                "error": "Validation failed",
-            }), 400
+            return jsonify(
+                {
+                    "error": "Validation failed",
+                }
+            ), 400
 
         if updated is None:
-            return jsonify({
-                "error": "Failed to update schedule",
-            }), 500
+            return jsonify(
+                {
+                    "error": "Failed to update schedule",
+                }
+            ), 500
 
-        return jsonify({
-            "message": "Schedule updated",
-            "schedule": updated.to_dict(),
-        }), 200
+        return jsonify(
+            {
+                "message": "Schedule updated",
+                "schedule": updated.to_dict(),
+            }
+        ), 200
 
     except Exception as e:
         logger.error(f"Error updating schedule: {e}", exc_info=True)
-        return jsonify({
-            "error": "Internal server error",
-        }), 500
+        return jsonify(
+            {
+                "error": "Internal server error",
+            }
+        ), 500
 
 
 @scheduler_ui_bp.route("/schedules/<schedule_id>", methods=["DELETE"])
 @limiter.limit("30 per minute")
-def delete_schedule(schedule_id: str):
+def delete_schedule(schedule_id: str) -> tuple[Response, int]:
     """
     Delete a schedule.
 
@@ -565,9 +617,11 @@ def delete_schedule(schedule_id: str):
         # Check if schedule exists
         existing = service.get_schedule(schedule_id)
         if existing is None:
-            return jsonify({
-                "error": "Schedule not found",
-            }), 404
+            return jsonify(
+                {
+                    "error": "Schedule not found",
+                }
+            ), 404
 
         # Delete via service (handles built-in check)
         try:
@@ -575,25 +629,33 @@ def delete_schedule(schedule_id: str):
         except ValueError as e:
             # Built-in schedule protection
             logger.warning(f"Delete blocked for built-in schedule: {e}")
-            return jsonify({
-                "error": "Cannot delete built-in schedule",
-            }), 403
+            return jsonify(
+                {
+                    "error": "Cannot delete built-in schedule",
+                }
+            ), 403
 
         if not success:
-            return jsonify({
-                "error": "Failed to delete schedule",
-            }), 500
+            return jsonify(
+                {
+                    "error": "Failed to delete schedule",
+                }
+            ), 500
 
-        return jsonify({
-            "message": "Schedule deleted",
-            "schedule_id": schedule_id,
-        }), 200
+        return jsonify(
+            {
+                "message": "Schedule deleted",
+                "schedule_id": schedule_id,
+            }
+        ), 200
 
     except Exception as e:
         logger.error(f"Error deleting schedule: {e}", exc_info=True)
-        return jsonify({
-            "error": "Internal server error",
-        }), 500
+        return jsonify(
+            {
+                "error": "Internal server error",
+            }
+        ), 500
 
 
 # ============================================================================
@@ -603,7 +665,7 @@ def delete_schedule(schedule_id: str):
 
 @scheduler_ui_bp.route("/schedules/<schedule_id>/activate", methods=["POST"])
 @limiter.limit("10 per minute")
-def activate_schedule(schedule_id: str):
+def activate_schedule(schedule_id: str) -> tuple[Response, int]:
     """
     Activate a schedule.
 
@@ -642,18 +704,22 @@ def activate_schedule(schedule_id: str):
 
         # Require both coordinates or neither
         if lat_provided != lon_provided:
-            return jsonify({
-                "error": "Both latitude and longitude must be provided together",
-            }), 400
+            return jsonify(
+                {
+                    "error": "Both latitude and longitude must be provided together",
+                }
+            ), 400
 
         # Type validation for coordinates
         try:
             latitude = float(data["latitude"]) if lat_provided else 0.0
             longitude = float(data["longitude"]) if lon_provided else 0.0
         except (ValueError, TypeError):
-            return jsonify({
-                "error": "Coordinates must be numeric",
-            }), 400
+            return jsonify(
+                {
+                    "error": "Coordinates must be numeric",
+                }
+            ), 400
 
         timezone_name = data.get("timezone", "UTC")
 
@@ -662,16 +728,20 @@ def activate_schedule(schedule_id: str):
         if lat_provided and lon_provided:
             valid, coord_error = validate_coordinates(latitude, longitude)
             if not valid:
-                return jsonify({
-                    "error": f"Invalid coordinates: {coord_error}",
-                }), 400
+                return jsonify(
+                    {
+                        "error": f"Invalid coordinates: {coord_error}",
+                    }
+                ), 400
 
         # Validate timezone
         valid, tz_error = validate_timezone(timezone_name)
         if not valid:
-            return jsonify({
-                "error": f"Invalid timezone: {tz_error}",
-            }), 400
+            return jsonify(
+                {
+                    "error": f"Invalid timezone: {tz_error}",
+                }
+            ), 400
 
         service = get_scheduler_service()
 
@@ -687,32 +757,40 @@ def activate_schedule(schedule_id: str):
         except ScheduleConflictError as e:
             # Log conflict details, return generic message
             logger.info(f"Schedule conflict detected: {e}")
-            return jsonify({
-                "error": "Schedule conflict detected",
-                "conflict": True,
-            }), 409
+            return jsonify(
+                {
+                    "error": "Schedule conflict detected",
+                    "conflict": True,
+                }
+            ), 409
         except ScheduleActivationError as e:
             # Log detailed error, return generic message
             logger.warning(f"Schedule activation failed: {e}")
-            return jsonify({
-                "error": "Schedule activation failed",
-            }), 400
+            return jsonify(
+                {
+                    "error": "Schedule activation failed",
+                }
+            ), 400
 
-        return jsonify({
-            "message": "Schedule activated",
-            "schedule_id": schedule_id,
-        }), 200
+        return jsonify(
+            {
+                "message": "Schedule activated",
+                "schedule_id": schedule_id,
+            }
+        ), 200
 
     except Exception as e:
         logger.error(f"Error activating schedule: {e}", exc_info=True)
-        return jsonify({
-            "error": "Internal server error",
-        }), 500
+        return jsonify(
+            {
+                "error": "Internal server error",
+            }
+        ), 500
 
 
 @scheduler_ui_bp.route("/schedules/deactivate", methods=["POST"])
 @limiter.limit("10 per minute")
-def deactivate_current_schedule():
+def deactivate_current_schedule() -> tuple[Response, int]:
     """
     Deactivate the currently active schedule.
 
@@ -732,32 +810,40 @@ def deactivate_current_schedule():
         # Check if there's an active schedule
         active = service.get_active_schedule()
         if active is None:
-            return jsonify({
-                "message": "No active schedule to deactivate",
-                "was_active": False,
-                "schedule_id": None,
-            }), 200
+            return jsonify(
+                {
+                    "message": "No active schedule to deactivate",
+                    "was_active": False,
+                    "schedule_id": None,
+                }
+            ), 200
 
         # Deactivate
         success = service.deactivate_schedule()
 
         if not success:
-            return jsonify({
-                "error": "Failed to deactivate schedule",
-            }), 500
+            return jsonify(
+                {
+                    "error": "Failed to deactivate schedule",
+                }
+            ), 500
 
-        return jsonify({
-            "message": "Schedule deactivated",
-            "was_active": True,
-            "schedule_id": active.schedule_id,
-        }), 200
+        return jsonify(
+            {
+                "message": "Schedule deactivated",
+                "was_active": True,
+                "schedule_id": active.schedule_id,
+            }
+        ), 200
 
     except Exception as e:
         logger.error(f"Error deactivating schedule: {e}", exc_info=True)
-        return jsonify({
-            "error": "Internal server error",
-            "message": "Failed to deactivate schedule",
-        }), 500
+        return jsonify(
+            {
+                "error": "Internal server error",
+                "message": "Failed to deactivate schedule",
+            }
+        ), 500
 
 
 # ============================================================================
@@ -767,7 +853,7 @@ def deactivate_current_schedule():
 
 @scheduler_ui_bp.route("/schedules/<schedule_id>/validate", methods=["POST"])
 @limiter.limit("30 per minute")
-def validate_schedule_endpoint(schedule_id: str):
+def validate_schedule_endpoint(schedule_id: str) -> tuple[Response, int]:
     """
     Validate a schedule for conflicts without activating.
 
@@ -804,18 +890,22 @@ def validate_schedule_endpoint(schedule_id: str):
 
         # Require both coordinates or neither
         if lat_provided != lon_provided:
-            return jsonify({
-                "error": "Both latitude and longitude must be provided together",
-            }), 400
+            return jsonify(
+                {
+                    "error": "Both latitude and longitude must be provided together",
+                }
+            ), 400
 
         # Type validation for coordinates
         try:
             latitude = float(data["latitude"]) if lat_provided else 0.0
             longitude = float(data["longitude"]) if lon_provided else 0.0
         except (ValueError, TypeError):
-            return jsonify({
-                "error": "Coordinates must be numeric",
-            }), 400
+            return jsonify(
+                {
+                    "error": "Coordinates must be numeric",
+                }
+            ), 400
 
         timezone_name = data.get("timezone", "UTC")
 
@@ -823,18 +913,22 @@ def validate_schedule_endpoint(schedule_id: str):
         if lat_provided and lon_provided:
             valid, coord_error = validate_coordinates(latitude, longitude)
             if not valid:
-                return jsonify({
-                    "error": f"Invalid coordinates: {coord_error}",
-                }), 400
+                return jsonify(
+                    {
+                        "error": f"Invalid coordinates: {coord_error}",
+                    }
+                ), 400
 
         service = get_scheduler_service()
 
         # Check if schedule exists
         schedule = service.get_schedule(schedule_id)
         if schedule is None:
-            return jsonify({
-                "error": "Schedule not found",
-            }), 404
+            return jsonify(
+                {
+                    "error": "Schedule not found",
+                }
+            ), 404
 
         # Get cached conflict report
         report = service.get_cached_conflict_report(
@@ -849,24 +943,29 @@ def validate_schedule_endpoint(schedule_id: str):
         total_conflicts = len(report.conflicts)
         try:
             from webui.backend.lib.schedule_conflict import SEVERITY_ERROR
+
             blocking_count = len([c for c in report.conflicts if c.severity == SEVERITY_ERROR])
         except ImportError:
             blocking_count = 0
 
-        return jsonify({
-            "schedule_id": schedule_id,
-            "valid": not report.has_blocking_conflicts,
-            "has_warnings": total_conflicts > 0 and not report.has_blocking_conflicts,
-            "conflicts": [c.to_dict() for c in report.conflicts],
-            "total_conflicts": total_conflicts,
-            "blocking_conflicts": blocking_count,
-        }), 200
+        return jsonify(
+            {
+                "schedule_id": schedule_id,
+                "valid": not report.has_blocking_conflicts,
+                "has_warnings": total_conflicts > 0 and not report.has_blocking_conflicts,
+                "conflicts": [c.to_dict() for c in report.conflicts],
+                "total_conflicts": total_conflicts,
+                "blocking_conflicts": blocking_count,
+            }
+        ), 200
 
     except Exception as e:
         logger.error(f"Error validating schedule: {e}", exc_info=True)
-        return jsonify({
-            "error": "Internal server error",
-        }), 500
+        return jsonify(
+            {
+                "error": "Internal server error",
+            }
+        ), 500
 
 
 # ============================================================================
@@ -982,7 +1081,7 @@ def list_builtin_patterns() -> list[dict]:
 
 
 @scheduler_ui_bp.route("/patterns/builtin", methods=["GET"])
-def list_builtin_patterns_endpoint():
+def list_builtin_patterns_endpoint() -> tuple[Response, int]:
     """
     List all built-in event patterns.
 
@@ -1011,15 +1110,17 @@ def list_builtin_patterns_endpoint():
 
     except Exception as e:
         logger.error(f"Error listing built-in patterns: {e}", exc_info=True)
-        return jsonify({
-            "error": "Internal server error",
-            "message": "Failed to list built-in patterns",
-        }), 500
+        return jsonify(
+            {
+                "error": "Internal server error",
+                "message": "Failed to list built-in patterns",
+            }
+        ), 500
 
 
 @scheduler_ui_bp.route("/patterns/validate", methods=["POST"])
 @limiter.limit("30 per minute")
-def validate_pattern_endpoint():
+def validate_pattern_endpoint() -> tuple[Response, int]:
     """
     Validate an event pattern structure.
 
@@ -1051,56 +1152,72 @@ def validate_pattern_endpoint():
         try:
             data = request.get_json()
         except BadRequest:
-            return jsonify({
-                "valid": False,
-                "error": "Request body must be valid JSON",
-            }), 400
+            return jsonify(
+                {
+                    "valid": False,
+                    "error": "Request body must be valid JSON",
+                }
+            ), 400
 
         if data is None:
-            return jsonify({
-                "valid": False,
-                "error": "Request body must be valid JSON",
-            }), 400
+            return jsonify(
+                {
+                    "valid": False,
+                    "error": "Request body must be valid JSON",
+                }
+            ), 400
 
         if not isinstance(data, dict):
-            return jsonify({
-                "valid": False,
-                "error": "Request body must be a JSON object",
-            }), 400
+            return jsonify(
+                {
+                    "valid": False,
+                    "error": "Request body must be a JSON object",
+                }
+            ), 400
 
         # Convert dict to EventPattern for validation
         try:
             pattern = EventPattern.from_dict(data)
         except KeyError as e:
-            return jsonify({
-                "valid": False,
-                "error": f"Missing required field: {e}",
-            }), 400
+            return jsonify(
+                {
+                    "valid": False,
+                    "error": f"Missing required field: {e}",
+                }
+            ), 400
         except Exception as e:
             # Log the detailed error server-side, but return a generic message to the client
             logger.error(f"Invalid pattern structure: {e}", exc_info=True)
-            return jsonify({
-                "valid": False,
-                "error": "Invalid pattern structure",
-            }), 400
+            return jsonify(
+                {
+                    "valid": False,
+                    "error": "Invalid pattern structure",
+                }
+            ), 400
 
         # Validate using existing validation function
         valid, error = validate_event_pattern(pattern)
 
         if valid:
-            return jsonify({
-                "valid": True,
-                "pattern": pattern.to_dict(),
-            }), 200
+            return jsonify(
+                {
+                    "valid": True,
+                    "pattern": pattern.to_dict(),
+                }
+            ), 200
         else:
-            return jsonify({
-                "valid": False,
-                "error": error,
-            }), 400
+            return jsonify(
+                {
+                    "valid": False,
+                    "error": error,
+                }
+            ), 400
 
     except Exception as e:
         logger.error(f"Error validating pattern: {e}", exc_info=True)
-        return jsonify({
-            "valid": False,
-            "error": "Internal server error during validation",
-        }), 500
+        return jsonify(
+            {
+                "valid": False,
+                "error": "Internal server error during validation",
+            }
+        ), 500


### PR DESCRIPTION
## Summary
- Add 5 required built-in event patterns for the scheduler UI
- Patterns embedded in schedule JSON files (single-file storage model)
- API endpoint to list all built-in patterns with metadata

## Acceptance Criteria
- [x] uv_capture_cycle pattern (15 min UV + photo)
- [x] attract_session pattern (60 min attract lights)
- [x] flash_capture pattern (instant flash + photo)
- [x] dawn_transect pattern
- [x] dusk_transect pattern

## Test Plan
- [x] 24 unit tests passing
- [x] 21 integration tests passing
- [x] All patterns pass schema validation
- [x] API endpoint returns all 5 patterns with correct metadata

## Files Changed
- `Tests/unit/test_builtin_event_patterns.py` - 24 unit tests
- `Tests/integration/test_builtin_patterns_api.py` - 21 integration tests
- `webui/backend/presets_builtin/schedules/extended_attract_session.json` - Attract Session pattern
- `webui/backend/presets_builtin/schedules/flash_capture_survey.json` - Flash Capture pattern
- `webui/backend/presets_builtin/schedules/dawn_dusk_survey.json` - Dawn/Dusk Transect patterns