### PR TITLE
feat(scheduler): Add event pattern hooks (#222)

### DIFF
--- a/Firmware/webui/frontend/src/hooks/__tests__/useEventPatterns.test.jsx
+++ b/Firmware/webui/frontend/src/hooks/__tests__/useEventPatterns.test.jsx
@@ -1,0 +1,393 @@
+/**
+ * Tests for useEventPatterns hooks (Issue #222)
+ *
+ * Comprehensive test suite following TDD approach - tests written BEFORE implementation.
+ * Tests React Query hooks for Event Pattern operations.
+ *
+ * Reference: useSchedules.test.jsx for testing patterns
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  useBuiltinPatterns,
+  useValidatePattern,
+  usePatternDuration,
+} from '../useEventPatterns';
+import * as schedulerApi from '../../utils/schedulerApi';
+
+// Mock the API module
+vi.mock('../../utils/schedulerApi');
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false }
+    }
+  });
+  return ({ children }) => (
+    <QueryClientProvider client={queryClient}>
+      {children}
+    </QueryClientProvider>
+  );
+};
+
+// =============================================================================
+// useBuiltinPatterns Tests
+// =============================================================================
+
+describe('useBuiltinPatterns', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches built-in patterns successfully', async () => {
+    const mockBuiltinPatterns = {
+      patterns: [
+        {
+          pattern_id: 'uv-capture-cycle',
+          name: 'UV Capture Cycle',
+          category: 'built-in',
+          description: 'Turn on UV, capture photo, turn off',
+          actions: [
+            { action_type: 'gpio', action_name: 'attract_on', offset_minutes: 0 },
+            { action_type: 'camera', action_name: 'takephoto', offset_minutes: 5 },
+            { action_type: 'gpio', action_name: 'attract_off', offset_minutes: 15 }
+          ],
+          duration_minutes: 15
+        },
+        {
+          pattern_id: 'flash-capture',
+          name: 'Flash Capture',
+          category: 'built-in',
+          description: 'Use flash for capture',
+          actions: [
+            { action_type: 'gpio', action_name: 'flash_on', offset_minutes: 0 },
+            { action_type: 'camera', action_name: 'takephoto', offset_minutes: 1 },
+            { action_type: 'gpio', action_name: 'flash_off', offset_minutes: 2 }
+          ],
+          duration_minutes: 2
+        }
+      ],
+      total: 2
+    };
+
+    schedulerApi.listBuiltinPatterns.mockResolvedValue({ data: mockBuiltinPatterns });
+
+    const { result } = renderHook(() => useBuiltinPatterns(), {
+      wrapper: createWrapper()
+    });
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(mockBuiltinPatterns);
+    expect(schedulerApi.listBuiltinPatterns).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles empty patterns list', async () => {
+    schedulerApi.listBuiltinPatterns.mockResolvedValue({
+      data: { patterns: [], total: 0 }
+    });
+
+    const { result } = renderHook(() => useBuiltinPatterns(), {
+      wrapper: createWrapper()
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data.patterns).toEqual([]);
+    expect(result.current.data.total).toBe(0);
+  });
+
+  it('handles fetch error', async () => {
+    const mockError = new Error('Failed to fetch built-in patterns');
+    schedulerApi.listBuiltinPatterns.mockRejectedValue(mockError);
+
+    const { result } = renderHook(() => useBuiltinPatterns(), {
+      wrapper: createWrapper()
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toBe(mockError);
+  });
+
+  it('uses correct query key', async () => {
+    schedulerApi.listBuiltinPatterns.mockResolvedValue({
+      data: { patterns: [], total: 0 }
+    });
+
+    const { result } = renderHook(() => useBuiltinPatterns(), {
+      wrapper: createWrapper()
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    // Verify API was called (query key is internal to React Query)
+    expect(schedulerApi.listBuiltinPatterns).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts custom queryOptions', async () => {
+    schedulerApi.listBuiltinPatterns.mockResolvedValue({
+      data: { patterns: [], total: 0 }
+    });
+
+    // Test that queryOptions are passed through
+    const { result } = renderHook(
+      () => useBuiltinPatterns({ staleTime: 1000 }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(schedulerApi.listBuiltinPatterns).toHaveBeenCalledTimes(1);
+  });
+});
+
+// =============================================================================
+// useValidatePattern Tests
+// =============================================================================
+
+describe('useValidatePattern', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('validates pattern successfully', async () => {
+    const mockResponse = {
+      valid: true,
+      pattern: {
+        pattern_id: 'test-pattern',
+        name: 'Test Pattern',
+        description: 'A test pattern',
+        actions: [
+          { action_type: 'camera', action_name: 'takephoto', offset_minutes: 0 }
+        ],
+        category: 'user',
+        duration_minutes: 0
+      }
+    };
+
+    schedulerApi.validatePattern.mockResolvedValue({ data: mockResponse });
+
+    const { result } = renderHook(() => useValidatePattern(), {
+      wrapper: createWrapper()
+    });
+
+    result.current.mutate({
+      name: 'Test Pattern',
+      description: 'A test pattern',
+      actions: [
+        { action_type: 'camera', action_name: 'takephoto', offset_minutes: 0 }
+      ]
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data.data).toEqual(mockResponse);
+    expect(schedulerApi.validatePattern).toHaveBeenCalledWith({
+      name: 'Test Pattern',
+      description: 'A test pattern',
+      actions: [
+        { action_type: 'camera', action_name: 'takephoto', offset_minutes: 0 }
+      ]
+    });
+  });
+
+  it('returns validation errors for invalid pattern', async () => {
+    const mockResponse = {
+      valid: false,
+      error: 'Pattern name is required'
+    };
+
+    schedulerApi.validatePattern.mockResolvedValue({ data: mockResponse });
+
+    const { result } = renderHook(() => useValidatePattern(), {
+      wrapper: createWrapper()
+    });
+
+    result.current.mutate({
+      name: '',
+      actions: []
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data.data.valid).toBe(false);
+    expect(result.current.data.data.error).toBe('Pattern name is required');
+  });
+
+  it('handles API error', async () => {
+    const mockError = new Error('Pattern validation failed');
+    schedulerApi.validatePattern.mockRejectedValue(mockError);
+
+    const { result } = renderHook(() => useValidatePattern(), {
+      wrapper: createWrapper()
+    });
+
+    result.current.mutate({ name: 'test', actions: [] });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toBe(mockError);
+  });
+
+  it('handles missing required fields in response', async () => {
+    const mockResponse = {
+      valid: false,
+      error: 'Missing required field: name'
+    };
+
+    schedulerApi.validatePattern.mockResolvedValue({ data: mockResponse });
+
+    const { result } = renderHook(() => useValidatePattern(), {
+      wrapper: createWrapper()
+    });
+
+    result.current.mutate({ actions: [] });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data.data.valid).toBe(false);
+  });
+});
+
+// =============================================================================
+// usePatternDuration Tests
+// =============================================================================
+
+describe('usePatternDuration', () => {
+  it('returns 0 for null pattern', () => {
+    const { result } = renderHook(() => usePatternDuration(null), {
+      wrapper: createWrapper()
+    });
+
+    expect(result.current).toBe(0);
+  });
+
+  it('returns 0 for undefined pattern', () => {
+    const { result } = renderHook(() => usePatternDuration(undefined), {
+      wrapper: createWrapper()
+    });
+
+    expect(result.current).toBe(0);
+  });
+
+  it('returns 0 for pattern with no actions property', () => {
+    const { result } = renderHook(() => usePatternDuration({ name: 'test' }), {
+      wrapper: createWrapper()
+    });
+
+    expect(result.current).toBe(0);
+  });
+
+  it('returns 0 for pattern with empty actions array', () => {
+    const { result } = renderHook(
+      () => usePatternDuration({ name: 'test', actions: [] }),
+      { wrapper: createWrapper() }
+    );
+
+    expect(result.current).toBe(0);
+  });
+
+  it('calculates duration from single action', () => {
+    const pattern = {
+      name: 'Single Action',
+      actions: [
+        { action_type: 'camera', action_name: 'takephoto', offset_minutes: 10 }
+      ]
+    };
+
+    const { result } = renderHook(() => usePatternDuration(pattern), {
+      wrapper: createWrapper()
+    });
+
+    expect(result.current).toBe(10);
+  });
+
+  it('calculates max offset from multiple actions', () => {
+    const pattern = {
+      name: 'UV Capture Cycle',
+      actions: [
+        { action_type: 'gpio', action_name: 'attract_on', offset_minutes: 0 },
+        { action_type: 'camera', action_name: 'takephoto', offset_minutes: 5 },
+        { action_type: 'gpio', action_name: 'attract_off', offset_minutes: 15 }
+      ]
+    };
+
+    const { result } = renderHook(() => usePatternDuration(pattern), {
+      wrapper: createWrapper()
+    });
+
+    expect(result.current).toBe(15);
+  });
+
+  it('handles undefined offset_minutes (defaults to 0)', () => {
+    const pattern = {
+      name: 'Missing Offset',
+      actions: [
+        { action_type: 'camera', action_name: 'takephoto' },
+        { action_type: 'gpio', action_name: 'attract_on', offset_minutes: 5 }
+      ]
+    };
+
+    const { result } = renderHook(() => usePatternDuration(pattern), {
+      wrapper: createWrapper()
+    });
+
+    expect(result.current).toBe(5);
+  });
+
+  it('memoizes result correctly - same pattern returns same value', () => {
+    const pattern = {
+      name: 'Test Pattern',
+      actions: [
+        { action_type: 'camera', action_name: 'takephoto', offset_minutes: 10 }
+      ]
+    };
+
+    const { result, rerender } = renderHook(
+      ({ pattern }) => usePatternDuration(pattern),
+      { wrapper: createWrapper(), initialProps: { pattern } }
+    );
+
+    const firstResult = result.current;
+
+    // Rerender with same pattern object
+    rerender({ pattern });
+
+    expect(result.current).toBe(firstResult);
+    expect(result.current).toBe(10);
+  });
+});

--- a/Firmware/webui/frontend/src/hooks/__tests__/useEventPatterns.test.jsx
+++ b/Firmware/webui/frontend/src/hooks/__tests__/useEventPatterns.test.jsx
@@ -17,6 +17,7 @@ import {
   usePatternDuration,
 } from '../useEventPatterns';
 import * as schedulerApi from '../../utils/schedulerApi';
+import { QUERY_KEYS } from '../../utils/queryKeys';
 
 // Mock the API module
 vi.mock('../../utils/schedulerApi');
@@ -128,20 +129,35 @@ describe('useBuiltinPatterns', () => {
   });
 
   it('uses correct query key', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false }
+      }
+    });
+
     schedulerApi.listBuiltinPatterns.mockResolvedValue({
       data: { patterns: [], total: 0 }
     });
 
-    const { result } = renderHook(() => useBuiltinPatterns(), {
-      wrapper: createWrapper()
-    });
+    const wrapper = ({ children }) => (
+      <QueryClientProvider client={queryClient}>
+        {children}
+      </QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useBuiltinPatterns(), { wrapper });
 
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true);
     });
 
-    // Verify API was called (query key is internal to React Query)
-    expect(schedulerApi.listBuiltinPatterns).toHaveBeenCalledTimes(1);
+    // Verify the correct query key is used in the cache
+    const cachedQueries = queryClient.getQueryCache().findAll({
+      queryKey: QUERY_KEYS.BUILTIN_PATTERNS
+    });
+    expect(cachedQueries).toHaveLength(1);
+    expect(cachedQueries[0].queryKey).toEqual(QUERY_KEYS.BUILTIN_PATTERNS);
   });
 
   it('accepts custom queryOptions', async () => {

--- a/Firmware/webui/frontend/src/hooks/__tests__/useSchedules.test.jsx
+++ b/Firmware/webui/frontend/src/hooks/__tests__/useSchedules.test.jsx
@@ -104,7 +104,7 @@ describe('useSchedules', () => {
         {
           id: 'sunset_moths',
           name: 'Sunset Moths',
-          category: 'builtin',
+          category: 'built-in',
           events: []
         }
       ],
@@ -538,14 +538,14 @@ describe('useBuiltinSchedules', () => {
         {
           id: 'sunset_moths',
           name: 'Sunset Moths',
-          category: 'builtin',
+          category: 'built-in',
           description: 'Capture moths at dusk',
           events: []
         },
         {
           id: 'hourly_survey',
           name: 'Hourly Survey',
-          category: 'builtin',
+          category: 'built-in',
           description: 'Take photos every hour',
           events: []
         }

--- a/Firmware/webui/frontend/src/hooks/__tests__/useSchedules.test.jsx
+++ b/Firmware/webui/frontend/src/hooks/__tests__/useSchedules.test.jsx
@@ -4,6 +4,8 @@
  * Comprehensive test suite following TDD approach - tests written BEFORE implementation.
  * Tests React Query hooks for Scheduler UI API integration.
  *
+ * Event pattern hook tests are in useEventPatterns.test.jsx (Issue #222).
+ *
  * Reference: useDeployments.test.jsx for testing patterns
  */
 
@@ -17,14 +19,12 @@ import {
   useActiveSchedule,
   useSchedulePreview,
   useBuiltinSchedules,
-  useBuiltinPatterns,
   useCreateSchedule,
   useUpdateSchedule,
   useDeleteSchedule,
   useActivateSchedule,
   useDeactivateSchedule,
   useValidateSchedule,
-  useValidatePattern
 } from '../useSchedules';
 import * as schedulerApi from '../../utils/schedulerApi';
 
@@ -583,65 +583,7 @@ describe('useBuiltinSchedules', () => {
   });
 });
 
-describe('useBuiltinPatterns', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it('fetches built-in patterns successfully', async () => {
-    const mockBuiltinPatterns = {
-      patterns: [
-        {
-          id: 'hourly_interval',
-          name: 'Hourly Interval',
-          category: 'builtin',
-          description: 'Take photos every hour',
-          events: []
-        },
-        {
-          id: 'sunset_offset',
-          name: 'Sunset Offset',
-          category: 'builtin',
-          description: 'Trigger relative to sunset',
-          events: []
-        }
-      ],
-      total: 2
-    };
-
-    schedulerApi.listBuiltinPatterns.mockResolvedValue({ data: mockBuiltinPatterns });
-
-    const { result } = renderHook(() => useBuiltinPatterns(), {
-      wrapper: createWrapper()
-    });
-
-    await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true);
-    });
-
-    expect(result.current.data).toEqual(mockBuiltinPatterns);
-    expect(schedulerApi.listBuiltinPatterns).toHaveBeenCalledTimes(1);
-  });
-
-  it('handles fetch error', async () => {
-    const mockError = new Error('Failed to fetch built-in patterns');
-    schedulerApi.listBuiltinPatterns.mockRejectedValue(mockError);
-
-    const { result } = renderHook(() => useBuiltinPatterns(), {
-      wrapper: createWrapper()
-    });
-
-    await waitFor(() => {
-      expect(result.current.isError).toBe(true);
-    });
-
-    expect(result.current.error).toBe(mockError);
-  });
-});
+// Note: useBuiltinPatterns tests are in useEventPatterns.test.jsx (Issue #222)
 
 describe('useCreateSchedule', () => {
   beforeEach(() => {
@@ -1200,87 +1142,4 @@ describe('useValidateSchedule', () => {
   });
 });
 
-describe('useValidatePattern', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it('validates pattern successfully', async () => {
-    const mockResponse = {
-      valid: true,
-      errors: [],
-      warnings: []
-    };
-
-    schedulerApi.validatePattern.mockResolvedValue({ data: mockResponse });
-
-    const { result } = renderHook(() => useValidatePattern(), {
-      wrapper: createWrapper()
-    });
-
-    result.current.mutate({
-      name: 'evening_capture',
-      action: 'take_photo',
-      trigger: { type: 'solar', solar_event: 'sunset', offset_minutes: 30 }
-    });
-
-    await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true);
-    });
-
-    expect(result.current.data.data).toEqual(mockResponse);
-    expect(schedulerApi.validatePattern).toHaveBeenCalledWith({
-      name: 'evening_capture',
-      action: 'take_photo',
-      trigger: { type: 'solar', solar_event: 'sunset', offset_minutes: 30 }
-    });
-  });
-
-  it('returns validation errors for invalid pattern', async () => {
-    const mockResponse = {
-      valid: false,
-      errors: ['Invalid trigger type'],
-      warnings: []
-    };
-
-    schedulerApi.validatePattern.mockResolvedValue({ data: mockResponse });
-
-    const { result } = renderHook(() => useValidatePattern(), {
-      wrapper: createWrapper()
-    });
-
-    result.current.mutate({
-      name: 'bad_pattern',
-      action: 'take_photo',
-      trigger: { type: 'invalid' }
-    });
-
-    await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true);
-    });
-
-    expect(result.current.data.data.valid).toBe(false);
-    expect(result.current.data.data.errors).toContain('Invalid trigger type');
-  });
-
-  it('handles API error', async () => {
-    const mockError = new Error('Pattern validation failed');
-    schedulerApi.validatePattern.mockRejectedValue(mockError);
-
-    const { result } = renderHook(() => useValidatePattern(), {
-      wrapper: createWrapper()
-    });
-
-    result.current.mutate({ name: 'test', action: 'take_photo', trigger: {} });
-
-    await waitFor(() => {
-      expect(result.current.isError).toBe(true);
-    });
-
-    expect(result.current.error).toBe(mockError);
-  });
-});
+// Note: useValidatePattern tests are in useEventPatterns.test.jsx (Issue #222)

--- a/Firmware/webui/frontend/src/hooks/useEventPatterns.js
+++ b/Firmware/webui/frontend/src/hooks/useEventPatterns.js
@@ -153,22 +153,32 @@ export function useValidatePattern() {
  * - Checking if patterns fit within time windows
  * - Scheduling calculations
  *
- * @param {Object|null} pattern - Event pattern object
+ * **Performance Note:** This hook uses useMemo with the pattern object as a
+ * dependency. If the parent component creates a new pattern object on each
+ * render (even with the same data), useMemo will recalculate because the
+ * object reference changes. To prevent unnecessary recalculations, callers
+ * should memoize the pattern object.
+ *
+ * @param {Object|null} pattern - Event pattern object (should be memoized)
  * @param {Array} [pattern.actions] - Array of action objects with offset_minutes
  * @returns {number} Maximum offset in minutes, or 0 if no actions
  *
  * @example
- * const pattern = {
+ * // Good: Pattern is memoized, duration only recalculates when data changes
+ * const pattern = useMemo(() => ({
  *   name: 'UV Capture Cycle',
  *   actions: [
  *     { action_type: 'gpio', action_name: 'attract_on', offset_minutes: 0 },
  *     { action_type: 'camera', action_name: 'takephoto', offset_minutes: 5 },
  *     { action_type: 'gpio', action_name: 'attract_off', offset_minutes: 15 }
  *   ]
- * }
+ * }), [])
+ * const duration = usePatternDuration(pattern) // "15"
  *
- * const duration = usePatternDuration(pattern)
- * console.log(`Pattern takes ${duration} minutes`) // "Pattern takes 15 minutes"
+ * @example
+ * // Also good: Pattern comes from React Query (already stable reference)
+ * const { data } = useBuiltinPatterns()
+ * const duration = usePatternDuration(data?.patterns?.[0])
  */
 export function usePatternDuration(pattern) {
   return useMemo(() => {

--- a/Firmware/webui/frontend/src/hooks/useEventPatterns.js
+++ b/Firmware/webui/frontend/src/hooks/useEventPatterns.js
@@ -1,0 +1,180 @@
+/**
+ * React Query hooks for Event Pattern operations (Issue #222)
+ *
+ * Provides hooks for managing event patterns:
+ * - useBuiltinPatterns: List built-in event patterns
+ * - useValidatePattern: Validate event pattern configuration
+ * - usePatternDuration: Calculate pattern duration from actions
+ *
+ * Naming Convention:
+ * - Query hooks: use<Resource> (e.g., useBuiltinPatterns)
+ * - Mutation hooks: use<Action><Resource> (e.g., useValidatePattern)
+ * - Utility hooks: use<Utility> (e.g., usePatternDuration)
+ *
+ * Query Options:
+ * All query hooks accept an optional queryOptions parameter to customize React Query behavior
+ * (e.g., refetchInterval, onSuccess, onError). These are spread after the default options.
+ */
+
+import { useMemo } from 'react'
+import { useQuery, useMutation } from '@tanstack/react-query'
+import { QUERY_KEYS } from '../utils/queryKeys'
+import {
+  listBuiltinPatterns,
+  validatePattern,
+} from '../utils/schedulerApi'
+
+// =============================================================================
+// Configuration
+// =============================================================================
+
+/**
+ * Query cache configuration for event pattern data.
+ *
+ * STALE_TIME (5 min): How long data is considered "fresh" before refetching.
+ * Built-in patterns are static (loaded from disk), so 5 minutes is appropriate.
+ */
+const QUERY_CONFIG = {
+  STALE_TIME: 5 * 60 * 1000, // 5 minutes
+}
+
+/**
+ * Centralized mutation error handler for development debugging.
+ *
+ * Logs errors to console in development mode only. In production,
+ * errors are surfaced via React Query's isError/error properties.
+ *
+ * @param {Error} error - The error from the mutation
+ * @param {string} operation - Name of the operation for context
+ */
+function handleMutationError(error, operation) {
+  if (import.meta.env.DEV) {
+    console.error(`[EventPattern ${operation}]:`, error.message || error)
+  }
+}
+
+// =============================================================================
+// Query Hooks
+// =============================================================================
+
+/**
+ * List built-in event patterns
+ *
+ * Fetches pre-defined event patterns extracted from built-in schedules.
+ * Built-in patterns are read-only templates that can be used when creating
+ * new schedules or understanding common pattern structures.
+ *
+ * @param {Object} [queryOptions] - React Query options (refetchInterval, onSuccess, etc.)
+ * @returns {Object} React Query result
+ * @returns {Object} data - { patterns: [...], total, warnings }
+ * @returns {boolean} isLoading - Whether initial query is loading
+ * @returns {boolean} isError - Whether an error occurred
+ * @returns {Object} error - Error object if query failed
+ *
+ * @example
+ * const { data, isLoading } = useBuiltinPatterns()
+ * if (data) {
+ *   console.log(`${data.total} built-in patterns`)
+ *   data.patterns.forEach(p => console.log(p.name))
+ * }
+ */
+export function useBuiltinPatterns(queryOptions = {}) {
+  return useQuery({
+    queryKey: QUERY_KEYS.BUILTIN_PATTERNS,
+    queryFn: async () => {
+      const response = await listBuiltinPatterns()
+      return response.data
+    },
+    staleTime: QUERY_CONFIG.STALE_TIME,
+    ...queryOptions,
+  })
+}
+
+// =============================================================================
+// Mutation Hooks
+// =============================================================================
+
+/**
+ * Validate event pattern mutation
+ *
+ * Validates a pattern structure without saving it. Useful for providing
+ * real-time validation feedback in pattern builder UIs.
+ *
+ * @returns {Object} React Query mutation result
+ * @returns {Function} mutate - Mutation function (fire and forget)
+ * @returns {Function} mutateAsync - Async mutation function (returns promise)
+ * @returns {boolean} isPending - Whether mutation is in progress
+ * @returns {boolean} isError - Whether mutation failed
+ * @returns {Object} error - Error object if mutation failed
+ * @returns {Object} data - Response data on success { valid, pattern?, error? }
+ *
+ * @example
+ * const { mutate, isPending, data } = useValidatePattern()
+ *
+ * const handleValidate = () => {
+ *   mutate({
+ *     name: 'UV Capture Cycle',
+ *     description: 'Turn on UV, capture, turn off',
+ *     actions: [
+ *       { action_type: 'gpio', action_name: 'attract_on', offset_minutes: 0 },
+ *       { action_type: 'camera', action_name: 'takephoto', offset_minutes: 5 },
+ *       { action_type: 'gpio', action_name: 'attract_off', offset_minutes: 15 }
+ *     ]
+ *   }, {
+ *     onSuccess: (response) => {
+ *       if (response.data.valid) {
+ *         console.log('Pattern is valid!')
+ *       } else {
+ *         console.error('Validation error:', response.data.error)
+ *       }
+ *     }
+ *   })
+ * }
+ */
+export function useValidatePattern() {
+  return useMutation({
+    mutationFn: (data) => validatePattern(data),
+    onError: (error) => handleMutationError(error, 'validatePattern'),
+  })
+}
+
+// =============================================================================
+// Utility Hooks
+// =============================================================================
+
+/**
+ * Calculate the total duration of a pattern based on action offsets
+ *
+ * Returns the maximum offset_minutes value from all actions in the pattern.
+ * This represents how long the pattern takes to complete from start to finish.
+ *
+ * Useful for:
+ * - Displaying pattern duration in UI
+ * - Checking if patterns fit within time windows
+ * - Scheduling calculations
+ *
+ * @param {Object|null} pattern - Event pattern object
+ * @param {Array} [pattern.actions] - Array of action objects with offset_minutes
+ * @returns {number} Maximum offset in minutes, or 0 if no actions
+ *
+ * @example
+ * const pattern = {
+ *   name: 'UV Capture Cycle',
+ *   actions: [
+ *     { action_type: 'gpio', action_name: 'attract_on', offset_minutes: 0 },
+ *     { action_type: 'camera', action_name: 'takephoto', offset_minutes: 5 },
+ *     { action_type: 'gpio', action_name: 'attract_off', offset_minutes: 15 }
+ *   ]
+ * }
+ *
+ * const duration = usePatternDuration(pattern)
+ * console.log(`Pattern takes ${duration} minutes`) // "Pattern takes 15 minutes"
+ */
+export function usePatternDuration(pattern) {
+  return useMemo(() => {
+    if (!pattern?.actions?.length) return 0
+    return Math.max(...pattern.actions.map(a => a.offset_minutes ?? 0))
+  }, [pattern])
+}
+
+export default useBuiltinPatterns

--- a/Firmware/webui/frontend/src/hooks/useSchedules.js
+++ b/Firmware/webui/frontend/src/hooks/useSchedules.js
@@ -7,14 +7,17 @@
  * - useActiveSchedule: Get active schedule
  * - useSchedulePreview: Get schedule preview
  * - useBuiltinSchedules: List built-in schedules
- * - useBuiltinPatterns: List built-in patterns
  * - useCreateSchedule: Create new schedule
  * - useUpdateSchedule: Update existing schedule
  * - useDeleteSchedule: Delete schedule
  * - useActivateSchedule: Activate schedule
  * - useDeactivateSchedule: Deactivate schedule
  * - useValidateSchedule: Validate schedule configuration
+ *
+ * Event Pattern hooks are in useEventPatterns.js (Issue #222):
+ * - useBuiltinPatterns: List built-in patterns
  * - useValidatePattern: Validate event pattern
+ * - usePatternDuration: Calculate pattern duration
  *
  * Naming Convention:
  * - Query hooks: use<Resource> (e.g., useSchedules, useSchedule)
@@ -35,14 +38,12 @@ import {
   getActiveSchedule,
   getSchedulePreview,
   listBuiltinSchedules,
-  listBuiltinPatterns,
   createSchedule,
   updateSchedule,
   deleteSchedule,
   activateSchedule,
   deactivateSchedule,
   validateSchedule,
-  validatePattern,
 } from '../utils/schedulerApi'
 
 // =============================================================================
@@ -258,35 +259,6 @@ export function useBuiltinSchedules(queryOptions = {}) {
       return response.data
     },
     staleTime: QUERY_CONFIG.STALE_TIME, // 5 minutes - built-in schedules are static
-    ...queryOptions,
-  })
-}
-
-/**
- * List built-in event patterns
- *
- * @param {Object} [queryOptions] - React Query options (refetchInterval, onSuccess, etc.)
- * @returns {Object} React Query result
- * @returns {Object} data - { patterns: [...], total }
- * @returns {boolean} isLoading - Whether initial query is loading
- * @returns {boolean} isError - Whether an error occurred
- * @returns {Object} error - Error object if query failed
- *
- * @example
- * const { data, isLoading } = useBuiltinPatterns()
- * if (data) {
- *   console.log(`${data.total} built-in patterns`)
- *   data.patterns.forEach(p => console.log(p.name))
- * }
- */
-export function useBuiltinPatterns(queryOptions = {}) {
-  return useQuery({
-    queryKey: QUERY_KEYS.BUILTIN_PATTERNS,
-    queryFn: async () => {
-      const response = await listBuiltinPatterns()
-      return response.data
-    },
-    staleTime: QUERY_CONFIG.STALE_TIME, // 5 minutes - built-in patterns are static
     ...queryOptions,
   })
 }
@@ -539,20 +511,11 @@ export function useValidateSchedule() {
   })
 }
 
-/**
- * Validate event pattern mutation
- *
- * @returns {Object} React Query mutation result
- *
- * @example
- * const { mutate, isPending } = useValidatePattern()
- * mutate({ name: 'test', action: 'take_photo', trigger: {...} })
- */
-export function useValidatePattern() {
-  return useMutation({
-    mutationFn: (data) => validatePattern(data),
-    onError: (error) => handleMutationError(error, 'validatePattern'),
-  })
-}
-
 export default useSchedules
+
+// =============================================================================
+// Re-exports for backward compatibility (Issue #222)
+// =============================================================================
+// Pattern hooks have been moved to useEventPatterns.js
+// These re-exports maintain backward compatibility for existing imports
+export { useBuiltinPatterns, useValidatePattern } from './useEventPatterns'

--- a/Firmware/webui/frontend/src/utils/schedulerApi.js
+++ b/Firmware/webui/frontend/src/utils/schedulerApi.js
@@ -266,10 +266,12 @@ export const validateSchedule = (id, data) =>
  * Response: {
  *   schedules: [
  *     {
- *       id: "sunset_moths",
+ *       schedule_id: "sunset_moths",
  *       name: "Sunset Moths",
  *       description: "Capture moths at dusk",
- *       category: "builtin",
+ *       trigger_type: "solar",
+ *       enabled: true,
+ *       is_active: false,
  *       ...
  *     },
  *     ...
@@ -288,16 +290,18 @@ export const listBuiltinSchedules = () =>
  * Response: {
  *   patterns: [
  *     {
- *       id: "hourly_interval",
- *       name: "Hourly Interval",
- *       description: "Take photos every hour",
- *       category: "builtin",
- *       events: [...],
+ *       pattern_id: "uv_capture_cycle",
+ *       name: "UV Capture Cycle",
+ *       description: "Turn on UV, capture photo, turn off",
+ *       category: "built-in",
+ *       actions: [...],
+ *       source_schedule: "Nightly Moth Survey",
+ *       duration_minutes: 15,
  *       ...
  *     },
  *     ...
  *   ],
- *   total: 5
+ *   warnings: []
  * }
  */
 export const listBuiltinPatterns = () =>


### PR DESCRIPTION
## Summary

- Create `useEventPatterns.js` with React Query hooks for event pattern operations
- Extract pattern hooks from `useSchedules.js` to dedicated file with backward compatibility
- Add 17 unit tests following TDD workflow

### New Hooks
| Hook | Type | Description |
|------|------|-------------|
| `useBuiltinPatterns` | Query | List built-in event patterns |
| `useValidatePattern` | Mutation | Validate event pattern configuration |
| `usePatternDuration` | Utility | Calculate pattern duration from actions |

### Files Changed
- **New**: `webui/frontend/src/hooks/useEventPatterns.js`
- **New**: `webui/frontend/src/hooks/__tests__/useEventPatterns.test.jsx`
- **Modified**: `webui/frontend/src/hooks/useSchedules.js` (add re-exports)
- **Modified**: `webui/frontend/src/hooks/__tests__/useSchedules.test.jsx` (move tests)

## Test plan
- [x] 17 new tests in useEventPatterns.test.jsx passing
- [x] 38 existing tests in useSchedules.test.jsx passing
- [x] Re-exports maintain backward compatibility
- [x] ESLint passes without new errors

Closes #222