### PR TITLE
refactor(scheduler): Extract shared PropTypes to dedicated module (#262)

### DIFF
--- a/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/EventPatternSelector.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/EventPatternSelector.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { PatternList } from '../PatternLibrary';
 import { PatternEditor } from '../PatternEditor';
+import { PatternSelectionPropType } from './propTypes';
 
 /**
  * EventPatternSelector Component
@@ -218,28 +219,8 @@ const EventPatternSelector = ({
   );
 };
 
-/** PropTypes shape for action in a pattern */
-const ActionPropType = PropTypes.shape({
-  action_id: PropTypes.string,
-  type: PropTypes.string.isRequired,
-  parameters: PropTypes.object,
-});
-
-/** PropTypes shape for pattern */
-const PatternPropType = PropTypes.shape({
-  pattern_id: PropTypes.string,
-  name: PropTypes.string.isRequired,
-  description: PropTypes.string,
-  actions: PropTypes.arrayOf(ActionPropType).isRequired,
-  category: PropTypes.string,
-  tags: PropTypes.arrayOf(PropTypes.string),
-});
-
 EventPatternSelector.propTypes = {
-  value: PropTypes.shape({
-    source: PropTypes.oneOf(['library', 'custom']),
-    pattern: PatternPropType,
-  }),
+  value: PatternSelectionPropType,
   onChange: PropTypes.func.isRequired,
   disabled: PropTypes.bool,
   errors: PropTypes.shape({

--- a/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/PreviewSection.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/PreviewSection.jsx
@@ -1,5 +1,10 @@
 import { useMemo } from 'react';
 import PropTypes from 'prop-types';
+import {
+  TriggerPropType,
+  PatternPropType,
+  DateRangePropType,
+} from './propTypes';
 
 /**
  * Format interval for display
@@ -27,7 +32,10 @@ const formatInterval = (minutes) => {
 const getTriggerSummaryText = (trigger) => {
   if (!trigger) return null;
 
-  switch (trigger.type) {
+  // Use trigger_type (standardized field name)
+  const triggerType = trigger.trigger_type;
+
+  switch (triggerType) {
     case 'interval':
       return `Every ${formatInterval(trigger.interval_minutes)} from ${trigger.time_window?.start_time || ''} to ${trigger.time_window?.end_time || ''}`;
 
@@ -46,13 +54,13 @@ const getTriggerSummaryText = (trigger) => {
       if (trigger.days_of_week && trigger.days_of_week.length < 7) {
         const dayNames = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
         const days = trigger.days_of_week.map(d => dayNames[d]).join(', ');
-        return `At ${trigger.time} on ${days}`;
+        return `At ${trigger.time_of_day} on ${days}`;
       }
-      return `Daily at ${trigger.time}`;
+      return `Daily at ${trigger.time_of_day}`;
 
     case 'moon_phase': {
-      const phase = trigger.phase?.replace(/_/g, ' ') || 'moon phase';
-      return `At ${trigger.time || 'sunset'} on ${phase}`;
+      const phase = trigger.moon_phase?.replace(/_/g, ' ') || 'moon phase';
+      return `At ${trigger.time_of_day || 'sunset'} on ${phase}`;
     }
 
     case 'sensor':
@@ -270,7 +278,7 @@ const PreviewSection = ({
       )}
 
       {/* Execution Preview */}
-      {trigger && pattern && trigger.type !== 'sensor' && (
+      {trigger && pattern && trigger.trigger_type !== 'sensor' && (
         <div>
           <p className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
             Example Executions:
@@ -298,58 +306,9 @@ const PreviewSection = ({
   );
 };
 
-/** PropTypes shape for time window configuration */
-const TimeWindowPropType = PropTypes.shape({
-  start_time: PropTypes.string,
-  end_time: PropTypes.string,
-  start_offset_minutes: PropTypes.number,
-  end_offset_minutes: PropTypes.number,
-});
-
-/** PropTypes shape for trigger configuration */
-const TriggerPropType = PropTypes.shape({
-  type: PropTypes.oneOf(['interval', 'solar', 'moon_phase', 'fixed_time', 'sensor']),
-  // Interval trigger
-  interval_minutes: PropTypes.number,
-  time_window: TimeWindowPropType,
-  // Solar trigger
-  solar_event: PropTypes.string,
-  offset_minutes: PropTypes.number,
-  // Fixed time trigger
-  time: PropTypes.string,
-  // Moon phase trigger
-  phase: PropTypes.string,
-  offset_days: PropTypes.number,
-  // Common
-  days_of_week: PropTypes.arrayOf(PropTypes.number),
-  // Sensor trigger
-  sensor_type: PropTypes.string,
-  threshold: PropTypes.number,
-});
-
-/** PropTypes shape for action in a pattern */
-const ActionPropType = PropTypes.shape({
-  action_id: PropTypes.string,
-  type: PropTypes.string.isRequired,
-  parameters: PropTypes.object,
-});
-
-/** PropTypes shape for pattern configuration */
-const PatternPropType = PropTypes.shape({
-  pattern_id: PropTypes.string,
-  name: PropTypes.string.isRequired,
-  description: PropTypes.string,
-  actions: PropTypes.arrayOf(ActionPropType).isRequired,
-  category: PropTypes.string,
-  tags: PropTypes.arrayOf(PropTypes.string),
-});
-
 PreviewSection.propTypes = {
   trigger: TriggerPropType,
-  dateRange: PropTypes.shape({
-    start_date: PropTypes.string,
-    end_date: PropTypes.string,
-  }),
+  dateRange: DateRangePropType,
   pattern: PatternPropType,
   disabled: PropTypes.bool,
 };

--- a/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/ScheduleEditor.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/ScheduleEditor.jsx
@@ -5,6 +5,7 @@ import EventPatternSelector from './EventPatternSelector';
 import DateRangeSection from './DateRangeSection';
 import PreviewSection from './PreviewSection';
 import { TRIGGER_DEFAULTS, SCHEDULE_LIMITS } from './constants';
+import { TriggerPropType, PatternPropType, DateRangePropType } from './propTypes';
 
 /** Delay before focusing name input to allow drawer animation to start */
 const FOCUS_DELAY_MS = 100;
@@ -508,50 +509,6 @@ const ScheduleEditor = ({
   );
 };
 
-/** PropTypes shape for trigger configuration */
-const TriggerPropType = PropTypes.shape({
-  trigger_type: PropTypes.oneOf(['interval', 'solar', 'moon_phase', 'fixed_time', 'sensor']),
-  // Interval trigger
-  interval_minutes: PropTypes.number,
-  time_window: PropTypes.shape({
-    start_time: PropTypes.string,
-    end_time: PropTypes.string,
-    start_offset_minutes: PropTypes.number,
-    end_offset_minutes: PropTypes.number,
-  }),
-  // Solar trigger
-  solar_event: PropTypes.string,
-  offset_minutes: PropTypes.number,
-  // Moon phase trigger
-  moon_phase: PropTypes.string,
-  time_of_day: PropTypes.string,
-  offset_days: PropTypes.number,
-  // Sensor trigger
-  sensor_type: PropTypes.string,
-  comparison: PropTypes.string,
-  threshold: PropTypes.number,
-  cooldown_minutes: PropTypes.number,
-  // Common
-  days_of_week: PropTypes.arrayOf(PropTypes.number),
-});
-
-/** PropTypes shape for action in a pattern */
-const ActionPropType = PropTypes.shape({
-  action_id: PropTypes.string,
-  type: PropTypes.string.isRequired,
-  parameters: PropTypes.object,
-});
-
-/** PropTypes shape for event pattern */
-const PatternPropType = PropTypes.shape({
-  pattern_id: PropTypes.string,
-  name: PropTypes.string.isRequired,
-  description: PropTypes.string,
-  actions: PropTypes.arrayOf(ActionPropType).isRequired,
-  category: PropTypes.string,
-  tags: PropTypes.arrayOf(PropTypes.string),
-});
-
 ScheduleEditor.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   schedule: PropTypes.shape({
@@ -560,10 +517,7 @@ ScheduleEditor.propTypes = {
     description: PropTypes.string,
     trigger: TriggerPropType,
     event_patterns: PropTypes.arrayOf(PatternPropType),
-    date_range: PropTypes.shape({
-      start_date: PropTypes.string,
-      end_date: PropTypes.string,
-    }),
+    date_range: DateRangePropType,
   }),
   onSave: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,

--- a/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/TriggerForm.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/TriggerForm.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import { TRIGGER_TYPES, TRIGGER_DEFAULTS } from './constants';
+import { TimeWindowPropType, TriggerErrorsPropType } from './propTypes';
 import IntervalTriggerForm from './IntervalTriggerForm';
 import SolarTriggerForm from './SolarTriggerForm';
 import MoonPhaseTriggerForm from './MoonPhaseTriggerForm';
@@ -143,31 +144,6 @@ const TriggerForm = ({
     </div>
   );
 };
-
-/** PropTypes shape for time window configuration */
-const TimeWindowPropType = PropTypes.shape({
-  start_time: PropTypes.string,
-  end_time: PropTypes.string,
-  start_offset_minutes: PropTypes.number,
-  end_offset_minutes: PropTypes.number,
-});
-
-/** PropTypes shape for trigger errors */
-const TriggerErrorsPropType = PropTypes.shape({
-  trigger_type: PropTypes.string,
-  interval_minutes: PropTypes.string,
-  time_window: PropTypes.object,
-  solar_event: PropTypes.string,
-  offset_minutes: PropTypes.string,
-  moon_phase: PropTypes.string,
-  time_of_day: PropTypes.string,
-  offset_days: PropTypes.string,
-  sensor_type: PropTypes.string,
-  comparison: PropTypes.string,
-  threshold: PropTypes.string,
-  cooldown_minutes: PropTypes.string,
-  days_of_week: PropTypes.string,
-});
 
 TriggerForm.propTypes = {
   value: PropTypes.shape({

--- a/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/__tests__/PreviewSection.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/__tests__/PreviewSection.test.jsx
@@ -18,7 +18,7 @@ describe('PreviewSection', () => {
   };
 
   const mockIntervalTrigger = {
-    type: 'interval',
+    trigger_type: 'interval',
     interval_minutes: 60,
     time_window: {
       start_time: '21:00',
@@ -30,15 +30,15 @@ describe('PreviewSection', () => {
   };
 
   const mockSolarTrigger = {
-    type: 'solar',
+    trigger_type: 'solar',
     solar_event: 'sunset',
     offset_minutes: 30,
     days_of_week: [0, 1, 2, 3, 4], // Mon-Fri
   };
 
   const mockFixedTimeTrigger = {
-    type: 'fixed_time',
-    time: '21:00',
+    trigger_type: 'fixed_time',
+    time_of_day: '21:00',
     days_of_week: null,
   };
 
@@ -342,7 +342,8 @@ describe('PreviewSection', () => {
 
     it('shows days of week when specified', () => {
       const weekdayTrigger = {
-        ...mockFixedTimeTrigger,
+        trigger_type: 'fixed_time',
+        time_of_day: '21:00',
         days_of_week: [0, 1, 2, 3, 4], // Mon-Fri
       };
 
@@ -571,7 +572,7 @@ describe('PreviewSection', () => {
 
     it('handles sensor trigger type (not supported for preview)', () => {
       const sensorTrigger = {
-        type: 'sensor',
+        trigger_type: 'sensor',
         sensor_type: 'light_level',
         threshold: 100,
       };
@@ -590,10 +591,10 @@ describe('PreviewSection', () => {
 
     it('handles moon_phase trigger type', () => {
       const moonTrigger = {
-        type: 'moon_phase',
-        phase: 'full_moon',
+        trigger_type: 'moon_phase',
+        moon_phase: 'full_moon',
         offset_days: 0,
-        time: '21:00',
+        time_of_day: '21:00',
       };
 
       render(

--- a/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/__tests__/propTypes.test.js
+++ b/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/__tests__/propTypes.test.js
@@ -1,0 +1,350 @@
+/**
+ * Tests for shared PropTypes module (Issue #262)
+ *
+ * Verifies that all PropTypes are properly exported and validate
+ * expected data structures.
+ */
+
+import PropTypes from 'prop-types';
+import {
+  TimeWindowPropType,
+  TriggerErrorsPropType,
+  TriggerPropType,
+  ActionPropType,
+  PatternPropType,
+  DateRangePropType,
+  PatternSelectionPropType,
+  SchedulePropType,
+} from '../propTypes';
+
+// Helper to test PropTypes validation
+// PropTypes.checkPropTypes returns undefined if valid, logs warning if invalid
+const checkPropType = (propType, value, propName = 'testProp') => {
+  const props = { [propName]: value };
+  const propTypes = { [propName]: propType };
+
+  // Capture console.error to detect PropTypes warnings
+  const originalError = console.error;
+  let errorMessage = null;
+  console.error = (msg) => {
+    errorMessage = msg;
+  };
+
+  PropTypes.checkPropTypes(propTypes, props, propName, 'TestComponent');
+
+  console.error = originalError;
+  return errorMessage;
+};
+
+describe('propTypes exports', () => {
+  it('exports TimeWindowPropType', () => {
+    expect(TimeWindowPropType).toBeDefined();
+  });
+
+  it('exports TriggerErrorsPropType', () => {
+    expect(TriggerErrorsPropType).toBeDefined();
+  });
+
+  it('exports TriggerPropType', () => {
+    expect(TriggerPropType).toBeDefined();
+  });
+
+  it('exports ActionPropType', () => {
+    expect(ActionPropType).toBeDefined();
+  });
+
+  it('exports PatternPropType', () => {
+    expect(PatternPropType).toBeDefined();
+  });
+
+  it('exports DateRangePropType', () => {
+    expect(DateRangePropType).toBeDefined();
+  });
+
+  it('exports PatternSelectionPropType', () => {
+    expect(PatternSelectionPropType).toBeDefined();
+  });
+
+  it('exports SchedulePropType', () => {
+    expect(SchedulePropType).toBeDefined();
+  });
+});
+
+describe('TimeWindowPropType', () => {
+  it('accepts valid time window', () => {
+    const validTimeWindow = {
+      start_time: '21:00',
+      end_time: '05:00',
+      start_offset_minutes: 30,
+      end_offset_minutes: 0,
+    };
+    const error = checkPropType(TimeWindowPropType, validTimeWindow);
+    expect(error).toBeNull();
+  });
+
+  it('accepts partial time window', () => {
+    const partialTimeWindow = {
+      start_time: '21:00',
+      end_time: '05:00',
+    };
+    const error = checkPropType(TimeWindowPropType, partialTimeWindow);
+    expect(error).toBeNull();
+  });
+
+  it('accepts null/undefined', () => {
+    const error = checkPropType(TimeWindowPropType, null);
+    expect(error).toBeNull();
+  });
+});
+
+describe('TriggerErrorsPropType', () => {
+  it('accepts valid error object', () => {
+    const validErrors = {
+      trigger_type: 'Please select a trigger type',
+      interval_minutes: 'Must be at least 1 minute',
+    };
+    const error = checkPropType(TriggerErrorsPropType, validErrors);
+    expect(error).toBeNull();
+  });
+
+  it('accepts empty error object', () => {
+    const error = checkPropType(TriggerErrorsPropType, {});
+    expect(error).toBeNull();
+  });
+});
+
+describe('TriggerPropType', () => {
+  it('accepts interval trigger', () => {
+    const intervalTrigger = {
+      trigger_type: 'interval',
+      interval_minutes: 60,
+      time_window: {
+        start_time: '21:00',
+        end_time: '05:00',
+      },
+      days_of_week: [0, 1, 2, 3, 4],
+    };
+    const error = checkPropType(TriggerPropType, intervalTrigger);
+    expect(error).toBeNull();
+  });
+
+  it('accepts solar trigger', () => {
+    const solarTrigger = {
+      trigger_type: 'solar',
+      solar_event: 'sunset',
+      offset_minutes: 30,
+    };
+    const error = checkPropType(TriggerPropType, solarTrigger);
+    expect(error).toBeNull();
+  });
+
+  it('accepts moon_phase trigger', () => {
+    const moonPhaseTrigger = {
+      trigger_type: 'moon_phase',
+      moon_phase: 'full',
+      time_of_day: '21:00',
+      offset_days: 2,
+    };
+    const error = checkPropType(TriggerPropType, moonPhaseTrigger);
+    expect(error).toBeNull();
+  });
+
+  it('accepts fixed_time trigger', () => {
+    const fixedTimeTrigger = {
+      trigger_type: 'fixed_time',
+      time_of_day: '21:00',
+      days_of_week: [0, 1, 2, 3, 4, 5, 6],
+    };
+    const error = checkPropType(TriggerPropType, fixedTimeTrigger);
+    expect(error).toBeNull();
+  });
+
+  it('accepts sensor trigger', () => {
+    const sensorTrigger = {
+      trigger_type: 'sensor',
+      sensor_type: 'motion',
+      comparison: 'gt',
+      threshold: 0.5,
+      cooldown_minutes: 5,
+    };
+    const error = checkPropType(TriggerPropType, sensorTrigger);
+    expect(error).toBeNull();
+  });
+
+  it('rejects invalid trigger_type', () => {
+    const invalidTrigger = {
+      trigger_type: 'invalid_type',
+    };
+    const error = checkPropType(TriggerPropType, invalidTrigger);
+    expect(error).not.toBeNull();
+  });
+});
+
+describe('ActionPropType', () => {
+  it('accepts valid action with all fields', () => {
+    const validAction = {
+      action_id: 'action-123',
+      type: 'gpio',
+      parameters: { pin: 'uv_on' },
+    };
+    const error = checkPropType(ActionPropType, validAction);
+    expect(error).toBeNull();
+  });
+
+  it('accepts action without action_id', () => {
+    const actionWithoutId = {
+      type: 'camera',
+      parameters: {},
+    };
+    const error = checkPropType(ActionPropType, actionWithoutId);
+    expect(error).toBeNull();
+  });
+
+  it('rejects action without type', () => {
+    const actionWithoutType = {
+      action_id: 'action-123',
+      parameters: {},
+    };
+    const error = checkPropType(ActionPropType, actionWithoutType);
+    expect(error).not.toBeNull();
+  });
+});
+
+describe('PatternPropType', () => {
+  it('accepts valid pattern', () => {
+    const validPattern = {
+      pattern_id: 'pattern-123',
+      name: 'UV Capture Cycle',
+      description: 'Turn on UV, capture photo, turn off UV',
+      actions: [
+        { action_id: '1', type: 'gpio', parameters: { pin: 'uv_on' } },
+        { action_id: '2', type: 'camera', parameters: {} },
+      ],
+      category: 'user',
+      tags: ['uv', 'capture'],
+    };
+    const error = checkPropType(PatternPropType, validPattern);
+    expect(error).toBeNull();
+  });
+
+  it('accepts pattern with minimal required fields', () => {
+    const minimalPattern = {
+      name: 'Simple Pattern',
+      actions: [{ type: 'camera' }],
+    };
+    const error = checkPropType(PatternPropType, minimalPattern);
+    expect(error).toBeNull();
+  });
+
+  it('rejects pattern without name', () => {
+    const patternWithoutName = {
+      pattern_id: 'pattern-123',
+      actions: [{ type: 'camera' }],
+    };
+    const error = checkPropType(PatternPropType, patternWithoutName);
+    expect(error).not.toBeNull();
+  });
+
+  it('rejects pattern without actions', () => {
+    const patternWithoutActions = {
+      pattern_id: 'pattern-123',
+      name: 'Empty Pattern',
+    };
+    const error = checkPropType(PatternPropType, patternWithoutActions);
+    expect(error).not.toBeNull();
+  });
+});
+
+describe('DateRangePropType', () => {
+  it('accepts valid date range', () => {
+    const validDateRange = {
+      start_date: '2024-06-01',
+      end_date: '2024-08-31',
+    };
+    const error = checkPropType(DateRangePropType, validDateRange);
+    expect(error).toBeNull();
+  });
+
+  it('accepts partial date range', () => {
+    const partialDateRange = {
+      start_date: '2024-06-01',
+    };
+    const error = checkPropType(DateRangePropType, partialDateRange);
+    expect(error).toBeNull();
+  });
+});
+
+describe('PatternSelectionPropType', () => {
+  it('accepts library pattern selection', () => {
+    const librarySelection = {
+      source: 'library',
+      pattern: {
+        pattern_id: '123',
+        name: 'UV Cycle',
+        actions: [{ type: 'gpio' }],
+      },
+    };
+    const error = checkPropType(PatternSelectionPropType, librarySelection);
+    expect(error).toBeNull();
+  });
+
+  it('accepts custom pattern selection', () => {
+    const customSelection = {
+      source: 'custom',
+      pattern: {
+        name: 'My Custom Pattern',
+        actions: [{ type: 'camera' }],
+      },
+    };
+    const error = checkPropType(PatternSelectionPropType, customSelection);
+    expect(error).toBeNull();
+  });
+
+  it('rejects invalid source', () => {
+    const invalidSelection = {
+      source: 'invalid',
+      pattern: {
+        name: 'Test',
+        actions: [{ type: 'camera' }],
+      },
+    };
+    const error = checkPropType(PatternSelectionPropType, invalidSelection);
+    expect(error).not.toBeNull();
+  });
+});
+
+describe('SchedulePropType', () => {
+  it('accepts valid schedule', () => {
+    const validSchedule = {
+      schedule_id: 'sched-123',
+      name: 'Summer Moth Survey',
+      description: 'Nightly moth capture from June to August',
+      trigger: {
+        trigger_type: 'solar',
+        solar_event: 'sunset',
+        offset_minutes: 30,
+      },
+      event_patterns: [
+        {
+          pattern_id: 'pattern-1',
+          name: 'UV Capture',
+          actions: [{ type: 'gpio' }],
+        },
+      ],
+      date_range: {
+        start_date: '2024-06-01',
+        end_date: '2024-08-31',
+      },
+    };
+    const error = checkPropType(SchedulePropType, validSchedule);
+    expect(error).toBeNull();
+  });
+
+  it('accepts partial schedule', () => {
+    const partialSchedule = {
+      name: 'Basic Schedule',
+    };
+    const error = checkPropType(SchedulePropType, partialSchedule);
+    expect(error).toBeNull();
+  });
+});

--- a/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/__tests__/propTypes.test.js
+++ b/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/__tests__/propTypes.test.js
@@ -8,6 +8,7 @@
 import PropTypes from 'prop-types';
 import {
   TimeWindowPropType,
+  TimeWindowErrorsPropType,
   TriggerErrorsPropType,
   TriggerPropType,
   ActionPropType,
@@ -39,6 +40,10 @@ const checkPropType = (propType, value, propName = 'testProp') => {
 describe('propTypes exports', () => {
   it('exports TimeWindowPropType', () => {
     expect(TimeWindowPropType).toBeDefined();
+  });
+
+  it('exports TimeWindowErrorsPropType', () => {
+    expect(TimeWindowErrorsPropType).toBeDefined();
   });
 
   it('exports TriggerErrorsPropType', () => {
@@ -97,6 +102,36 @@ describe('TimeWindowPropType', () => {
   });
 });
 
+describe('TimeWindowErrorsPropType', () => {
+  it('accepts valid time window errors', () => {
+    const validTimeWindowErrors = {
+      start_time: 'Invalid start time format',
+      end_time: 'End time must be after start time',
+      general: 'Time window is required',
+    };
+    const error = checkPropType(TimeWindowErrorsPropType, validTimeWindowErrors);
+    expect(error).toBeNull();
+  });
+
+  it('accepts partial time window errors', () => {
+    const partialErrors = {
+      start_time: 'Invalid format',
+    };
+    const error = checkPropType(TimeWindowErrorsPropType, partialErrors);
+    expect(error).toBeNull();
+  });
+
+  it('accepts empty error object', () => {
+    const error = checkPropType(TimeWindowErrorsPropType, {});
+    expect(error).toBeNull();
+  });
+
+  it('accepts null/undefined', () => {
+    const error = checkPropType(TimeWindowErrorsPropType, null);
+    expect(error).toBeNull();
+  });
+});
+
 describe('TriggerErrorsPropType', () => {
   it('accepts valid error object', () => {
     const validErrors = {
@@ -109,6 +144,19 @@ describe('TriggerErrorsPropType', () => {
 
   it('accepts empty error object', () => {
     const error = checkPropType(TriggerErrorsPropType, {});
+    expect(error).toBeNull();
+  });
+
+  it('accepts nested time_window errors', () => {
+    const errorsWithTimeWindow = {
+      interval_minutes: 'Required',
+      time_window: {
+        start_time: 'Invalid format',
+        end_time: 'Must be after start',
+        general: 'Time window is required',
+      },
+    };
+    const error = checkPropType(TriggerErrorsPropType, errorsWithTimeWindow);
     expect(error).toBeNull();
   });
 });

--- a/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/index.js
+++ b/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/index.js
@@ -65,3 +65,15 @@ export {
   TRIGGER_DEFAULTS,
   TIME_FORMAT_REGEX,
 } from './constants';
+
+// PropTypes (shared shapes)
+export {
+  TimeWindowPropType,
+  TriggerErrorsPropType,
+  TriggerPropType,
+  ActionPropType,
+  PatternPropType,
+  DateRangePropType,
+  PatternSelectionPropType,
+  SchedulePropType,
+} from './propTypes';

--- a/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/index.js
+++ b/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/index.js
@@ -69,6 +69,7 @@ export {
 // PropTypes (shared shapes)
 export {
   TimeWindowPropType,
+  TimeWindowErrorsPropType,
   TriggerErrorsPropType,
   TriggerPropType,
   ActionPropType,

--- a/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/propTypes.js
+++ b/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/propTypes.js
@@ -33,13 +33,23 @@ export const TimeWindowPropType = PropTypes.shape({
 });
 
 /**
+ * PropTypes shape for time window validation errors.
+ * Used within TriggerErrorsPropType for time window field errors.
+ */
+export const TimeWindowErrorsPropType = PropTypes.shape({
+  start_time: PropTypes.string,
+  end_time: PropTypes.string,
+  general: PropTypes.string,
+});
+
+/**
  * PropTypes shape for trigger validation errors.
  * Each field corresponds to a potential error message for that trigger field.
  */
 export const TriggerErrorsPropType = PropTypes.shape({
   trigger_type: PropTypes.string,
   interval_minutes: PropTypes.string,
-  time_window: PropTypes.object,
+  time_window: TimeWindowErrorsPropType,
   solar_event: PropTypes.string,
   offset_minutes: PropTypes.string,
   moon_phase: PropTypes.string,

--- a/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/propTypes.js
+++ b/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/propTypes.js
@@ -1,0 +1,193 @@
+/**
+ * Shared PropTypes for Schedule Editor Components (Issue #262)
+ *
+ * This module provides centralized PropTypes definitions for the ScheduleEditor
+ * component family, eliminating duplication and ensuring consistency across:
+ * - TriggerForm
+ * - PreviewSection
+ * - ScheduleEditor
+ * - EventPatternSelector
+ *
+ * @module components/scheduler/ScheduleEditor/propTypes
+ */
+
+import PropTypes from 'prop-types';
+
+/**
+ * PropTypes shape for time window configuration.
+ * Used in interval triggers to define when executions can occur.
+ *
+ * @example
+ * {
+ *   start_time: '21:00',
+ *   end_time: '05:00',
+ *   start_offset_minutes: 30,
+ *   end_offset_minutes: 0
+ * }
+ */
+export const TimeWindowPropType = PropTypes.shape({
+  start_time: PropTypes.string,
+  end_time: PropTypes.string,
+  start_offset_minutes: PropTypes.number,
+  end_offset_minutes: PropTypes.number,
+});
+
+/**
+ * PropTypes shape for trigger validation errors.
+ * Each field corresponds to a potential error message for that trigger field.
+ */
+export const TriggerErrorsPropType = PropTypes.shape({
+  trigger_type: PropTypes.string,
+  interval_minutes: PropTypes.string,
+  time_window: PropTypes.object,
+  solar_event: PropTypes.string,
+  offset_minutes: PropTypes.string,
+  moon_phase: PropTypes.string,
+  time_of_day: PropTypes.string,
+  offset_days: PropTypes.string,
+  sensor_type: PropTypes.string,
+  comparison: PropTypes.string,
+  threshold: PropTypes.string,
+  cooldown_minutes: PropTypes.string,
+  days_of_week: PropTypes.string,
+});
+
+/**
+ * PropTypes shape for trigger configuration.
+ * Supports all trigger types: interval, solar, moon_phase, fixed_time, sensor.
+ *
+ * @example
+ * // Interval trigger
+ * {
+ *   trigger_type: 'interval',
+ *   interval_minutes: 60,
+ *   time_window: { start_time: '21:00', end_time: '05:00' },
+ *   days_of_week: [0, 1, 2, 3, 4]
+ * }
+ *
+ * @example
+ * // Solar trigger
+ * {
+ *   trigger_type: 'solar',
+ *   solar_event: 'sunset',
+ *   offset_minutes: 30
+ * }
+ */
+export const TriggerPropType = PropTypes.shape({
+  trigger_type: PropTypes.oneOf(['interval', 'solar', 'moon_phase', 'fixed_time', 'sensor']),
+  // Interval trigger fields
+  interval_minutes: PropTypes.number,
+  time_window: TimeWindowPropType,
+  // Solar trigger fields
+  solar_event: PropTypes.string,
+  offset_minutes: PropTypes.number,
+  // Moon phase trigger fields
+  moon_phase: PropTypes.string,
+  time_of_day: PropTypes.string,
+  offset_days: PropTypes.number,
+  // Fixed time trigger fields
+  // (time_of_day is shared with moon phase)
+  // Sensor trigger fields
+  sensor_type: PropTypes.string,
+  comparison: PropTypes.string,
+  threshold: PropTypes.number,
+  cooldown_minutes: PropTypes.number,
+  // Common fields
+  days_of_week: PropTypes.arrayOf(PropTypes.number),
+});
+
+/**
+ * PropTypes shape for an action within a pattern.
+ *
+ * @example
+ * {
+ *   action_id: 'abc-123',
+ *   type: 'gpio',
+ *   parameters: { pin: 'attract_on' }
+ * }
+ */
+export const ActionPropType = PropTypes.shape({
+  action_id: PropTypes.string,
+  type: PropTypes.string.isRequired,
+  parameters: PropTypes.object,
+});
+
+/**
+ * PropTypes shape for an event pattern.
+ * Patterns define reusable sequences of actions.
+ *
+ * @example
+ * {
+ *   pattern_id: 'pattern-123',
+ *   name: 'UV Capture Cycle',
+ *   description: 'Turn on UV, capture photo, turn off UV',
+ *   actions: [
+ *     { action_id: '1', type: 'gpio', parameters: { pin: 'uv_on' } },
+ *     { action_id: '2', type: 'camera', parameters: {} },
+ *     { action_id: '3', type: 'gpio', parameters: { pin: 'uv_off' } }
+ *   ],
+ *   category: 'user',
+ *   tags: ['uv', 'capture']
+ * }
+ */
+export const PatternPropType = PropTypes.shape({
+  pattern_id: PropTypes.string,
+  name: PropTypes.string.isRequired,
+  description: PropTypes.string,
+  actions: PropTypes.arrayOf(ActionPropType).isRequired,
+  category: PropTypes.string,
+  tags: PropTypes.arrayOf(PropTypes.string),
+});
+
+/**
+ * PropTypes shape for date range configuration.
+ * Used to define schedule validity period.
+ *
+ * @example
+ * {
+ *   start_date: '2024-06-01',
+ *   end_date: '2024-08-31'
+ * }
+ */
+export const DateRangePropType = PropTypes.shape({
+  start_date: PropTypes.string,
+  end_date: PropTypes.string,
+});
+
+/**
+ * PropTypes shape for pattern selection in EventPatternSelector.
+ * Indicates whether pattern comes from library or is custom-defined.
+ *
+ * @example
+ * {
+ *   source: 'library',
+ *   pattern: { pattern_id: '123', name: 'UV Cycle', ... }
+ * }
+ */
+export const PatternSelectionPropType = PropTypes.shape({
+  source: PropTypes.oneOf(['library', 'custom']),
+  pattern: PatternPropType,
+});
+
+/**
+ * PropTypes shape for a complete schedule.
+ * Used by ScheduleEditor for the main schedule prop.
+ *
+ * @example
+ * {
+ *   schedule_id: 'sched-123',
+ *   name: 'Summer Moth Survey',
+ *   description: 'Nightly moth capture from June to August',
+ *   trigger: { trigger_type: 'solar', ... },
+ *   event_patterns: [{ pattern_id: '1', name: 'UV Cycle', ... }],
+ *   date_range: { start_date: '2024-06-01', end_date: '2024-08-31' }
+ * }
+ */
+export const SchedulePropType = PropTypes.shape({
+  schedule_id: PropTypes.string,
+  name: PropTypes.string,
+  description: PropTypes.string,
+  trigger: TriggerPropType,
+  event_patterns: PropTypes.arrayOf(PatternPropType),
+  date_range: DateRangePropType,
+});


### PR DESCRIPTION
## Summary

- Create centralized `propTypes.js` module eliminating PropTypes duplication across scheduler components
- Extract 8 shared PropTypes: TimeWindow, TriggerErrors, Trigger, Action, Pattern, DateRange, PatternSelection, Schedule
- Standardize field names across components (trigger_type, time_of_day, moon_phase)

## Changes

| File | Action |
|------|--------|
| `propTypes.js` | **CREATE** - New shared PropTypes module with JSDoc documentation |
| `propTypes.test.js` | **CREATE** - 33 tests for PropTypes validation |
| `TriggerForm.jsx` | Remove local defs, import from propTypes |
| `PreviewSection.jsx` | Remove local defs, fix field name inconsistencies |
| `ScheduleEditor.jsx` | Remove local defs, import from propTypes |
| `EventPatternSelector.jsx` | Remove local defs, import from propTypes |
| `index.js` | Export all PropTypes for external use |

## Test plan

- [x] All 975 scheduler tests pass
- [x] All 33 propTypes.test.js tests pass
- [x] Lint passes (0 errors)
- [x] No duplicate PropTypes definitions remain in component files
- [x] PropTypes importable from ScheduleEditor/index.js

Closes #262