### PR TITLE
docs(scheduler): Standardize JSDoc comments in ScheduleEditor components (#263)

### DIFF
--- a/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/EventPatternSelector.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/EventPatternSelector.jsx
@@ -220,9 +220,13 @@ const EventPatternSelector = ({
 };
 
 EventPatternSelector.propTypes = {
+  /** Pattern selection configuration with source ('library' or 'custom') and selected pattern */
   value: PatternSelectionPropType,
+  /** Callback when pattern selection changes */
   onChange: PropTypes.func.isRequired,
+  /** Whether the pattern selector is disabled */
   disabled: PropTypes.bool,
+  /** Validation errors for pattern fields */
   errors: PropTypes.shape({
     pattern: PropTypes.string,
   }),

--- a/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/FixedTimeTriggerForm.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/FixedTimeTriggerForm.jsx
@@ -199,12 +199,16 @@ const FixedTimeTriggerForm = ({
 };
 
 FixedTimeTriggerForm.propTypes = {
+  /** Fixed time trigger configuration with time_of_day (HH:MM) and optional days_of_week array */
   value: PropTypes.shape({
     time_of_day: PropTypes.string.isRequired,
     days_of_week: PropTypes.arrayOf(PropTypes.number),
   }),
+  /** Callback when fixed time trigger configuration changes */
   onChange: PropTypes.func.isRequired,
+  /** Whether the form is disabled */
   disabled: PropTypes.bool,
+  /** Validation errors for fixed time trigger fields */
   errors: PropTypes.shape({
     time_of_day: PropTypes.string,
     days_of_week: PropTypes.string,

--- a/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/IntervalTriggerForm.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/IntervalTriggerForm.jsx
@@ -333,6 +333,7 @@ const IntervalTriggerForm = ({
 };
 
 IntervalTriggerForm.propTypes = {
+  /** Interval trigger configuration with repeat interval, time window, and optional days */
   value: PropTypes.shape({
     interval_minutes: PropTypes.number.isRequired,
     time_window: PropTypes.shape({
@@ -343,8 +344,11 @@ IntervalTriggerForm.propTypes = {
     }).isRequired,
     days_of_week: PropTypes.arrayOf(PropTypes.number), // null = all days
   }),
+  /** Callback when interval trigger configuration changes */
   onChange: PropTypes.func.isRequired,
+  /** Whether the form is disabled */
   disabled: PropTypes.bool,
+  /** Validation errors for interval trigger fields */
   errors: PropTypes.shape({
     interval_minutes: PropTypes.string,
     time_window: PropTypes.object,

--- a/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/MoonPhaseTriggerForm.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/MoonPhaseTriggerForm.jsx
@@ -264,13 +264,17 @@ const MoonPhaseTriggerForm = ({
 };
 
 MoonPhaseTriggerForm.propTypes = {
+  /** Moon phase trigger configuration containing moon_phase, time_of_day, and offset_days */
   value: PropTypes.shape({
     moon_phase: PropTypes.string.isRequired,
     time_of_day: PropTypes.string.isRequired,
     offset_days: PropTypes.number.isRequired,
   }),
+  /** Callback when moon phase trigger configuration changes */
   onChange: PropTypes.func.isRequired,
+  /** Whether the form is disabled */
   disabled: PropTypes.bool,
+  /** Validation errors for moon phase trigger fields */
   errors: PropTypes.shape({
     moon_phase: PropTypes.string,
     time_of_day: PropTypes.string,

--- a/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/PreviewSection.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/PreviewSection.jsx
@@ -307,9 +307,13 @@ const PreviewSection = ({
 };
 
 PreviewSection.propTypes = {
+  /** Trigger configuration object defining when the schedule executes */
   trigger: TriggerPropType,
+  /** Date range configuration with optional start_date and end_date */
   dateRange: DateRangePropType,
+  /** Pattern configuration with name and actions array */
   pattern: PatternPropType,
+  /** Whether the preview section is disabled */
   disabled: PropTypes.bool,
 };
 

--- a/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/ScheduleEditor.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/ScheduleEditor.jsx
@@ -510,7 +510,9 @@ const ScheduleEditor = ({
 };
 
 ScheduleEditor.propTypes = {
+  /** Whether the editor drawer is open */
   isOpen: PropTypes.bool.isRequired,
+  /** Schedule to edit (null for new). Contains trigger, patterns, date range. */
   schedule: PropTypes.shape({
     schedule_id: PropTypes.string,
     name: PropTypes.string,
@@ -519,7 +521,9 @@ ScheduleEditor.propTypes = {
     event_patterns: PropTypes.arrayOf(PatternPropType),
     date_range: DateRangePropType,
   }),
+  /** Callback when schedule is saved. Receives complete schedule object. */
   onSave: PropTypes.func.isRequired,
+  /** Callback when editor is cancelled/closed */
   onCancel: PropTypes.func.isRequired,
 };
 

--- a/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/SensorTriggerForm.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/SensorTriggerForm.jsx
@@ -289,14 +289,18 @@ const SensorTriggerForm = ({
 };
 
 SensorTriggerForm.propTypes = {
+  /** Sensor trigger configuration containing sensor_type, comparison, threshold, and cooldown_minutes */
   value: PropTypes.shape({
     sensor_type: PropTypes.string.isRequired,
     comparison: PropTypes.string.isRequired,
     threshold: PropTypes.number.isRequired,
     cooldown_minutes: PropTypes.number.isRequired,
   }),
+  /** Callback when sensor trigger configuration changes */
   onChange: PropTypes.func.isRequired,
+  /** Whether the form is disabled */
   disabled: PropTypes.bool,
+  /** Validation errors for sensor trigger fields */
   errors: PropTypes.shape({
     sensor_type: PropTypes.string,
     comparison: PropTypes.string,

--- a/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/SolarTriggerForm.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/SolarTriggerForm.jsx
@@ -303,13 +303,17 @@ const SolarTriggerForm = ({
 };
 
 SolarTriggerForm.propTypes = {
+  /** Solar trigger configuration containing solar_event, offset_minutes, and optional days_of_week */
   value: PropTypes.shape({
     solar_event: PropTypes.string.isRequired,
     offset_minutes: PropTypes.number.isRequired,
     days_of_week: PropTypes.arrayOf(PropTypes.number),
   }),
+  /** Callback when solar trigger configuration changes */
   onChange: PropTypes.func.isRequired,
+  /** Whether the form is disabled */
   disabled: PropTypes.bool,
+  /** Validation errors for solar trigger fields */
   errors: PropTypes.shape({
     solar_event: PropTypes.string,
     offset_minutes: PropTypes.string,

--- a/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/TimeWindowInput.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/TimeWindowInput.jsx
@@ -424,15 +424,20 @@ const TimeWindowInput = ({
 };
 
 TimeWindowInput.propTypes = {
+  /** Time window configuration with start/end times (HH:MM or solar event) and optional offset minutes */
   value: PropTypes.shape({
     start_time: PropTypes.string,
     end_time: PropTypes.string,
     start_offset_minutes: PropTypes.number,
     end_offset_minutes: PropTypes.number,
   }),
+  /** Callback when time window configuration changes */
   onChange: PropTypes.func.isRequired,
+  /** Whether the time window input is disabled */
   disabled: PropTypes.bool,
+  /** Whether to show solar event options (default true) */
   showSolarEvents: PropTypes.bool,
+  /** Validation errors for time window fields */
   errors: PropTypes.shape({
     start_time: PropTypes.string,
     end_time: PropTypes.string,

--- a/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/TriggerForm.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/TriggerForm.jsx
@@ -146,6 +146,7 @@ const TriggerForm = ({
 };
 
 TriggerForm.propTypes = {
+  /** Trigger configuration with type-specific fields. Type determines which fields are active. */
   value: PropTypes.shape({
     trigger_type: PropTypes.oneOf(['interval', 'solar', 'moon_phase', 'fixed_time', 'sensor']).isRequired,
     // Interval trigger fields
@@ -168,8 +169,11 @@ TriggerForm.propTypes = {
     // Common fields
     days_of_week: PropTypes.arrayOf(PropTypes.number),
   }),
+  /** Callback when trigger configuration changes */
   onChange: PropTypes.func.isRequired,
+  /** Whether the form is disabled */
   disabled: PropTypes.bool,
+  /** Validation errors for trigger fields */
   errors: TriggerErrorsPropType,
 };
 


### PR DESCRIPTION
## Summary

- Add PropTypes JSDoc comments to 10 ScheduleEditor component files
- Follow template format from DaysOfWeekSelector.jsx and DateRangeSection.jsx
- All 595 ScheduleEditor tests passing

## Files Updated

- ScheduleEditor.jsx
- TriggerForm.jsx
- IntervalTriggerForm.jsx
- SolarTriggerForm.jsx
- MoonPhaseTriggerForm.jsx
- FixedTimeTriggerForm.jsx
- SensorTriggerForm.jsx
- TimeWindowInput.jsx
- EventPatternSelector.jsx
- PreviewSection.jsx

## Test Plan

- [x] `npm run lint` - passes (0 errors, only pre-existing warnings)
- [x] `npm test -- ScheduleEditor --run` - 595 tests passing
- [x] All props have `/** description */` comments
- [x] Consistent formatting throughout

Closes #263