### PR TITLE
feat(scheduler): Implement Conflict Resolver components (#229)

### DIFF
--- a/Firmware/webui/frontend/src/components/scheduler/CalendarView/ExecutionMarker.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/CalendarView/ExecutionMarker.jsx
@@ -190,10 +190,4 @@ ExecutionMarker.propTypes = {
   conflictMessage: PropTypes.string,
 }
 
-ExecutionMarker.defaultProps = {
-  compact: false,
-  conflictSeverity: null,
-  conflictMessage: '',
-}
-
 export default memo(ExecutionMarker)

--- a/Firmware/webui/frontend/src/components/scheduler/CalendarView/ExecutionMarker.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/CalendarView/ExecutionMarker.jsx
@@ -3,6 +3,7 @@
  *
  * Displays pattern executions as colored pills/badges in the calendar view.
  * Supports both compact (month view) and full (week/day view) display modes.
+ * Supports conflict highlighting for schedule conflicts (Issue #229).
  *
  * @module components/scheduler/CalendarView/ExecutionMarker
  */
@@ -24,6 +25,15 @@ const COLOR_CLASS_MAP = {
   'bg-orange-500': { dark: 'dark:bg-orange-600', ring: 'focus:ring-orange-400' },
   'bg-pink-500': { dark: 'dark:bg-pink-600', ring: 'focus:ring-pink-400' },
   'bg-cyan-500': { dark: 'dark:bg-cyan-600', ring: 'focus:ring-cyan-400' },
+}
+
+/**
+ * Conflict severity ring classes for highlighting conflicting executions (Issue #229).
+ * Error severity shows red ring, warning severity shows amber ring.
+ */
+const CONFLICT_RING_CLASSES = {
+  error: 'ring-2 ring-red-500 dark:ring-red-400',
+  warning: 'ring-2 ring-amber-500 dark:ring-amber-400',
 }
 
 /**
@@ -51,6 +61,8 @@ function truncateText(text, maxLength) {
  * @param {Array} [props.execution.actions] - Array of action objects
  * @param {Function} props.onClick - Click handler
  * @param {boolean} [props.compact=false] - Compact display mode for month view
+ * @param {string|null} [props.conflictSeverity=null] - Conflict severity for highlighting ('error'|'warning'|null)
+ * @param {string} [props.conflictMessage] - Message describing the conflict
  * @returns {JSX.Element} Execution marker component
  *
  * @example
@@ -67,8 +79,17 @@ function truncateText(text, maxLength) {
  *   onClick={() => handleClick(execution)}
  *   compact
  * />
+ *
+ * @example
+ * // With conflict highlighting (Issue #229)
+ * <ExecutionMarker
+ *   execution={execution}
+ *   onClick={() => handleClick(execution)}
+ *   conflictSeverity="error"
+ *   conflictMessage="Camera resource conflict with Flash Photo"
+ * />
  */
-function ExecutionMarker({ execution, onClick, compact = false }) {
+function ExecutionMarker({ execution, onClick, compact = false, conflictSeverity = null, conflictMessage = '' }) {
   const { pattern_id, pattern_name, start_time } = execution
 
   // Get consistent color for this pattern
@@ -86,6 +107,9 @@ function ExecutionMarker({ execution, onClick, compact = false }) {
     ? truncateText(pattern_name, 10)
     : truncateText(pattern_name, 30)
 
+  // Get conflict ring classes if there's a conflict (Issue #229)
+  const conflictRingClass = conflictSeverity ? CONFLICT_RING_CLASSES[conflictSeverity] : ''
+
   // Base classes for the marker - using static classes for Tailwind JIT
   const baseClasses = [
     'inline-flex items-center gap-1.5',
@@ -97,7 +121,8 @@ function ExecutionMarker({ execution, onClick, compact = false }) {
     'hover:brightness-110 hover:scale-105',
     'focus:outline-none focus:ring-2 focus:ring-offset-1',
     colorMapping.ring,
-  ].join(' ')
+    conflictRingClass, // Add conflict highlighting if present
+  ].filter(Boolean).join(' ')
 
   const textClasses = compact
     ? 'text-xs font-medium truncate max-w-[80px]'
@@ -116,14 +141,23 @@ function ExecutionMarker({ execution, onClick, compact = false }) {
     }
   }
 
+  // Build title and aria-label, including conflict info if present (Issue #229)
+  const baseTitle = `${pattern_name} at ${timeStr}`
+  const baseAriaLabel = `Scheduled execution: ${pattern_name} at ${timeStr}`
+
+  const title = conflictMessage ? `${baseTitle} - ${conflictMessage}` : baseTitle
+  const ariaLabel = conflictSeverity
+    ? `${baseAriaLabel} - conflict: ${conflictMessage || conflictSeverity}`
+    : baseAriaLabel
+
   return (
     <button
       type="button"
       onClick={handleClick}
       onKeyDown={handleKeyDown}
       className={baseClasses}
-      title={`${pattern_name} at ${timeStr}`}
-      aria-label={`Scheduled execution: ${pattern_name} at ${timeStr}`}
+      title={title}
+      aria-label={ariaLabel}
     >
       {/* Time display (hidden in compact mode) */}
       {!compact && (
@@ -137,6 +171,7 @@ function ExecutionMarker({ execution, onClick, compact = false }) {
 }
 
 ExecutionMarker.propTypes = {
+  /** Execution object containing pattern and timing details */
   execution: PropTypes.shape({
     pattern_id: PropTypes.string.isRequired,
     pattern_name: PropTypes.string.isRequired,
@@ -145,8 +180,20 @@ ExecutionMarker.propTypes = {
     trigger_info: PropTypes.string,
     actions: PropTypes.array,
   }).isRequired,
+  /** Click handler for when marker is selected */
   onClick: PropTypes.func.isRequired,
+  /** Compact display mode for month view */
   compact: PropTypes.bool,
+  /** Conflict severity for highlighting ('error'|'warning'|null) - Issue #229 */
+  conflictSeverity: PropTypes.oneOf(['error', 'warning', null]),
+  /** Message describing the conflict - Issue #229 */
+  conflictMessage: PropTypes.string,
+}
+
+ExecutionMarker.defaultProps = {
+  compact: false,
+  conflictSeverity: null,
+  conflictMessage: '',
 }
 
 export default memo(ExecutionMarker)

--- a/Firmware/webui/frontend/src/components/scheduler/CalendarView/__tests__/ExecutionMarker.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/CalendarView/__tests__/ExecutionMarker.test.jsx
@@ -283,6 +283,84 @@ describe('ExecutionMarker', () => {
     })
   })
 
+  describe('Conflict Highlighting (Issue #229)', () => {
+    it('shows red ring for error severity conflict', () => {
+      const { container } = render(
+        <ExecutionMarker
+          execution={mockExecution}
+          onClick={mockOnClick}
+          conflictSeverity="error"
+        />
+      )
+      const button = container.querySelector('button')
+      expect(button.className).toMatch(/ring-red/)
+    })
+
+    it('shows amber ring for warning severity conflict', () => {
+      const { container } = render(
+        <ExecutionMarker
+          execution={mockExecution}
+          onClick={mockOnClick}
+          conflictSeverity="warning"
+        />
+      )
+      const button = container.querySelector('button')
+      expect(button.className).toMatch(/ring-amber/)
+    })
+
+    it('shows no conflict ring when conflictSeverity is null', () => {
+      const { container } = render(
+        <ExecutionMarker
+          execution={mockExecution}
+          onClick={mockOnClick}
+          conflictSeverity={null}
+        />
+      )
+      const button = container.querySelector('button')
+      // Should not have conflict ring classes (ring-red or ring-amber)
+      expect(button.className).not.toMatch(/ring-red/)
+      expect(button.className).not.toMatch(/ring-amber/)
+    })
+
+    it('includes conflict message in title when provided', () => {
+      render(
+        <ExecutionMarker
+          execution={mockExecution}
+          onClick={mockOnClick}
+          conflictSeverity="error"
+          conflictMessage="Camera resource conflict"
+        />
+      )
+      const button = screen.getByRole('button')
+      expect(button.getAttribute('title')).toContain('Camera resource conflict')
+    })
+
+    it('includes conflict message in aria-label when provided', () => {
+      render(
+        <ExecutionMarker
+          execution={mockExecution}
+          onClick={mockOnClick}
+          conflictSeverity="error"
+          conflictMessage="Camera resource conflict"
+        />
+      )
+      const button = screen.getByRole('button')
+      expect(button.getAttribute('aria-label')).toContain('conflict')
+    })
+
+    it('has dark mode classes for conflict ring', () => {
+      const { container } = render(
+        <ExecutionMarker
+          execution={mockExecution}
+          onClick={mockOnClick}
+          conflictSeverity="error"
+        />
+      )
+      const button = container.querySelector('button')
+      expect(button.className).toMatch(/dark:ring-red/)
+    })
+  })
+
   describe('Edge Cases', () => {
     it('handles missing optional fields gracefully', () => {
       const minimalExecution = {

--- a/Firmware/webui/frontend/src/components/scheduler/ConflictResolver/ConflictItem.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ConflictResolver/ConflictItem.jsx
@@ -20,6 +20,7 @@
  * return <ConflictItem conflict={conflict} />
  */
 
+import { memo } from 'react'
 import PropTypes from 'prop-types'
 import {
   ExclamationTriangleIcon,
@@ -29,22 +30,7 @@ import {
   BoltIcon,
 } from '@heroicons/react/24/outline'
 import { ConflictPropType, CONFLICT_TYPE_LABELS } from './ConflictPropTypes'
-
-/**
- * Format ISO timestamp to HH:MM display
- */
-function formatTime(isoString) {
-  try {
-    const date = new Date(isoString)
-    return date.toLocaleTimeString('en-US', {
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: false,
-    })
-  } catch {
-    return isoString
-  }
-}
+import { formatTime } from '../CalendarView/calendarUtils'
 
 /**
  * Get the appropriate icon for a conflict type
@@ -166,4 +152,4 @@ ConflictItem.propTypes = {
   conflict: ConflictPropType.isRequired,
 }
 
-export default ConflictItem
+export default memo(ConflictItem)

--- a/Firmware/webui/frontend/src/components/scheduler/ConflictResolver/ConflictItem.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ConflictResolver/ConflictItem.jsx
@@ -1,0 +1,169 @@
+/**
+ * ConflictItem component (Issue #229)
+ *
+ * Displays a single schedule conflict with severity-based styling.
+ * Shows conflict type, involved patterns, time range, and resolution suggestion.
+ *
+ * @component
+ * @example
+ * const conflict = {
+ *   conflict_type: 'resource_contention',
+ *   severity: 'error',
+ *   event1_name: 'UV Capture',
+ *   event2_name: 'Flash Photo',
+ *   start_time: '2024-06-15T21:30:00Z',
+ *   end_time: '2024-06-15T21:45:00Z',
+ *   resource: 'camera',
+ *   message: 'Camera conflict...',
+ *   suggested_resolution: 'Adjust timing...',
+ * }
+ * return <ConflictItem conflict={conflict} />
+ */
+
+import PropTypes from 'prop-types'
+import {
+  ExclamationTriangleIcon,
+  ExclamationCircleIcon,
+  ClockIcon,
+  CubeIcon,
+  BoltIcon,
+} from '@heroicons/react/24/outline'
+import { ConflictPropType, CONFLICT_TYPE_LABELS } from './ConflictPropTypes'
+
+/**
+ * Format ISO timestamp to HH:MM display
+ */
+function formatTime(isoString) {
+  try {
+    const date = new Date(isoString)
+    return date.toLocaleTimeString('en-US', {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    })
+  } catch {
+    return isoString
+  }
+}
+
+/**
+ * Get the appropriate icon for a conflict type
+ */
+function getConflictTypeIcon(conflictType) {
+  switch (conflictType) {
+    case 'time_overlap':
+      return ClockIcon
+    case 'resource_contention':
+      return CubeIcon
+    case 'gpio_state_conflict':
+      return BoltIcon
+    default:
+      return ExclamationCircleIcon
+  }
+}
+
+/**
+ * Styling constants for severity variants
+ */
+const SEVERITY_STYLES = {
+  error: {
+    container: [
+      'bg-red-50 border-red-200 text-red-900',
+      'dark:bg-red-900/20 dark:border-red-800 dark:text-red-100',
+    ].join(' '),
+    icon: 'text-red-600 dark:text-red-400',
+    badge: 'bg-red-100 text-red-800 dark:bg-red-900/50 dark:text-red-200',
+  },
+  warning: {
+    container: [
+      'bg-amber-50 border-amber-200 text-amber-900',
+      'dark:bg-amber-900/20 dark:border-amber-800 dark:text-amber-100',
+    ].join(' '),
+    icon: 'text-amber-600 dark:text-amber-400',
+    badge: 'bg-amber-100 text-amber-800 dark:bg-amber-900/50 dark:text-amber-200',
+  },
+}
+
+/**
+ * ConflictItem displays a single schedule conflict with appropriate styling
+ */
+function ConflictItem({ conflict }) {
+  const {
+    conflict_type,
+    severity,
+    event1_name,
+    event2_name,
+    start_time,
+    end_time,
+    resource,
+    message,
+    suggested_resolution,
+  } = conflict
+
+  const styles = SEVERITY_STYLES[severity] || SEVERITY_STYLES.warning
+  const SeverityIcon = severity === 'error' ? ExclamationTriangleIcon : ExclamationCircleIcon
+  const TypeIcon = getConflictTypeIcon(conflict_type)
+  const typeLabel = CONFLICT_TYPE_LABELS[conflict_type] || conflict_type
+
+  const ariaLabel = `${severity === 'error' ? 'Blocking' : 'Warning'} conflict: ${message}`
+
+  return (
+    <li
+      role="listitem"
+      aria-label={ariaLabel}
+      className={`p-3 border rounded-lg ${styles.container}`}
+    >
+      {/* Header: Icon + Type Badge */}
+      <div className="flex items-start gap-2">
+        <SeverityIcon className={`h-5 w-5 flex-shrink-0 mt-0.5 ${styles.icon}`} />
+
+        <div className="flex-1 min-w-0">
+          {/* Conflict Type Badge */}
+          <div className="flex items-center gap-2 mb-1">
+            <span
+              className={`inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded ${styles.badge}`}
+            >
+              <TypeIcon className="h-3 w-3" />
+              {typeLabel}
+            </span>
+            {resource && (
+              <span className="text-xs opacity-75">
+                ({resource})
+              </span>
+            )}
+          </div>
+
+          {/* Pattern Names */}
+          <div className="text-sm font-medium mb-1">
+            <span>{event1_name}</span>
+            <span className="mx-1 opacity-50">↔</span>
+            <span>{event2_name}</span>
+          </div>
+
+          {/* Time Range */}
+          <div className="text-xs opacity-75 mb-2">
+            {formatTime(start_time)} – {formatTime(end_time)}
+          </div>
+
+          {/* Message */}
+          <p className="text-sm mb-2">{message}</p>
+
+          {/* Suggested Resolution */}
+          {suggested_resolution && (
+            <div className="text-xs opacity-90 bg-white/50 dark:bg-black/20 rounded p-2">
+              <span className="font-medium">Suggestion: </span>
+              {suggested_resolution}
+            </div>
+          )}
+        </div>
+      </div>
+    </li>
+  )
+}
+
+ConflictItem.propTypes = {
+  /** The conflict object to display */
+  conflict: ConflictPropType.isRequired,
+}
+
+export default ConflictItem

--- a/Firmware/webui/frontend/src/components/scheduler/ConflictResolver/ConflictList.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ConflictResolver/ConflictList.jsx
@@ -11,6 +11,9 @@
  *
  * // Compact mode (max 3, with "+N more" link)
  * <ConflictList conflicts={conflicts} compact onViewAll={() => setShowAll(true)} />
+ *
+ * // Compact mode with custom limit
+ * <ConflictList conflicts={conflicts} compact compactLimit={5} onViewAll={() => setShowAll(true)} />
  */
 
 import PropTypes from 'prop-types'
@@ -19,9 +22,9 @@ import { ConflictsPropType } from './ConflictPropTypes'
 import ConflictItem from './ConflictItem'
 
 /**
- * Maximum conflicts to show in compact mode
+ * Default maximum conflicts to show in compact mode
  */
-const COMPACT_LIMIT = 3
+const DEFAULT_COMPACT_LIMIT = 3
 
 /**
  * Sort and group conflicts by severity (errors first)
@@ -35,7 +38,7 @@ function groupConflicts(conflicts) {
 /**
  * ConflictList displays conflicts grouped by severity with optional compact mode
  */
-function ConflictList({ conflicts, compact = false, onViewAll }) {
+function ConflictList({ conflicts, compact = false, compactLimit = DEFAULT_COMPACT_LIMIT, onViewAll }) {
   // Handle empty/null/undefined conflicts
   if (!conflicts || conflicts.length === 0) {
     return null
@@ -45,14 +48,14 @@ function ConflictList({ conflicts, compact = false, onViewAll }) {
   const totalCount = conflicts.length
   const blockingCount = errors.length
 
-  // In compact mode, limit to COMPACT_LIMIT conflicts
+  // In compact mode, limit to compactLimit conflicts
   let displayConflicts = []
   let hiddenCount = 0
 
   if (compact) {
     // Prioritize errors, then warnings
     const combined = [...errors, ...warnings]
-    displayConflicts = combined.slice(0, COMPACT_LIMIT)
+    displayConflicts = combined.slice(0, compactLimit)
     hiddenCount = combined.length - displayConflicts.length
   } else {
     displayConflicts = [...errors, ...warnings]
@@ -145,8 +148,10 @@ function ConflictList({ conflicts, compact = false, onViewAll }) {
 ConflictList.propTypes = {
   /** Array of conflict objects to display */
   conflicts: ConflictsPropType,
-  /** Whether to show compact mode (max 3 conflicts) */
+  /** Whether to show compact mode (limits visible conflicts) */
   compact: PropTypes.bool,
+  /** Maximum conflicts to show in compact mode (default: 3) */
+  compactLimit: PropTypes.number,
   /** Callback when "+N more" is clicked in compact mode */
   onViewAll: PropTypes.func,
 }
@@ -154,6 +159,7 @@ ConflictList.propTypes = {
 ConflictList.defaultProps = {
   conflicts: null,
   compact: false,
+  compactLimit: DEFAULT_COMPACT_LIMIT,
   onViewAll: undefined,
 }
 

--- a/Firmware/webui/frontend/src/components/scheduler/ConflictResolver/ConflictList.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ConflictResolver/ConflictList.jsx
@@ -1,0 +1,160 @@
+/**
+ * ConflictList component (Issue #229)
+ *
+ * Displays a list of schedule conflicts grouped by severity.
+ * Supports compact mode for embedding in banners.
+ *
+ * @component
+ * @example
+ * // Full list
+ * <ConflictList conflicts={conflicts} />
+ *
+ * // Compact mode (max 3, with "+N more" link)
+ * <ConflictList conflicts={conflicts} compact onViewAll={() => setShowAll(true)} />
+ */
+
+import PropTypes from 'prop-types'
+import { ExclamationTriangleIcon, ExclamationCircleIcon } from '@heroicons/react/24/outline'
+import { ConflictsPropType } from './ConflictPropTypes'
+import ConflictItem from './ConflictItem'
+
+/**
+ * Maximum conflicts to show in compact mode
+ */
+const COMPACT_LIMIT = 3
+
+/**
+ * Sort and group conflicts by severity (errors first)
+ */
+function groupConflicts(conflicts) {
+  const errors = conflicts.filter((c) => c.severity === 'error')
+  const warnings = conflicts.filter((c) => c.severity === 'warning')
+  return { errors, warnings }
+}
+
+/**
+ * ConflictList displays conflicts grouped by severity with optional compact mode
+ */
+function ConflictList({ conflicts, compact = false, onViewAll }) {
+  // Handle empty/null/undefined conflicts
+  if (!conflicts || conflicts.length === 0) {
+    return null
+  }
+
+  const { errors, warnings } = groupConflicts(conflicts)
+  const totalCount = conflicts.length
+  const blockingCount = errors.length
+
+  // In compact mode, limit to COMPACT_LIMIT conflicts
+  let displayConflicts = []
+  let hiddenCount = 0
+
+  if (compact) {
+    // Prioritize errors, then warnings
+    const combined = [...errors, ...warnings]
+    displayConflicts = combined.slice(0, COMPACT_LIMIT)
+    hiddenCount = combined.length - displayConflicts.length
+  } else {
+    displayConflicts = [...errors, ...warnings]
+  }
+
+  // Determine which sections to show based on what's in displayConflicts
+  const displayErrors = displayConflicts.filter((c) => c.severity === 'error')
+  const displayWarnings = displayConflicts.filter((c) => c.severity === 'warning')
+
+  const showErrorSection = displayErrors.length > 0
+  const showWarningSection = displayWarnings.length > 0
+  const showBothSections = showErrorSection && showWarningSection
+
+  return (
+    <div className="space-y-4 dark:text-gray-100">
+      {/* Summary Header */}
+      <div className="flex items-center gap-2 text-sm font-medium">
+        <span>
+          {totalCount} conflict{totalCount !== 1 ? 's' : ''} detected
+        </span>
+        {blockingCount > 0 && (
+          <span className="text-red-600 dark:text-red-400">
+            ({blockingCount} blocking)
+          </span>
+        )}
+      </div>
+
+      {/* Error Section */}
+      {showErrorSection && (
+        <section>
+          {showBothSections && (
+            <h3 className="flex items-center gap-1.5 text-sm font-medium text-red-800 dark:text-red-300 mb-2">
+              <ExclamationTriangleIcon className="h-4 w-4" />
+              Blocking Conflicts
+            </h3>
+          )}
+          <ul
+            role="list"
+            aria-label={`${displayErrors.length} blocking conflict${displayErrors.length !== 1 ? 's' : ''}`}
+            className="space-y-2"
+          >
+            {displayErrors.map((conflict, index) => (
+              <ConflictItem
+                key={`error-${conflict.event1_id}-${conflict.event2_id}-${index}`}
+                conflict={conflict}
+              />
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {/* Warning Section */}
+      {showWarningSection && (
+        <section>
+          {showBothSections && (
+            <h3 className="flex items-center gap-1.5 text-sm font-medium text-amber-800 dark:text-amber-300 mb-2">
+              <ExclamationCircleIcon className="h-4 w-4" />
+              Warnings
+            </h3>
+          )}
+          <ul
+            role="list"
+            aria-label={`${displayWarnings.length} warning${displayWarnings.length !== 1 ? 's' : ''}`}
+            className="space-y-2"
+          >
+            {displayWarnings.map((conflict, index) => (
+              <ConflictItem
+                key={`warning-${conflict.event1_id}-${conflict.event2_id}-${index}`}
+                conflict={conflict}
+              />
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {/* Show "+N more" link in compact mode if there are hidden conflicts */}
+      {compact && hiddenCount > 0 && (
+        <button
+          type="button"
+          onClick={onViewAll}
+          className="text-sm text-blue-600 dark:text-blue-400 hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 rounded"
+        >
+          +{hiddenCount} more conflict{hiddenCount !== 1 ? 's' : ''}
+        </button>
+      )}
+    </div>
+  )
+}
+
+ConflictList.propTypes = {
+  /** Array of conflict objects to display */
+  conflicts: ConflictsPropType,
+  /** Whether to show compact mode (max 3 conflicts) */
+  compact: PropTypes.bool,
+  /** Callback when "+N more" is clicked in compact mode */
+  onViewAll: PropTypes.func,
+}
+
+ConflictList.defaultProps = {
+  conflicts: null,
+  compact: false,
+  onViewAll: undefined,
+}
+
+export default ConflictList

--- a/Firmware/webui/frontend/src/components/scheduler/ConflictResolver/ConflictList.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ConflictResolver/ConflictList.jsx
@@ -38,7 +38,7 @@ function groupConflicts(conflicts) {
 /**
  * ConflictList displays conflicts grouped by severity with optional compact mode
  */
-function ConflictList({ conflicts, compact = false, compactLimit = DEFAULT_COMPACT_LIMIT, onViewAll }) {
+function ConflictList({ conflicts = null, compact = false, compactLimit = DEFAULT_COMPACT_LIMIT, onViewAll = undefined }) {
   // Handle empty/null/undefined conflicts
   if (!conflicts || conflicts.length === 0) {
     return null
@@ -132,7 +132,7 @@ function ConflictList({ conflicts, compact = false, compactLimit = DEFAULT_COMPA
       )}
 
       {/* Show "+N more" link in compact mode if there are hidden conflicts */}
-      {compact && hiddenCount > 0 && (
+      {compact && hiddenCount > 0 && onViewAll && (
         <button
           type="button"
           onClick={onViewAll}
@@ -154,13 +154,6 @@ ConflictList.propTypes = {
   compactLimit: PropTypes.number,
   /** Callback when "+N more" is clicked in compact mode */
   onViewAll: PropTypes.func,
-}
-
-ConflictList.defaultProps = {
-  conflicts: null,
-  compact: false,
-  compactLimit: DEFAULT_COMPACT_LIMIT,
-  onViewAll: undefined,
 }
 
 export default ConflictList

--- a/Firmware/webui/frontend/src/components/scheduler/ConflictResolver/ConflictPropTypes.js
+++ b/Firmware/webui/frontend/src/components/scheduler/ConflictResolver/ConflictPropTypes.js
@@ -1,0 +1,63 @@
+/**
+ * Shared PropTypes for Conflict Resolver components (Issue #229)
+ *
+ * These PropTypes match the backend Conflict dataclass from
+ * webui/backend/lib/schedule_conflict.py
+ */
+
+import PropTypes from 'prop-types'
+
+/**
+ * Valid conflict types from backend
+ */
+export const CONFLICT_TYPES = ['time_overlap', 'resource_contention', 'gpio_state_conflict']
+
+/**
+ * Severity levels
+ * - error: Blocking conflicts that prevent activation
+ * - warning: Advisory conflicts that allow activation with warning
+ */
+export const SEVERITY_LEVELS = ['error', 'warning']
+
+/**
+ * PropType for a single conflict
+ *
+ * Matches backend Conflict.to_dict() output from schedule_conflict.py
+ */
+export const ConflictPropType = PropTypes.shape({
+  conflict_type: PropTypes.oneOf(CONFLICT_TYPES).isRequired,
+  severity: PropTypes.oneOf(SEVERITY_LEVELS).isRequired,
+  event1_id: PropTypes.string.isRequired,
+  event1_name: PropTypes.string.isRequired,
+  event2_id: PropTypes.string.isRequired,
+  event2_name: PropTypes.string.isRequired,
+  start_time: PropTypes.string.isRequired,
+  end_time: PropTypes.string.isRequired,
+  resource: PropTypes.string,
+  message: PropTypes.string.isRequired,
+  suggested_resolution: PropTypes.string.isRequired,
+})
+
+/**
+ * PropType for a list of conflicts
+ */
+export const ConflictsPropType = PropTypes.arrayOf(ConflictPropType)
+
+/**
+ * Human-readable labels for conflict types
+ */
+export const CONFLICT_TYPE_LABELS = {
+  time_overlap: 'Time Overlap',
+  resource_contention: 'Resource Conflict',
+  gpio_state_conflict: 'GPIO State Conflict',
+}
+
+/**
+ * Human-readable labels for severity levels
+ */
+export const SEVERITY_LABELS = {
+  error: 'Blocking',
+  warning: 'Warning',
+}
+
+export default ConflictPropType

--- a/Firmware/webui/frontend/src/components/scheduler/ConflictResolver/ConflictWarningBanner.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ConflictResolver/ConflictWarningBanner.jsx
@@ -1,0 +1,221 @@
+/**
+ * ConflictWarningBanner component (Issue #229)
+ *
+ * Displays a warning banner when schedule conflicts are detected.
+ * Shows severity-appropriate styling and allows viewing conflict details.
+ *
+ * @component
+ * @example
+ * // Blocking conflicts (prevents activation)
+ * <ConflictWarningBanner
+ *   conflicts={conflicts}
+ *   hasBlockingConflicts
+ *   blockingCount={2}
+ *   warningCount={1}
+ *   onViewDetails={() => openModal()}
+ * />
+ *
+ * // Warnings only (allows activation with confirmation)
+ * <ConflictWarningBanner
+ *   conflicts={conflicts}
+ *   warningCount={3}
+ *   onDismiss={() => setDismissed(true)}
+ * />
+ */
+
+import { useState } from 'react'
+import PropTypes from 'prop-types'
+import {
+  ExclamationTriangleIcon,
+  ExclamationCircleIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+  XMarkIcon,
+} from '@heroicons/react/24/outline'
+import { ConflictsPropType } from './ConflictPropTypes'
+import ConflictList from './ConflictList'
+
+/**
+ * Styling for severity variants
+ */
+const SEVERITY_STYLES = {
+  error: {
+    container: [
+      'bg-red-50 border-red-200',
+      'dark:bg-red-900/20 dark:border-red-800',
+    ].join(' '),
+    icon: 'text-red-600 dark:text-red-400',
+    title: 'text-red-800 dark:text-red-200',
+    text: 'text-red-700 dark:text-red-300',
+    button: [
+      'text-red-700 bg-white border-red-300',
+      'hover:bg-red-50 focus:ring-red-500',
+      'dark:bg-red-900/50 dark:text-red-200 dark:border-red-700 dark:hover:bg-red-900',
+    ].join(' '),
+  },
+  warning: {
+    container: [
+      'bg-amber-50 border-amber-200',
+      'dark:bg-amber-900/20 dark:border-amber-800',
+    ].join(' '),
+    icon: 'text-amber-600 dark:text-amber-400',
+    title: 'text-amber-800 dark:text-amber-200',
+    text: 'text-amber-700 dark:text-amber-300',
+    button: [
+      'text-amber-700 bg-white border-amber-300',
+      'hover:bg-amber-50 focus:ring-amber-500',
+      'dark:bg-amber-900/50 dark:text-amber-200 dark:border-amber-700 dark:hover:bg-amber-900',
+    ].join(' '),
+  },
+}
+
+/**
+ * Button base classes
+ */
+const BUTTON_BASE = [
+  'inline-flex items-center gap-1.5 px-3 py-1.5',
+  'text-sm font-medium border rounded-md',
+  'focus:outline-none focus:ring-2 focus:ring-offset-2',
+  'transition-colors',
+].join(' ')
+
+/**
+ * ConflictWarningBanner displays a warning when conflicts are detected
+ */
+function ConflictWarningBanner({
+  conflicts,
+  hasBlockingConflicts = false,
+  blockingCount = 0,
+  warningCount = 0,
+  onViewDetails,
+  onDismiss,
+}) {
+  const [isExpanded, setIsExpanded] = useState(false)
+
+  // Handle empty/null/undefined conflicts
+  if (!conflicts || conflicts.length === 0) {
+    return null
+  }
+
+  // Calculate counts if not provided
+  const actualBlockingCount = blockingCount || conflicts.filter((c) => c.severity === 'error').length
+  const actualWarningCount = warningCount || conflicts.filter((c) => c.severity === 'warning').length
+  const isBlocking = hasBlockingConflicts || actualBlockingCount > 0
+  const totalCount = conflicts.length
+
+  const styles = isBlocking ? SEVERITY_STYLES.error : SEVERITY_STYLES.warning
+  const Icon = isBlocking ? ExclamationTriangleIcon : ExclamationCircleIcon
+
+  const role = isBlocking ? 'alert' : 'status'
+  const ariaLive = isBlocking ? 'assertive' : 'polite'
+
+  const handleToggleExpand = () => {
+    setIsExpanded((prev) => !prev)
+    if (!isExpanded && onViewDetails) {
+      onViewDetails()
+    }
+  }
+
+  return (
+    <div
+      role={role}
+      aria-live={ariaLive}
+      className={`border rounded-lg p-4 ${styles.container}`}
+    >
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-start gap-3">
+          <Icon className={`h-5 w-5 flex-shrink-0 mt-0.5 ${styles.icon}`} />
+
+          <div>
+            {/* Title */}
+            <h4 className={`font-medium ${styles.title}`}>
+              {totalCount} conflict{totalCount !== 1 ? 's' : ''} detected
+              {actualBlockingCount > 0 && (
+                <span className="ml-2 text-sm font-normal">
+                  ({actualBlockingCount} blocking
+                  {actualWarningCount > 0 && `, ${actualWarningCount} warning${actualWarningCount !== 1 ? 's' : ''}`})
+                </span>
+              )}
+            </h4>
+
+            {/* Message */}
+            <p className={`text-sm mt-1 ${styles.text}`}>
+              {isBlocking
+                ? 'Cannot activate schedule with blocking conflicts. Please resolve them first.'
+                : 'Potential scheduling issues detected. Review before activating.'}
+            </p>
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center gap-2 flex-shrink-0">
+          {/* View Details / Hide Details button */}
+          <button
+            type="button"
+            onClick={handleToggleExpand}
+            className={`${BUTTON_BASE} ${styles.button}`}
+          >
+            {isExpanded ? (
+              <>
+                <ChevronUpIcon className="h-4 w-4" />
+                Hide Details
+              </>
+            ) : (
+              <>
+                <ChevronDownIcon className="h-4 w-4" />
+                View Details
+              </>
+            )}
+          </button>
+
+          {/* Dismiss button (warnings only) */}
+          {!isBlocking && onDismiss && (
+            <button
+              type="button"
+              onClick={onDismiss}
+              className={`${BUTTON_BASE} ${styles.button}`}
+              aria-label="Dismiss"
+            >
+              <XMarkIcon className="h-4 w-4" />
+              Dismiss
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Expanded Conflict List */}
+      {isExpanded && (
+        <div className="mt-4 pt-4 border-t border-current/10">
+          <ConflictList conflicts={conflicts} />
+        </div>
+      )}
+    </div>
+  )
+}
+
+ConflictWarningBanner.propTypes = {
+  /** Array of conflict objects */
+  conflicts: ConflictsPropType,
+  /** Whether there are blocking (error severity) conflicts */
+  hasBlockingConflicts: PropTypes.bool,
+  /** Number of blocking conflicts */
+  blockingCount: PropTypes.number,
+  /** Number of warning conflicts */
+  warningCount: PropTypes.number,
+  /** Callback when "View Details" is clicked */
+  onViewDetails: PropTypes.func,
+  /** Callback when "Dismiss" is clicked (warnings only) */
+  onDismiss: PropTypes.func,
+}
+
+ConflictWarningBanner.defaultProps = {
+  conflicts: null,
+  hasBlockingConflicts: false,
+  blockingCount: 0,
+  warningCount: 0,
+  onViewDetails: undefined,
+  onDismiss: undefined,
+}
+
+export default ConflictWarningBanner

--- a/Firmware/webui/frontend/src/components/scheduler/ConflictResolver/ConflictWarningBanner.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ConflictResolver/ConflictWarningBanner.jsx
@@ -83,12 +83,12 @@ const BUTTON_BASE = [
  * ConflictWarningBanner displays a warning when conflicts are detected
  */
 function ConflictWarningBanner({
-  conflicts,
+  conflicts = null,
   hasBlockingConflicts = false,
-  blockingCount = 0,
-  warningCount = 0,
-  onViewDetails,
-  onDismiss,
+  blockingCount,
+  warningCount,
+  onViewDetails = undefined,
+  onDismiss = undefined,
 }) {
   const [isExpanded, setIsExpanded] = useState(false)
 
@@ -97,9 +97,9 @@ function ConflictWarningBanner({
     return null
   }
 
-  // Calculate counts if not provided
-  const actualBlockingCount = blockingCount || conflicts.filter((c) => c.severity === 'error').length
-  const actualWarningCount = warningCount || conflicts.filter((c) => c.severity === 'warning').length
+  // Calculate counts if not provided (use nullish coalescing to allow 0)
+  const actualBlockingCount = blockingCount ?? conflicts.filter((c) => c.severity === 'error').length
+  const actualWarningCount = warningCount ?? conflicts.filter((c) => c.severity === 'warning').length
   const isBlocking = hasBlockingConflicts || actualBlockingCount > 0
   const totalCount = conflicts.length
 
@@ -199,23 +199,14 @@ ConflictWarningBanner.propTypes = {
   conflicts: ConflictsPropType,
   /** Whether there are blocking (error severity) conflicts */
   hasBlockingConflicts: PropTypes.bool,
-  /** Number of blocking conflicts */
+  /** Number of blocking conflicts (uses nullish coalescing, so 0 is valid) */
   blockingCount: PropTypes.number,
-  /** Number of warning conflicts */
+  /** Number of warning conflicts (uses nullish coalescing, so 0 is valid) */
   warningCount: PropTypes.number,
   /** Callback when "View Details" is clicked */
   onViewDetails: PropTypes.func,
   /** Callback when "Dismiss" is clicked (warnings only) */
   onDismiss: PropTypes.func,
-}
-
-ConflictWarningBanner.defaultProps = {
-  conflicts: null,
-  hasBlockingConflicts: false,
-  blockingCount: 0,
-  warningCount: 0,
-  onViewDetails: undefined,
-  onDismiss: undefined,
 }
 
 export default ConflictWarningBanner

--- a/Firmware/webui/frontend/src/components/scheduler/ConflictResolver/__tests__/ConflictItem.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ConflictResolver/__tests__/ConflictItem.test.jsx
@@ -1,0 +1,192 @@
+/**
+ * Tests for ConflictItem component (Issue #229)
+ *
+ * TDD: Tests written first to define expected behavior
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import ConflictItem from '../ConflictItem'
+
+// Test fixtures matching backend Conflict.to_dict() output
+const mockErrorConflict = {
+  conflict_type: 'resource_contention',
+  severity: 'error',
+  event1_id: 'pattern-1',
+  event1_name: 'UV Capture',
+  event2_id: 'pattern-2',
+  event2_name: 'Flash Photo',
+  start_time: '2024-06-15T21:30:00Z',
+  end_time: '2024-06-15T21:45:00Z',
+  resource: 'camera',
+  message: 'Camera resource conflict: both patterns use takephoto at the same time',
+  suggested_resolution: 'Adjust action timing so camera is not used simultaneously',
+}
+
+const mockWarningConflict = {
+  conflict_type: 'time_overlap',
+  severity: 'warning',
+  event1_id: 'pattern-1',
+  event1_name: 'Morning Survey',
+  event2_id: 'pattern-2',
+  event2_name: 'Dawn Capture',
+  start_time: '2024-06-15T05:00:00Z',
+  end_time: '2024-06-15T05:15:00Z',
+  resource: '',
+  message: "Patterns 'Morning Survey' and 'Dawn Capture' overlap from 05:00:00 to 05:15:00",
+  suggested_resolution: 'Adjust pattern offsets or increase interval between triggers',
+}
+
+const mockGpioConflict = {
+  conflict_type: 'gpio_state_conflict',
+  severity: 'error',
+  event1_id: 'pattern-1',
+  event1_name: 'Attract On',
+  event2_id: 'pattern-2',
+  event2_name: 'Attract Off',
+  start_time: '2024-06-15T22:00:00Z',
+  end_time: '2024-06-15T22:05:00Z',
+  resource: 'attract',
+  message: 'GPIO state conflict: attract_on and attract_off cannot be active simultaneously',
+  suggested_resolution: 'Ensure attract state changes don\'t overlap: add delay between attract_on and attract_off',
+}
+
+describe('ConflictItem', () => {
+  describe('Rendering', () => {
+    it('renders conflict message', () => {
+      render(<ConflictItem conflict={mockErrorConflict} />)
+
+      expect(screen.getByText(/Camera resource conflict/)).toBeInTheDocument()
+    })
+
+    it('renders event names', () => {
+      render(<ConflictItem conflict={mockErrorConflict} />)
+
+      expect(screen.getByText(/UV Capture/)).toBeInTheDocument()
+      expect(screen.getByText(/Flash Photo/)).toBeInTheDocument()
+    })
+
+    it('renders suggested resolution', () => {
+      render(<ConflictItem conflict={mockErrorConflict} />)
+
+      expect(screen.getByText(/Adjust action timing/)).toBeInTheDocument()
+    })
+
+    it('renders time range', () => {
+      const { container } = render(<ConflictItem conflict={mockErrorConflict} />)
+
+      // Should display formatted time (may vary by locale/timezone)
+      // Check that a time range element exists with the expected format
+      const timeRange = container.querySelector('.text-xs.opacity-75.mb-2')
+      expect(timeRange).toBeInTheDocument()
+      expect(timeRange.textContent).toMatch(/\d{2}:\d{2}/)
+      expect(timeRange.textContent).toMatch(/–/)
+    })
+
+    it('renders resource name when provided', () => {
+      const { container } = render(<ConflictItem conflict={mockErrorConflict} />)
+
+      // Resource is shown in parentheses
+      const resourceSpan = container.querySelector('.text-xs.opacity-75')
+      expect(resourceSpan).toBeInTheDocument()
+      expect(resourceSpan.textContent).toContain('camera')
+    })
+
+    it('handles missing resource gracefully', () => {
+      const { container } = render(<ConflictItem conflict={mockWarningConflict} />)
+
+      // Should not crash, should still render the message
+      const message = container.querySelector('p.text-sm')
+      expect(message).toBeInTheDocument()
+      expect(message.textContent).toMatch(/overlap/i)
+    })
+  })
+
+  describe('Severity Styling', () => {
+    it('renders error styling for severity="error"', () => {
+      const { container } = render(<ConflictItem conflict={mockErrorConflict} />)
+
+      // Check for red-related classes
+      const item = container.firstChild
+      expect(item.className).toMatch(/red/)
+    })
+
+    it('renders warning styling for severity="warning"', () => {
+      const { container } = render(<ConflictItem conflict={mockWarningConflict} />)
+
+      // Check for amber-related classes
+      const item = container.firstChild
+      expect(item.className).toMatch(/amber/)
+    })
+
+    it('shows appropriate icon for error severity', () => {
+      const { container } = render(<ConflictItem conflict={mockErrorConflict} />)
+
+      // Should have an SVG icon
+      const icon = container.querySelector('svg')
+      expect(icon).toBeInTheDocument()
+    })
+
+    it('shows appropriate icon for warning severity', () => {
+      const { container } = render(<ConflictItem conflict={mockWarningConflict} />)
+
+      // Should have an SVG icon
+      const icon = container.querySelector('svg')
+      expect(icon).toBeInTheDocument()
+    })
+  })
+
+  describe('Conflict Types', () => {
+    it('renders label for time_overlap', () => {
+      render(<ConflictItem conflict={mockWarningConflict} />)
+
+      // Use getAllByText since label appears in badge
+      expect(screen.getAllByText(/Time Overlap/i).length).toBeGreaterThan(0)
+    })
+
+    it('renders label for resource_contention', () => {
+      render(<ConflictItem conflict={mockErrorConflict} />)
+
+      // Use getAllByText since label appears in badge
+      expect(screen.getAllByText(/Resource Conflict/i).length).toBeGreaterThan(0)
+    })
+
+    it('renders label for gpio_state_conflict', () => {
+      render(<ConflictItem conflict={mockGpioConflict} />)
+
+      // Use getAllByText since label appears in badge
+      expect(screen.getAllByText(/GPIO State Conflict/i).length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('has appropriate role="listitem"', () => {
+      render(<ConflictItem conflict={mockErrorConflict} />)
+
+      expect(screen.getByRole('listitem')).toBeInTheDocument()
+    })
+
+    it('has aria-label describing the conflict', () => {
+      render(<ConflictItem conflict={mockErrorConflict} />)
+
+      const item = screen.getByRole('listitem')
+      expect(item).toHaveAttribute('aria-label')
+    })
+  })
+
+  describe('Dark Mode', () => {
+    it('has dark mode classes for error variant', () => {
+      const { container } = render(<ConflictItem conflict={mockErrorConflict} />)
+
+      const item = container.firstChild
+      expect(item.className).toMatch(/dark:/)
+    })
+
+    it('has dark mode classes for warning variant', () => {
+      const { container } = render(<ConflictItem conflict={mockWarningConflict} />)
+
+      const item = container.firstChild
+      expect(item.className).toMatch(/dark:/)
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/components/scheduler/ConflictResolver/__tests__/ConflictItem.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ConflictResolver/__tests__/ConflictItem.test.jsx
@@ -77,9 +77,10 @@ describe('ConflictItem', () => {
 
       // Should display formatted time (may vary by locale/timezone)
       // Check that a time range element exists with the expected format
+      // Hours may be 1 or 2 digits, minutes are always 2 digits
       const timeRange = container.querySelector('.text-xs.opacity-75.mb-2')
       expect(timeRange).toBeInTheDocument()
-      expect(timeRange.textContent).toMatch(/\d{2}:\d{2}/)
+      expect(timeRange.textContent).toMatch(/\d{1,2}:\d{2}/)
       expect(timeRange.textContent).toMatch(/–/)
     })
 

--- a/Firmware/webui/frontend/src/components/scheduler/ConflictResolver/__tests__/ConflictList.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ConflictResolver/__tests__/ConflictList.test.jsx
@@ -237,6 +237,32 @@ describe('ConflictList', () => {
 
       expect(handleViewAll).toHaveBeenCalled()
     })
+
+    it('respects custom compactLimit prop', () => {
+      const { container } = render(
+        <ConflictList conflicts={mixedConflicts} compact compactLimit={2} />
+      )
+
+      // Should only show 2 items with custom limit
+      const listItems = container.querySelectorAll('li')
+      expect(listItems.length).toBe(2)
+
+      // 4 conflicts - 2 shown = 2 more
+      expect(screen.getByText(/\+2 more/i)).toBeInTheDocument()
+    })
+
+    it('shows all conflicts when compactLimit exceeds conflict count', () => {
+      const { container } = render(
+        <ConflictList conflicts={mixedConflicts} compact compactLimit={10} />
+      )
+
+      // Should show all 4 items since limit is higher
+      const listItems = container.querySelectorAll('li')
+      expect(listItems.length).toBe(4)
+
+      // No "+N more" since all are shown
+      expect(screen.queryByText(/\+\d+ more/i)).not.toBeInTheDocument()
+    })
   })
 
   describe('Dark Mode', () => {

--- a/Firmware/webui/frontend/src/components/scheduler/ConflictResolver/__tests__/ConflictList.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ConflictResolver/__tests__/ConflictList.test.jsx
@@ -211,10 +211,17 @@ describe('ConflictList', () => {
     })
 
     it('shows "+N more" when more conflicts exist in compact mode', () => {
-      render(<ConflictList conflicts={mixedConflicts} compact />)
+      render(<ConflictList conflicts={mixedConflicts} compact onViewAll={() => {}} />)
 
       // 4 conflicts - 3 shown = 1 more
       expect(screen.getByText(/\+1 more/i)).toBeInTheDocument()
+    })
+
+    it('does not show "+N more" button when onViewAll is not provided', () => {
+      render(<ConflictList conflicts={mixedConflicts} compact />)
+
+      // Even though there are hidden conflicts, button should not render without callback
+      expect(screen.queryByText(/\+\d+ more/i)).not.toBeInTheDocument()
     })
 
     it('does not show "+N more" when all conflicts fit in compact mode', () => {
@@ -240,7 +247,7 @@ describe('ConflictList', () => {
 
     it('respects custom compactLimit prop', () => {
       const { container } = render(
-        <ConflictList conflicts={mixedConflicts} compact compactLimit={2} />
+        <ConflictList conflicts={mixedConflicts} compact compactLimit={2} onViewAll={() => {}} />
       )
 
       // Should only show 2 items with custom limit

--- a/Firmware/webui/frontend/src/components/scheduler/ConflictResolver/__tests__/ConflictList.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ConflictResolver/__tests__/ConflictList.test.jsx
@@ -1,0 +1,251 @@
+/**
+ * Tests for ConflictList component (Issue #229)
+ *
+ * TDD: Tests written first to define expected behavior
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ConflictList from '../ConflictList'
+
+// Test fixtures matching backend Conflict.to_dict() output
+const mockErrorConflict1 = {
+  conflict_type: 'resource_contention',
+  severity: 'error',
+  event1_id: 'pattern-1',
+  event1_name: 'UV Capture',
+  event2_id: 'pattern-2',
+  event2_name: 'Flash Photo',
+  start_time: '2024-06-15T21:30:00Z',
+  end_time: '2024-06-15T21:45:00Z',
+  resource: 'camera',
+  message: 'Camera resource conflict',
+  suggested_resolution: 'Adjust timing',
+}
+
+const mockErrorConflict2 = {
+  conflict_type: 'gpio_state_conflict',
+  severity: 'error',
+  event1_id: 'pattern-3',
+  event1_name: 'Attract On',
+  event2_id: 'pattern-4',
+  event2_name: 'Attract Off',
+  start_time: '2024-06-15T22:00:00Z',
+  end_time: '2024-06-15T22:05:00Z',
+  resource: 'attract',
+  message: 'GPIO state conflict',
+  suggested_resolution: 'Add delay',
+}
+
+const mockWarningConflict1 = {
+  conflict_type: 'time_overlap',
+  severity: 'warning',
+  event1_id: 'pattern-5',
+  event1_name: 'Morning Survey',
+  event2_id: 'pattern-6',
+  event2_name: 'Dawn Capture',
+  start_time: '2024-06-15T05:00:00Z',
+  end_time: '2024-06-15T05:15:00Z',
+  resource: '',
+  message: 'Patterns overlap',
+  suggested_resolution: 'Adjust offsets',
+}
+
+const mockWarningConflict2 = {
+  conflict_type: 'time_overlap',
+  severity: 'warning',
+  event1_id: 'pattern-7',
+  event1_name: 'Night Survey',
+  event2_id: 'pattern-8',
+  event2_name: 'Evening Capture',
+  start_time: '2024-06-15T20:00:00Z',
+  end_time: '2024-06-15T20:30:00Z',
+  resource: '',
+  message: 'Patterns overlap at evening',
+  suggested_resolution: 'Increase interval',
+}
+
+// Mixed conflicts for testing grouping
+const mixedConflicts = [
+  mockWarningConflict1, // warning first to test sorting
+  mockErrorConflict1,
+  mockWarningConflict2,
+  mockErrorConflict2,
+]
+
+describe('ConflictList', () => {
+  describe('Rendering', () => {
+    it('renders nothing when conflicts is empty', () => {
+      const { container } = render(<ConflictList conflicts={[]} />)
+
+      expect(container.firstChild).toBeNull()
+    })
+
+    it('renders nothing when conflicts is null', () => {
+      const { container } = render(<ConflictList conflicts={null} />)
+
+      expect(container.firstChild).toBeNull()
+    })
+
+    it('renders nothing when conflicts is undefined', () => {
+      const { container } = render(<ConflictList />)
+
+      expect(container.firstChild).toBeNull()
+    })
+
+    it('renders list of conflicts', () => {
+      render(<ConflictList conflicts={[mockErrorConflict1]} />)
+
+      expect(screen.getByText(/Camera resource conflict/)).toBeInTheDocument()
+    })
+
+    it('renders heading with conflict count', () => {
+      render(<ConflictList conflicts={mixedConflicts} />)
+
+      // Should show total count
+      expect(screen.getByText(/4 conflict/i)).toBeInTheDocument()
+    })
+
+    it('renders blocking conflict count when present', () => {
+      render(<ConflictList conflicts={mixedConflicts} />)
+
+      // Should indicate blocking conflicts
+      expect(screen.getByText(/2 blocking/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('Grouping', () => {
+    it('groups error conflicts before warning conflicts', () => {
+      const { container } = render(<ConflictList conflicts={mixedConflicts} />)
+
+      // Get all list items
+      const listItems = container.querySelectorAll('li')
+
+      // Should have 4 items
+      expect(listItems.length).toBe(4)
+
+      // First two should be errors (red styling)
+      expect(listItems[0].className).toMatch(/red/)
+      expect(listItems[1].className).toMatch(/red/)
+
+      // Last two should be warnings (amber styling)
+      expect(listItems[2].className).toMatch(/amber/)
+      expect(listItems[3].className).toMatch(/amber/)
+    })
+
+    it('renders error section header when errors exist', () => {
+      render(<ConflictList conflicts={mixedConflicts} />)
+
+      expect(screen.getByText(/Blocking Conflicts/i)).toBeInTheDocument()
+    })
+
+    it('renders warning section header when warnings exist', () => {
+      render(<ConflictList conflicts={mixedConflicts} />)
+
+      expect(screen.getByText(/Warnings/i)).toBeInTheDocument()
+    })
+
+    it('does not render warning header when only errors exist', () => {
+      render(<ConflictList conflicts={[mockErrorConflict1, mockErrorConflict2]} />)
+
+      expect(screen.queryByText(/Warnings/i)).not.toBeInTheDocument()
+    })
+
+    it('does not render error header when only warnings exist', () => {
+      render(<ConflictList conflicts={[mockWarningConflict1, mockWarningConflict2]} />)
+
+      expect(screen.queryByText(/Blocking Conflicts/i)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('ConflictItem Integration', () => {
+    it('renders ConflictItem for each conflict', () => {
+      render(<ConflictList conflicts={mixedConflicts} />)
+
+      // Check that all conflict messages are rendered
+      expect(screen.getByText(/Camera resource conflict/)).toBeInTheDocument()
+      expect(screen.getByText(/GPIO state conflict/)).toBeInTheDocument()
+      // Use getAllByText for "Patterns overlap" since it's a substring of both warning messages
+      const overlapTexts = screen.getAllByText(/Patterns overlap/)
+      expect(overlapTexts.length).toBe(2)
+    })
+
+    it('renders correct number of list items', () => {
+      const { container } = render(<ConflictList conflicts={mixedConflicts} />)
+
+      const listItems = container.querySelectorAll('li')
+      expect(listItems.length).toBe(4)
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('has role="list" on container', () => {
+      render(<ConflictList conflicts={[mockErrorConflict1]} />)
+
+      expect(screen.getByRole('list')).toBeInTheDocument()
+    })
+
+    it('has aria-label describing conflict list', () => {
+      render(<ConflictList conflicts={[mockErrorConflict1]} />)
+
+      const list = screen.getByRole('list')
+      expect(list).toHaveAttribute('aria-label')
+    })
+  })
+
+  describe('Compact Mode', () => {
+    it('renders all conflicts by default (not compact)', () => {
+      const { container } = render(<ConflictList conflicts={mixedConflicts} />)
+
+      const listItems = container.querySelectorAll('li')
+      expect(listItems.length).toBe(4)
+    })
+
+    it('limits visible conflicts to 3 in compact mode', () => {
+      const { container } = render(<ConflictList conflicts={mixedConflicts} compact />)
+
+      // Should only show 3 items
+      const listItems = container.querySelectorAll('li')
+      expect(listItems.length).toBe(3)
+    })
+
+    it('shows "+N more" when more conflicts exist in compact mode', () => {
+      render(<ConflictList conflicts={mixedConflicts} compact />)
+
+      // 4 conflicts - 3 shown = 1 more
+      expect(screen.getByText(/\+1 more/i)).toBeInTheDocument()
+    })
+
+    it('does not show "+N more" when all conflicts fit in compact mode', () => {
+      render(<ConflictList conflicts={[mockErrorConflict1, mockErrorConflict2]} compact />)
+
+      // Only 2 conflicts, fits in 3
+      expect(screen.queryByText(/\+\d+ more/i)).not.toBeInTheDocument()
+    })
+
+    it('calls onViewAll when "+N more" is clicked', async () => {
+      const user = userEvent.setup()
+      const handleViewAll = vi.fn()
+
+      render(
+        <ConflictList conflicts={mixedConflicts} compact onViewAll={handleViewAll} />
+      )
+
+      const moreButton = screen.getByText(/\+1 more/i)
+      await user.click(moreButton)
+
+      expect(handleViewAll).toHaveBeenCalled()
+    })
+  })
+
+  describe('Dark Mode', () => {
+    it('has dark mode classes on container', () => {
+      const { container } = render(<ConflictList conflicts={[mockErrorConflict1]} />)
+
+      // Container should have dark mode support
+      const wrapper = container.firstChild
+      expect(wrapper.className).toMatch(/dark:/)
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/components/scheduler/ConflictResolver/__tests__/ConflictWarningBanner.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ConflictResolver/__tests__/ConflictWarningBanner.test.jsx
@@ -1,0 +1,311 @@
+/**
+ * Tests for ConflictWarningBanner component (Issue #229)
+ *
+ * TDD: Tests written first to define expected behavior
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ConflictWarningBanner from '../ConflictWarningBanner'
+
+// Test fixtures
+const mockErrorConflict = {
+  conflict_type: 'resource_contention',
+  severity: 'error',
+  event1_id: 'pattern-1',
+  event1_name: 'UV Capture',
+  event2_id: 'pattern-2',
+  event2_name: 'Flash Photo',
+  start_time: '2024-06-15T21:30:00Z',
+  end_time: '2024-06-15T21:45:00Z',
+  resource: 'camera',
+  message: 'Camera resource conflict',
+  suggested_resolution: 'Adjust timing',
+}
+
+const mockWarningConflict = {
+  conflict_type: 'time_overlap',
+  severity: 'warning',
+  event1_id: 'pattern-3',
+  event1_name: 'Morning Survey',
+  event2_id: 'pattern-4',
+  event2_name: 'Dawn Capture',
+  start_time: '2024-06-15T05:00:00Z',
+  end_time: '2024-06-15T05:15:00Z',
+  resource: '',
+  message: 'Patterns overlap',
+  suggested_resolution: 'Adjust offsets',
+}
+
+const blockingConflicts = [mockErrorConflict]
+const warningConflicts = [mockWarningConflict]
+const mixedConflicts = [mockErrorConflict, mockWarningConflict]
+
+describe('ConflictWarningBanner', () => {
+  describe('Visibility', () => {
+    it('renders nothing when conflicts is empty', () => {
+      const { container } = render(<ConflictWarningBanner conflicts={[]} />)
+
+      expect(container.firstChild).toBeNull()
+    })
+
+    it('renders nothing when conflicts is null', () => {
+      const { container } = render(<ConflictWarningBanner conflicts={null} />)
+
+      expect(container.firstChild).toBeNull()
+    })
+
+    it('renders nothing when conflicts is undefined', () => {
+      const { container } = render(<ConflictWarningBanner />)
+
+      expect(container.firstChild).toBeNull()
+    })
+
+    it('renders banner when conflicts exist', () => {
+      render(<ConflictWarningBanner conflicts={blockingConflicts} />)
+
+      // Should render some content
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+  })
+
+  describe('Severity Variants', () => {
+    it('renders error banner when hasBlockingConflicts is true', () => {
+      const { container } = render(
+        <ConflictWarningBanner conflicts={blockingConflicts} hasBlockingConflicts />
+      )
+
+      // Check for red styling
+      const banner = container.firstChild
+      expect(banner.className).toMatch(/red/)
+    })
+
+    it('renders warning banner when only warnings exist', () => {
+      const { container } = render(
+        <ConflictWarningBanner conflicts={warningConflicts} />
+      )
+
+      // Check for amber styling
+      const banner = container.firstChild
+      expect(banner.className).toMatch(/amber/)
+    })
+
+    it('uses error icon for blocking conflicts', () => {
+      const { container } = render(
+        <ConflictWarningBanner conflicts={blockingConflicts} hasBlockingConflicts />
+      )
+
+      // Should have an SVG icon
+      const icon = container.querySelector('svg')
+      expect(icon).toBeInTheDocument()
+    })
+
+    it('uses warning icon for warnings only', () => {
+      const { container } = render(
+        <ConflictWarningBanner conflicts={warningConflicts} />
+      )
+
+      // Should have an SVG icon
+      const icon = container.querySelector('svg')
+      expect(icon).toBeInTheDocument()
+    })
+  })
+
+  describe('Content', () => {
+    it('displays blocking conflict count', () => {
+      render(
+        <ConflictWarningBanner
+          conflicts={mixedConflicts}
+          hasBlockingConflicts
+          blockingCount={1}
+          warningCount={1}
+        />
+      )
+
+      expect(screen.getByText(/1 blocking/i)).toBeInTheDocument()
+    })
+
+    it('displays warning count', () => {
+      render(
+        <ConflictWarningBanner
+          conflicts={mixedConflicts}
+          hasBlockingConflicts
+          blockingCount={1}
+          warningCount={1}
+        />
+      )
+
+      expect(screen.getByText(/1 warning/i)).toBeInTheDocument()
+    })
+
+    it('displays total conflict count', () => {
+      render(
+        <ConflictWarningBanner
+          conflicts={mixedConflicts}
+          hasBlockingConflicts
+          blockingCount={1}
+          warningCount={1}
+        />
+      )
+
+      expect(screen.getByText(/2 conflict/i)).toBeInTheDocument()
+    })
+
+    it('displays appropriate message for blocking conflicts', () => {
+      render(
+        <ConflictWarningBanner
+          conflicts={blockingConflicts}
+          hasBlockingConflicts
+          blockingCount={1}
+        />
+      )
+
+      expect(screen.getByText(/cannot activate/i)).toBeInTheDocument()
+    })
+
+    it('displays appropriate message for warnings only', () => {
+      render(
+        <ConflictWarningBanner conflicts={warningConflicts} warningCount={1} />
+      )
+
+      expect(screen.getByText(/potential/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('Actions', () => {
+    it('renders "View Details" button', () => {
+      render(<ConflictWarningBanner conflicts={blockingConflicts} />)
+
+      expect(screen.getByRole('button', { name: /view details/i })).toBeInTheDocument()
+    })
+
+    it('calls onViewDetails when button clicked', async () => {
+      const user = userEvent.setup()
+      const handleViewDetails = vi.fn()
+
+      render(
+        <ConflictWarningBanner
+          conflicts={blockingConflicts}
+          onViewDetails={handleViewDetails}
+        />
+      )
+
+      await user.click(screen.getByRole('button', { name: /view details/i }))
+      expect(handleViewDetails).toHaveBeenCalled()
+    })
+
+    it('renders "Dismiss" button for warnings only', () => {
+      render(
+        <ConflictWarningBanner
+          conflicts={warningConflicts}
+          onDismiss={() => {}}
+        />
+      )
+
+      expect(screen.getByRole('button', { name: /dismiss/i })).toBeInTheDocument()
+    })
+
+    it('calls onDismiss when dismiss button clicked', async () => {
+      const user = userEvent.setup()
+      const handleDismiss = vi.fn()
+
+      render(
+        <ConflictWarningBanner
+          conflicts={warningConflicts}
+          onDismiss={handleDismiss}
+        />
+      )
+
+      await user.click(screen.getByRole('button', { name: /dismiss/i }))
+      expect(handleDismiss).toHaveBeenCalled()
+    })
+
+    it('does not render dismiss for blocking conflicts', () => {
+      render(
+        <ConflictWarningBanner
+          conflicts={blockingConflicts}
+          hasBlockingConflicts
+          onDismiss={() => {}}
+        />
+      )
+
+      expect(screen.queryByRole('button', { name: /dismiss/i })).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Expanded State', () => {
+    it('toggles ConflictList visibility on "View Details" click', async () => {
+      const user = userEvent.setup()
+
+      render(<ConflictWarningBanner conflicts={blockingConflicts} />)
+
+      // Initially, detailed conflict list should not be visible
+      expect(screen.queryByRole('list')).not.toBeInTheDocument()
+
+      // Click View Details
+      await user.click(screen.getByRole('button', { name: /view details/i }))
+
+      // Now conflict list should be visible
+      expect(screen.getByRole('list')).toBeInTheDocument()
+
+      // Click again to hide
+      await user.click(screen.getByRole('button', { name: /hide details/i }))
+
+      // List should be hidden again
+      expect(screen.queryByRole('list')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('has role="alert" for blocking conflicts', () => {
+      render(
+        <ConflictWarningBanner conflicts={blockingConflicts} hasBlockingConflicts />
+      )
+
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+
+    it('has role="status" for warnings only', () => {
+      render(<ConflictWarningBanner conflicts={warningConflicts} />)
+
+      expect(screen.getByRole('status')).toBeInTheDocument()
+    })
+
+    it('has aria-live="assertive" for blocking conflicts', () => {
+      render(
+        <ConflictWarningBanner conflicts={blockingConflicts} hasBlockingConflicts />
+      )
+
+      const banner = screen.getByRole('alert')
+      expect(banner).toHaveAttribute('aria-live', 'assertive')
+    })
+
+    it('has aria-live="polite" for warnings', () => {
+      render(<ConflictWarningBanner conflicts={warningConflicts} />)
+
+      const banner = screen.getByRole('status')
+      expect(banner).toHaveAttribute('aria-live', 'polite')
+    })
+  })
+
+  describe('Dark Mode', () => {
+    it('has dark mode classes for error variant', () => {
+      const { container } = render(
+        <ConflictWarningBanner conflicts={blockingConflicts} hasBlockingConflicts />
+      )
+
+      const banner = container.firstChild
+      expect(banner.className).toMatch(/dark:/)
+    })
+
+    it('has dark mode classes for warning variant', () => {
+      const { container } = render(
+        <ConflictWarningBanner conflicts={warningConflicts} />
+      )
+
+      const banner = container.firstChild
+      expect(banner.className).toMatch(/dark:/)
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/components/scheduler/ConflictResolver/index.js
+++ b/Firmware/webui/frontend/src/components/scheduler/ConflictResolver/index.js
@@ -1,0 +1,20 @@
+/**
+ * Conflict Resolver components (Issue #229)
+ *
+ * Components for displaying and resolving schedule conflicts.
+ */
+
+// PropTypes - exported first for use in other components
+export {
+  ConflictPropType,
+  ConflictsPropType,
+  CONFLICT_TYPES,
+  SEVERITY_LEVELS,
+  CONFLICT_TYPE_LABELS,
+  SEVERITY_LABELS,
+} from './ConflictPropTypes'
+
+// Components
+export { default as ConflictItem } from './ConflictItem'
+export { default as ConflictList } from './ConflictList'
+export { default as ConflictWarningBanner } from './ConflictWarningBanner'


### PR DESCRIPTION
## Summary

Implements Issue #229 - Scheduler Conflict Resolver for the Visual Scheduler UI.

- **ConflictItem**: Individual conflict display with severity-based styling (red for error/blocking, amber for warning)
- **ConflictList**: Groups conflicts by severity (errors first, then warnings) with compact mode (3 items + "+N more")
- **ConflictWarningBanner**: Warning banner with expandable conflict list, appropriate ARIA roles for accessibility
- **ExecutionMarker**: Extended with `conflictSeverity` and `conflictMessage` props for calendar conflict highlighting

### Features
- Overlap detection display with conflict type icons (time overlap, resource contention, GPIO state)
- Resolution suggestions displayed for each conflict
- Conflict highlighting in calendar view (red/amber rings)
- Warning banner before schedule activation
- Full dark mode support
- Comprehensive accessibility (ARIA roles, labels, keyboard navigation)

### Technical Details
- PropTypes match backend `Conflict.to_dict()` structure from `schedule_conflict.py`
- Uses shared `formatTime` utility from `calendarUtils.js` (no duplication)
- `React.memo` applied to `ConflictItem` for render optimization
- TDD approach with 98 tests total (63 ConflictResolver + 35 ExecutionMarker)

## Test plan

- [x] All 98 tests pass (`npm test -- ConflictResolver ExecutionMarker --run`)
- [x] ESLint passes (`npm run lint`)
- [x] Production build succeeds (`npm run build`)
- [ ] Manual testing of conflict display in calendar view
- [ ] Verify dark mode styling
- [ ] Test screen reader accessibility

## Files Changed

| Component | Lines | Description |
|-----------|-------|-------------|
| ConflictPropTypes.js | 63 | Shared PropTypes matching backend |
| ConflictItem.jsx | 155 | Individual conflict display |
| ConflictList.jsx | 160 | Grouped conflict list with compact mode |
| ConflictWarningBanner.jsx | 221 | Warning banner with expand/collapse |
| ExecutionMarker.jsx | +51 | Conflict highlighting support |
| Tests | 833 | Comprehensive test coverage |

Closes #229