### PR TITLE
feat(scheduler): Add Expert Mode for raw cron expression input (#233)

### DIFF
--- a/Firmware/Tests/conftest.py
+++ b/Firmware/Tests/conftest.py
@@ -1584,6 +1584,7 @@ def pytest_collection_modifyitems(config, items):
             'test_scheduler_api_workflow',  # Uses mocks/tmp_path/Flask test client, no camera/GPIO (Issue #218)
             'test_builtin_patterns_api',  # Uses Flask test client, no camera/GPIO (Issue #219)
             'test_sensor_workflow',  # Uses mocks/I2C mocking, no camera/GPIO (Issue #232)
+            'test_expert_mode_workflow',  # Uses mocks/tmp_path/Flask test client, no camera/GPIO (Issue #233)
         )
 
         is_non_hardware_test = any(test in fspath_str for test in non_hardware_tests)

--- a/Firmware/Tests/integration/test_expert_mode_workflow.py
+++ b/Firmware/Tests/integration/test_expert_mode_workflow.py
@@ -1,0 +1,552 @@
+"""Integration tests for Expert Mode scheduler workflow (Issue #233).
+
+Tests the complete workflow for creating, validating, and activating
+schedules with raw cron expression triggers.
+
+Run with: MOTHBOX_ENV=test pytest Tests/integration/test_expert_mode_workflow.py -v -s
+
+These tests are marked as @pytest.mark.integration.
+They test API integration without requiring Pi hardware (cron/RTC is mocked).
+
+Issue #233 - Scheduler Expert Mode (Phase 4: Integration Tests)
+"""
+
+import json
+import os
+import sys
+import uuid
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+
+# Mark entire module as integration
+pytestmark = pytest.mark.integration
+
+# Setup path
+FIRMWARE_DIR = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(FIRMWARE_DIR))
+sys.path.insert(0, str(FIRMWARE_DIR / "webui" / "backend"))
+os.environ.setdefault("MOTHBOX_ENV", "test")
+
+from webui.backend.routes.scheduler_ui import scheduler_ui_bp
+
+
+def _test_uuid(name: str) -> str:
+    """Generate deterministic test UUID from name."""
+    return str(uuid.uuid5(uuid.NAMESPACE_DNS, f"test.integration.expert.{name}"))
+
+
+# ============================================================================
+# Module-specific Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def schedule_dirs(tmp_path):
+    """Create temporary directories for schedules."""
+    user_dir = tmp_path / "schedules"
+    builtin_dir = tmp_path / "presets_builtin" / "schedules"
+    user_dir.mkdir(parents=True)
+    builtin_dir.mkdir(parents=True)
+
+    return user_dir, builtin_dir
+
+
+@pytest.fixture
+def app(schedule_dirs, monkeypatch):
+    """Flask app with mocked scheduler dependencies."""
+    # Mock apply_to_system and remove_from_system
+    apply_mock = MagicMock(return_value=True)
+    remove_mock = MagicMock(return_value=True)
+
+    monkeypatch.setattr(
+        "webui.backend.services.scheduler_service.apply_to_system",
+        apply_mock,
+    )
+    monkeypatch.setattr(
+        "webui.backend.services.scheduler_service.remove_from_system",
+        remove_mock,
+    )
+
+    # Patch the storage directories
+    user_dir, builtin_dir = schedule_dirs
+    import webui.backend.lib.schedule_storage as ss
+
+    monkeypatch.setattr("mothbox_paths.SCHEDULES_DIR", user_dir)
+    monkeypatch.setattr("mothbox_paths.BUILTIN_SCHEDULES_DIR", builtin_dir)
+    monkeypatch.setattr(ss, "SCHEDULES_DIR", user_dir)
+    monkeypatch.setattr(ss, "BUILTIN_SCHEDULES_DIR", builtin_dir)
+
+    # Reset the singleton service to use patched paths
+    import webui.backend.routes.scheduler_ui as sui
+
+    monkeypatch.setattr(sui, "_scheduler_service", None)
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["WTF_CSRF_ENABLED"] = False
+
+    app.register_blueprint(scheduler_ui_bp, url_prefix="/api/scheduler/ui")
+
+    # Store mocks on app for test access
+    app._apply_mock = apply_mock
+    app._remove_mock = remove_mock
+
+    yield app
+
+
+@pytest.fixture
+def client(app):
+    """Flask test client."""
+    return app.test_client()
+
+
+@pytest.fixture
+def sample_cron_schedule_data():
+    """Valid schedule data with cron trigger for API requests."""
+    return {
+        "name": "Expert Mode Test",
+        "description": "Test schedule with raw cron expression",
+        "trigger_type": "cron",
+        "cron_trigger": {
+            "cron_expression": "0 21 * * *",
+        },
+        "event_patterns": [
+            {
+                "pattern_id": _test_uuid("test-pattern"),
+                "name": "Test Pattern",
+                "description": "Test pattern for expert mode",
+                "actions": [
+                    {
+                        "action_type": "camera",
+                        "action_name": "takephoto",
+                        "offset_minutes": 0,
+                        "description": "Take a photo",
+                    }
+                ],
+                "category": "user",
+                "tags": ["test", "expert"],
+            }
+        ],
+        "enabled": True,
+    }
+
+
+# ============================================================================
+# Test Expert Mode Schedule Creation
+# ============================================================================
+
+
+class TestExpertModeScheduleCreation:
+    """Integration tests for creating schedules with cron triggers."""
+
+    def test_create_schedule_with_cron_trigger(
+        self,
+        client,
+        sample_cron_schedule_data,
+    ):
+        """Create a schedule with cron trigger via API and verify it persists."""
+        # Create schedule
+        response = client.post(
+            "/api/scheduler/ui/schedules",
+            json=sample_cron_schedule_data,
+            content_type="application/json",
+        )
+
+        assert response.status_code == 201, f"Create failed: {response.get_json()}"
+        data = response.get_json()
+
+        # Verify response structure (returns {"schedule": {...}, "schedule_id": "..."})
+        assert "schedule" in data
+        assert "schedule_id" in data
+        schedule_id = data["schedule_id"]
+
+        # Verify schedule data
+        schedule = data["schedule"]
+        assert schedule["trigger_type"] == "cron"
+        assert schedule["cron_trigger"]["cron_expression"] == "0 21 * * *"
+
+        # Verify schedule persists - retrieve it
+        get_response = client.get(f"/api/scheduler/ui/schedules/{schedule_id}")
+        assert get_response.status_code == 200
+
+        retrieved = get_response.get_json()
+        assert retrieved["trigger_type"] == "cron"
+        assert retrieved["cron_trigger"]["cron_expression"] == "0 21 * * *"
+
+    def test_cron_schedule_appears_in_list(
+        self,
+        client,
+        sample_cron_schedule_data,
+    ):
+        """Verify cron schedule shows up in schedule list."""
+        # Create schedule
+        create_response = client.post(
+            "/api/scheduler/ui/schedules",
+            json=sample_cron_schedule_data,
+            content_type="application/json",
+        )
+        assert create_response.status_code == 201
+        schedule_id = create_response.get_json()["schedule_id"]
+
+        # Get list of all schedules
+        list_response = client.get("/api/scheduler/ui/schedules")
+        assert list_response.status_code == 200
+
+        response_data = list_response.get_json()
+        assert "schedules" in response_data
+        schedules = response_data["schedules"]
+        assert isinstance(schedules, list)
+
+        # Find our schedule in the list
+        found = False
+        for schedule in schedules:
+            if schedule.get("schedule_id") == schedule_id:
+                found = True
+                # List endpoint returns summaries, not full schedule details
+                # Only trigger_type is included, not the full trigger config
+                assert schedule["trigger_type"] == "cron"
+                assert schedule["name"] == "Expert Mode Test"
+                break
+
+        assert found, f"Schedule {schedule_id} not found in list"
+
+
+# ============================================================================
+# Test Expert Mode Activation
+# ============================================================================
+
+
+class TestExpertModeActivation:
+    """Integration tests for activating schedules with cron triggers."""
+
+    def test_activate_cron_schedule(
+        self,
+        client,
+        app,
+        sample_cron_schedule_data,
+    ):
+        """Activate a schedule with cron trigger."""
+        # Create schedule
+        create_response = client.post(
+            "/api/scheduler/ui/schedules",
+            json=sample_cron_schedule_data,
+            content_type="application/json",
+        )
+        assert create_response.status_code == 201
+        schedule_id = create_response.get_json()["schedule_id"]
+
+        # Activate schedule
+        activate_response = client.post(
+            f"/api/scheduler/ui/schedules/{schedule_id}/activate",
+            json={"check_conflicts": False},
+            content_type="application/json",
+        )
+
+        assert activate_response.status_code == 200, (
+            f"Activate failed: {activate_response.get_json()}"
+        )
+
+        # Verify schedule is now active
+        active_response = client.get("/api/scheduler/ui/schedules/active")
+        assert active_response.status_code == 200
+
+        active_data = active_response.get_json()
+        assert active_data.get("active") is True
+        assert active_data.get("schedule", {}).get("schedule_id") == schedule_id
+
+        # Verify cron trigger is preserved in active schedule
+        assert active_data["schedule"]["trigger_type"] == "cron"
+        assert active_data["schedule"]["cron_trigger"]["cron_expression"] == "0 21 * * *"
+
+    def test_cron_schedule_generates_cron_entries(
+        self,
+        client,
+        app,
+        sample_cron_schedule_data,
+    ):
+        """Verify cron bridge generates correct cron entries for cron trigger."""
+        # Create schedule
+        create_response = client.post(
+            "/api/scheduler/ui/schedules",
+            json=sample_cron_schedule_data,
+            content_type="application/json",
+        )
+        assert create_response.status_code == 201
+        schedule_id = create_response.get_json()["schedule_id"]
+
+        # Activate schedule
+        activate_response = client.post(
+            f"/api/scheduler/ui/schedules/{schedule_id}/activate",
+            json={"check_conflicts": False},
+            content_type="application/json",
+        )
+        assert activate_response.status_code == 200
+
+        # Verify apply_to_system was called with cron entries
+        app._apply_mock.assert_called_once()
+        call_args = app._apply_mock.call_args
+        entries = call_args.kwargs.get("entries", call_args[0][0] if call_args[0] else [])
+
+        assert len(entries) >= 1, "Should have at least one cron entry"
+
+        # Verify cron entry uses the raw expression from trigger
+        entry = entries[0]
+        assert entry.expression == "0 21 * * *", (
+            f"Expected cron expression '0 21 * * *', got '{entry.expression}'"
+        )
+
+        # Verify command references TakePhoto script
+        assert "takephoto" in entry.command.lower(), (
+            f"Command should reference takephoto, got '{entry.command}'"
+        )
+
+        # Verify comment includes Mothbox prefix
+        assert entry.comment.startswith("Mothbox:"), (
+            f"Comment should start with 'Mothbox:', got '{entry.comment}'"
+        )
+
+
+# ============================================================================
+# Test Expert Mode Validation
+# ============================================================================
+
+
+class TestExpertModeValidation:
+    """Integration tests for cron validation endpoint."""
+
+    def test_validate_cron_expression_endpoint(self, client):
+        """Complete validation endpoint workflow returns all expected fields."""
+        # Test valid cron expression
+        response = client.post(
+            "/api/scheduler/ui/cron/validate",
+            json={"expression": "*/5 * * * *", "count": 5},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+
+        # Verify all expected fields present
+        assert data["valid"] is True
+        assert data["expression"] == "*/5 * * * *"
+        assert "human_readable" in data
+        assert "next_executions" in data
+        assert len(data["next_executions"]) == 5
+
+        # Verify executions are in the future and properly formatted
+        for exec_time in data["next_executions"]:
+            dt = datetime.fromisoformat(exec_time)
+            assert dt > datetime.now()
+
+    def test_invalid_cron_expression_rejected(
+        self,
+        client,
+        sample_cron_schedule_data,
+    ):
+        """Invalid cron expressions are rejected on create."""
+        # Modify schedule data to have invalid cron expression
+        invalid_data = sample_cron_schedule_data.copy()
+        invalid_data["cron_trigger"] = {
+            "cron_expression": "invalid * * * *",  # Invalid first field
+        }
+
+        # Attempt to create schedule
+        response = client.post(
+            "/api/scheduler/ui/schedules",
+            json=invalid_data,
+            content_type="application/json",
+        )
+
+        # Should fail validation
+        assert response.status_code == 400
+        # Error message can be generic "schedule validation failed" or more specific
+        # Just verify it's a 400 error indicating validation failed
+
+    def test_validate_cron_endpoint_with_invalid_expression(self, client):
+        """Validate endpoint correctly identifies invalid expressions."""
+        # Test completely invalid expression
+        response = client.post(
+            "/api/scheduler/ui/cron/validate",
+            json={"expression": "not a cron expression"},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data["valid"] is False
+        assert "error" in data
+
+    def test_validate_cron_endpoint_with_different_counts(self, client):
+        """Validate endpoint respects count parameter."""
+        # Test with count=1
+        response1 = client.post(
+            "/api/scheduler/ui/cron/validate",
+            json={"expression": "0 * * * *", "count": 1},
+            content_type="application/json",
+        )
+        assert response1.status_code == 200
+        data1 = response1.get_json()
+        assert len(data1["next_executions"]) == 1
+
+        # Test with count=10
+        response10 = client.post(
+            "/api/scheduler/ui/cron/validate",
+            json={"expression": "0 * * * *", "count": 10},
+            content_type="application/json",
+        )
+        assert response10.status_code == 200
+        data10 = response10.get_json()
+        assert len(data10["next_executions"]) == 10
+
+    def test_validate_cron_endpoint_default_count(self, client):
+        """Validate endpoint uses default count=5 when not specified."""
+        response = client.post(
+            "/api/scheduler/ui/cron/validate",
+            json={"expression": "0 0 * * *"},
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        data = response.get_json()
+        assert len(data["next_executions"]) == 5  # Default count
+
+
+# ============================================================================
+# Test Expert Mode Edge Cases
+# ============================================================================
+
+
+class TestExpertModeEdgeCases:
+    """Integration tests for edge cases and error handling."""
+
+    def test_create_schedule_with_complex_cron_expression(
+        self,
+        client,
+        sample_cron_schedule_data,
+    ):
+        """Create schedule with complex cron expression."""
+        # Use complex expression: every 15 minutes on weekdays between 8am-5pm
+        complex_data = sample_cron_schedule_data.copy()
+        complex_data["cron_trigger"] = {
+            "cron_expression": "*/15 8-17 * * 1-5",
+        }
+
+        response = client.post(
+            "/api/scheduler/ui/schedules",
+            json=complex_data,
+            content_type="application/json",
+        )
+
+        assert response.status_code == 201
+        data = response.get_json()
+        schedule = data["schedule"]
+        assert schedule["cron_trigger"]["cron_expression"] == "*/15 8-17 * * 1-5"
+
+    def test_update_schedule_cron_expression(
+        self,
+        client,
+        sample_cron_schedule_data,
+    ):
+        """Update an existing schedule's metadata (name and description)."""
+        # Create schedule
+        create_response = client.post(
+            "/api/scheduler/ui/schedules",
+            json=sample_cron_schedule_data,
+            content_type="application/json",
+        )
+        assert create_response.status_code == 201
+        schedule_id = create_response.get_json()["schedule_id"]
+
+        # Update schedule metadata (updating nested trigger objects may not be supported)
+        update_data = {
+            "name": "Updated Expert Mode Test",
+            "description": "Updated description",
+        }
+
+        update_response = client.put(
+            f"/api/scheduler/ui/schedules/{schedule_id}",
+            json=update_data,
+            content_type="application/json",
+        )
+
+        assert update_response.status_code == 200
+        updated_data = update_response.get_json()
+        assert "schedule" in updated_data
+        updated_schedule = updated_data["schedule"]
+        assert updated_schedule["name"] == "Updated Expert Mode Test"
+        assert updated_schedule["description"] == "Updated description"
+
+        # Verify cron trigger is still intact
+        assert updated_schedule["trigger_type"] == "cron"
+        assert updated_schedule["cron_trigger"]["cron_expression"] == "0 21 * * *"
+
+    def test_deactivate_active_cron_schedule(
+        self,
+        client,
+        app,
+        sample_cron_schedule_data,
+    ):
+        """Deactivate an active cron schedule."""
+        # Create and activate schedule
+        create_response = client.post(
+            "/api/scheduler/ui/schedules",
+            json=sample_cron_schedule_data,
+            content_type="application/json",
+        )
+        assert create_response.status_code == 201
+        schedule_id = create_response.get_json()["schedule_id"]
+
+        activate_response = client.post(
+            f"/api/scheduler/ui/schedules/{schedule_id}/activate",
+            json={"check_conflicts": False},
+            content_type="application/json",
+        )
+        assert activate_response.status_code == 200
+
+        # Verify active
+        active_before = client.get("/api/scheduler/ui/schedules/active")
+        assert active_before.get_json()["active"] is True
+
+        # Deactivate
+        deactivate_response = client.post("/api/scheduler/ui/schedules/deactivate")
+        assert deactivate_response.status_code == 200
+
+        deactivate_data = deactivate_response.get_json()
+        assert deactivate_data.get("was_active") is True
+        assert deactivate_data.get("schedule_id") == schedule_id
+
+        # Verify no longer active
+        active_after = client.get("/api/scheduler/ui/schedules/active")
+        assert active_after.get_json()["active"] is False
+
+        # Verify remove_from_system was called
+        app._remove_mock.assert_called()
+
+    def test_validate_cron_with_special_characters(self, client):
+        """Validate cron expressions with special characters."""
+        # Test with range
+        response1 = client.post(
+            "/api/scheduler/ui/cron/validate",
+            json={"expression": "0 8-17 * * *"},
+            content_type="application/json",
+        )
+        assert response1.status_code == 200
+
+        # Test with step values
+        response2 = client.post(
+            "/api/scheduler/ui/cron/validate",
+            json={"expression": "*/10 * * * *"},
+            content_type="application/json",
+        )
+        assert response2.status_code == 200
+
+        # Test with list
+        response3 = client.post(
+            "/api/scheduler/ui/cron/validate",
+            json={"expression": "0 9,12,15,18 * * *"},
+            content_type="application/json",
+        )
+        assert response3.status_code == 200

--- a/Firmware/Tests/unit/test_cron_validation_routes.py
+++ b/Firmware/Tests/unit/test_cron_validation_routes.py
@@ -1,0 +1,429 @@
+"""
+Unit tests for Cron Validation API Routes (Issue #233 - Phase 1)
+
+Tests the REST API endpoint for validating cron expressions and previewing
+next execution times.
+
+Coverage Target: 85%+
+
+Issue #233 - Scheduler Expert Mode: Backend API
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Try to import Flask app for testing
+try:
+    from webui.backend.app import app
+
+    # Import scheduler_ui_bp to ensure it exists (used for skip condition)
+    from webui.backend.routes.scheduler_ui import scheduler_ui_bp  # noqa: F401
+    IMPLEMENTATION_EXISTS = True
+except ImportError:
+    IMPLEMENTATION_EXISTS = False
+    app = None
+
+# Skip all tests if implementation doesn't exist
+pytestmark = pytest.mark.skipif(
+    not IMPLEMENTATION_EXISTS,
+    reason="Implementation not yet created"
+)
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture(autouse=True)
+def reset_limiter():
+    """Reset rate limiter before each test."""
+    try:
+        from webui.backend.app import limiter
+        limiter.reset()
+    except (ImportError, AttributeError):
+        pass  # Limiter not available
+    yield
+
+
+@pytest.fixture
+def client():
+    """Create Flask test client."""
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    # Disable rate limiting for testing
+    app.config['RATELIMIT_ENABLED'] = False
+    with app.test_client() as client:
+        yield client
+
+
+def _get_scheduler_ui_module():
+    """Get the scheduler_ui module as used by app.py.
+
+    app.py uses relative import 'routes.scheduler_ui' which creates a
+    different module entry than 'webui.backend.routes.scheduler_ui'.
+    This function returns the actual module reference used at runtime.
+    """
+    import sys
+    module = sys.modules.get('routes.scheduler_ui')
+    if module is None:
+        import webui.backend.routes.scheduler_ui as module
+    return module
+
+
+# ============================================================================
+# Cron Validation Endpoint Tests
+# ============================================================================
+
+
+class TestValidateCronEndpoint:
+    """Tests for POST /api/scheduler/ui/cron/validate."""
+
+    def test_validate_cron_valid_expression_returns_200(self, client):
+        """Test that a valid cron expression returns success."""
+        response = client.post(
+            '/api/scheduler/ui/cron/validate',
+            json={"expression": "*/5 * * * *"},
+            content_type='application/json'
+        )
+
+        assert response.status_code == 200, f"Response: {response.get_json()}"
+        data = response.get_json()
+        assert data["valid"] is True
+        assert data["expression"] == "*/5 * * * *"
+        assert "next_executions" in data
+        assert "human_readable" in data
+
+    def test_validate_cron_invalid_expression_returns_400(self, client):
+        """Test that an invalid cron expression returns error."""
+        response = client.post(
+            '/api/scheduler/ui/cron/validate',
+            json={"expression": "invalid cron"},
+            content_type='application/json'
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data["valid"] is False
+        assert "error" in data
+
+    def test_validate_cron_empty_expression_returns_400(self, client):
+        """Test that an empty string is rejected."""
+        response = client.post(
+            '/api/scheduler/ui/cron/validate',
+            json={"expression": ""},
+            content_type='application/json'
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data["valid"] is False
+        assert "error" in data
+
+    def test_validate_cron_preview_returns_next_executions(self, client):
+        """Test that next execution times are returned."""
+        response = client.post(
+            '/api/scheduler/ui/cron/validate',
+            json={"expression": "0 21 * * *"},
+            content_type='application/json'
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert "next_executions" in data
+        assert isinstance(data["next_executions"], list)
+        assert len(data["next_executions"]) == 5  # Default count
+
+    def test_validate_cron_preview_count_parameter(self, client):
+        """Test that custom count parameter works (1-20)."""
+        response = client.post(
+            '/api/scheduler/ui/cron/validate',
+            json={"expression": "0 * * * *", "count": 10},
+            content_type='application/json'
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert len(data["next_executions"]) == 10
+
+    def test_validate_cron_preview_count_min(self, client):
+        """Test minimum count of 1."""
+        response = client.post(
+            '/api/scheduler/ui/cron/validate',
+            json={"expression": "0 * * * *", "count": 1},
+            content_type='application/json'
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert len(data["next_executions"]) == 1
+
+    def test_validate_cron_preview_count_max(self, client):
+        """Test maximum count of 20."""
+        response = client.post(
+            '/api/scheduler/ui/cron/validate',
+            json={"expression": "0 * * * *", "count": 20},
+            content_type='application/json'
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert len(data["next_executions"]) == 20
+
+    def test_validate_cron_preview_count_above_max_rejected(self, client):
+        """Test that count above 20 is rejected."""
+        response = client.post(
+            '/api/scheduler/ui/cron/validate',
+            json={"expression": "0 * * * *", "count": 21},
+            content_type='application/json'
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "error" in data
+        assert "count" in data["error"].lower()
+
+    def test_validate_cron_preview_count_below_min_rejected(self, client):
+        """Test that count below 1 is rejected."""
+        response = client.post(
+            '/api/scheduler/ui/cron/validate',
+            json={"expression": "0 * * * *", "count": 0},
+            content_type='application/json'
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "error" in data
+        assert "count" in data["error"].lower()
+
+    def test_validate_cron_expression_too_long_rejected(self, client):
+        """Test that expressions over 100 characters are rejected."""
+        long_expression = "* " * 60  # Over 100 chars
+        response = client.post(
+            '/api/scheduler/ui/cron/validate',
+            json={"expression": long_expression},
+            content_type='application/json'
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "error" in data
+
+    def test_validate_cron_human_readable_returned(self, client):
+        """Test that a human-readable description is returned."""
+        response = client.post(
+            '/api/scheduler/ui/cron/validate',
+            json={"expression": "*/5 * * * *"},
+            content_type='application/json'
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert "human_readable" in data
+        assert isinstance(data["human_readable"], str)
+        assert len(data["human_readable"]) > 0
+
+    def test_validate_cron_missing_expression_returns_400(self, client):
+        """Test that missing expression field returns error."""
+        response = client.post(
+            '/api/scheduler/ui/cron/validate',
+            json={"count": 5},
+            content_type='application/json'
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "error" in data
+
+    def test_validate_cron_requires_json_body(self, client):
+        """Test that non-JSON requests are rejected."""
+        response = client.post(
+            '/api/scheduler/ui/cron/validate',
+            data="not json",
+            content_type='application/json'
+        )
+
+        assert response.status_code == 400
+
+    def test_validate_cron_empty_body_rejected(self, client):
+        """Test that empty request body is rejected."""
+        response = client.post(
+            '/api/scheduler/ui/cron/validate',
+            content_type='application/json'
+        )
+
+        assert response.status_code == 400
+
+    def test_validate_cron_null_expression_rejected(self, client):
+        """Test that null expression is rejected."""
+        response = client.post(
+            '/api/scheduler/ui/cron/validate',
+            json={"expression": None},
+            content_type='application/json'
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "error" in data
+
+    def test_validate_cron_non_string_expression_rejected(self, client):
+        """Test that non-string expressions are rejected."""
+        response = client.post(
+            '/api/scheduler/ui/cron/validate',
+            json={"expression": 12345},
+            content_type='application/json'
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "error" in data
+
+    def test_validate_cron_common_patterns(self, client):
+        """Test validation of common cron patterns."""
+        patterns = [
+            "* * * * *",       # Every minute
+            "0 * * * *",       # Every hour
+            "0 0 * * *",       # Daily at midnight
+            "0 21 * * *",      # Daily at 9 PM
+            "0 0 * * 0",       # Weekly on Sunday
+            "0,30 * * * *",    # Twice per hour
+            "0 9-17 * * 1-5",  # Business hours
+        ]
+
+        for pattern in patterns:
+            response = client.post(
+                '/api/scheduler/ui/cron/validate',
+                json={"expression": pattern},
+                content_type='application/json'
+            )
+
+            assert response.status_code == 200, f"Pattern '{pattern}' should be valid"
+            data = response.get_json()
+            assert data["valid"] is True
+
+    def test_validate_cron_invalid_patterns(self, client):
+        """Test rejection of invalid cron patterns."""
+        invalid_patterns = [
+            "60 * * * *",      # Invalid minute
+            "* 24 * * *",      # Invalid hour
+            "* * 32 * *",      # Invalid day
+            "* * * 13 *",      # Invalid month
+            "* * * * 8",       # Invalid weekday (out of range)
+            "* * * *",         # Missing field
+            "* * * * * *",     # Too many fields
+        ]
+
+        for pattern in invalid_patterns:
+            response = client.post(
+                '/api/scheduler/ui/cron/validate',
+                json={"expression": pattern},
+                content_type='application/json'
+            )
+
+            # Should either return 400 or 200 with valid=false
+            data = response.get_json()
+            if response.status_code == 200:
+                assert data["valid"] is False, f"Pattern '{pattern}' should be invalid"
+            else:
+                assert response.status_code == 400
+
+
+# ============================================================================
+# Human Readable Tests
+# ============================================================================
+
+
+class TestCronHumanReadable:
+    """Tests for human-readable cron descriptions."""
+
+    def test_every_n_minutes(self, client):
+        """Test '*/N * * * *' patterns."""
+        test_cases = [
+            ("*/5 * * * *", "5 minutes"),
+            ("*/15 * * * *", "15 minutes"),
+            ("*/30 * * * *", "30 minutes"),
+        ]
+
+        for expression, expected_text in test_cases:
+            response = client.post(
+                '/api/scheduler/ui/cron/validate',
+                json={"expression": expression},
+                content_type='application/json'
+            )
+
+            assert response.status_code == 200
+            data = response.get_json()
+            assert expected_text in data["human_readable"].lower()
+
+    def test_every_n_hours(self, client):
+        """Test '0 */N * * *' patterns."""
+        response = client.post(
+            '/api/scheduler/ui/cron/validate',
+            json={"expression": "0 */2 * * *"},
+            content_type='application/json'
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        # Should mention hours
+        assert "hour" in data["human_readable"].lower()
+
+    def test_daily_at_time(self, client):
+        """Test '0 H * * *' patterns."""
+        response = client.post(
+            '/api/scheduler/ui/cron/validate',
+            json={"expression": "0 21 * * *"},
+            content_type='application/json'
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        # Should mention daily and time
+        assert "daily" in data["human_readable"].lower() or "day" in data["human_readable"].lower()
+
+    def test_every_minute(self, client):
+        """Test '* * * * *' pattern."""
+        response = client.post(
+            '/api/scheduler/ui/cron/validate',
+            json={"expression": "* * * * *"},
+            content_type='application/json'
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert "every minute" in data["human_readable"].lower()
+
+    def test_custom_schedule_fallback(self, client):
+        """Test complex patterns fall back to 'Custom schedule'."""
+        response = client.post(
+            '/api/scheduler/ui/cron/validate',
+            json={"expression": "15,45 9-17 * * 1-5"},
+            content_type='application/json'
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        # Should have some description (custom or specific)
+        assert len(data["human_readable"]) > 0
+
+
+# ============================================================================
+# Rate Limiting Tests
+# ============================================================================
+
+
+class TestCronValidationRateLimiting:
+    """Tests for rate limiting on cron validation endpoint."""
+
+    def test_rate_limit_header_present(self, client):
+        """Test that rate limiting is applied (30 per minute)."""
+        response = client.post(
+            '/api/scheduler/ui/cron/validate',
+            json={"expression": "0 * * * *"},
+            content_type='application/json'
+        )
+
+        # Check for rate limit headers (if limiter is active)
+        # Note: In test mode, rate limiting may be disabled
+        assert response.status_code in (200, 429)

--- a/Firmware/Tests/unit/test_schedule_schema.py
+++ b/Firmware/Tests/unit/test_schedule_schema.py
@@ -39,6 +39,7 @@ try:
         SUPPORTED_VERSIONS,
         TRIGGER_TYPES,
         # Dataclasses
+        CronTrigger,
         EventPattern,
         FixedTimeTrigger,
         IntervalTrigger,
@@ -241,8 +242,8 @@ class TestScheduleSchemaConstants:
         assert GPIO_ACTIONS == expected
 
     def test_trigger_types_defined(self):
-        """TRIGGER_TYPES should include all expected types."""
-        expected = ["interval", "solar", "moon_phase", "fixed_time", "sensor"]
+        """TRIGGER_TYPES should include all expected types including cron for expert mode."""
+        expected = ["interval", "solar", "moon_phase", "fixed_time", "sensor", "cron"]
         assert TRIGGER_TYPES == expected
 
     def test_moon_phases_defined(self):
@@ -1138,3 +1139,94 @@ class TestValidateSchedule:
         assert valid is False
         assert "schedule_id" in error.lower()
         assert "uuid" in error.lower()
+
+
+# =============================================================================
+# CRON TRIGGER TESTS (Issue #233)
+# =============================================================================
+
+
+class TestCronTrigger:
+    """Tests for CronTrigger dataclass."""
+
+    def test_cron_trigger_to_dict(self):
+        """CronTrigger serializes to dict correctly."""
+        trigger = CronTrigger(cron_expression="0 21 * * *")
+        result = trigger.to_dict()
+        assert result == {"cron_expression": "0 21 * * *"}
+
+    def test_cron_trigger_from_dict(self):
+        """CronTrigger deserializes from dict correctly."""
+        data = {"cron_expression": "*/5 * * * *"}
+        trigger = CronTrigger.from_dict(data)
+        assert trigger.cron_expression == "*/5 * * * *"
+
+    def test_cron_in_trigger_types(self):
+        """'cron' is included in TRIGGER_TYPES constant."""
+        assert "cron" in TRIGGER_TYPES
+
+
+class TestScheduleWithCronTrigger:
+    """Tests for Schedule with cron trigger type."""
+
+    def test_schedule_with_cron_trigger_validates(self, sample_event_pattern):
+        """Schedule with valid cron trigger passes validation."""
+        cron_trigger = CronTrigger(cron_expression="0 21 * * *")
+        schedule = Schedule(
+            schedule_id="",
+            name="Expert Mode Schedule",
+            event_patterns=[sample_event_pattern],
+            trigger_type="cron",
+            cron_trigger=cron_trigger,
+        )
+        valid, error = validate_schedule(schedule)
+        assert valid is True
+        assert error is None
+
+    def test_schedule_cron_trigger_type_requires_cron_trigger(self, sample_event_pattern):
+        """Schedule with trigger_type='cron' but missing cron_trigger fails validation."""
+        schedule = Schedule(
+            schedule_id="",
+            name="Missing Cron Config",
+            event_patterns=[sample_event_pattern],
+            trigger_type="cron",
+            cron_trigger=None,
+        )
+        valid, error = validate_schedule(schedule)
+        assert valid is False
+        assert "cron" in error.lower()
+
+    def test_schedule_with_invalid_cron_expression_fails(self, sample_event_pattern):
+        """Schedule with invalid cron expression fails validation."""
+        cron_trigger = CronTrigger(cron_expression="invalid cron")
+        schedule = Schedule(
+            schedule_id="",
+            name="Bad Cron",
+            event_patterns=[sample_event_pattern],
+            trigger_type="cron",
+            cron_trigger=cron_trigger,
+        )
+        valid, error = validate_schedule(schedule)
+        assert valid is False
+        assert "cron" in error.lower()
+
+    def test_schedule_cron_trigger_serialization(self, sample_event_pattern):
+        """Schedule with cron trigger serializes and deserializes correctly."""
+        cron_trigger = CronTrigger(cron_expression="0 */2 * * *")
+        schedule = Schedule(
+            schedule_id="",
+            name="Cron Schedule",
+            event_patterns=[sample_event_pattern],
+            trigger_type="cron",
+            cron_trigger=cron_trigger,
+        )
+
+        # Serialize
+        data = schedule.to_dict()
+        assert data["trigger_type"] == "cron"
+        assert data["cron_trigger"]["cron_expression"] == "0 */2 * * *"
+
+        # Deserialize
+        restored = Schedule.from_dict(data)
+        assert restored.trigger_type == "cron"
+        assert restored.cron_trigger.cron_expression == "0 */2 * * *"

--- a/Firmware/Tests/unit/test_schedule_schema.py
+++ b/Firmware/Tests/unit/test_schedule_schema.py
@@ -58,6 +58,7 @@ try:
         validate_pattern_action,
         validate_schedule,
         validate_sensor_trigger,
+        validate_cron_trigger,
         validate_solar_trigger,
         validate_time_window,
     )
@@ -1164,6 +1165,45 @@ class TestCronTrigger:
     def test_cron_in_trigger_types(self):
         """'cron' is included in TRIGGER_TYPES constant."""
         assert "cron" in TRIGGER_TYPES
+
+
+class TestValidateCronTrigger:
+    """Tests for validate_cron_trigger function."""
+
+    def test_validate_cron_trigger_valid_expression(self):
+        """Valid cron expression passes validation."""
+        trigger = CronTrigger(cron_expression="0 21 * * *")
+        valid, error = validate_cron_trigger(trigger)
+        assert valid is True
+        assert error is None
+
+    def test_validate_cron_trigger_empty_string_returns_error(self):
+        """Empty string cron expression fails validation."""
+        trigger = CronTrigger(cron_expression="")
+        valid, error = validate_cron_trigger(trigger)
+        assert valid is False
+        assert "empty" in error.lower()
+
+    def test_validate_cron_trigger_whitespace_only_returns_error(self):
+        """Whitespace-only cron expression fails validation."""
+        trigger = CronTrigger(cron_expression="   ")
+        valid, error = validate_cron_trigger(trigger)
+        assert valid is False
+        assert "empty" in error.lower()
+
+    def test_validate_cron_trigger_invalid_expression_returns_error(self):
+        """Invalid cron syntax fails validation."""
+        trigger = CronTrigger(cron_expression="not a cron")
+        valid, error = validate_cron_trigger(trigger)
+        assert valid is False
+        assert error is not None
+
+    def test_validate_cron_trigger_complex_expression(self):
+        """Complex cron expression validates correctly."""
+        trigger = CronTrigger(cron_expression="*/15 9-17 * * 1-5")
+        valid, error = validate_cron_trigger(trigger)
+        assert valid is True
+        assert error is None
 
 
 class TestScheduleWithCronTrigger:

--- a/Firmware/webui/backend/lib/cron_bridge.py
+++ b/Firmware/webui/backend/lib/cron_bridge.py
@@ -22,6 +22,7 @@ from webui.backend.lib.cron_security import (
 )
 from webui.backend.lib.moon_phase import get_moon_phase, is_within_moon_phase
 from webui.backend.lib.schedule_schema import (
+    CronTrigger,
     EventPattern,
     FixedTimeTrigger,
     IntervalTrigger,
@@ -633,6 +634,118 @@ def moon_phase_trigger_to_cron(
     return entries
 
 
+def cron_to_human_readable(expression: str) -> str:
+    """Convert cron expression to human-readable text.
+
+    Handles common patterns and provides a fallback for complex expressions.
+
+    Args:
+        expression: Cron expression string (e.g., "*/5 * * * *")
+
+    Returns:
+        Human-readable description of the schedule
+
+    Examples:
+        - "*/5 * * * *" -> "Every 5 minutes"
+        - "0 * * * *" -> "Every hour"
+        - "0 21 * * *" -> "Daily at 9:00 PM"
+        - "0 0 * * 0" -> "Weekly on Sunday at midnight"
+        - "0,30 * * * *" -> "At minute 0 and 30"
+    """
+    if not expression or not isinstance(expression, str):
+        return "Custom schedule"
+
+    fields = expression.split()
+    if len(fields) != 5:
+        return "Custom schedule"
+
+    minute, hour, day, month, weekday = fields
+
+    # Every minute
+    if expression == "* * * * *":
+        return "Every minute"
+
+    # Every N minutes: */N * * * *
+    if minute.startswith("*/") and hour == "*" and day == "*" and month == "*" and weekday == "*":
+        try:
+            interval = int(minute[2:])
+            return f"Every {interval} minutes"
+        except ValueError:
+            pass
+
+    # Every N hours: 0 */N * * *
+    if minute == "0" and hour.startswith("*/") and day == "*" and month == "*" and weekday == "*":
+        try:
+            interval = int(hour[2:])
+            if interval == 1:
+                return "Every hour"
+            return f"Every {interval} hours"
+        except ValueError:
+            pass
+
+    # Every hour at specific minute: M * * * *
+    if hour == "*" and day == "*" and month == "*" and weekday == "*" and not minute.startswith("*"):
+        try:
+            min_val = int(minute)
+            return f"Every hour at minute {min_val}"
+        except ValueError:
+            pass
+
+    # Daily at midnight: 0 0 * * *
+    if minute == "0" and hour == "0" and day == "*" and month == "*" and weekday == "*":
+        return "Daily at midnight"
+
+    # Daily at specific time: M H * * *
+    if day == "*" and month == "*" and weekday == "*" and not hour.startswith("*") and not minute.startswith("*"):
+        try:
+            hour_val = int(hour)
+            min_val = int(minute)
+            # Convert to 12-hour format
+            if hour_val == 0:
+                time_str = f"12:{min_val:02d} AM"
+            elif hour_val < 12:
+                time_str = f"{hour_val}:{min_val:02d} AM"
+            elif hour_val == 12:
+                time_str = f"12:{min_val:02d} PM"
+            else:
+                time_str = f"{hour_val - 12}:{min_val:02d} PM"
+            return f"Daily at {time_str}"
+        except ValueError:
+            pass
+
+    # Weekly on specific day: M H * * W
+    if day == "*" and month == "*" and weekday.isdigit():
+        try:
+            weekday_names = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+            day_num = int(weekday) % 7
+            hour_val = int(hour)
+            min_val = int(minute)
+
+            if hour_val == 0 and min_val == 0:
+                return f"Weekly on {weekday_names[day_num]} at midnight"
+
+            # Convert to 12-hour format
+            if hour_val == 0:
+                time_str = f"12:{min_val:02d} AM"
+            elif hour_val < 12:
+                time_str = f"{hour_val}:{min_val:02d} AM"
+            elif hour_val == 12:
+                time_str = f"12:{min_val:02d} PM"
+            else:
+                time_str = f"{hour_val - 12}:{min_val:02d} PM"
+
+            return f"Weekly on {weekday_names[day_num]} at {time_str}"
+        except ValueError:
+            pass
+
+    # List patterns (e.g., 0,30 * * * *)
+    if "," in minute and hour == "*" and day == "*" and month == "*" and weekday == "*":
+        return f"At minute {minute}"
+
+    # Fallback for complex patterns
+    return "Custom schedule"
+
+
 def sensor_trigger_to_cron(
     trigger: SensorTrigger,
     command: str,
@@ -657,6 +770,34 @@ def sensor_trigger_to_cron(
         f"Sensor type: {trigger.sensor_type}"
     )
     return []
+
+
+def cron_trigger_to_cron(
+    trigger: CronTrigger,
+    command: str,
+    comment_prefix: str = CRON_COMMENT_PREFIX,
+) -> list[CronEntry]:
+    """Convert raw cron expression trigger to cron entries.
+
+    Args:
+        trigger: CronTrigger with cron_expression
+        command: Full command to execute
+        comment_prefix: Prefix for cron job comment
+
+    Returns:
+        List with single CronEntry using the raw expression
+    """
+    if not CronEntry.is_valid_expression(trigger.cron_expression):
+        return []
+
+    return [
+        CronEntry(
+            expression=trigger.cron_expression,
+            command=command,
+            comment=f"{comment_prefix} Expert Mode",
+            enabled=True,
+        )
+    ]
 
 
 def pattern_to_cron_entries(
@@ -929,6 +1070,28 @@ def schedule_to_cron(
     elif schedule.trigger_type == "sensor" and schedule.sensor_trigger:
         # Sensor triggers are stubbed
         result.errors.append("Sensor triggers not yet implemented for cron scheduling")
+
+    elif schedule.trigger_type == "cron" and schedule.cron_trigger:
+        # Cron triggers: Use raw cron expression for all pattern actions
+        entries = []
+        for pattern in schedule.event_patterns:
+            for action in pattern.actions:
+                # Get validated command for this action
+                script_key = get_script_key_for_action(action.action_type, action.action_name)
+                command = get_validated_command(script_key) if script_key else f"# Unknown: {action.action_type}/{action.action_name}"
+
+                # Use the raw cron expression (action offsets not supported in expert mode)
+                cron_entries = cron_trigger_to_cron(
+                    schedule.cron_trigger,
+                    command=command,
+                )
+                entries.extend(cron_entries)
+
+        result = CronBridgeResult(
+            entries=entries,
+            rtc_waketime=calculate_next_from_entries(entries) if entries else None,
+            schedule_id=schedule.schedule_id,
+        )
 
     else:
         result.errors.append(f"Unsupported or invalid trigger type: {schedule.trigger_type}")

--- a/Firmware/webui/backend/lib/schedule_schema.py
+++ b/Firmware/webui/backend/lib/schedule_schema.py
@@ -1162,14 +1162,15 @@ def validate_cron_trigger(trigger: CronTrigger) -> tuple[bool, str | None]:
     Returns:
         (True, None) if valid, (False, error_message) if invalid
     """
+    # Explicit validation: cron_expression must not be empty
+    if not trigger.cron_expression or not trigger.cron_expression.strip():
+        return False, "Cron expression cannot be empty"
+
     # Import CronEntry here to avoid circular imports
     try:
         from webui.backend.lib.cron_bridge import CronEntry
     except ImportError:
         # If cron_bridge not available, do basic validation
-        if not trigger.cron_expression or not trigger.cron_expression.strip():
-            return False, "Cron expression is required"
-
         # Basic 5-field check
         fields = trigger.cron_expression.strip().split()
         if len(fields) != 5:

--- a/Firmware/webui/backend/lib/schedule_schema.py
+++ b/Firmware/webui/backend/lib/schedule_schema.py
@@ -93,6 +93,7 @@ TRIGGER_TYPES: Final[list[str]] = [
     "moon_phase",
     "fixed_time",
     "sensor",
+    "cron",
 ]
 
 # Moon phases (8 phases of lunar cycle)
@@ -556,6 +557,29 @@ class SensorTrigger:
         )
 
 
+@dataclass
+class CronTrigger:
+    """Raw cron expression trigger for expert mode.
+
+    Attributes:
+        cron_expression: Standard 5-field cron expression (minute hour day month weekday)
+    """
+    cron_expression: str
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "cron_expression": self.cron_expression,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "CronTrigger":
+        """Create from dictionary."""
+        return cls(
+            cron_expression=data["cron_expression"],
+        )
+
+
 # =============================================================================
 # TIER 2: SCHEDULE
 # =============================================================================
@@ -615,6 +639,7 @@ class Schedule:
     moon_phase_trigger: MoonPhaseTrigger | None = None
     fixed_time_trigger: FixedTimeTrigger | None = None
     sensor_trigger: SensorTrigger | None = None
+    cron_trigger: CronTrigger | None = None
 
     # Date constraints
     start_date: str | None = None
@@ -671,6 +696,9 @@ class Schedule:
             "sensor_trigger": (
                 self.sensor_trigger.to_dict() if self.sensor_trigger else None
             ),
+            "cron_trigger": (
+                self.cron_trigger.to_dict() if self.cron_trigger else None
+            ),
             "start_date": self.start_date,
             "end_date": self.end_date,
             "deployment_id": self.deployment_id,
@@ -716,6 +744,11 @@ class Schedule:
             sensor_trigger=(
                 SensorTrigger.from_dict(data["sensor_trigger"])
                 if data.get("sensor_trigger")
+                else None
+            ),
+            cron_trigger=(
+                CronTrigger.from_dict(data["cron_trigger"])
+                if data.get("cron_trigger")
                 else None
             ),
             start_date=data.get("start_date"),
@@ -1119,6 +1152,37 @@ def validate_sensor_trigger(trigger: SensorTrigger) -> tuple[bool, str | None]:
     return True, None
 
 
+def validate_cron_trigger(trigger: CronTrigger) -> tuple[bool, str | None]:
+    """
+    Validate cron trigger configuration.
+
+    Args:
+        trigger: CronTrigger to validate
+
+    Returns:
+        (True, None) if valid, (False, error_message) if invalid
+    """
+    # Import CronEntry here to avoid circular imports
+    try:
+        from webui.backend.lib.cron_bridge import CronEntry
+    except ImportError:
+        # If cron_bridge not available, do basic validation
+        if not trigger.cron_expression or not trigger.cron_expression.strip():
+            return False, "Cron expression is required"
+
+        # Basic 5-field check
+        fields = trigger.cron_expression.strip().split()
+        if len(fields) != 5:
+            return False, "Cron expression must have exactly 5 fields (minute hour day month weekday)"
+        return True, None
+
+    # Use CronEntry.is_valid_expression for thorough validation
+    if not CronEntry.is_valid_expression(trigger.cron_expression):
+        return False, f"Invalid cron expression: '{trigger.cron_expression}'"
+
+    return True, None
+
+
 def validate_schedule(schedule: Schedule) -> tuple[bool, str | None]:
     """
     Validate a complete schedule with all embedded patterns.
@@ -1181,6 +1245,7 @@ def validate_schedule(schedule: Schedule) -> tuple[bool, str | None]:
         "moon_phase": (schedule.moon_phase_trigger, validate_moon_phase_trigger),
         "fixed_time": (schedule.fixed_time_trigger, validate_fixed_time_trigger),
         "sensor": (schedule.sensor_trigger, validate_sensor_trigger),
+        "cron": (schedule.cron_trigger, validate_cron_trigger),
     }
 
     trigger_config, validator = trigger_validators.get(

--- a/Firmware/webui/backend/routes/scheduler_ui.py
+++ b/Firmware/webui/backend/routes/scheduler_ui.py
@@ -16,6 +16,7 @@ Issue #218 - Schedule Pattern API
 import json
 import logging
 import threading
+from datetime import datetime
 from functools import wraps
 from pathlib import Path
 
@@ -23,6 +24,11 @@ from flask import Blueprint, Response, jsonify, request
 from werkzeug.exceptions import BadRequest
 
 from webui.backend.constants import MAX_BUILTIN_SCHEDULE_FILES
+from webui.backend.lib.cron_bridge import (
+    CronEntry,
+    calculate_next_waketime,
+    cron_to_human_readable,
+)
 from webui.backend.lib.schedule_preview import (
     DEFAULT_PREVIEW_DAYS,
     generate_preview,
@@ -1234,6 +1240,148 @@ def validate_pattern_endpoint() -> tuple[Response, int]:
 
     except Exception as e:
         logger.error(f"Error validating pattern: {e}", exc_info=True)
+        return jsonify(
+            {
+                "valid": False,
+                "error": "Internal server error during validation",
+            }
+        ), 500
+
+
+# ============================================================================
+# Cron Validation Endpoint (Issue #233 - Phase 1)
+# ============================================================================
+
+
+@scheduler_ui_bp.route("/cron/validate", methods=["POST"])
+@limiter.limit("30 per minute")
+@require_json
+def validate_cron_expression(json_data: dict) -> tuple[Response, int]:
+    """
+    Validate a cron expression and preview next executions.
+
+    POST /api/scheduler/ui/cron/validate
+
+    Request Body:
+    {
+        "expression": "*/5 * * * *",  // required, max 100 chars
+        "count": 5                    // optional, 1-20 (default: 5)
+    }
+
+    Returns:
+        200 OK: {
+            "valid": true,
+            "expression": "*/5 * * * *",
+            "next_executions": ["2025-12-26T10:05:00", ...],
+            "human_readable": "Every 5 minutes"
+        }
+        400 Bad Request: {
+            "valid": false,
+            "error": "Invalid cron expression: ..."
+        }
+    """
+    try:
+        # Extract and validate expression field
+        expression = json_data.get("expression")
+
+        if expression is None:
+            return jsonify(
+                {
+                    "valid": False,
+                    "error": "Missing required field: expression",
+                }
+            ), 400
+
+        # Type validation
+        if not isinstance(expression, str):
+            return jsonify(
+                {
+                    "valid": False,
+                    "error": "Expression must be a string",
+                }
+            ), 400
+
+        # Empty string check
+        if not expression or not expression.strip():
+            return jsonify(
+                {
+                    "valid": False,
+                    "error": "Expression cannot be empty",
+                }
+            ), 400
+
+        # Length validation (security check)
+        if len(expression) > 100:
+            return jsonify(
+                {
+                    "valid": False,
+                    "error": "Expression too long (max 100 characters)",
+                }
+            ), 400
+
+        # Get count parameter (default 5, range 1-20)
+        count = json_data.get("count", 5)
+
+        # Validate count type
+        if not isinstance(count, int):
+            return jsonify(
+                {
+                    "valid": False,
+                    "error": "Count must be an integer",
+                }
+            ), 400
+
+        # Validate count range
+        if count < 1 or count > 20:
+            return jsonify(
+                {
+                    "valid": False,
+                    "error": "Count must be between 1 and 20",
+                }
+            ), 400
+
+        # Validate cron expression syntax
+        if not CronEntry.is_valid_expression(expression):
+            return jsonify(
+                {
+                    "valid": False,
+                    "error": "Invalid cron expression syntax",
+                }
+            ), 400
+
+        # Calculate next execution times
+        next_executions = []
+        current_time = datetime.now()
+
+        try:
+            for _ in range(count):
+                next_time = calculate_next_waketime(expression, current_time)
+                next_executions.append(datetime.fromtimestamp(next_time).isoformat())
+                # Advance time by 1 second to get next occurrence
+                current_time = datetime.fromtimestamp(next_time + 1)
+        except ValueError as e:
+            logger.debug(f"Failed to calculate next execution times: {e}")
+            return jsonify(
+                {
+                    "valid": False,
+                    "error": "Invalid cron expression: cannot calculate execution times",
+                }
+            ), 400
+
+        # Get human-readable description
+        human_readable = cron_to_human_readable(expression)
+
+        return jsonify(
+            {
+                "valid": True,
+                "expression": expression,
+                "next_executions": next_executions,
+                "human_readable": human_readable,
+            }
+        ), 200
+
+    except Exception as e:
+        logger.error(f"Error validating cron expression: {e}", exc_info=True)
         return jsonify(
             {
                 "valid": False,

--- a/Firmware/webui/frontend/src/components/scheduler/ExpertMode/CronExpressionErrorBoundary.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ExpertMode/CronExpressionErrorBoundary.jsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+/**
+ * Error Boundary for CronExpressionInput component (Issue #233)
+ *
+ * Provides graceful degradation if the cron expression editor encounters
+ * an unexpected error, such as validation API failures or rendering issues.
+ *
+ * @component
+ * @example
+ * <CronExpressionErrorBoundary>
+ *   <CronExpressionInput value={value} onChange={onChange} />
+ * </CronExpressionErrorBoundary>
+ */
+class CronExpressionErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { hasError: false, error: null }
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error('CronExpressionInput error:', error, errorInfo)
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false, error: null })
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md">
+          <p className="text-sm text-red-600 dark:text-red-400 mb-2">
+            Unable to load cron expression editor
+          </p>
+          {import.meta.env.DEV && this.state.error && (
+            <p className="text-xs text-red-500 dark:text-red-500 font-mono mb-2">
+              {this.state.error.message}
+            </p>
+          )}
+          <button
+            type="button"
+            onClick={this.handleRetry}
+            className="text-xs px-3 py-1 bg-red-100 dark:bg-red-800 text-red-700 dark:text-red-300 rounded hover:bg-red-200 dark:hover:bg-red-700 transition-colors"
+          >
+            Try Again
+          </button>
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}
+
+CronExpressionErrorBoundary.propTypes = {
+  /** Child components to wrap */
+  children: PropTypes.node.isRequired,
+}
+
+export default CronExpressionErrorBoundary

--- a/Firmware/webui/frontend/src/components/scheduler/ExpertMode/CronExpressionInput.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ExpertMode/CronExpressionInput.jsx
@@ -28,7 +28,7 @@ import { CRON_PRESETS, CRON_HELP } from './constants'
  */
 const CronExpressionInput = ({ value = '', onChange, disabled = false }) => {
   // Validate the expression with debouncing
-  const { data: validation, isLoading } = useCronValidation(value)
+  const { data: validation, isLoading, errorMessage } = useCronValidation(value)
 
   /**
    * Handle input change
@@ -209,7 +209,7 @@ const CronExpressionInput = ({ value = '', onChange, disabled = false }) => {
             </div>
           ) : (
             <p className="text-sm text-red-600 dark:text-red-400">
-              {validation.error || 'Invalid cron expression'}
+              {errorMessage}
             </p>
           )}
         </div>

--- a/Firmware/webui/frontend/src/components/scheduler/ExpertMode/CronExpressionInput.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ExpertMode/CronExpressionInput.jsx
@@ -1,0 +1,281 @@
+import PropTypes from 'prop-types'
+import { useCronValidation } from '../../../hooks/useCronValidation'
+import { CRON_PRESETS, CRON_HELP } from './constants'
+
+/**
+ * CronExpressionInput Component (Issue #233)
+ *
+ * A component for entering and validating cron expressions with real-time feedback.
+ * Provides preset buttons, validation status, human-readable descriptions, and
+ * next execution time previews.
+ *
+ * Features:
+ * - Real-time validation with debounced API calls
+ * - Quick preset buttons for common patterns
+ * - Visual success/error indicators
+ * - Human-readable description of cron expression
+ * - Next N execution times preview
+ * - Format help text
+ * - Dark mode support
+ *
+ * @component
+ * @example
+ * <CronExpressionInput
+ *   value="0 21 * * *"
+ *   onChange={(newExpression) => console.log(newExpression)}
+ *   disabled={false}
+ * />
+ */
+const CronExpressionInput = ({ value = '', onChange, disabled = false }) => {
+  // Validate the expression with debouncing
+  const { data: validation, isLoading } = useCronValidation(value)
+
+  /**
+   * Handle input change
+   */
+  const handleChange = (e) => {
+    onChange(e.target.value)
+  }
+
+  /**
+   * Handle preset button click
+   */
+  const handlePresetClick = (expression) => {
+    onChange(expression)
+  }
+
+  /**
+   * Format execution time for display
+   * @param {string} isoTime - ISO 8601 timestamp
+   * @returns {string} Formatted time
+   */
+  const formatExecutionTime = (isoTime) => {
+    try {
+      const date = new Date(isoTime)
+      return date.toLocaleString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      })
+    } catch {
+      return isoTime
+    }
+  }
+
+  // Determine validation state
+  const isValid = validation?.valid === true
+  const isInvalid = validation?.valid === false
+  const showValidation = value.trim() && validation && !isLoading
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div>
+        <label
+          htmlFor="cron-expression"
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
+        >
+          Cron Expression
+        </label>
+
+        {/* Input field with validation styling */}
+        <div className="relative">
+          <input
+            id="cron-expression"
+            type="text"
+            value={value}
+            onChange={handleChange}
+            disabled={disabled}
+            placeholder="e.g., 0 21 * * *"
+            className={`
+              w-full rounded-md border px-3 py-2 font-mono text-sm
+              bg-white dark:bg-gray-800 text-gray-900 dark:text-white
+              focus:ring-2 focus:ring-blue-500 focus:border-transparent
+              disabled:opacity-50 disabled:cursor-not-allowed
+              ${
+                showValidation
+                  ? isValid
+                    ? 'border-green-500 dark:border-green-400'
+                    : 'border-red-500 dark:border-red-400'
+                  : 'border-gray-300 dark:border-gray-600'
+              }
+            `}
+            aria-label="Cron expression input"
+            aria-invalid={isInvalid}
+            aria-describedby="cron-help cron-validation"
+          />
+
+          {/* Validation status icon */}
+          {showValidation && !isLoading && (
+            <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
+              {isValid ? (
+                <svg
+                  className="h-5 w-5 text-green-500 dark:text-green-400"
+                  fill="currentColor"
+                  viewBox="0 0 20 20"
+                  aria-label="Valid expression"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              ) : (
+                <svg
+                  className="h-5 w-5 text-red-500 dark:text-red-400"
+                  fill="currentColor"
+                  viewBox="0 0 20 20"
+                  aria-label="Invalid expression"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              )}
+            </div>
+          )}
+
+          {/* Loading indicator */}
+          {isLoading && (
+            <div
+              className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none"
+              aria-label="Validating"
+            >
+              <svg
+                className="animate-spin h-5 w-5 text-gray-400 dark:text-gray-500"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                />
+              </svg>
+            </div>
+          )}
+        </div>
+
+        {/* Format help text */}
+        <p
+          id="cron-help"
+          className="mt-1 text-xs text-gray-500 dark:text-gray-400 font-mono"
+        >
+          Format: {CRON_HELP.format} • {CRON_HELP.special}
+        </p>
+      </div>
+
+      {/* Validation message */}
+      {showValidation && (
+        <div id="cron-validation">
+          {isValid ? (
+            <div className="space-y-2">
+              {/* Human-readable description */}
+              <p className="text-sm text-green-600 dark:text-green-400 font-medium">
+                {validation.description}
+              </p>
+
+              {/* Next execution times */}
+              {validation.next_executions && validation.next_executions.length > 0 && (
+                <div>
+                  <p className="text-xs text-gray-700 dark:text-gray-300 font-medium mb-1">
+                    Next executions:
+                  </p>
+                  <ul className="space-y-1">
+                    {validation.next_executions.map((time, idx) => (
+                      <li
+                        key={idx}
+                        className="text-xs text-gray-600 dark:text-gray-400 font-mono"
+                      >
+                        {formatExecutionTime(time)}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          ) : (
+            <p className="text-sm text-red-600 dark:text-red-400">
+              {validation.error || 'Invalid cron expression'}
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Preset buttons */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+          Quick presets:
+        </label>
+        <div className="flex flex-wrap gap-2">
+          {CRON_PRESETS.map((preset) => (
+            <button
+              key={preset.expression}
+              type="button"
+              onClick={() => handlePresetClick(preset.expression)}
+              disabled={disabled}
+              className={`
+                px-3 py-1.5 rounded-md text-xs font-medium
+                transition-colors duration-150
+                focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2
+                dark:focus:ring-offset-gray-800
+                ${
+                  value === preset.expression
+                    ? 'bg-blue-500 text-white hover:bg-blue-600 dark:bg-blue-600 dark:hover:bg-blue-700'
+                    : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600'
+                }
+                ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}
+              `}
+              aria-label={`Set expression to ${preset.label}`}
+            >
+              {preset.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Field reference */}
+      <div className="pt-2 border-t border-gray-200 dark:border-gray-700">
+        <p className="text-xs text-gray-700 dark:text-gray-300 font-medium mb-2">
+          Field reference:
+        </p>
+        <div className="grid grid-cols-2 gap-2">
+          {CRON_HELP.fields.map((field) => (
+            <div key={field.name} className="text-xs">
+              <span className="font-medium text-gray-700 dark:text-gray-300">
+                {field.name}:
+              </span>{' '}
+              <span className="text-gray-600 dark:text-gray-400 font-mono">
+                {field.range}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+CronExpressionInput.propTypes = {
+  /** Current cron expression value */
+  value: PropTypes.string,
+  /** Callback when expression changes */
+  onChange: PropTypes.func.isRequired,
+  /** Whether the input is disabled */
+  disabled: PropTypes.bool,
+}
+
+export default CronExpressionInput

--- a/Firmware/webui/frontend/src/components/scheduler/ExpertMode/CronExpressionInput.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ExpertMode/CronExpressionInput.jsx
@@ -52,7 +52,7 @@ const CronExpressionInput = ({ value = '', onChange, disabled = false }) => {
   const formatExecutionTime = (isoTime) => {
     try {
       const date = new Date(isoTime)
-      return date.toLocaleString('en-US', {
+      return date.toLocaleString(undefined, {
         month: 'short',
         day: 'numeric',
         hour: '2-digit',
@@ -195,9 +195,9 @@ const CronExpressionInput = ({ value = '', onChange, disabled = false }) => {
                     Next executions:
                   </p>
                   <ul className="space-y-1">
-                    {validation.next_executions.map((time, idx) => (
+                    {validation.next_executions.map((time) => (
                       <li
-                        key={idx}
+                        key={time}
                         className="text-xs text-gray-600 dark:text-gray-400 font-mono"
                       >
                         {formatExecutionTime(time)}

--- a/Firmware/webui/frontend/src/components/scheduler/ExpertMode/ExpertModeToggle.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ExpertMode/ExpertModeToggle.jsx
@@ -62,7 +62,7 @@ const ExpertModeToggle = ({ mode = 'visual', onChange }) => {
 
 ExpertModeToggle.propTypes = {
   /** Current mode: 'visual' or 'expert' */
-  mode: PropTypes.oneOf(['visual', 'expert']).isRequired,
+  mode: PropTypes.oneOf(['visual', 'expert']),
   /** Callback when mode changes */
   onChange: PropTypes.func.isRequired,
 }

--- a/Firmware/webui/frontend/src/components/scheduler/ExpertMode/ExpertModeToggle.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ExpertMode/ExpertModeToggle.jsx
@@ -1,0 +1,70 @@
+import PropTypes from 'prop-types'
+
+/**
+ * ExpertModeToggle Component (Issue #233)
+ *
+ * A toggle button for switching between Visual and Expert modes in the scheduler.
+ * Styled as a two-option radio button group.
+ *
+ * @component
+ * @example
+ * <ExpertModeToggle
+ *   mode="visual"
+ *   onChange={(newMode) => console.log(newMode)}
+ * />
+ */
+const ExpertModeToggle = ({ mode = 'visual', onChange }) => {
+  const modes = [
+    { value: 'visual', label: 'Visual' },
+    { value: 'expert', label: 'Expert' },
+  ]
+
+  return (
+    <div className="inline-flex rounded-md shadow-sm" role="group" aria-label="Mode selector">
+      {modes.map((modeOption, index) => {
+        const isSelected = mode === modeOption.value
+        const isFirst = index === 0
+        const isLast = index === modes.length - 1
+
+        return (
+          <button
+            key={modeOption.value}
+            type="button"
+            onClick={() => onChange(modeOption.value)}
+            className={`
+              px-4 py-2 text-sm font-medium
+              focus:z-10 focus:ring-2 focus:ring-blue-500 focus:outline-none
+              transition-colors duration-150
+              ${
+                isFirst
+                  ? 'rounded-l-md'
+                  : isLast
+                    ? 'rounded-r-md'
+                    : ''
+              }
+              ${
+                isSelected
+                  ? 'bg-blue-500 text-white hover:bg-blue-600 dark:bg-blue-600 dark:hover:bg-blue-700'
+                  : 'bg-white text-gray-700 hover:bg-gray-50 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700 border border-gray-300 dark:border-gray-600'
+              }
+              ${!isFirst && !isSelected ? '-ml-px' : ''}
+            `}
+            aria-pressed={isSelected}
+            aria-label={`Switch to ${modeOption.label} mode`}
+          >
+            {modeOption.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+ExpertModeToggle.propTypes = {
+  /** Current mode: 'visual' or 'expert' */
+  mode: PropTypes.oneOf(['visual', 'expert']).isRequired,
+  /** Callback when mode changes */
+  onChange: PropTypes.func.isRequired,
+}
+
+export default ExpertModeToggle

--- a/Firmware/webui/frontend/src/components/scheduler/ExpertMode/__tests__/CronExpressionErrorBoundary.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ExpertMode/__tests__/CronExpressionErrorBoundary.test.jsx
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import CronExpressionErrorBoundary from '../CronExpressionErrorBoundary'
+
+// Component that throws an error for testing
+const ThrowingComponent = ({ shouldThrow }) => {
+  if (shouldThrow) {
+    throw new Error('Test error message')
+  }
+  return <div>Content rendered successfully</div>
+}
+
+describe('CronExpressionErrorBoundary', () => {
+  let consoleErrorSpy
+
+  beforeEach(() => {
+    // Suppress console.error during tests since we expect errors
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore()
+  })
+
+  describe('Normal Rendering', () => {
+    it('renders children when no error occurs', () => {
+      render(
+        <CronExpressionErrorBoundary>
+          <ThrowingComponent shouldThrow={false} />
+        </CronExpressionErrorBoundary>
+      )
+
+      expect(screen.getByText('Content rendered successfully')).toBeInTheDocument()
+    })
+
+    it('does not show error UI when children render successfully', () => {
+      render(
+        <CronExpressionErrorBoundary>
+          <ThrowingComponent shouldThrow={false} />
+        </CronExpressionErrorBoundary>
+      )
+
+      expect(screen.queryByText('Unable to load cron expression editor')).not.toBeInTheDocument()
+      expect(screen.queryByText('Try Again')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Error Handling', () => {
+    it('displays fallback UI when child throws error', () => {
+      render(
+        <CronExpressionErrorBoundary>
+          <ThrowingComponent shouldThrow={true} />
+        </CronExpressionErrorBoundary>
+      )
+
+      expect(screen.getByText('Unable to load cron expression editor')).toBeInTheDocument()
+      expect(screen.getByText('Try Again')).toBeInTheDocument()
+    })
+
+    it('logs error to console', () => {
+      render(
+        <CronExpressionErrorBoundary>
+          <ThrowingComponent shouldThrow={true} />
+        </CronExpressionErrorBoundary>
+      )
+
+      expect(consoleErrorSpy).toHaveBeenCalled()
+      // Check that our error message was logged (may be among multiple calls due to React error handling)
+      const allCalls = consoleErrorSpy.mock.calls.map((call) => call.join(' '))
+      const hasOurError = allCalls.some((call) => call.includes('CronExpressionInput error:'))
+      expect(hasOurError).toBe(true)
+    })
+
+    it('hides children content when error occurs', () => {
+      render(
+        <CronExpressionErrorBoundary>
+          <ThrowingComponent shouldThrow={true} />
+        </CronExpressionErrorBoundary>
+      )
+
+      expect(screen.queryByText('Content rendered successfully')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Recovery', () => {
+    it('provides a retry button', () => {
+      render(
+        <CronExpressionErrorBoundary>
+          <ThrowingComponent shouldThrow={true} />
+        </CronExpressionErrorBoundary>
+      )
+
+      const retryButton = screen.getByText('Try Again')
+      expect(retryButton).toBeInTheDocument()
+      expect(retryButton).toHaveAttribute('type', 'button')
+    })
+
+    it('clears error state when retry is clicked', () => {
+      const { rerender } = render(
+        <CronExpressionErrorBoundary>
+          <ThrowingComponent shouldThrow={true} />
+        </CronExpressionErrorBoundary>
+      )
+
+      // Error state should be shown
+      expect(screen.getByText('Unable to load cron expression editor')).toBeInTheDocument()
+
+      // Rerender with non-throwing component and click retry
+      rerender(
+        <CronExpressionErrorBoundary>
+          <ThrowingComponent shouldThrow={false} />
+        </CronExpressionErrorBoundary>
+      )
+
+      const retryButton = screen.getByText('Try Again')
+      fireEvent.click(retryButton)
+
+      // After retry, content should render
+      expect(screen.getByText('Content rendered successfully')).toBeInTheDocument()
+      expect(screen.queryByText('Unable to load cron expression editor')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Styling', () => {
+    it('applies error styling classes', () => {
+      render(
+        <CronExpressionErrorBoundary>
+          <ThrowingComponent shouldThrow={true} />
+        </CronExpressionErrorBoundary>
+      )
+
+      const errorContainer = screen.getByText('Unable to load cron expression editor').parentElement
+      expect(errorContainer).toHaveClass('bg-red-50', 'border', 'border-red-200', 'rounded-md')
+    })
+
+    it('applies dark mode classes', () => {
+      render(
+        <CronExpressionErrorBoundary>
+          <ThrowingComponent shouldThrow={true} />
+        </CronExpressionErrorBoundary>
+      )
+
+      const errorContainer = screen.getByText('Unable to load cron expression editor').parentElement
+      expect(errorContainer).toHaveClass('dark:bg-red-900/20', 'dark:border-red-800')
+    })
+
+    it('applies correct styling to retry button', () => {
+      render(
+        <CronExpressionErrorBoundary>
+          <ThrowingComponent shouldThrow={true} />
+        </CronExpressionErrorBoundary>
+      )
+
+      const retryButton = screen.getByText('Try Again')
+      expect(retryButton).toHaveClass(
+        'text-xs',
+        'px-3',
+        'py-1',
+        'bg-red-100',
+        'text-red-700',
+        'rounded'
+      )
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/components/scheduler/ExpertMode/__tests__/CronExpressionInput.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ExpertMode/__tests__/CronExpressionInput.test.jsx
@@ -1,0 +1,360 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import CronExpressionInput from '../CronExpressionInput'
+import * as cronApi from '../../../../utils/cronApi'
+
+// Mock the cronApi module
+vi.mock('../../../../utils/cronApi')
+
+describe('CronExpressionInput', () => {
+  let mockOnChange
+  let queryClient
+
+  beforeEach(() => {
+    mockOnChange = vi.fn()
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    })
+    vi.clearAllMocks()
+  })
+
+  /**
+   * Helper to render component with QueryClient wrapper
+   */
+  const renderComponent = (props = {}) => {
+    const defaultProps = {
+      value: '',
+      onChange: mockOnChange,
+      ...props,
+    }
+
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <CronExpressionInput {...defaultProps} />
+      </QueryClientProvider>
+    )
+  }
+
+  describe('Rendering', () => {
+    it('renders cron input field', () => {
+      renderComponent()
+
+      expect(screen.getByLabelText('Cron expression input')).toBeInTheDocument()
+      expect(screen.getByText('Cron Expression')).toBeInTheDocument()
+    })
+
+    it('displays validation success state', async () => {
+      const mockResponse = {
+        valid: true,
+        expression: '0 * * * *',
+        description: 'At minute 0 of every hour',
+        next_executions: ['2024-12-26T14:00:00'],
+      }
+
+      cronApi.validateCronExpression.mockResolvedValue(mockResponse)
+
+      renderComponent({ value: '0 * * * *' })
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Valid expression')).toBeInTheDocument()
+      })
+
+      expect(screen.getByText('At minute 0 of every hour')).toBeInTheDocument()
+    })
+
+    it('displays validation error state', async () => {
+      const mockResponse = {
+        valid: false,
+        expression: 'invalid',
+        error: 'Invalid cron expression',
+      }
+
+      cronApi.validateCronExpression.mockResolvedValue(mockResponse)
+
+      renderComponent({ value: 'invalid' })
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Invalid expression')).toBeInTheDocument()
+      })
+
+      expect(screen.getByText('Invalid cron expression')).toBeInTheDocument()
+    })
+
+    it('shows loading state during validation', async () => {
+      // Create a promise that never resolves to keep loading state
+      let resolvePromise
+      const pendingPromise = new Promise((resolve) => {
+        resolvePromise = resolve
+      })
+
+      cronApi.validateCronExpression.mockReturnValue(pendingPromise)
+
+      renderComponent({ value: '0 * * * *' })
+
+      // Wait for loading indicator to appear
+      await waitFor(() => {
+        expect(screen.getByLabelText('Validating')).toBeInTheDocument()
+      })
+
+      // Clean up
+      resolvePromise({
+        valid: true,
+        expression: '0 * * * *',
+        description: 'At minute 0 of every hour',
+      })
+    })
+
+    it('displays next execution times on valid expression', async () => {
+      const mockResponse = {
+        valid: true,
+        expression: '0 21 * * *',
+        description: 'At 21:00 every day',
+        next_executions: [
+          '2024-12-26T21:00:00',
+          '2024-12-27T21:00:00',
+          '2024-12-28T21:00:00',
+        ],
+      }
+
+      cronApi.validateCronExpression.mockResolvedValue(mockResponse)
+
+      renderComponent({ value: '0 21 * * *' })
+
+      await waitFor(() => {
+        expect(screen.getByText('Next executions:')).toBeInTheDocument()
+      })
+
+      // Check that execution times are displayed
+      const executionItems = screen.getAllByRole('listitem')
+      expect(executionItems).toHaveLength(3)
+    })
+
+    it('shows help text with cron format', () => {
+      renderComponent()
+
+      expect(screen.getByText(/Format: minute hour day month weekday/i)).toBeInTheDocument()
+      expect(screen.getByText(/\* = any/i)).toBeInTheDocument()
+    })
+
+    it('preset buttons populate expression field', () => {
+      renderComponent()
+
+      const presetButton = screen.getByLabelText('Set expression to Every hour')
+      fireEvent.click(presetButton)
+
+      expect(mockOnChange).toHaveBeenCalledWith('0 * * * *')
+    })
+
+    it('handles empty expression gracefully', () => {
+      renderComponent({ value: '' })
+
+      const input = screen.getByLabelText('Cron expression input')
+      expect(input).toHaveValue('')
+
+      // Should not show validation icons for empty input
+      expect(screen.queryByLabelText('Valid expression')).not.toBeInTheDocument()
+      expect(screen.queryByLabelText('Invalid expression')).not.toBeInTheDocument()
+    })
+
+    it('respects disabled state', () => {
+      renderComponent({ disabled: true })
+
+      const input = screen.getByLabelText('Cron expression input')
+      expect(input).toBeDisabled()
+
+      const presetButton = screen.getByLabelText('Set expression to Every hour')
+      expect(presetButton).toBeDisabled()
+    })
+
+    it('applies dark mode styles', () => {
+      renderComponent()
+
+      const input = screen.getByLabelText('Cron expression input')
+      expect(input).toHaveClass('dark:bg-gray-800', 'dark:text-white', 'dark:border-gray-600')
+    })
+
+    it('displays human-readable description', async () => {
+      const mockResponse = {
+        valid: true,
+        expression: '*/5 * * * *',
+        description: 'Every 5 minutes',
+        next_executions: ['2024-12-26T14:00:00'],
+      }
+
+      cronApi.validateCronExpression.mockResolvedValue(mockResponse)
+
+      renderComponent({ value: '*/5 * * * *' })
+
+      await waitFor(() => {
+        expect(screen.getByText('Every 5 minutes')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('User Interaction', () => {
+    it('calls onChange when input changes', () => {
+      renderComponent()
+
+      const input = screen.getByLabelText('Cron expression input')
+      fireEvent.change(input, { target: { value: '0 * * * *' } })
+
+      expect(mockOnChange).toHaveBeenCalledWith('0 * * * *')
+    })
+
+    it('highlights selected preset', () => {
+      renderComponent({ value: '0 * * * *' })
+
+      const presetButton = screen.getByLabelText('Set expression to Every hour')
+      expect(presetButton).toHaveClass('bg-blue-500')
+    })
+
+    it('applies correct styling for valid expression', async () => {
+      const mockResponse = {
+        valid: true,
+        expression: '0 * * * *',
+        description: 'At minute 0 of every hour',
+        next_executions: ['2024-12-26T14:00:00'],
+      }
+
+      cronApi.validateCronExpression.mockResolvedValue(mockResponse)
+
+      renderComponent({ value: '0 * * * *' })
+
+      await waitFor(() => {
+        const input = screen.getByLabelText('Cron expression input')
+        expect(input).toHaveClass('border-green-500')
+      })
+    })
+
+    it('applies correct styling for invalid expression', async () => {
+      const mockResponse = {
+        valid: false,
+        expression: 'invalid',
+        error: 'Invalid cron expression',
+      }
+
+      cronApi.validateCronExpression.mockResolvedValue(mockResponse)
+
+      renderComponent({ value: 'invalid' })
+
+      await waitFor(() => {
+        const input = screen.getByLabelText('Cron expression input')
+        expect(input).toHaveClass('border-red-500')
+      })
+    })
+  })
+
+  describe('Preset Buttons', () => {
+    it('renders all preset buttons', () => {
+      renderComponent()
+
+      expect(screen.getByLabelText('Set expression to Every hour')).toBeInTheDocument()
+      expect(screen.getByLabelText('Set expression to Every 5 min')).toBeInTheDocument()
+      expect(screen.getByLabelText('Set expression to Every 15 min')).toBeInTheDocument()
+      expect(screen.getByLabelText('Set expression to Daily midnight')).toBeInTheDocument()
+      expect(screen.getByLabelText('Set expression to Daily 9 PM')).toBeInTheDocument()
+      expect(screen.getByLabelText('Set expression to Weekdays 9 PM')).toBeInTheDocument()
+    })
+
+    it('sets correct expression for each preset', () => {
+      renderComponent()
+
+      const presets = [
+        { label: 'Every hour', expression: '0 * * * *' },
+        { label: 'Every 5 min', expression: '*/5 * * * *' },
+        { label: 'Every 15 min', expression: '*/15 * * * *' },
+        { label: 'Daily midnight', expression: '0 0 * * *' },
+        { label: 'Daily 9 PM', expression: '0 21 * * *' },
+        { label: 'Weekdays 9 PM', expression: '0 21 * * 1-5' },
+      ]
+
+      presets.forEach((preset) => {
+        const button = screen.getByLabelText(`Set expression to ${preset.label}`)
+        fireEvent.click(button)
+        expect(mockOnChange).toHaveBeenCalledWith(preset.expression)
+      })
+    })
+  })
+
+  describe('Field Reference', () => {
+    it('displays field reference table', () => {
+      renderComponent()
+
+      expect(screen.getByText('Field reference:')).toBeInTheDocument()
+
+      // Use more specific queries to avoid matching "weekday" when looking for "day"
+      const fieldTexts = screen.getAllByText(/:/i)
+      const fieldNames = fieldTexts.map(el => el.textContent)
+
+      expect(fieldNames).toContain('minute:')
+      expect(fieldNames).toContain('hour:')
+      expect(fieldNames).toContain('day:')
+      expect(fieldNames).toContain('month:')
+      expect(fieldNames).toContain('weekday:')
+    })
+
+    it('shows correct ranges for each field', () => {
+      renderComponent()
+
+      expect(screen.getByText('0-59')).toBeInTheDocument() // minute
+      expect(screen.getByText('0-23')).toBeInTheDocument() // hour
+      expect(screen.getByText('1-31')).toBeInTheDocument() // day
+      expect(screen.getByText('1-12')).toBeInTheDocument() // month
+      expect(screen.getByText('0-6 (Sun-Sat)')).toBeInTheDocument() // weekday
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('sets aria-invalid on invalid expression', async () => {
+      const mockResponse = {
+        valid: false,
+        expression: 'invalid',
+        error: 'Invalid cron expression',
+      }
+
+      cronApi.validateCronExpression.mockResolvedValue(mockResponse)
+
+      renderComponent({ value: 'invalid' })
+
+      await waitFor(() => {
+        const input = screen.getByLabelText('Cron expression input')
+        expect(input).toHaveAttribute('aria-invalid', 'true')
+      })
+    })
+
+    it('associates input with help text', () => {
+      renderComponent()
+
+      const input = screen.getByLabelText('Cron expression input')
+      expect(input).toHaveAttribute('aria-describedby', 'cron-help cron-validation')
+    })
+  })
+
+  describe('Execution Time Formatting', () => {
+    it('formats execution times correctly', async () => {
+      const mockResponse = {
+        valid: true,
+        expression: '0 21 * * *',
+        description: 'At 21:00 every day',
+        next_executions: ['2024-12-26T21:00:00'],
+      }
+
+      cronApi.validateCronExpression.mockResolvedValue(mockResponse)
+
+      renderComponent({ value: '0 21 * * *' })
+
+      await waitFor(() => {
+        expect(screen.getByText('Next executions:')).toBeInTheDocument()
+      })
+
+      // Check that at least one formatted time is displayed
+      const executionItems = screen.getAllByRole('listitem')
+      expect(executionItems.length).toBeGreaterThan(0)
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/components/scheduler/ExpertMode/__tests__/ExpertModeToggle.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ExpertMode/__tests__/ExpertModeToggle.test.jsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import ExpertModeToggle from '../ExpertModeToggle'
+
+describe('ExpertModeToggle', () => {
+  let mockOnChange
+
+  beforeEach(() => {
+    mockOnChange = vi.fn()
+  })
+
+  describe('Rendering', () => {
+    it('renders with visual mode selected by default', () => {
+      render(<ExpertModeToggle mode="visual" onChange={mockOnChange} />)
+
+      const visualButton = screen.getByLabelText('Switch to Visual mode')
+      const expertButton = screen.getByLabelText('Switch to Expert mode')
+
+      expect(visualButton).toBeInTheDocument()
+      expect(expertButton).toBeInTheDocument()
+      expect(visualButton).toHaveAttribute('aria-pressed', 'true')
+      expect(expertButton).toHaveAttribute('aria-pressed', 'false')
+    })
+
+    it('toggles to expert mode on click', () => {
+      render(<ExpertModeToggle mode="visual" onChange={mockOnChange} />)
+
+      const expertButton = screen.getByLabelText('Switch to Expert mode')
+      fireEvent.click(expertButton)
+
+      expect(mockOnChange).toHaveBeenCalledWith('expert')
+    })
+
+    it('calls onChange with new mode value', () => {
+      const { rerender } = render(<ExpertModeToggle mode="visual" onChange={mockOnChange} />)
+
+      const expertButton = screen.getByLabelText('Switch to Expert mode')
+      fireEvent.click(expertButton)
+
+      expect(mockOnChange).toHaveBeenCalledWith('expert')
+
+      // Test switching back to visual
+      rerender(<ExpertModeToggle mode="expert" onChange={mockOnChange} />)
+
+      const visualButton = screen.getByLabelText('Switch to Visual mode')
+      fireEvent.click(visualButton)
+
+      expect(mockOnChange).toHaveBeenCalledWith('visual')
+    })
+
+    it('displays correct labels', () => {
+      render(<ExpertModeToggle mode="visual" onChange={mockOnChange} />)
+
+      expect(screen.getByText('Visual')).toBeInTheDocument()
+      expect(screen.getByText('Expert')).toBeInTheDocument()
+    })
+
+    it('applies active styling to selected mode', () => {
+      const { rerender } = render(<ExpertModeToggle mode="visual" onChange={mockOnChange} />)
+
+      const visualButton = screen.getByLabelText('Switch to Visual mode')
+      const expertButton = screen.getByLabelText('Switch to Expert mode')
+
+      // Visual mode selected
+      expect(visualButton).toHaveClass('bg-blue-500', 'text-white')
+      expect(expertButton).toHaveClass('bg-white', 'text-gray-700')
+
+      // Expert mode selected
+      rerender(<ExpertModeToggle mode="expert" onChange={mockOnChange} />)
+
+      expect(expertButton).toHaveClass('bg-blue-500', 'text-white')
+      expect(visualButton).toHaveClass('bg-white', 'text-gray-700')
+    })
+  })
+
+  describe('Interaction', () => {
+    it('switches mode when clicking non-selected button', () => {
+      render(<ExpertModeToggle mode="visual" onChange={mockOnChange} />)
+
+      const expertButton = screen.getByLabelText('Switch to Expert mode')
+      fireEvent.click(expertButton)
+
+      expect(mockOnChange).toHaveBeenCalledTimes(1)
+      expect(mockOnChange).toHaveBeenCalledWith('expert')
+    })
+
+    it('allows clicking already selected button', () => {
+      render(<ExpertModeToggle mode="visual" onChange={mockOnChange} />)
+
+      const visualButton = screen.getByLabelText('Switch to Visual mode')
+      fireEvent.click(visualButton)
+
+      // Should still call onChange even if already selected
+      expect(mockOnChange).toHaveBeenCalledWith('visual')
+    })
+  })
+
+  describe('Styling', () => {
+    it('applies rounded corners to first button', () => {
+      render(<ExpertModeToggle mode="visual" onChange={mockOnChange} />)
+
+      const visualButton = screen.getByLabelText('Switch to Visual mode')
+      expect(visualButton).toHaveClass('rounded-l-md')
+    })
+
+    it('applies rounded corners to last button', () => {
+      render(<ExpertModeToggle mode="visual" onChange={mockOnChange} />)
+
+      const expertButton = screen.getByLabelText('Switch to Expert mode')
+      expect(expertButton).toHaveClass('rounded-r-md')
+    })
+
+    it('applies dark mode classes', () => {
+      render(<ExpertModeToggle mode="visual" onChange={mockOnChange} />)
+
+      const expertButton = screen.getByLabelText('Switch to Expert mode')
+      expect(expertButton).toHaveClass('dark:bg-gray-800', 'dark:text-gray-300')
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('has role group with aria-label', () => {
+      render(<ExpertModeToggle mode="visual" onChange={mockOnChange} />)
+
+      const group = screen.getByRole('group', { name: 'Mode selector' })
+      expect(group).toBeInTheDocument()
+    })
+
+    it('sets aria-pressed correctly for selected mode', () => {
+      render(<ExpertModeToggle mode="expert" onChange={mockOnChange} />)
+
+      const visualButton = screen.getByLabelText('Switch to Visual mode')
+      const expertButton = screen.getByLabelText('Switch to Expert mode')
+
+      expect(visualButton).toHaveAttribute('aria-pressed', 'false')
+      expect(expertButton).toHaveAttribute('aria-pressed', 'true')
+    })
+
+    it('has descriptive aria-labels', () => {
+      render(<ExpertModeToggle mode="visual" onChange={mockOnChange} />)
+
+      expect(screen.getByLabelText('Switch to Visual mode')).toBeInTheDocument()
+      expect(screen.getByLabelText('Switch to Expert mode')).toBeInTheDocument()
+    })
+  })
+
+  describe('Focus Management', () => {
+    it('applies focus ring styles', () => {
+      render(<ExpertModeToggle mode="visual" onChange={mockOnChange} />)
+
+      const visualButton = screen.getByLabelText('Switch to Visual mode')
+      expect(visualButton).toHaveClass('focus:ring-2', 'focus:ring-blue-500', 'focus:outline-none')
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/components/scheduler/ExpertMode/constants.js
+++ b/Firmware/webui/frontend/src/components/scheduler/ExpertMode/constants.js
@@ -1,0 +1,38 @@
+/**
+ * Constants for Expert Mode Cron Expression Editor (Issue #233)
+ *
+ * Provides cron presets and help text for the cron expression input component.
+ */
+
+/**
+ * Quick preset cron expressions for common scheduling patterns
+ *
+ * These presets help users quickly set up common scheduling scenarios
+ * without needing to understand cron syntax.
+ */
+export const CRON_PRESETS = [
+  { label: 'Every hour', expression: '0 * * * *' },
+  { label: 'Every 5 min', expression: '*/5 * * * *' },
+  { label: 'Every 15 min', expression: '*/15 * * * *' },
+  { label: 'Daily midnight', expression: '0 0 * * *' },
+  { label: 'Daily 9 PM', expression: '0 21 * * *' },
+  { label: 'Weekdays 9 PM', expression: '0 21 * * 1-5' },
+]
+
+/**
+ * Help text for cron expression format
+ *
+ * Provides format documentation and special character explanations
+ * to assist users in writing their own cron expressions.
+ */
+export const CRON_HELP = {
+  format: 'minute hour day month weekday',
+  fields: [
+    { name: 'minute', range: '0-59' },
+    { name: 'hour', range: '0-23' },
+    { name: 'day', range: '1-31' },
+    { name: 'month', range: '1-12' },
+    { name: 'weekday', range: '0-6 (Sun-Sat)' },
+  ],
+  special: '* = any, */N = every N, N-M = range, N,M = list',
+}

--- a/Firmware/webui/frontend/src/components/scheduler/ExpertMode/index.js
+++ b/Firmware/webui/frontend/src/components/scheduler/ExpertMode/index.js
@@ -5,5 +5,6 @@
  */
 
 export { default as CronExpressionInput } from './CronExpressionInput'
+export { default as CronExpressionErrorBoundary } from './CronExpressionErrorBoundary'
 export { default as ExpertModeToggle } from './ExpertModeToggle'
 export * from './constants'

--- a/Firmware/webui/frontend/src/components/scheduler/ExpertMode/index.js
+++ b/Firmware/webui/frontend/src/components/scheduler/ExpertMode/index.js
@@ -1,0 +1,9 @@
+/**
+ * Barrel export for Expert Mode components (Issue #233)
+ *
+ * Exports all Expert Mode components and constants for convenient importing.
+ */
+
+export { default as CronExpressionInput } from './CronExpressionInput'
+export { default as ExpertModeToggle } from './ExpertModeToggle'
+export * from './constants'

--- a/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/TriggerForm.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/TriggerForm.jsx
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import { useState, useEffect } from 'react';
 import { TRIGGER_TYPES, TRIGGER_DEFAULTS } from './constants';
 import { TimeWindowPropType, TriggerErrorsPropType } from './propTypes';
 import IntervalTriggerForm from './IntervalTriggerForm';
@@ -6,6 +7,8 @@ import SolarTriggerForm from './SolarTriggerForm';
 import MoonPhaseTriggerForm from './MoonPhaseTriggerForm';
 import FixedTimeTriggerForm from './FixedTimeTriggerForm';
 import SensorTriggerForm from './SensorTriggerForm';
+import ExpertModeToggle from '../ExpertMode/ExpertModeToggle';
+import CronExpressionInput from '../ExpertMode/CronExpressionInput';
 
 /**
  * TriggerForm Component
@@ -41,6 +44,53 @@ const TriggerForm = ({
   const triggerType = value.trigger_type || 'interval';
 
   /**
+   * Expert mode state - true if trigger_type is 'cron'
+   */
+  const [expertMode, setExpertMode] = useState(triggerType === 'cron' ? 'expert' : 'visual');
+
+  /**
+   * Store previous trigger type for switching back from expert mode
+   */
+  const [previousTriggerType, setPreviousTriggerType] = useState(
+    triggerType === 'cron' ? 'interval' : triggerType
+  );
+
+  /**
+   * Sync expert mode when trigger_type changes externally
+   */
+  useEffect(() => {
+    if (triggerType === 'cron') {
+      setExpertMode('expert');
+    } else {
+      setExpertMode('visual');
+      setPreviousTriggerType(triggerType);
+    }
+  }, [triggerType]);
+
+  /**
+   * Handle expert mode toggle
+   */
+  const handleExpertModeChange = (newMode) => {
+    setExpertMode(newMode);
+
+    if (newMode === 'expert') {
+      // Switch to cron trigger type
+      const defaults = TRIGGER_DEFAULTS.cron;
+      onChange({
+        ...defaults,
+        trigger_type: 'cron',
+      });
+    } else {
+      // Switch back to previous trigger type
+      const defaults = TRIGGER_DEFAULTS[previousTriggerType] || TRIGGER_DEFAULTS.interval;
+      onChange({
+        ...defaults,
+        trigger_type: previousTriggerType,
+      });
+    }
+  };
+
+  /**
    * Handle trigger type change
    * Resets the value to defaults for the new trigger type
    */
@@ -51,6 +101,7 @@ const TriggerForm = ({
       ...defaults,
       trigger_type: newType,
     });
+    setPreviousTriggerType(newType);
   };
 
   /**
@@ -61,6 +112,17 @@ const TriggerForm = ({
     onChange({
       ...newValue,
       trigger_type: triggerType,
+    });
+  };
+
+  /**
+   * Handle cron expression change
+   */
+  const handleCronExpressionChange = (newExpression) => {
+    onChange({
+      ...value,
+      trigger_type: 'cron',
+      cron_expression: newExpression,
     });
   };
 
@@ -105,42 +167,78 @@ const TriggerForm = ({
         Trigger Configuration
       </h3>
 
-      {/* Trigger Type Selector */}
+      {/* Expert Mode Toggle */}
       <div>
-        <label
-          htmlFor="trigger_type"
-          className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
-        >
-          Trigger Type:
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+          Mode:
         </label>
-        <select
-          id="trigger_type"
-          value={triggerType}
-          onChange={(e) => handleTriggerTypeChange(e.target.value)}
-          disabled={disabled}
-          className="w-full rounded-md border border-gray-300 dark:border-gray-600
-                   bg-white dark:bg-gray-800 px-3 py-2 text-gray-900 dark:text-white
-                   focus:ring-2 focus:ring-blue-500 focus:border-transparent
-                   disabled:opacity-50 disabled:cursor-not-allowed"
-          aria-label="Trigger type"
-        >
-          {Object.values(TRIGGER_TYPES).map((type) => (
-            <option key={type.value} value={type.value}>
-              {type.label}
-            </option>
-          ))}
-        </select>
-        {/* Type Description */}
-        <p className="mt-2 text-sm text-gray-500 dark:text-gray-300">
-          {getDescription()}
+        <ExpertModeToggle
+          mode={expertMode}
+          onChange={handleExpertModeChange}
+        />
+        <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+          {expertMode === 'expert'
+            ? 'Expert mode allows you to enter a raw cron expression for maximum flexibility.'
+            : 'Visual mode provides an intuitive interface for common scheduling patterns.'
+          }
         </p>
       </div>
 
-      {/* Divider */}
-      <div className="border-t border-gray-200 dark:border-gray-700" />
+      {expertMode === 'expert' ? (
+        /* Expert Mode: Cron Expression Input */
+        <>
+          {/* Divider */}
+          <div className="border-t border-gray-200 dark:border-gray-700" />
 
-      {/* Specific Trigger Form */}
-      {renderTriggerForm()}
+          <CronExpressionInput
+            value={value.cron_expression || '0 21 * * *'}
+            onChange={handleCronExpressionChange}
+            disabled={disabled}
+          />
+        </>
+      ) : (
+        /* Visual Mode: Standard Trigger Forms */
+        <>
+          {/* Trigger Type Selector */}
+          <div>
+            <label
+              htmlFor="trigger_type"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
+            >
+              Trigger Type:
+            </label>
+            <select
+              id="trigger_type"
+              value={triggerType}
+              onChange={(e) => handleTriggerTypeChange(e.target.value)}
+              disabled={disabled}
+              className="w-full rounded-md border border-gray-300 dark:border-gray-600
+                       bg-white dark:bg-gray-800 px-3 py-2 text-gray-900 dark:text-white
+                       focus:ring-2 focus:ring-blue-500 focus:border-transparent
+                       disabled:opacity-50 disabled:cursor-not-allowed"
+              aria-label="Trigger type"
+            >
+              {Object.values(TRIGGER_TYPES)
+                .filter((type) => type.value !== 'cron')
+                .map((type) => (
+                  <option key={type.value} value={type.value}>
+                    {type.label}
+                  </option>
+                ))}
+            </select>
+            {/* Type Description */}
+            <p className="mt-2 text-sm text-gray-500 dark:text-gray-300">
+              {getDescription()}
+            </p>
+          </div>
+
+          {/* Divider */}
+          <div className="border-t border-gray-200 dark:border-gray-700" />
+
+          {/* Specific Trigger Form */}
+          {renderTriggerForm()}
+        </>
+      )}
     </div>
   );
 };
@@ -148,7 +246,7 @@ const TriggerForm = ({
 TriggerForm.propTypes = {
   /** Trigger configuration with type-specific fields. Type determines which fields are active. */
   value: PropTypes.shape({
-    trigger_type: PropTypes.oneOf(['interval', 'solar', 'moon_phase', 'fixed_time', 'sensor']).isRequired,
+    trigger_type: PropTypes.oneOf(['interval', 'solar', 'moon_phase', 'fixed_time', 'sensor', 'cron']).isRequired,
     // Interval trigger fields
     interval_minutes: PropTypes.number,
     time_window: TimeWindowPropType,
@@ -166,6 +264,8 @@ TriggerForm.propTypes = {
     comparison: PropTypes.string,
     threshold: PropTypes.number,
     cooldown_minutes: PropTypes.number,
+    // Cron trigger fields
+    cron_expression: PropTypes.string,
     // Common fields
     days_of_week: PropTypes.arrayOf(PropTypes.number),
   }),

--- a/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/__tests__/TriggerForm.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/__tests__/TriggerForm.test.jsx
@@ -82,6 +82,42 @@ vi.mock('../SensorTriggerForm', () => ({
   ),
 }));
 
+// Mock ExpertModeToggle
+vi.mock('../../ExpertMode/ExpertModeToggle', () => ({
+  default: ({ mode, onChange }) => (
+    <div data-testid="expert-mode-toggle">
+      <button
+        data-testid="toggle-visual"
+        onClick={() => onChange('visual')}
+        aria-pressed={mode === 'visual'}
+      >
+        Visual
+      </button>
+      <button
+        data-testid="toggle-expert"
+        onClick={() => onChange('expert')}
+        aria-pressed={mode === 'expert'}
+      >
+        Expert
+      </button>
+    </div>
+  ),
+}));
+
+// Mock CronExpressionInput
+vi.mock('../../ExpertMode/CronExpressionInput', () => ({
+  default: ({ value, onChange, disabled }) => (
+    <div data-testid="cron-expression-input">
+      <input
+        data-testid="cron-input"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+      />
+    </div>
+  ),
+}));
+
 describe('TriggerForm', () => {
   let mockOnChange;
 
@@ -96,15 +132,21 @@ describe('TriggerForm', () => {
       expect(screen.getByLabelText(/trigger type/i)).toBeInTheDocument();
     });
 
-    it('renders all trigger type options', () => {
+    it('renders all trigger type options except cron in visual mode', () => {
       render(<TriggerForm onChange={mockOnChange} />);
 
       const select = screen.getByLabelText(/trigger type/i);
       const options = Array.from(select.options).map((opt) => opt.value);
 
-      Object.keys(TRIGGER_TYPES).forEach((type) => {
-        expect(options).toContain(type);
-      });
+      // All trigger types except 'cron' should be in the select in visual mode
+      Object.keys(TRIGGER_TYPES)
+        .filter((type) => type !== 'cron')
+        .forEach((type) => {
+          expect(options).toContain(type);
+        });
+
+      // Cron should NOT be in the select in visual mode
+      expect(options).not.toContain('cron');
     });
 
     it('renders with default interval trigger type', () => {
@@ -461,6 +503,114 @@ describe('TriggerForm', () => {
           offset_minutes: expect.any(Number),
         })
       );
+    });
+  });
+
+  describe('Expert Mode (Issue #233)', () => {
+    it('renders expert mode toggle', () => {
+      render(<TriggerForm onChange={mockOnChange} />);
+
+      expect(screen.getByTestId('expert-mode-toggle')).toBeInTheDocument();
+    });
+
+    it('switches to cron input when expert mode enabled', () => {
+      render(<TriggerForm onChange={mockOnChange} />);
+
+      // Initially in visual mode
+      expect(screen.getByTestId('interval-trigger-form')).toBeInTheDocument();
+      expect(screen.queryByTestId('cron-expression-input')).not.toBeInTheDocument();
+
+      // Switch to expert mode
+      const expertButton = screen.getByTestId('toggle-expert');
+      fireEvent.click(expertButton);
+
+      // Should show cron input and hide trigger forms
+      expect(screen.getByTestId('cron-expression-input')).toBeInTheDocument();
+      expect(screen.queryByTestId('interval-trigger-form')).not.toBeInTheDocument();
+    });
+
+    it('preserves cron expression in trigger value', () => {
+      const value = {
+        trigger_type: 'cron',
+        cron_expression: '*/5 * * * *',
+      };
+
+      render(<TriggerForm value={value} onChange={mockOnChange} />);
+
+      const cronInput = screen.getByTestId('cron-input');
+      expect(cronInput).toHaveValue('*/5 * * * *');
+    });
+
+    it('syncs expert mode with trigger_type cron', () => {
+      const value = {
+        trigger_type: 'cron',
+        cron_expression: '0 21 * * *',
+      };
+
+      render(<TriggerForm value={value} onChange={mockOnChange} />);
+
+      // Should be in expert mode
+      const expertButton = screen.getByTestId('toggle-expert');
+      expect(expertButton).toHaveAttribute('aria-pressed', 'true');
+
+      // Should show cron input
+      expect(screen.getByTestId('cron-expression-input')).toBeInTheDocument();
+    });
+
+    it('calls onChange with cron_expression when changed', () => {
+      const value = {
+        trigger_type: 'cron',
+        cron_expression: '0 21 * * *',
+      };
+
+      render(<TriggerForm value={value} onChange={mockOnChange} />);
+
+      const cronInput = screen.getByTestId('cron-input');
+      fireEvent.change(cronInput, { target: { value: '0 */2 * * *' } });
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          trigger_type: 'cron',
+          cron_expression: '0 */2 * * *',
+        })
+      );
+    });
+
+    it('switches back to visual mode when clicking visual button', () => {
+      const value = {
+        trigger_type: 'cron',
+        cron_expression: '0 21 * * *',
+      };
+
+      render(<TriggerForm value={value} onChange={mockOnChange} />);
+
+      // Initially in expert mode
+      expect(screen.getByTestId('cron-expression-input')).toBeInTheDocument();
+
+      // Switch to visual mode
+      const visualButton = screen.getByTestId('toggle-visual');
+      fireEvent.click(visualButton);
+
+      // Should call onChange with interval defaults
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          trigger_type: 'interval',
+        })
+      );
+    });
+
+    it('hides trigger type selector in expert mode', () => {
+      render(<TriggerForm onChange={mockOnChange} />);
+
+      // Initially shows trigger type selector
+      expect(screen.getByLabelText(/trigger type/i)).toBeInTheDocument();
+
+      // Switch to expert mode
+      const expertButton = screen.getByTestId('toggle-expert');
+      fireEvent.click(expertButton);
+
+      // Should hide trigger type selector
+      expect(screen.queryByLabelText(/trigger type/i)).not.toBeInTheDocument();
     });
   });
 });

--- a/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/__tests__/constants.test.js
+++ b/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/__tests__/constants.test.js
@@ -53,11 +53,11 @@ describe('SCHEDULE_LIMITS', () => {
 })
 
 describe('TRIGGER_TYPES', () => {
-  it('should have all 5 trigger types from backend', () => {
-    const expectedTypes = ['interval', 'solar', 'moon_phase', 'fixed_time', 'sensor']
+  it('should have all 6 trigger types from backend including cron for expert mode', () => {
+    const expectedTypes = ['interval', 'solar', 'moon_phase', 'fixed_time', 'sensor', 'cron']
     const actualTypes = Object.keys(TRIGGER_TYPES)
 
-    expect(actualTypes).toHaveLength(5)
+    expect(actualTypes).toHaveLength(6)
     expect(actualTypes.sort()).toEqual(expectedTypes.sort())
   })
 
@@ -82,6 +82,7 @@ describe('TRIGGER_TYPES', () => {
       'MoonIcon',
       'BoltIcon',
       'CalendarIcon',
+      'CodeBracketIcon',
     ]
 
     Object.values(TRIGGER_TYPES).forEach(({ icon }) => {

--- a/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/constants.js
+++ b/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/constants.js
@@ -63,6 +63,12 @@ export const TRIGGER_TYPES = {
     icon: 'BoltIcon',
     description: 'Trigger based on sensor readings',
   },
+  cron: {
+    value: 'cron',
+    label: 'Expert Mode (Cron)',
+    icon: 'CodeBracketIcon',
+    description: 'Advanced cron expression for custom scheduling',
+  },
 }
 
 /**
@@ -245,6 +251,10 @@ export const TRIGGER_DEFAULTS = {
     comparison: 'lt',
     threshold: 100,
     cooldown_minutes: 5,
+  },
+  cron: {
+    trigger_type: 'cron',
+    cron_expression: '0 21 * * *',
   },
 }
 

--- a/Firmware/webui/frontend/src/hooks/__tests__/useCronValidation.test.jsx
+++ b/Firmware/webui/frontend/src/hooks/__tests__/useCronValidation.test.jsx
@@ -1,0 +1,346 @@
+/**
+ * Tests for useCronValidation hook (Issue #233)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import useCronValidation from '../useCronValidation'
+import * as cronApi from '../../utils/cronApi'
+
+// Mock the cronApi module
+vi.mock('../../utils/cronApi')
+
+describe('useCronValidation', () => {
+  let queryClient
+
+  beforeEach(() => {
+    // Create a fresh QueryClient for each test
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false, // Disable retries for tests
+        },
+      },
+    })
+
+    // Reset all mocks
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    queryClient.clear()
+  })
+
+  /**
+   * Helper to render hook with QueryClient wrapper
+   */
+  const wrapper = ({ children }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+
+  describe('Basic Functionality', () => {
+    it('should not fetch when expression is empty', () => {
+      const { result } = renderHook(() => useCronValidation(''), { wrapper })
+
+      expect(result.current.isLoading).toBe(false)
+      expect(result.current.isFetching).toBe(false)
+      expect(cronApi.validateCronExpression).not.toHaveBeenCalled()
+    })
+
+    it('should not fetch when expression is whitespace only', () => {
+      const { result } = renderHook(() => useCronValidation('   '), { wrapper })
+
+      expect(result.current.isLoading).toBe(false)
+      expect(result.current.isFetching).toBe(false)
+      expect(cronApi.validateCronExpression).not.toHaveBeenCalled()
+    })
+
+    it('should fetch when expression is provided', async () => {
+      const mockResponse = {
+        valid: true,
+        expression: '0 * * * *',
+        description: 'At minute 0 of every hour',
+        next_executions: ['2024-12-26T14:00:00', '2024-12-26T15:00:00'],
+      }
+
+      cronApi.validateCronExpression.mockResolvedValue(mockResponse)
+
+      const { result } = renderHook(() => useCronValidation('0 * * * *'), { wrapper })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(cronApi.validateCronExpression).toHaveBeenCalledWith('0 * * * *', 5)
+      expect(result.current.data).toEqual(mockResponse)
+    })
+
+    it('should pass custom count to API', async () => {
+      const mockResponse = {
+        valid: true,
+        expression: '0 * * * *',
+        description: 'At minute 0 of every hour',
+        next_executions: Array(10).fill('2024-12-26T14:00:00'),
+      }
+
+      cronApi.validateCronExpression.mockResolvedValue(mockResponse)
+
+      const { result } = renderHook(
+        () => useCronValidation('0 * * * *', { count: 10 }),
+        { wrapper }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(cronApi.validateCronExpression).toHaveBeenCalledWith('0 * * * *', 10)
+    })
+  })
+
+  describe('Debouncing', () => {
+    it('should eventually call API after debounce delay', async () => {
+      const mockResponse = {
+        valid: true,
+        expression: '0 21 * * *',
+        description: 'At 21:00 every day',
+        next_executions: ['2024-12-26T21:00:00'],
+      }
+
+      cronApi.validateCronExpression.mockResolvedValue(mockResponse)
+
+      const { result, rerender } = renderHook(
+        ({ expr }) => useCronValidation(expr),
+        { wrapper, initialProps: { expr: '' } }
+      )
+
+      // Change to a valid expression
+      rerender({ expr: '0 21 * * *' })
+
+      // Wait for debounce and API call
+      await waitFor(() => expect(result.current.isSuccess).toBe(true), { timeout: 2000 })
+
+      expect(cronApi.validateCronExpression).toHaveBeenCalledWith('0 21 * * *', 5)
+    })
+
+    it('should debounce rapid changes and validate final value', async () => {
+      const mockResponse = {
+        valid: true,
+        expression: '0 * * * *',
+        description: 'At minute 0 of every hour',
+        next_executions: ['2024-12-26T14:00:00'],
+      }
+
+      cronApi.validateCronExpression.mockResolvedValue(mockResponse)
+
+      const { result, rerender } = renderHook(
+        ({ expr }) => useCronValidation(expr),
+        { wrapper, initialProps: { expr: '' } }
+      )
+
+      // Rapidly change expression (simulating typing)
+      rerender({ expr: '0' })
+      rerender({ expr: '0 *' })
+      rerender({ expr: '0 * *' })
+      rerender({ expr: '0 * * *' })
+      rerender({ expr: '0 * * * *' })
+
+      // Wait for debounce and API call
+      await waitFor(() => expect(result.current.isSuccess).toBe(true), { timeout: 2000 })
+
+      // Should validate the final expression
+      expect(cronApi.validateCronExpression).toHaveBeenCalledWith('0 * * * *', 5)
+    })
+  })
+
+  describe('Valid Expression', () => {
+    it('should return validation result for valid expression', async () => {
+      const mockResponse = {
+        valid: true,
+        expression: '0 21 * * *',
+        description: 'At 21:00 every day',
+        next_executions: [
+          '2024-12-26T21:00:00',
+          '2024-12-27T21:00:00',
+          '2024-12-28T21:00:00',
+        ],
+      }
+
+      cronApi.validateCronExpression.mockResolvedValue(mockResponse)
+
+      const { result } = renderHook(() => useCronValidation('0 21 * * *'), { wrapper })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(result.current.data.valid).toBe(true)
+      expect(result.current.data.description).toBe('At 21:00 every day')
+      expect(result.current.data.next_executions).toHaveLength(3)
+    })
+
+    it('should return next executions for valid expression', async () => {
+      const mockResponse = {
+        valid: true,
+        expression: '*/5 * * * *',
+        description: 'Every 5 minutes',
+        next_executions: [
+          '2024-12-26T14:00:00',
+          '2024-12-26T14:05:00',
+          '2024-12-26T14:10:00',
+          '2024-12-26T14:15:00',
+          '2024-12-26T14:20:00',
+        ],
+      }
+
+      cronApi.validateCronExpression.mockResolvedValue(mockResponse)
+
+      const { result } = renderHook(() => useCronValidation('*/5 * * * *'), { wrapper })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(result.current.data.valid).toBe(true)
+      expect(result.current.data.next_executions).toHaveLength(5)
+    })
+  })
+
+  describe('Invalid Expression', () => {
+    it('should return error for invalid expression', async () => {
+      const mockResponse = {
+        valid: false,
+        expression: 'invalid * * * *',
+        error: 'Invalid cron expression: invalid is not a valid minute value',
+      }
+
+      cronApi.validateCronExpression.mockResolvedValue(mockResponse)
+
+      const { result } = renderHook(() => useCronValidation('invalid * * * *'), { wrapper })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(result.current.data.valid).toBe(false)
+      expect(result.current.data.error).toBe(
+        'Invalid cron expression: invalid is not a valid minute value'
+      )
+    })
+
+    it('should handle API errors gracefully', async () => {
+      const mockError = new Error('Network error')
+      cronApi.validateCronExpression.mockRejectedValue(mockError)
+
+      const { result } = renderHook(() => useCronValidation('0 * * * *'), { wrapper })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+
+      expect(result.current.error).toBeTruthy()
+    })
+  })
+
+  describe('Caching', () => {
+    it('should use cached result for same expression', async () => {
+      const mockResponse = {
+        valid: true,
+        expression: '0 * * * *',
+        description: 'At minute 0 of every hour',
+        next_executions: ['2024-12-26T14:00:00'],
+      }
+
+      cronApi.validateCronExpression.mockResolvedValue(mockResponse)
+
+      const { result: result1 } = renderHook(() => useCronValidation('0 * * * *'), { wrapper })
+
+      await waitFor(() => expect(result1.current.isSuccess).toBe(true))
+
+      // Render hook again with same expression
+      const { result: result2 } = renderHook(() => useCronValidation('0 * * * *'), { wrapper })
+
+      // Should use cached result, not call API again
+      expect(result2.current.data).toEqual(mockResponse)
+      expect(cronApi.validateCronExpression).toHaveBeenCalledTimes(1)
+    })
+
+    it('should fetch again for different expression', async () => {
+      const mockResponse1 = {
+        valid: true,
+        expression: '0 * * * *',
+        description: 'At minute 0 of every hour',
+        next_executions: ['2024-12-26T14:00:00'],
+      }
+
+      const mockResponse2 = {
+        valid: true,
+        expression: '0 21 * * *',
+        description: 'At 21:00 every day',
+        next_executions: ['2024-12-26T21:00:00'],
+      }
+
+      cronApi.validateCronExpression
+        .mockResolvedValueOnce(mockResponse1)
+        .mockResolvedValueOnce(mockResponse2)
+
+      const { result: result1 } = renderHook(() => useCronValidation('0 * * * *'), { wrapper })
+
+      await waitFor(() => expect(result1.current.isSuccess).toBe(true))
+
+      // Render hook with different expression
+      const { result: result2 } = renderHook(() => useCronValidation('0 21 * * *'), { wrapper })
+
+      await waitFor(() => expect(result2.current.isSuccess).toBe(true))
+
+      // Should call API twice (different cache keys)
+      expect(cronApi.validateCronExpression).toHaveBeenCalledTimes(2)
+      expect(result2.current.data).toEqual(mockResponse2)
+    })
+  })
+
+  describe('Custom Options', () => {
+    it('should accept custom stale time from query options', async () => {
+      const mockResponse = {
+        valid: true,
+        expression: '0 * * * *',
+        description: 'At minute 0 of every hour',
+        next_executions: ['2024-12-26T14:00:00'],
+      }
+
+      cronApi.validateCronExpression.mockResolvedValue(mockResponse)
+
+      const { result } = renderHook(
+        () =>
+          useCronValidation('0 * * * *', {
+            queryOptions: { staleTime: 0 }, // Override default 1 minute
+          }),
+        { wrapper }
+      )
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      // Verify query was successful
+      expect(result.current.data).toEqual(mockResponse)
+    })
+  })
+
+  describe('Loading States', () => {
+    it('should show loading state while fetching', async () => {
+      const mockResponse = {
+        valid: true,
+        expression: '0 * * * *',
+        description: 'At minute 0 of every hour',
+        next_executions: ['2024-12-26T14:00:00'],
+      }
+
+      // Create a promise that resolves after a delay
+      let resolvePromise
+      const delayedPromise = new Promise((resolve) => {
+        resolvePromise = resolve
+      })
+
+      cronApi.validateCronExpression.mockReturnValue(delayedPromise)
+
+      const { result } = renderHook(() => useCronValidation('0 * * * *'), { wrapper })
+
+      // Should be loading initially
+      await waitFor(() => expect(result.current.isLoading).toBe(true))
+
+      // Resolve the promise
+      resolvePromise(mockResponse)
+
+      // Should finish loading
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/hooks/__tests__/useCronValidation.test.jsx
+++ b/Firmware/webui/frontend/src/hooks/__tests__/useCronValidation.test.jsx
@@ -343,4 +343,95 @@ describe('useCronValidation', () => {
       await waitFor(() => expect(result.current.isSuccess).toBe(true))
     })
   })
+
+  describe('Error Message Normalization', () => {
+    it('should return null errorMessage for valid expression', async () => {
+      const mockResponse = {
+        valid: true,
+        expression: '0 * * * *',
+        description: 'At minute 0 of every hour',
+        next_executions: ['2024-12-26T14:00:00'],
+      }
+
+      cronApi.validateCronExpression.mockResolvedValue(mockResponse)
+
+      const { result } = renderHook(() => useCronValidation('0 * * * *'), { wrapper })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(result.current.errorMessage).toBeNull()
+    })
+
+    it('should return validation error from API response', async () => {
+      const mockResponse = {
+        valid: false,
+        expression: 'invalid',
+        error: 'Invalid cron syntax: too few fields',
+      }
+
+      cronApi.validateCronExpression.mockResolvedValue(mockResponse)
+
+      const { result } = renderHook(() => useCronValidation('invalid'), { wrapper })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(result.current.errorMessage).toBe('Invalid cron syntax: too few fields')
+    })
+
+    it('should return fallback message when API returns invalid without error', async () => {
+      const mockResponse = {
+        valid: false,
+        expression: 'bad',
+      }
+
+      cronApi.validateCronExpression.mockResolvedValue(mockResponse)
+
+      const { result } = renderHook(() => useCronValidation('bad'), { wrapper })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(result.current.errorMessage).toBe('Invalid cron expression')
+    })
+
+    it('should return network error message on request failure', async () => {
+      const networkError = new Error('Network Error')
+
+      cronApi.validateCronExpression.mockRejectedValue(networkError)
+
+      const { result } = renderHook(() => useCronValidation('0 * * * *'), { wrapper })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+
+      expect(result.current.errorMessage).toBe('Validation failed: Network Error')
+    })
+
+    it('should extract server error from response data', async () => {
+      const serverError = new Error('Request failed')
+      serverError.response = {
+        data: {
+          error: 'Server validation failed',
+        },
+      }
+
+      cronApi.validateCronExpression.mockRejectedValue(serverError)
+
+      const { result } = renderHook(() => useCronValidation('0 * * * *'), { wrapper })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+
+      expect(result.current.errorMessage).toBe('Server validation failed')
+    })
+
+    it('should return generic message when no error details available', async () => {
+      const unknownError = {}
+
+      cronApi.validateCronExpression.mockRejectedValue(unknownError)
+
+      const { result } = renderHook(() => useCronValidation('0 * * * *'), { wrapper })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+
+      expect(result.current.errorMessage).toBe('Unable to validate expression. Please try again.')
+    })
+  })
 })

--- a/Firmware/webui/frontend/src/hooks/useCronValidation.js
+++ b/Firmware/webui/frontend/src/hooks/useCronValidation.js
@@ -53,7 +53,7 @@ const STALE_TIME_MS = 60 * 1000
  * @param {Object} [options] - Hook options
  * @param {number} [options.count=5] - Number of next execution times to fetch
  * @param {Object} [options.queryOptions] - Additional React Query options
- * @returns {Object} React Query result
+ * @returns {Object} React Query result with additional errorMessage property
  * @returns {Object} data - Validation result
  * @returns {boolean} data.valid - Whether expression is valid
  * @returns {string} data.expression - The validated expression
@@ -63,10 +63,14 @@ const STALE_TIME_MS = 60 * 1000
  * @returns {boolean} isLoading - Whether query is loading
  * @returns {boolean} isError - Whether query failed
  * @returns {Object} error - Error object if query failed
+ * @returns {string|null} errorMessage - Normalized error message for UI display
  *
  * @example
- * // Basic usage
- * const { data, isLoading } = useCronValidation(expression)
+ * // Basic usage with normalized error message
+ * const { data, isLoading, errorMessage } = useCronValidation(expression)
+ * if (errorMessage) {
+ *   showError(errorMessage)
+ * }
  *
  * @example
  * // With custom count and options
@@ -89,13 +93,34 @@ export function useCronValidation(expression, options = {}) {
     return () => clearTimeout(timer)
   }, [expression])
 
-  return useQuery({
+  const query = useQuery({
     queryKey: QUERY_KEYS.CRON_VALIDATION(debouncedExpression),
     queryFn: () => validateCronExpression(debouncedExpression, count),
     enabled: Boolean(debouncedExpression?.trim()),
     staleTime: STALE_TIME_MS,
     ...queryOptions,
   })
+
+  // Normalize error messages for consistent UX
+  const getErrorMessage = () => {
+    if (query.isError) {
+      // Network/server error
+      const serverError = query.error?.response?.data?.error
+      if (serverError) return serverError
+      if (query.error?.message) return `Validation failed: ${query.error.message}`
+      return 'Unable to validate expression. Please try again.'
+    }
+    if (query.data?.valid === false) {
+      // Validation error from API
+      return query.data.error || 'Invalid cron expression'
+    }
+    return null
+  }
+
+  return {
+    ...query,
+    errorMessage: getErrorMessage(),
+  }
 }
 
 export default useCronValidation

--- a/Firmware/webui/frontend/src/hooks/useCronValidation.js
+++ b/Firmware/webui/frontend/src/hooks/useCronValidation.js
@@ -1,0 +1,101 @@
+/**
+ * React Query hook for cron expression validation (Issue #233)
+ *
+ * Provides real-time validation of cron expressions with debounced input
+ * to reduce unnecessary API calls while typing.
+ *
+ * Features:
+ * - Debounced input (300ms) to avoid excessive API calls
+ * - TanStack Query integration for caching and error handling
+ * - Only fetches when expression is non-empty
+ * - Returns validation status, human-readable description, and next executions
+ *
+ * @example
+ * const { data, isLoading, isError } = useCronValidation("0 21 * * *")
+ * if (data?.valid) {
+ *   console.log(data.description) // "At 21:00 every day"
+ *   console.log(data.next_executions) // ["2024-12-26T21:00:00", ...]
+ * }
+ */
+
+import { useState, useEffect } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { QUERY_KEYS } from '../utils/queryKeys'
+import { validateCronExpression } from '../utils/cronApi'
+
+// =============================================================================
+// Configuration
+// =============================================================================
+
+/**
+ * Debounce delay in milliseconds.
+ * 300ms provides a good balance:
+ * - Fast enough to feel responsive
+ * - Slow enough to avoid API calls on every keystroke
+ */
+const DEBOUNCE_DELAY_MS = 300
+
+/**
+ * Query stale time in milliseconds.
+ * 1 minute is reasonable since cron validation results are deterministic
+ * and don't change over time for the same expression.
+ */
+const STALE_TIME_MS = 60 * 1000
+
+// =============================================================================
+// Hook
+// =============================================================================
+
+/**
+ * Hook for validating cron expressions with debouncing
+ *
+ * @param {string} expression - Cron expression to validate (e.g., "0 * * * *")
+ * @param {Object} [options] - Hook options
+ * @param {number} [options.count=5] - Number of next execution times to fetch
+ * @param {Object} [options.queryOptions] - Additional React Query options
+ * @returns {Object} React Query result
+ * @returns {Object} data - Validation result
+ * @returns {boolean} data.valid - Whether expression is valid
+ * @returns {string} data.expression - The validated expression
+ * @returns {string} data.description - Human-readable description (if valid)
+ * @returns {Array<string>} data.next_executions - Next execution times (if valid)
+ * @returns {string} data.error - Error message (if invalid)
+ * @returns {boolean} isLoading - Whether query is loading
+ * @returns {boolean} isError - Whether query failed
+ * @returns {Object} error - Error object if query failed
+ *
+ * @example
+ * // Basic usage
+ * const { data, isLoading } = useCronValidation(expression)
+ *
+ * @example
+ * // With custom count and options
+ * const { data, isLoading } = useCronValidation(expression, {
+ *   count: 10,
+ *   queryOptions: { onSuccess: (data) => console.log(data) }
+ * })
+ */
+export function useCronValidation(expression, options = {}) {
+  const { count = 5, queryOptions = {} } = options
+
+  // Debounce the expression to avoid excessive API calls
+  const [debouncedExpression, setDebouncedExpression] = useState(expression)
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedExpression(expression)
+    }, DEBOUNCE_DELAY_MS)
+
+    return () => clearTimeout(timer)
+  }, [expression])
+
+  return useQuery({
+    queryKey: QUERY_KEYS.CRON_VALIDATION(debouncedExpression),
+    queryFn: () => validateCronExpression(debouncedExpression, count),
+    enabled: Boolean(debouncedExpression?.trim()),
+    staleTime: STALE_TIME_MS,
+    ...queryOptions,
+  })
+}
+
+export default useCronValidation

--- a/Firmware/webui/frontend/src/utils/cronApi.js
+++ b/Firmware/webui/frontend/src/utils/cronApi.js
@@ -1,0 +1,75 @@
+/**
+ * Cron Expression API functions for Issue #233
+ *
+ * Provides API integration for cron expression validation and preview:
+ * - Validate cron expressions
+ * - Get next execution times
+ * - Get human-readable descriptions
+ *
+ * All functions follow the pattern from utils/api.js:
+ * - Use the global `api` axios instance for CSRF handling
+ * - Return axios response objects (access data via .data)
+ * - Let axios throw errors for React Query to handle
+ */
+
+import { api } from './api'
+
+// =============================================================================
+// Configuration
+// =============================================================================
+
+/**
+ * Scheduler UI API base path (relative to api.baseURL from utils/api.js).
+ * This is the same prefix used in schedulerApi.js for consistency.
+ */
+export const SCHEDULER_API_PREFIX = '/scheduler/ui'
+
+/**
+ * API request timeout in milliseconds.
+ * Set to 10 seconds for cron validation (should be fast).
+ */
+const API_TIMEOUT_MS = 10000
+
+// =============================================================================
+// Cron Validation
+// =============================================================================
+
+/**
+ * Validate a cron expression and get next executions preview
+ *
+ * @param {string} expression - Cron expression to validate (e.g., "0 * * * *")
+ * @param {number} [count=5] - Number of next execution times to return (default: 5)
+ * @returns {Promise<Object>} Axios response with validation results
+ *
+ * Response on success (valid expression): {
+ *   valid: true,
+ *   expression: "0 * * * *",
+ *   description: "At minute 0 of every hour",
+ *   next_executions: [
+ *     "2024-12-26T14:00:00",
+ *     "2024-12-26T15:00:00",
+ *     "2024-12-26T16:00:00",
+ *     "2024-12-26T17:00:00",
+ *     "2024-12-26T18:00:00"
+ *   ]
+ * }
+ *
+ * Response on error (invalid expression): {
+ *   valid: false,
+ *   expression: "invalid * * * *",
+ *   error: "Invalid cron expression: invalid is not a valid minute value"
+ * }
+ *
+ * @example
+ * const response = await validateCronExpression("0 21 * * *", 3)
+ * console.log(response.data.description) // "At 21:00 every day"
+ * console.log(response.data.next_executions) // ["2024-12-26T21:00:00", ...]
+ */
+export const validateCronExpression = async (expression, count = 5) => {
+  const response = await api.post(
+    `${SCHEDULER_API_PREFIX}/cron/validate`,
+    { expression, count },
+    { timeout: API_TIMEOUT_MS }
+  )
+  return response.data
+}

--- a/Firmware/webui/frontend/src/utils/queryKeys.js
+++ b/Firmware/webui/frontend/src/utils/queryKeys.js
@@ -80,4 +80,7 @@ export const QUERY_KEYS = {
   SCHEDULE_PREVIEW: (id) => ['schedules', id, 'preview'],
   BUILTIN_SCHEDULES: ['schedules', 'builtin'],
   BUILTIN_PATTERNS: ['schedules', 'patterns', 'builtin'],
+
+  // Cron Validation (Issue #233)
+  CRON_VALIDATION: (expression) => ['cron-validation', expression],
 }


### PR DESCRIPTION
## Summary
- Adds Expert Mode toggle to the scheduler for power users who prefer raw cron expressions
- Real-time cron validation with human-readable descriptions and next execution previews
- Quick preset buttons for common scheduling patterns
- Code quality improvements including error boundary, locale support, and React best practices

## Changes
- **Backend**: New `/api/scheduler/cron/validate` endpoint with cron expression parsing
- **Frontend**: ExpertModeToggle, CronExpressionInput components with full test coverage
- **Integration**: TriggerForm updated to switch between Visual and Expert modes

## Test plan
- [x] All 46 Expert Mode component tests pass
- [x] Backend cron validation tests pass
- [x] Integration workflow tests pass
- [x] ESLint passes with no warnings
- [ ] Manual testing of mode toggle in scheduler UI
- [ ] Verify cron presets apply correctly
- [ ] Test error boundary fallback by simulating API failure