### PR TITLE
test(scheduler): Add E2E tests for scheduler UI (#234)

### DIFF
--- a/Firmware/webui/frontend/e2e/fixtures/test-helpers.js
+++ b/Firmware/webui/frontend/e2e/fixtures/test-helpers.js
@@ -9,6 +9,10 @@
  * These values account for network latency to remote Pi server
  */
 export const TIMEOUTS = {
+  /** Very short delay for UI transitions and animations */
+  TRANSITION: 500,
+  /** Short delay for save operations to complete */
+  SAVE: 1000,
   /** Short timeout for optional/fast elements (e.g., spinners that may not appear) */
   SHORT: 2000,
   /** Medium timeout for UI transitions and state changes */

--- a/Firmware/webui/frontend/e2e/pages/scheduler.page.js
+++ b/Firmware/webui/frontend/e2e/pages/scheduler.page.js
@@ -1,0 +1,575 @@
+/**
+ * Scheduler Page Object
+ *
+ * Encapsulates interactions with the scheduler page for E2E testing.
+ * Covers schedule CRUD, activation/deactivation, and calendar navigation.
+ */
+
+import { TIMEOUTS } from '../fixtures/test-helpers.js'
+
+export class SchedulerPage {
+  /**
+   * @param {import('@playwright/test').Page} page
+   */
+  constructor(page) {
+    this.page = page
+
+    // Selectors - using multiple fallbacks for flexibility
+    this.selectors = {
+      // Page heading
+      pageHeading: 'text=Schedule',
+
+      // Tabs
+      schedulesTab: 'button:has-text("Schedules")',
+      calendarTab: 'button:has-text("Calendar")',
+      schedulesPanel: '#schedules-panel',
+      calendarPanel: '#calendar-panel',
+
+      // Toolbar
+      newScheduleButton: 'button:has-text("New Schedule")',
+
+      // Schedule List
+      scheduleCard: 'article[role="article"]',
+      scheduleCardByName: (name) => `article[role="article"]:has-text("${name}")`,
+      editButton: 'button:has-text("Edit")',
+      activateButton: 'button:has-text("Activate")',
+      deactivateButton: 'button:has-text("Deactivate")',
+      deleteButton: 'button:has-text("Delete")',
+
+      // Active Badge (within card)
+      activeBadge: 'text=Active',
+
+      // Active Banner (top-level status)
+      activeBanner: '[role="status"]',
+      bannerDeactivateButton: '[role="status"] button:has-text("Deactivate")',
+      bannerScheduleName: '[role="status"] span',
+
+      // Editor Drawer
+      editorDrawer: '[data-testid="schedule-editor-drawer"]',
+      drawerBackdrop: '[data-testid="drawer-backdrop"]',
+      editorTitle: '[data-testid="schedule-editor-drawer"] h2',
+      scheduleNameInput: '#schedule-name',
+      scheduleDescriptionInput: '#schedule-description',
+      saveButton: '[data-testid="schedule-editor-drawer"] button:has-text("Save")',
+      cancelButton: '[data-testid="schedule-editor-drawer"] button:has-text("Cancel")',
+      closeButton: 'button[aria-label="Close"]',
+
+      // Delete Confirmation Dialog
+      confirmDialog: '[role="alertdialog"], [role="dialog"]:has-text("Delete")',
+      confirmDeleteButton: 'button:has-text("Confirm"), button:has-text("Delete"):not([role="dialog"] button:first-of-type)',
+      cancelDeleteButton: '[role="alertdialog"] button:has-text("Cancel"), [role="dialog"]:has-text("Delete") button:has-text("Cancel")',
+
+      // Calendar View
+      scheduleSelector: '#calendar-panel select',
+      dayViewButton: 'button:has-text("Day")',
+      weekViewButton: 'button:has-text("Week")',
+      monthViewButton: 'button:has-text("Month")',
+      todayButton: 'button:has-text("Today")',
+      prevButton: 'button[aria-label*="Previous"], button[aria-label*="Prev"]',
+      nextButton: 'button[aria-label*="Next"]',
+      emptyCalendarState: 'text=No schedule selected',
+      calendarDateDisplay: '#calendar-panel header, #calendar-panel h2, #calendar-panel [class*="header"]',
+
+      // Loading states
+      loadingSpinner: '.loading, [data-testid="loading-spinner"]',
+      emptySchedulesState: 'text=No schedules',
+
+      // Toast notifications
+      toastSuccess: '.toast-success, [class*="toast"]:has-text("success")',
+      toastError: '.toast-error, [class*="toast"]:has-text("error"), [class*="toast"]:has-text("fail")',
+    }
+  }
+
+  // ============================================================
+  // Navigation
+  // ============================================================
+
+  /**
+   * Navigate to scheduler page
+   */
+  async goto() {
+    await this.page.goto('/scheduler')
+    await this.page.waitForLoadState('networkidle')
+    await this.waitForLoad()
+  }
+
+  /**
+   * Wait for scheduler page to finish loading
+   */
+  async waitForLoad() {
+    // Wait for loading spinner to disappear (if present)
+    try {
+      await this.page.waitForSelector(this.selectors.loadingSpinner, {
+        state: 'hidden',
+        timeout: TIMEOUTS.MEDIUM,
+      })
+    } catch {
+      // Spinner might not appear on fast loads
+    }
+
+    // Wait for network to settle
+    await this.page.waitForLoadState('networkidle')
+  }
+
+  /**
+   * Switch to Schedules tab
+   */
+  async switchToSchedulesTab() {
+    await this.page.click(this.selectors.schedulesTab)
+    await this.page.locator(this.selectors.schedulesPanel).waitFor({ state: 'visible', timeout: TIMEOUTS.SHORT })
+  }
+
+  /**
+   * Switch to Calendar tab
+   */
+  async switchToCalendarTab() {
+    await this.page.click(this.selectors.calendarTab)
+    await this.page.locator(this.selectors.calendarPanel).waitFor({ state: 'visible', timeout: TIMEOUTS.SHORT })
+  }
+
+  // ============================================================
+  // Schedule List Operations
+  // ============================================================
+
+  /**
+   * Get count of visible schedule cards
+   * @returns {Promise<number>}
+   */
+  async getScheduleCount() {
+    return this.page.locator(this.selectors.scheduleCard).count()
+  }
+
+  /**
+   * Check if any schedules exist
+   * @returns {Promise<boolean>}
+   */
+  async hasSchedules() {
+    const count = await this.getScheduleCount()
+    return count > 0
+  }
+
+  /**
+   * Get schedule card by index
+   * @param {number} index - Zero-based index
+   * @returns {import('@playwright/test').Locator}
+   */
+  getScheduleCardByIndex(index) {
+    return this.page.locator(this.selectors.scheduleCard).nth(index)
+  }
+
+  /**
+   * Get schedule card by name
+   * @param {string} name - Schedule name
+   * @returns {import('@playwright/test').Locator}
+   */
+  getScheduleCardByName(name) {
+    return this.page.locator(this.selectors.scheduleCardByName(name))
+  }
+
+  /**
+   * Check if a schedule card exists by name
+   * @param {string} name - Schedule name
+   * @returns {Promise<boolean>}
+   */
+  async hasScheduleWithName(name) {
+    return this.page.locator(this.selectors.scheduleCardByName(name)).isVisible()
+  }
+
+  /**
+   * Click Edit button on a schedule card
+   * @param {number} index - Zero-based index
+   */
+  async clickEditOnSchedule(index) {
+    const card = this.getScheduleCardByIndex(index)
+    await card.locator(this.selectors.editButton).click()
+    await this.waitForEditorOpen()
+  }
+
+  /**
+   * Click Activate button on a schedule card
+   * @param {number} index - Zero-based index
+   */
+  async clickActivateOnSchedule(index) {
+    const card = this.getScheduleCardByIndex(index)
+    await card.locator(this.selectors.activateButton).click()
+    // Wait for network and potential state change
+    await this.page.waitForLoadState('networkidle')
+  }
+
+  /**
+   * Click Deactivate button on a schedule card
+   * @param {number} index - Zero-based index
+   */
+  async clickDeactivateOnSchedule(index) {
+    const card = this.getScheduleCardByIndex(index)
+    await card.locator(this.selectors.deactivateButton).click()
+    await this.page.waitForLoadState('networkidle')
+  }
+
+  /**
+   * Click Delete button on a schedule card
+   * @param {number} index - Zero-based index
+   */
+  async clickDeleteOnSchedule(index) {
+    const card = this.getScheduleCardByIndex(index)
+    await card.locator(this.selectors.deleteButton).click()
+    // Wait for confirmation dialog
+    await this.page.locator(this.selectors.confirmDialog).waitFor({ state: 'visible', timeout: TIMEOUTS.SHORT }).catch(() => {})
+  }
+
+  /**
+   * Click Delete button on a schedule by name
+   * @param {string} name - Schedule name
+   */
+  async clickDeleteOnScheduleByName(name) {
+    const card = this.getScheduleCardByName(name)
+    await card.locator(this.selectors.deleteButton).click()
+    await this.page.locator(this.selectors.confirmDialog).waitFor({ state: 'visible', timeout: TIMEOUTS.SHORT }).catch(() => {})
+  }
+
+  /**
+   * Check if a schedule card has active badge
+   * @param {number} index - Zero-based index
+   * @returns {Promise<boolean>}
+   */
+  async isScheduleActive(index) {
+    const card = this.getScheduleCardByIndex(index)
+    return card.locator(this.selectors.activeBadge).isVisible()
+  }
+
+  /**
+   * Find the index of the first inactive schedule
+   * @returns {Promise<number>} Index or -1 if none found
+   */
+  async findFirstInactiveSchedule() {
+    const count = await this.getScheduleCount()
+    for (let i = 0; i < count; i++) {
+      const isActive = await this.isScheduleActive(i)
+      if (!isActive) {
+        return i
+      }
+    }
+    return -1
+  }
+
+  /**
+   * Find the index of the active schedule
+   * @returns {Promise<number>} Index or -1 if none active
+   */
+  async findActiveSchedule() {
+    const count = await this.getScheduleCount()
+    for (let i = 0; i < count; i++) {
+      const isActive = await this.isScheduleActive(i)
+      if (isActive) {
+        return i
+      }
+    }
+    return -1
+  }
+
+  // ============================================================
+  // Active Banner Operations
+  // ============================================================
+
+  /**
+   * Check if active banner is visible
+   * @returns {Promise<boolean>}
+   */
+  async isActiveBannerVisible() {
+    return this.page.locator(this.selectors.activeBanner).isVisible()
+  }
+
+  /**
+   * Get the name of the active schedule from banner
+   * @returns {Promise<string|null>}
+   */
+  async getActiveBannerScheduleName() {
+    const banner = this.page.locator(this.selectors.activeBanner)
+    if (!(await banner.isVisible())) {
+      return null
+    }
+    const text = await banner.textContent()
+    // Extract name from "Active: Schedule Name"
+    const match = text.match(/Active:\s*(.+?)(?:\s*Deactivate)?$/i)
+    return match ? match[1].trim() : null
+  }
+
+  /**
+   * Click Deactivate button in active banner
+   */
+  async clickBannerDeactivate() {
+    await this.page.click(this.selectors.bannerDeactivateButton)
+    await this.page.waitForLoadState('networkidle')
+  }
+
+  // ============================================================
+  // Editor Drawer Operations
+  // ============================================================
+
+  /**
+   * Click New Schedule button to open editor
+   */
+  async clickNewSchedule() {
+    await this.page.click(this.selectors.newScheduleButton)
+    await this.waitForEditorOpen()
+  }
+
+  /**
+   * Check if editor drawer is open
+   * @returns {Promise<boolean>}
+   */
+  async isEditorOpen() {
+    return this.page.locator(this.selectors.editorDrawer).isVisible()
+  }
+
+  /**
+   * Wait for editor drawer to open
+   */
+  async waitForEditorOpen() {
+    await this.page.locator(this.selectors.editorDrawer).waitFor({ state: 'visible', timeout: TIMEOUTS.MEDIUM })
+  }
+
+  /**
+   * Wait for editor drawer to close
+   */
+  async waitForEditorClose() {
+    await this.page.locator(this.selectors.editorDrawer).waitFor({ state: 'hidden', timeout: TIMEOUTS.MEDIUM })
+  }
+
+  /**
+   * Get editor title text
+   * @returns {Promise<string>}
+   */
+  async getEditorTitle() {
+    return this.page.locator(this.selectors.editorTitle).textContent()
+  }
+
+  /**
+   * Fill schedule name input
+   * @param {string} name
+   */
+  async fillScheduleName(name) {
+    await this.page.fill(this.selectors.scheduleNameInput, name)
+  }
+
+  /**
+   * Fill schedule description input
+   * @param {string} description
+   */
+  async fillScheduleDescription(description) {
+    await this.page.fill(this.selectors.scheduleDescriptionInput, description)
+  }
+
+  /**
+   * Get schedule name input value
+   * @returns {Promise<string>}
+   */
+  async getScheduleNameValue() {
+    return this.page.locator(this.selectors.scheduleNameInput).inputValue()
+  }
+
+  /**
+   * Click Save button in editor
+   */
+  async clickSave() {
+    await this.page.click(this.selectors.saveButton)
+    // Wait for network operation
+    await this.page.waitForLoadState('networkidle')
+  }
+
+  /**
+   * Click Cancel button in editor
+   */
+  async clickCancel() {
+    await this.page.click(this.selectors.cancelButton)
+    await this.waitForEditorClose()
+  }
+
+  /**
+   * Close editor via X button or Escape
+   */
+  async closeEditor() {
+    // Try X button first
+    const closeButton = this.page.locator(this.selectors.closeButton)
+    if (await closeButton.isVisible()) {
+      await closeButton.click()
+    } else {
+      // Fallback to Escape key
+      await this.page.keyboard.press('Escape')
+    }
+    await this.waitForEditorClose()
+  }
+
+  // ============================================================
+  // Delete Confirmation Dialog
+  // ============================================================
+
+  /**
+   * Check if delete confirmation dialog is open
+   * @returns {Promise<boolean>}
+   */
+  async isConfirmDialogOpen() {
+    return this.page.locator(this.selectors.confirmDialog).isVisible()
+  }
+
+  /**
+   * Confirm delete in dialog
+   */
+  async confirmDelete() {
+    await this.page.click(this.selectors.confirmDeleteButton)
+    await this.page.waitForLoadState('networkidle')
+  }
+
+  /**
+   * Cancel delete in dialog
+   */
+  async cancelDelete() {
+    await this.page.click(this.selectors.cancelDeleteButton)
+    await this.page.locator(this.selectors.confirmDialog).waitFor({ state: 'hidden', timeout: TIMEOUTS.SHORT }).catch(() => {})
+  }
+
+  // ============================================================
+  // Calendar Operations
+  // ============================================================
+
+  /**
+   * Select a schedule in the calendar dropdown
+   * @param {string} name - Schedule name to select
+   */
+  async selectScheduleInCalendar(name) {
+    const selector = this.page.locator(this.selectors.scheduleSelector)
+    await selector.selectOption({ label: name })
+    await this.page.waitForLoadState('networkidle')
+  }
+
+  /**
+   * Get available schedule options in calendar dropdown
+   * @returns {Promise<string[]>}
+   */
+  async getCalendarScheduleOptions() {
+    const selector = this.page.locator(this.selectors.scheduleSelector)
+    const options = await selector.locator('option').allTextContents()
+    return options.filter(opt => opt.trim() !== '')
+  }
+
+  /**
+   * Click Day view button
+   */
+  async clickDayView() {
+    await this.page.click(this.selectors.dayViewButton)
+    await this.page.waitForLoadState('networkidle')
+  }
+
+  /**
+   * Click Week view button
+   */
+  async clickWeekView() {
+    await this.page.click(this.selectors.weekViewButton)
+    await this.page.waitForLoadState('networkidle')
+  }
+
+  /**
+   * Click Month view button
+   */
+  async clickMonthView() {
+    await this.page.click(this.selectors.monthViewButton)
+    await this.page.waitForLoadState('networkidle')
+  }
+
+  /**
+   * Click Today button
+   */
+  async clickToday() {
+    await this.page.click(this.selectors.todayButton)
+    await this.page.waitForLoadState('networkidle')
+  }
+
+  /**
+   * Click Previous navigation button
+   */
+  async clickPrevious() {
+    // Find any button that looks like a previous navigation
+    const prevButton = this.page.locator('button').filter({ has: this.page.locator('[class*="chevron-left"], [class*="ChevronLeft"], svg') }).first()
+    if (await prevButton.isVisible()) {
+      await prevButton.click()
+    } else {
+      // Fallback to aria-label pattern
+      await this.page.locator(this.selectors.prevButton).first().click()
+    }
+    await this.page.waitForLoadState('networkidle')
+  }
+
+  /**
+   * Click Next navigation button
+   */
+  async clickNext() {
+    const nextButton = this.page.locator('button').filter({ has: this.page.locator('[class*="chevron-right"], [class*="ChevronRight"], svg') }).last()
+    if (await nextButton.isVisible()) {
+      await nextButton.click()
+    } else {
+      await this.page.locator(this.selectors.nextButton).first().click()
+    }
+    await this.page.waitForLoadState('networkidle')
+  }
+
+  /**
+   * Check if empty calendar state is visible
+   * @returns {Promise<boolean>}
+   */
+  async isEmptyCalendarStateVisible() {
+    return this.page.locator(this.selectors.emptyCalendarState).isVisible()
+  }
+
+  /**
+   * Get current calendar date display text
+   * @returns {Promise<string>}
+   */
+  async getCalendarDateDisplay() {
+    const display = this.page.locator(this.selectors.calendarDateDisplay).first()
+    return display.textContent()
+  }
+
+  // ============================================================
+  // Utility Methods
+  // ============================================================
+
+  /**
+   * Generate unique test schedule name
+   * @returns {string}
+   */
+  generateTestScheduleName() {
+    return `e2e-test-schedule-${Date.now()}`
+  }
+
+  /**
+   * Check if loading spinner is visible
+   * @returns {Promise<boolean>}
+   */
+  async isLoading() {
+    return this.page.locator(this.selectors.loadingSpinner).isVisible()
+  }
+
+  /**
+   * Check if empty schedules state is visible
+   * @returns {Promise<boolean>}
+   */
+  async isEmptySchedulesStateVisible() {
+    return this.page.locator(this.selectors.emptySchedulesState).isVisible()
+  }
+
+  /**
+   * Wait for a toast notification
+   * @param {'success' | 'error'} type - Toast type
+   * @param {number} timeout - Max wait time
+   * @returns {Promise<boolean>} - True if toast appeared
+   */
+  async waitForToast(type, timeout = TIMEOUTS.MEDIUM) {
+    const selector = type === 'success' ? this.selectors.toastSuccess : this.selectors.toastError
+    try {
+      await this.page.locator(selector).waitFor({ state: 'visible', timeout })
+      return true
+    } catch {
+      return false
+    }
+  }
+}

--- a/Firmware/webui/frontend/e2e/pages/scheduler.page.js
+++ b/Firmware/webui/frontend/e2e/pages/scheduler.page.js
@@ -374,12 +374,26 @@ export class SchedulerPage {
   }
 
   /**
-   * Click Save button in editor
+   * Click Save button in editor and wait for API response
    */
   async clickSave() {
+    // Wait for either create (POST) or update (PUT) API response
+    const savePromise = this.page.waitForResponse(
+      (resp) =>
+        resp.url().includes('/api/scheduler/ui/schedules') &&
+        (resp.request().method() === 'POST' || resp.request().method() === 'PUT') &&
+        resp.status() < 400,
+      { timeout: TIMEOUTS.NETWORK }
+    )
+
     await this.page.click(this.selectors.saveButton)
-    // Wait for network operation
-    await this.page.waitForLoadState('networkidle')
+
+    try {
+      await savePromise
+    } catch {
+      // If no API response (e.g., validation error prevented submission),
+      // the test will verify this via isEditorOpen() check
+    }
   }
 
   /**

--- a/Firmware/webui/frontend/e2e/pages/scheduler.page.js
+++ b/Firmware/webui/frontend/e2e/pages/scheduler.page.js
@@ -65,8 +65,8 @@ export class SchedulerPage {
       weekViewButton: 'button:has-text("Week")',
       monthViewButton: 'button:has-text("Month")',
       todayButton: 'button:has-text("Today")',
-      prevButton: 'button[aria-label*="Previous"], button[aria-label*="Prev"]',
-      nextButton: 'button[aria-label*="Next"]',
+      prevButton: '[data-testid="calendar-nav-previous"], button[aria-label="Previous"]',
+      nextButton: '[data-testid="calendar-nav-next"], button[aria-label="Next"]',
       emptyCalendarState: 'text=No schedule selected',
       calendarDateDisplay: '#calendar-panel header, #calendar-panel h2, #calendar-panel [class*="header"]',
 
@@ -488,14 +488,7 @@ export class SchedulerPage {
    * Click Previous navigation button
    */
   async clickPrevious() {
-    // Find any button that looks like a previous navigation
-    const prevButton = this.page.locator('button').filter({ has: this.page.locator('[class*="chevron-left"], [class*="ChevronLeft"], svg') }).first()
-    if (await prevButton.isVisible()) {
-      await prevButton.click()
-    } else {
-      // Fallback to aria-label pattern
-      await this.page.locator(this.selectors.prevButton).first().click()
-    }
+    await this.page.click(this.selectors.prevButton)
     await this.page.waitForLoadState('networkidle')
   }
 
@@ -503,12 +496,7 @@ export class SchedulerPage {
    * Click Next navigation button
    */
   async clickNext() {
-    const nextButton = this.page.locator('button').filter({ has: this.page.locator('[class*="chevron-right"], [class*="ChevronRight"], svg') }).last()
-    if (await nextButton.isVisible()) {
-      await nextButton.click()
-    } else {
-      await this.page.locator(this.selectors.nextButton).first().click()
-    }
+    await this.page.click(this.selectors.nextButton)
     await this.page.waitForLoadState('networkidle')
   }
 

--- a/Firmware/webui/frontend/e2e/pages/scheduler.page.js
+++ b/Firmware/webui/frontend/e2e/pages/scheduler.page.js
@@ -77,6 +77,11 @@ export class SchedulerPage {
       // Toast notifications
       toastSuccess: '.toast-success, [class*="toast"]:has-text("success")',
       toastError: '.toast-error, [class*="toast"]:has-text("error"), [class*="toast"]:has-text("fail")',
+
+      // Event Pattern Selection
+      patternTabLibrary: '[data-testid="pattern-tab-library"], button[role="tab"]:has-text("Library")',
+      patternTabCustom: '[data-testid="pattern-tab-custom"], button[role="tab"]:has-text("Custom")',
+      patternCard: '[role="article"][aria-label^="Pattern:"]',
     }
   }
 
@@ -398,6 +403,37 @@ export class SchedulerPage {
       await this.page.keyboard.press('Escape')
     }
     await this.waitForEditorClose()
+  }
+
+  // ============================================================
+  // Event Pattern Selection
+  // ============================================================
+
+  /**
+   * Select the first available event pattern from the library
+   * @returns {Promise<boolean>} True if a pattern was selected
+   */
+  async selectFirstEventPattern() {
+    // Wait for patterns to load
+    const patternCard = this.page.locator(this.selectors.patternCard).first()
+    try {
+      await patternCard.waitFor({ state: 'visible', timeout: TIMEOUTS.MEDIUM })
+      await patternCard.click()
+      return true
+    } catch {
+      // No patterns available
+      return false
+    }
+  }
+
+  /**
+   * Check if an event pattern is currently selected
+   * @returns {Promise<boolean>}
+   */
+  async isEventPatternSelected() {
+    // Look for the pattern summary showing a selected pattern name
+    const summary = this.page.locator('[data-testid="schedule-editor-drawer"] .bg-gray-50 .font-medium')
+    return summary.isVisible()
   }
 
   // ============================================================

--- a/Firmware/webui/frontend/e2e/pages/scheduler.page.js
+++ b/Firmware/webui/frontend/e2e/pages/scheduler.page.js
@@ -55,9 +55,9 @@ export class SchedulerPage {
       closeButton: 'button[aria-label="Close"]',
 
       // Delete Confirmation Dialog
-      confirmDialog: '[role="alertdialog"], [role="dialog"]:has-text("Delete")',
-      confirmDeleteButton: 'button:has-text("Confirm"), button:has-text("Delete"):not([role="dialog"] button:first-of-type)',
-      cancelDeleteButton: '[role="alertdialog"] button:has-text("Cancel"), [role="dialog"]:has-text("Delete") button:has-text("Cancel")',
+      confirmDialog: '[data-testid="confirm-dialog"], [role="alertdialog"], [role="dialog"]:has-text("Delete")',
+      confirmDeleteButton: '[data-testid="confirm-dialog-confirm"], button:has-text("Confirm")',
+      cancelDeleteButton: '[data-testid="confirm-dialog-cancel"], button:has-text("Cancel")',
 
       // Calendar View
       scheduleSelector: '#calendar-panel select',

--- a/Firmware/webui/frontend/e2e/pages/scheduler.page.js
+++ b/Firmware/webui/frontend/e2e/pages/scheduler.page.js
@@ -446,7 +446,7 @@ export class SchedulerPage {
    */
   async isEventPatternSelected() {
     // Look for the pattern summary showing a selected pattern name
-    const summary = this.page.locator('[data-testid="schedule-editor-drawer"] .bg-gray-50 .font-medium')
+    const summary = this.page.locator('[data-testid="selected-pattern-summary"]')
     return summary.isVisible()
   }
 

--- a/Firmware/webui/frontend/e2e/pages/scheduler.page.js
+++ b/Firmware/webui/frontend/e2e/pages/scheduler.page.js
@@ -5,7 +5,7 @@
  * Covers schedule CRUD, activation/deactivation, and calendar navigation.
  */
 
-import { TIMEOUTS } from '../fixtures/test-helpers.js'
+import { TIMEOUTS, optionalWait } from '../fixtures/test-helpers.js'
 
 export class SchedulerPage {
   /**
@@ -214,7 +214,7 @@ export class SchedulerPage {
     const card = this.getScheduleCardByIndex(index)
     await card.locator(this.selectors.deleteButton).click()
     // Wait for confirmation dialog
-    await this.page.locator(this.selectors.confirmDialog).waitFor({ state: 'visible', timeout: TIMEOUTS.SHORT }).catch(() => {})
+    await optionalWait(this.page.locator(this.selectors.confirmDialog).waitFor({ state: 'visible', timeout: TIMEOUTS.SHORT }))
   }
 
   /**
@@ -224,7 +224,7 @@ export class SchedulerPage {
   async clickDeleteOnScheduleByName(name) {
     const card = this.getScheduleCardByName(name)
     await card.locator(this.selectors.deleteButton).click()
-    await this.page.locator(this.selectors.confirmDialog).waitFor({ state: 'visible', timeout: TIMEOUTS.SHORT }).catch(() => {})
+    await optionalWait(this.page.locator(this.selectors.confirmDialog).waitFor({ state: 'visible', timeout: TIMEOUTS.SHORT }))
   }
 
   /**
@@ -425,7 +425,7 @@ export class SchedulerPage {
    */
   async cancelDelete() {
     await this.page.click(this.selectors.cancelDeleteButton)
-    await this.page.locator(this.selectors.confirmDialog).waitFor({ state: 'hidden', timeout: TIMEOUTS.SHORT }).catch(() => {})
+    await optionalWait(this.page.locator(this.selectors.confirmDialog).waitFor({ state: 'hidden', timeout: TIMEOUTS.SHORT }))
   }
 
   // ============================================================

--- a/Firmware/webui/frontend/e2e/tests/scheduler-calendar.spec.js
+++ b/Firmware/webui/frontend/e2e/tests/scheduler-calendar.spec.js
@@ -139,62 +139,44 @@ test.describe('Scheduler Calendar View', () => {
 
   test('navigate to previous period', async ({ page }) => {
     const scheduler = new SchedulerPage(page)
-
-    // Switch to calendar tab
     await scheduler.switchToCalendarTab()
 
-    // Try to find a previous button by position or icon
-    const calendarNav = page.locator('#calendar-panel button').first()
-    if (await calendarNav.isVisible()) {
-      await calendarNav.click()
-      await page.waitForLoadState('networkidle')
-    }
+    const beforeDate = await scheduler.getCalendarDateDisplay()
+    await scheduler.clickPrevious()
+    const afterDate = await scheduler.getCalendarDateDisplay()
 
-    // Verify navigation buttons still work after click
-    const todayButton = page.locator('button:has-text("Today")')
-    await expect(todayButton).toBeVisible()
+    expect(beforeDate).not.toBe(afterDate)
   })
 
   test('navigate to next period', async ({ page }) => {
     const scheduler = new SchedulerPage(page)
-
-    // Switch to calendar tab
     await scheduler.switchToCalendarTab()
 
-    // Find navigation buttons - typically last buttons in header
-    const navButtons = page.locator('#calendar-panel button')
-    const count = await navButtons.count()
+    const beforeDate = await scheduler.getCalendarDateDisplay()
+    await scheduler.clickNext()
+    const afterDate = await scheduler.getCalendarDateDisplay()
 
-    if (count >= 2) {
-      // Last button is typically "next"
-      await navButtons.last().click()
-      await page.waitForLoadState('networkidle')
-    }
+    expect(beforeDate).not.toBe(afterDate)
   })
 
   test('Today button returns to current date', async ({ page }) => {
     const scheduler = new SchedulerPage(page)
-
-    // Switch to calendar tab
     await scheduler.switchToCalendarTab()
 
-    // Navigate away first (if possible)
-    const navButtons = page.locator('#calendar-panel button')
-    const count = await navButtons.count()
-    if (count >= 2) {
-      // Click next a couple times
-      await navButtons.last().click()
-      await page.waitForTimeout(300)
-      await navButtons.last().click()
-      await page.waitForTimeout(300)
-    }
+    // Capture today's display
+    const todayDisplay = await scheduler.getCalendarDateDisplay()
 
-    // Click Today button
+    // Navigate away
+    await scheduler.clickNext()
+    await scheduler.clickNext()
+    const awayDisplay = await scheduler.getCalendarDateDisplay()
+    expect(todayDisplay).not.toBe(awayDisplay)
+
+    // Return to today
     await scheduler.clickToday()
+    const returnDisplay = await scheduler.getCalendarDateDisplay()
 
-    // Verify we're back to today (implementation-specific check)
-    const todayButton = page.locator('button:has-text("Today")')
-    await expect(todayButton).toBeVisible()
+    expect(returnDisplay).toBe(todayDisplay)
   })
 
   test('month view shows calendar grid', async ({ page }) => {

--- a/Firmware/webui/frontend/e2e/tests/scheduler-calendar.spec.js
+++ b/Firmware/webui/frontend/e2e/tests/scheduler-calendar.spec.js
@@ -128,13 +128,12 @@ test.describe('Scheduler Calendar View', () => {
 
     await scheduler.selectScheduleInCalendar(scheduleToSelect)
 
-    // If a schedule is selected, empty state should eventually be hidden
-    // Note: might take a moment to load calendar data
+    // Wait for calendar to update after selection
     await page.waitForTimeout(TIMEOUTS.TRANSITION)
 
-    // Verify the selection worked - empty state may or may not be hidden
-    // depending on whether schedule has any executions to display
-    void (await scheduler.isEmptyCalendarStateVisible())
+    // Test verifies that schedule selection completes without error.
+    // We can't assert on empty state since it depends on whether the
+    // selected schedule has any executions to display.
   })
 
   test('navigate to previous period', async ({ page }) => {

--- a/Firmware/webui/frontend/e2e/tests/scheduler-calendar.spec.js
+++ b/Firmware/webui/frontend/e2e/tests/scheduler-calendar.spec.js
@@ -130,7 +130,7 @@ test.describe('Scheduler Calendar View', () => {
 
     // If a schedule is selected, empty state should eventually be hidden
     // Note: might take a moment to load calendar data
-    await page.waitForTimeout(500)
+    await page.waitForTimeout(TIMEOUTS.TRANSITION)
 
     // Verify the selection worked - empty state may or may not be hidden
     // depending on whether schedule has any executions to display

--- a/Firmware/webui/frontend/e2e/tests/scheduler-calendar.spec.js
+++ b/Firmware/webui/frontend/e2e/tests/scheduler-calendar.spec.js
@@ -1,11 +1,13 @@
 /**
  * Scheduler Calendar View E2E Tests
  *
- * Tests the calendar view functionality for schedule visualization
+ * Tests the calendar view functionality for schedule visualization.
+ * Existing tests (1-7) preserved as-is, new tests (8+) added at end.
  */
 
 import { test, expect } from '@playwright/test'
-import { isRateLimited } from '../fixtures/test-helpers.js'
+import { isRateLimited, TIMEOUTS } from '../fixtures/test-helpers.js'
+import { SchedulerPage } from '../pages/scheduler.page.js'
 
 test.describe('Scheduler Calendar View', () => {
   test.beforeEach(async ({ page }) => {
@@ -97,5 +99,167 @@ test.describe('Scheduler Calendar View', () => {
 
     // Verify day view is active
     await expect(dayButton).toHaveClass(/bg-blue|active|selected/)
+  })
+
+  // ============================================================
+  // NEW TESTS (8+) - Added for Issue #234
+  // ============================================================
+
+  test('select schedule in calendar dropdown', async ({ page }) => {
+    const scheduler = new SchedulerPage(page)
+
+    // Switch to calendar tab
+    await scheduler.switchToCalendarTab()
+
+    // Get available options
+    const options = await scheduler.getCalendarScheduleOptions()
+
+    if (options.length === 0) {
+      test.skip(true, 'No schedules available in dropdown')
+      return
+    }
+
+    // Select first schedule (skip empty option if present)
+    const scheduleToSelect = options.find(opt => opt.trim() !== '' && opt !== 'Select a schedule')
+    if (!scheduleToSelect) {
+      test.skip(true, 'No valid schedule options available')
+      return
+    }
+
+    await scheduler.selectScheduleInCalendar(scheduleToSelect)
+
+    // If a schedule is selected, empty state should eventually be hidden
+    // Note: might take a moment to load calendar data
+    await page.waitForTimeout(500)
+
+    // Verify the selection worked - empty state may or may not be hidden
+    // depending on whether schedule has any executions to display
+    void (await scheduler.isEmptyCalendarStateVisible())
+  })
+
+  test('navigate to previous period', async ({ page }) => {
+    const scheduler = new SchedulerPage(page)
+
+    // Switch to calendar tab
+    await scheduler.switchToCalendarTab()
+
+    // Try to find a previous button by position or icon
+    const calendarNav = page.locator('#calendar-panel button').first()
+    if (await calendarNav.isVisible()) {
+      await calendarNav.click()
+      await page.waitForLoadState('networkidle')
+    }
+
+    // Verify navigation buttons still work after click
+    const todayButton = page.locator('button:has-text("Today")')
+    await expect(todayButton).toBeVisible()
+  })
+
+  test('navigate to next period', async ({ page }) => {
+    const scheduler = new SchedulerPage(page)
+
+    // Switch to calendar tab
+    await scheduler.switchToCalendarTab()
+
+    // Find navigation buttons - typically last buttons in header
+    const navButtons = page.locator('#calendar-panel button')
+    const count = await navButtons.count()
+
+    if (count >= 2) {
+      // Last button is typically "next"
+      await navButtons.last().click()
+      await page.waitForLoadState('networkidle')
+    }
+  })
+
+  test('Today button returns to current date', async ({ page }) => {
+    const scheduler = new SchedulerPage(page)
+
+    // Switch to calendar tab
+    await scheduler.switchToCalendarTab()
+
+    // Navigate away first (if possible)
+    const navButtons = page.locator('#calendar-panel button')
+    const count = await navButtons.count()
+    if (count >= 2) {
+      // Click next a couple times
+      await navButtons.last().click()
+      await page.waitForTimeout(300)
+      await navButtons.last().click()
+      await page.waitForTimeout(300)
+    }
+
+    // Click Today button
+    await scheduler.clickToday()
+
+    // Verify we're back to today (implementation-specific check)
+    const todayButton = page.locator('button:has-text("Today")')
+    await expect(todayButton).toBeVisible()
+  })
+
+  test('month view shows calendar grid', async ({ page }) => {
+    const scheduler = new SchedulerPage(page)
+
+    // Switch to calendar tab
+    await scheduler.switchToCalendarTab()
+
+    // Click Month view
+    await scheduler.clickMonthView()
+
+    const monthButton = page.locator('button:has-text("Month")')
+    await expect(monthButton).toHaveClass(/bg-blue|active|selected/)
+
+    // Look for calendar grid indicators (day names, date cells, etc.)
+    const calendarContent = page.locator('#calendar-panel')
+    await expect(calendarContent).toBeVisible()
+  })
+
+  test('week view shows week layout', async ({ page }) => {
+    const scheduler = new SchedulerPage(page)
+
+    // Switch to calendar tab
+    await scheduler.switchToCalendarTab()
+
+    // Click Week view
+    await scheduler.clickWeekView()
+
+    const weekButton = page.locator('button:has-text("Week")')
+    await expect(weekButton).toHaveClass(/bg-blue|active|selected/)
+  })
+
+  test('day view shows single day', async ({ page }) => {
+    const scheduler = new SchedulerPage(page)
+
+    // Switch to calendar tab
+    await scheduler.switchToCalendarTab()
+
+    // Click Day view
+    await scheduler.clickDayView()
+
+    const dayButton = page.locator('button:has-text("Day")')
+    await expect(dayButton).toHaveClass(/bg-blue|active|selected/)
+  })
+
+  test('calendar retains view mode after navigation', async ({ page }) => {
+    const scheduler = new SchedulerPage(page)
+
+    // Switch to calendar tab
+    await scheduler.switchToCalendarTab()
+
+    // Switch to Week view
+    await scheduler.clickWeekView()
+
+    // Navigate (if navigation buttons exist)
+    const navButtons = page.locator('#calendar-panel button')
+    const count = await navButtons.count()
+    if (count >= 3) {
+      // Navigate forward
+      await navButtons.nth(count - 1).click()
+      await page.waitForLoadState('networkidle')
+    }
+
+    // Verify still in Week view
+    const weekButton = page.locator('button:has-text("Week")')
+    await expect(weekButton).toHaveClass(/bg-blue|active|selected/)
   })
 })

--- a/Firmware/webui/frontend/e2e/tests/scheduler-schedules.spec.js
+++ b/Firmware/webui/frontend/e2e/tests/scheduler-schedules.spec.js
@@ -277,9 +277,6 @@ test.describe('Scheduler Schedules', () => {
     // Save the schedule
     await scheduler.clickSave()
 
-    // Wait for save to complete
-    await page.waitForTimeout(TIMEOUTS.SAVE)
-
     // Verify save succeeded (editor should close)
     const editorStillOpen = await scheduler.isEditorOpen()
     expect(editorStillOpen, 'Editor should close after successful save').toBeFalsy()
@@ -314,7 +311,6 @@ test.describe('Scheduler Schedules', () => {
 
     // Save
     await scheduler.clickSave()
-    await page.waitForTimeout(TIMEOUTS.SAVE)
 
     // Verify save succeeded (editor should close)
     const editorStillOpen = await scheduler.isEditorOpen()
@@ -332,7 +328,6 @@ test.describe('Scheduler Schedules', () => {
     // Update name
     await scheduler.fillScheduleName(updatedName)
     await scheduler.clickSave()
-    await page.waitForTimeout(TIMEOUTS.SAVE)
 
     // If editor still open, close it
     if (await scheduler.isEditorOpen()) {

--- a/Firmware/webui/frontend/e2e/tests/scheduler-schedules.spec.js
+++ b/Firmware/webui/frontend/e2e/tests/scheduler-schedules.spec.js
@@ -161,7 +161,7 @@ test.describe('Scheduler Schedules', () => {
 
     // Wait for confirmation dialog or just verify the action was triggered
     // Some implementations may show inline confirmation
-    await page.waitForTimeout(500)
+    await page.waitForTimeout(TIMEOUTS.TRANSITION)
 
     // If dialog appeared, cancel it
     if (await scheduler.isConfirmDialogOpen()) {
@@ -278,7 +278,7 @@ test.describe('Scheduler Schedules', () => {
     await scheduler.clickSave()
 
     // Wait for save to complete
-    await page.waitForTimeout(1000)
+    await page.waitForTimeout(TIMEOUTS.SAVE)
 
     // Verify save succeeded (editor should close)
     const editorStillOpen = await scheduler.isEditorOpen()
@@ -314,7 +314,7 @@ test.describe('Scheduler Schedules', () => {
 
     // Save
     await scheduler.clickSave()
-    await page.waitForTimeout(1000)
+    await page.waitForTimeout(TIMEOUTS.SAVE)
 
     // Verify save succeeded (editor should close)
     const editorStillOpen = await scheduler.isEditorOpen()
@@ -332,7 +332,7 @@ test.describe('Scheduler Schedules', () => {
     // Update name
     await scheduler.fillScheduleName(updatedName)
     await scheduler.clickSave()
-    await page.waitForTimeout(1000)
+    await page.waitForTimeout(TIMEOUTS.SAVE)
 
     // If editor still open, close it
     if (await scheduler.isEditorOpen()) {
@@ -356,5 +356,95 @@ test.describe('Scheduler Schedules', () => {
     // Verify deletion
     const stillExists = await scheduler.hasScheduleWithName(nameToDelete)
     expect(stillExists).toBeFalsy()
+  })
+
+  // ============================================================
+  // Form Validation Tests
+  // ============================================================
+
+  test('save without name shows validation error', async ({ page }) => {
+    await scheduler.clickNewSchedule()
+
+    // Select pattern but don't fill name
+    await scheduler.selectFirstEventPattern()
+    await scheduler.clickSave()
+    await page.waitForTimeout(TIMEOUTS.TRANSITION)
+
+    // Editor should stay open with error
+    expect(await scheduler.isEditorOpen()).toBeTruthy()
+    const errorVisible = await page.locator('text=required').first().isVisible()
+    expect(errorVisible).toBeTruthy()
+
+    await scheduler.clickCancel()
+  })
+
+  test('save without event pattern shows validation error', async ({ page }) => {
+    await scheduler.clickNewSchedule()
+    await scheduler.fillScheduleName(scheduler.generateTestScheduleName())
+
+    // Don't select pattern, try to save
+    await scheduler.clickSave()
+    await page.waitForTimeout(TIMEOUTS.TRANSITION)
+
+    // Editor should stay open with error
+    expect(await scheduler.isEditorOpen()).toBeTruthy()
+    const errorVisible = await page.locator('text=pattern').first().isVisible()
+    expect(errorVisible).toBeTruthy()
+
+    await scheduler.clickCancel()
+  })
+
+  // ============================================================
+  // Edge Cases
+  // ============================================================
+
+  test('deleting active schedule removes active banner', async () => {
+    const activeIndex = await scheduler.findActiveSchedule()
+    if (activeIndex === -1) {
+      test.skip(true, 'No active schedule to test deletion')
+      return
+    }
+
+    // Delete the active schedule
+    await scheduler.clickDeleteOnSchedule(activeIndex)
+
+    if (await scheduler.isConfirmDialogOpen()) {
+      await scheduler.confirmDelete()
+      await scheduler.waitForLoad()
+    }
+
+    // Verify active banner is gone
+    const bannerVisible = await scheduler.isActiveBannerVisible()
+    expect(bannerVisible).toBeFalsy()
+  })
+
+  // ============================================================
+  // Toast Notifications
+  // ============================================================
+
+  test('successful activation shows success toast', async () => {
+    const inactiveIndex = await scheduler.findFirstInactiveSchedule()
+    if (inactiveIndex === -1) {
+      test.skip(true, 'No inactive schedules available')
+      return
+    }
+
+    await scheduler.clickActivateOnSchedule(inactiveIndex)
+
+    const toastAppeared = await scheduler.waitForToast('success')
+    expect(toastAppeared).toBeTruthy()
+  })
+
+  // ============================================================
+  // Keyboard Accessibility
+  // ============================================================
+
+  test('escape key closes editor', async ({ page }) => {
+    await scheduler.clickNewSchedule()
+    expect(await scheduler.isEditorOpen()).toBeTruthy()
+
+    await page.keyboard.press('Escape')
+
+    expect(await scheduler.isEditorOpen()).toBeFalsy()
   })
 })

--- a/Firmware/webui/frontend/e2e/tests/scheduler-schedules.spec.js
+++ b/Firmware/webui/frontend/e2e/tests/scheduler-schedules.spec.js
@@ -1,0 +1,374 @@
+/**
+ * Scheduler Schedules E2E Tests
+ *
+ * Tests the schedule CRUD workflows and activation/deactivation functionality.
+ * Uses full CRUD testing - creates test schedules with unique timestamps and cleans up after.
+ */
+
+import { test, expect } from '@playwright/test'
+import { SchedulerPage } from '../pages/scheduler.page.js'
+import { isRateLimited, TIMEOUTS } from '../fixtures/test-helpers.js'
+
+test.describe('Scheduler Schedules', () => {
+  /** @type {SchedulerPage} */
+  let scheduler
+
+  test.beforeEach(async ({ page }) => {
+    scheduler = new SchedulerPage(page)
+    await scheduler.goto()
+
+    // Check for rate limiting before each test
+    if (await isRateLimited(page)) {
+      test.skip(true, 'Rate limited by server (50/hour)')
+    }
+  })
+
+  test.afterEach(async () => {
+    // Ensure editor is closed after each test
+    if (await scheduler.isEditorOpen()) {
+      await scheduler.clickCancel().catch(() => {})
+    }
+  })
+
+  // ============================================================
+  // Basic Page Loading
+  // ============================================================
+
+  test('scheduler page loads', async () => {
+    // Verify we're on the scheduler page
+    const heading = scheduler.page.locator('text=Schedule')
+    await expect(heading.first()).toBeVisible()
+  })
+
+  test('schedules tab shows schedule list or empty state', async () => {
+    // Switch to Schedules tab (may already be default)
+    await scheduler.switchToSchedulesTab()
+
+    // Should show either schedule cards or empty state
+    const hasSchedules = await scheduler.hasSchedules()
+    const isEmptyState = await scheduler.isEmptySchedulesStateVisible()
+
+    expect(hasSchedules || isEmptyState).toBeTruthy()
+  })
+
+  test('both tabs are visible and functional', async ({ page }) => {
+    // Verify Schedules tab
+    const schedulesTab = page.locator('button:has-text("Schedules")')
+    await expect(schedulesTab).toBeVisible()
+
+    // Verify Calendar tab
+    const calendarTab = page.locator('button:has-text("Calendar")')
+    await expect(calendarTab).toBeVisible()
+
+    // Switch between tabs
+    await scheduler.switchToCalendarTab()
+    await expect(page.locator('#calendar-panel')).toBeVisible()
+
+    await scheduler.switchToSchedulesTab()
+    await expect(page.locator('#schedules-panel')).toBeVisible()
+  })
+
+  // ============================================================
+  // Editor Drawer Operations
+  // ============================================================
+
+  test('New Schedule button opens editor', async () => {
+    await scheduler.clickNewSchedule()
+
+    // Verify editor is open
+    expect(await scheduler.isEditorOpen()).toBeTruthy()
+
+    // Verify title is "Create Schedule"
+    const title = await scheduler.getEditorTitle()
+    expect(title).toContain('Create Schedule')
+
+    // Verify name input is empty
+    const nameValue = await scheduler.getScheduleNameValue()
+    expect(nameValue).toBe('')
+
+    // Close editor
+    await scheduler.clickCancel()
+    expect(await scheduler.isEditorOpen()).toBeFalsy()
+  })
+
+  test('cancel editor discards changes', async () => {
+    const initialCount = await scheduler.getScheduleCount()
+
+    // Open editor and fill some data
+    await scheduler.clickNewSchedule()
+    const testName = scheduler.generateTestScheduleName()
+    await scheduler.fillScheduleName(testName)
+
+    // Cancel
+    await scheduler.clickCancel()
+
+    // Verify drawer closed
+    expect(await scheduler.isEditorOpen()).toBeFalsy()
+
+    // Verify no new schedule was added
+    const finalCount = await scheduler.getScheduleCount()
+    expect(finalCount).toBe(initialCount)
+  })
+
+  test('close editor via X button', async () => {
+    await scheduler.clickNewSchedule()
+    expect(await scheduler.isEditorOpen()).toBeTruthy()
+
+    // Close via X button
+    await scheduler.closeEditor()
+    expect(await scheduler.isEditorOpen()).toBeFalsy()
+  })
+
+  test('edit existing schedule opens editor with data', async ({ page }) => {
+    void page // suppress unused warning
+    const scheduleCount = await scheduler.getScheduleCount()
+    if (scheduleCount === 0) {
+      test.skip(true, 'No schedules available for testing edit')
+      return
+    }
+
+    // Click Edit on first schedule
+    await scheduler.clickEditOnSchedule(0)
+
+    // Verify editor is open
+    expect(await scheduler.isEditorOpen()).toBeTruthy()
+
+    // Verify title is "Edit Schedule"
+    const title = await scheduler.getEditorTitle()
+    expect(title).toContain('Edit Schedule')
+
+    // Verify name input has a value (existing schedule name)
+    const nameValue = await scheduler.getScheduleNameValue()
+    expect(nameValue.length).toBeGreaterThan(0)
+
+    // Close editor
+    await scheduler.clickCancel()
+  })
+
+  // ============================================================
+  // Delete Operations
+  // ============================================================
+
+  test('delete schedule shows confirmation dialog', async ({ page }) => {
+    const scheduleCount = await scheduler.getScheduleCount()
+    if (scheduleCount === 0) {
+      test.skip(true, 'No schedules available for testing delete')
+      return
+    }
+
+    // Click Delete on first schedule
+    await scheduler.clickDeleteOnSchedule(0)
+
+    // Wait for confirmation dialog or just verify the action was triggered
+    // Some implementations may show inline confirmation
+    await page.waitForTimeout(500)
+
+    // If dialog appeared, cancel it
+    if (await scheduler.isConfirmDialogOpen()) {
+      await scheduler.cancelDelete()
+    }
+  })
+
+  // ============================================================
+  // Activation/Deactivation Operations
+  // ============================================================
+
+  test('activate schedule shows active state', async () => {
+    const scheduleCount = await scheduler.getScheduleCount()
+    if (scheduleCount === 0) {
+      test.skip(true, 'No schedules available for testing activation')
+      return
+    }
+
+    // Find an inactive schedule
+    const inactiveIndex = await scheduler.findFirstInactiveSchedule()
+    if (inactiveIndex === -1) {
+      test.skip(true, 'No inactive schedules available')
+      return
+    }
+
+    // Activate the schedule
+    await scheduler.clickActivateOnSchedule(inactiveIndex)
+
+    // Wait for UI to update
+    await scheduler.waitForLoad()
+
+    // Verify either:
+    // - The active banner appears
+    // - OR the card now shows active badge
+    const bannerVisible = await scheduler.isActiveBannerVisible()
+    const cardActive = await scheduler.isScheduleActive(inactiveIndex)
+
+    expect(bannerVisible || cardActive).toBeTruthy()
+  })
+
+  test('deactivate schedule from card', async () => {
+    // Find the active schedule
+    const activeIndex = await scheduler.findActiveSchedule()
+    if (activeIndex === -1) {
+      test.skip(true, 'No active schedule to deactivate')
+      return
+    }
+
+    // Deactivate from card
+    await scheduler.clickDeactivateOnSchedule(activeIndex)
+
+    // Wait for UI to update
+    await scheduler.waitForLoad()
+
+    // Verify the card no longer shows active (or banner disappeared)
+    const stillActive = await scheduler.isScheduleActive(activeIndex)
+    expect(stillActive).toBeFalsy()
+  })
+
+  test('deactivate from active banner', async () => {
+    // Check if active banner is visible
+    const bannerVisible = await scheduler.isActiveBannerVisible()
+    if (!bannerVisible) {
+      test.skip(true, 'No active schedule banner visible')
+      return
+    }
+
+    // Click deactivate in banner
+    await scheduler.clickBannerDeactivate()
+
+    // Wait for UI to update
+    await scheduler.waitForLoad()
+
+    // Verify banner disappeared
+    const stillVisible = await scheduler.isActiveBannerVisible()
+    expect(stillVisible).toBeFalsy()
+  })
+
+  test('active banner shows correct schedule name', async () => {
+    const bannerVisible = await scheduler.isActiveBannerVisible()
+    if (!bannerVisible) {
+      test.skip(true, 'No active schedule banner visible')
+      return
+    }
+
+    // Get the active schedule name from banner
+    const bannerName = await scheduler.getActiveBannerScheduleName()
+    expect(bannerName).toBeTruthy()
+    expect(bannerName.length).toBeGreaterThan(0)
+  })
+
+  // ============================================================
+  // Full CRUD Integration Tests
+  // ============================================================
+
+  test('create schedule with valid data and verify in list', async ({ page }) => {
+    const initialCount = await scheduler.getScheduleCount()
+    const testName = scheduler.generateTestScheduleName()
+
+    // Open editor
+    await scheduler.clickNewSchedule()
+
+    // Fill name
+    await scheduler.fillScheduleName(testName)
+
+    // Fill description (optional)
+    await scheduler.fillScheduleDescription('E2E test schedule - can be deleted')
+
+    // Note: Full creation requires selecting an event pattern
+    // For basic testing, just verify the form interaction
+    // The Save may fail validation if pattern is required
+
+    // Try to save - this tests the form submission flow
+    await scheduler.clickSave()
+
+    // Wait a moment for any response
+    await page.waitForTimeout(1000)
+
+    // If editor is still open, there might be a validation error
+    // or pattern selection is required - this is expected behavior
+    if (await scheduler.isEditorOpen()) {
+      // Editor still open means validation might have failed
+      // Check for error messages
+      const hasError = await page.locator('text=required, text=error').first().isVisible().catch(() => false)
+
+      // Close editor and skip test with explanation
+      await scheduler.clickCancel()
+
+      if (hasError) {
+        test.skip(true, 'Schedule creation requires event pattern selection')
+      }
+      return
+    }
+
+    // If we got here, schedule was created
+    const finalCount = await scheduler.getScheduleCount()
+    expect(finalCount).toBeGreaterThanOrEqual(initialCount)
+
+    // Verify schedule appears in list
+    const scheduleExists = await scheduler.hasScheduleWithName(testName)
+    expect(scheduleExists).toBeTruthy()
+
+    // Cleanup: Delete the created schedule
+    await scheduler.clickDeleteOnScheduleByName(testName)
+    if (await scheduler.isConfirmDialogOpen()) {
+      await scheduler.confirmDelete()
+    }
+  })
+
+  test('full CRUD workflow: create, edit, delete', async ({ page }) => {
+    const testName = scheduler.generateTestScheduleName()
+    const updatedName = `${testName}-updated`
+
+    // Create schedule
+    await scheduler.clickNewSchedule()
+    await scheduler.fillScheduleName(testName)
+    await scheduler.fillScheduleDescription('E2E CRUD test')
+
+    // Attempt save
+    await scheduler.clickSave()
+    await page.waitForTimeout(1000)
+
+    // If editor still open, skip (pattern required)
+    if (await scheduler.isEditorOpen()) {
+      await scheduler.clickCancel()
+      test.skip(true, 'Schedule creation requires event pattern selection')
+      return
+    }
+
+    // Verify creation
+    let scheduleExists = await scheduler.hasScheduleWithName(testName)
+    if (!scheduleExists) {
+      test.skip(true, 'Failed to create test schedule')
+      return
+    }
+
+    // Edit schedule
+    const card = scheduler.getScheduleCardByName(testName)
+    await card.locator('button:has-text("Edit")').click()
+    await scheduler.waitForEditorOpen()
+
+    // Update name
+    await scheduler.fillScheduleName(updatedName)
+    await scheduler.clickSave()
+    await page.waitForTimeout(1000)
+
+    // If editor still open, close it
+    if (await scheduler.isEditorOpen()) {
+      await scheduler.clickCancel()
+    }
+
+    // Wait for update
+    await scheduler.waitForLoad()
+
+    // Verify update (check either original or updated exists)
+    const updatedExists = await scheduler.hasScheduleWithName(updatedName)
+    const nameToDelete = updatedExists ? updatedName : testName
+
+    // Delete schedule
+    await scheduler.clickDeleteOnScheduleByName(nameToDelete)
+    if (await scheduler.isConfirmDialogOpen()) {
+      await scheduler.confirmDelete()
+      await scheduler.waitForLoad()
+    }
+
+    // Verify deletion
+    const stillExists = await scheduler.hasScheduleWithName(nameToDelete)
+    expect(stillExists).toBeFalsy()
+  })
+})

--- a/Firmware/webui/frontend/e2e/tests/scheduler-schedules.spec.js
+++ b/Firmware/webui/frontend/e2e/tests/scheduler-schedules.spec.js
@@ -261,38 +261,46 @@ test.describe('Scheduler Schedules', () => {
     const initialCount = await scheduler.getScheduleCount()
     const testName = scheduler.generateTestScheduleName()
 
-    // Open editor
-    await scheduler.clickNewSchedule()
+    try {
+      // Open editor
+      await scheduler.clickNewSchedule()
 
-    // Fill name
-    await scheduler.fillScheduleName(testName)
+      // Fill name
+      await scheduler.fillScheduleName(testName)
 
-    // Fill description (optional)
-    await scheduler.fillScheduleDescription('E2E test schedule - can be deleted')
+      // Fill description (optional)
+      await scheduler.fillScheduleDescription('E2E test schedule - can be deleted')
 
-    // Select an event pattern (required)
-    const patternSelected = await scheduler.selectFirstEventPattern()
-    expect(patternSelected, 'Event patterns should be available in library').toBeTruthy()
+      // Select an event pattern (required)
+      const patternSelected = await scheduler.selectFirstEventPattern()
+      expect(patternSelected, 'Event patterns should be available in library').toBeTruthy()
 
-    // Save the schedule
-    await scheduler.clickSave()
+      // Save the schedule
+      await scheduler.clickSave()
 
-    // Verify save succeeded (editor should close)
-    const editorStillOpen = await scheduler.isEditorOpen()
-    expect(editorStillOpen, 'Editor should close after successful save').toBeFalsy()
+      // Verify save succeeded (editor should close)
+      const editorStillOpen = await scheduler.isEditorOpen()
+      expect(editorStillOpen, 'Editor should close after successful save').toBeFalsy()
 
-    // Verify schedule was created
-    const finalCount = await scheduler.getScheduleCount()
-    expect(finalCount).toBeGreaterThanOrEqual(initialCount)
+      // Verify schedule was created
+      const finalCount = await scheduler.getScheduleCount()
+      expect(finalCount).toBeGreaterThanOrEqual(initialCount)
 
-    // Verify schedule appears in list
-    const scheduleExists = await scheduler.hasScheduleWithName(testName)
-    expect(scheduleExists).toBeTruthy()
-
-    // Cleanup: Delete the created schedule
-    await scheduler.clickDeleteOnScheduleByName(testName)
-    if (await scheduler.isConfirmDialogOpen()) {
-      await scheduler.confirmDelete()
+      // Verify schedule appears in list
+      const scheduleExists = await scheduler.hasScheduleWithName(testName)
+      expect(scheduleExists).toBeTruthy()
+    } finally {
+      // Guaranteed cleanup even if test fails
+      try {
+        if (await scheduler.hasScheduleWithName(testName)) {
+          await scheduler.clickDeleteOnScheduleByName(testName)
+          if (await scheduler.isConfirmDialogOpen()) {
+            await scheduler.confirmDelete()
+          }
+        }
+      } catch {
+        // Cleanup failure is acceptable
+      }
     }
   })
 
@@ -300,57 +308,75 @@ test.describe('Scheduler Schedules', () => {
     const testName = scheduler.generateTestScheduleName()
     const updatedName = `${testName}-updated`
 
-    // Create schedule
-    await scheduler.clickNewSchedule()
-    await scheduler.fillScheduleName(testName)
-    await scheduler.fillScheduleDescription('E2E CRUD test')
+    try {
+      // Create schedule
+      await scheduler.clickNewSchedule()
+      await scheduler.fillScheduleName(testName)
+      await scheduler.fillScheduleDescription('E2E CRUD test')
 
-    // Select an event pattern (required)
-    const patternSelected = await scheduler.selectFirstEventPattern()
-    expect(patternSelected, 'Event patterns should be available in library').toBeTruthy()
+      // Select an event pattern (required)
+      const patternSelected = await scheduler.selectFirstEventPattern()
+      expect(patternSelected, 'Event patterns should be available in library').toBeTruthy()
 
-    // Save
-    await scheduler.clickSave()
+      // Save
+      await scheduler.clickSave()
 
-    // Verify save succeeded (editor should close)
-    const editorStillOpen = await scheduler.isEditorOpen()
-    expect(editorStillOpen, 'Editor should close after successful save').toBeFalsy()
+      // Verify save succeeded (editor should close)
+      const editorStillOpen = await scheduler.isEditorOpen()
+      expect(editorStillOpen, 'Editor should close after successful save').toBeFalsy()
 
-    // Verify creation
-    const scheduleExists = await scheduler.hasScheduleWithName(testName)
-    expect(scheduleExists, 'Schedule should appear in list after creation').toBeTruthy()
+      // Verify creation
+      const scheduleExists = await scheduler.hasScheduleWithName(testName)
+      expect(scheduleExists, 'Schedule should appear in list after creation').toBeTruthy()
 
-    // Edit schedule
-    const card = scheduler.getScheduleCardByName(testName)
-    await card.locator('button:has-text("Edit")').click()
-    await scheduler.waitForEditorOpen()
+      // Edit schedule
+      const card = scheduler.getScheduleCardByName(testName)
+      await card.locator('button:has-text("Edit")').click()
+      await scheduler.waitForEditorOpen()
 
-    // Update name
-    await scheduler.fillScheduleName(updatedName)
-    await scheduler.clickSave()
+      // Update name
+      await scheduler.fillScheduleName(updatedName)
+      await scheduler.clickSave()
 
-    // If editor still open, close it
-    if (await scheduler.isEditorOpen()) {
-      await scheduler.clickCancel()
-    }
+      // If editor still open, close it
+      if (await scheduler.isEditorOpen()) {
+        await scheduler.clickCancel()
+      }
 
-    // Wait for update
-    await scheduler.waitForLoad()
-
-    // Verify update (check either original or updated exists)
-    const updatedExists = await scheduler.hasScheduleWithName(updatedName)
-    const nameToDelete = updatedExists ? updatedName : testName
-
-    // Delete schedule
-    await scheduler.clickDeleteOnScheduleByName(nameToDelete)
-    if (await scheduler.isConfirmDialogOpen()) {
-      await scheduler.confirmDelete()
+      // Wait for update
       await scheduler.waitForLoad()
-    }
 
-    // Verify deletion
-    const stillExists = await scheduler.hasScheduleWithName(nameToDelete)
-    expect(stillExists).toBeFalsy()
+      // Verify update (check either original or updated exists)
+      const updatedExists = await scheduler.hasScheduleWithName(updatedName)
+      const nameToDelete = updatedExists ? updatedName : testName
+
+      // Delete schedule
+      await scheduler.clickDeleteOnScheduleByName(nameToDelete)
+      if (await scheduler.isConfirmDialogOpen()) {
+        await scheduler.confirmDelete()
+        await scheduler.waitForLoad()
+      }
+
+      // Verify deletion
+      const stillExists = await scheduler.hasScheduleWithName(nameToDelete)
+      expect(stillExists).toBeFalsy()
+    } finally {
+      // Guaranteed cleanup even if test fails
+      try {
+        // Try to delete by updated name first, then original name
+        for (const name of [updatedName, testName]) {
+          if (await scheduler.hasScheduleWithName(name)) {
+            await scheduler.clickDeleteOnScheduleByName(name)
+            if (await scheduler.isConfirmDialogOpen()) {
+              await scheduler.confirmDelete()
+            }
+            break // Only delete once
+          }
+        }
+      } catch {
+        // Cleanup failure is acceptable
+      }
+    }
   })
 
   // ============================================================

--- a/Firmware/webui/frontend/e2e/tests/scheduler-schedules.spec.js
+++ b/Firmware/webui/frontend/e2e/tests/scheduler-schedules.spec.js
@@ -270,33 +270,21 @@ test.describe('Scheduler Schedules', () => {
     // Fill description (optional)
     await scheduler.fillScheduleDescription('E2E test schedule - can be deleted')
 
-    // Note: Full creation requires selecting an event pattern
-    // For basic testing, just verify the form interaction
-    // The Save may fail validation if pattern is required
+    // Select an event pattern (required)
+    const patternSelected = await scheduler.selectFirstEventPattern()
+    expect(patternSelected, 'Event patterns should be available in library').toBeTruthy()
 
-    // Try to save - this tests the form submission flow
+    // Save the schedule
     await scheduler.clickSave()
 
-    // Wait a moment for any response
+    // Wait for save to complete
     await page.waitForTimeout(1000)
 
-    // If editor is still open, there might be a validation error
-    // or pattern selection is required - this is expected behavior
-    if (await scheduler.isEditorOpen()) {
-      // Editor still open means validation might have failed
-      // Check for error messages
-      const hasError = await page.locator('text=required, text=error').first().isVisible().catch(() => false)
+    // Verify save succeeded (editor should close)
+    const editorStillOpen = await scheduler.isEditorOpen()
+    expect(editorStillOpen, 'Editor should close after successful save').toBeFalsy()
 
-      // Close editor and skip test with explanation
-      await scheduler.clickCancel()
-
-      if (hasError) {
-        test.skip(true, 'Schedule creation requires event pattern selection')
-      }
-      return
-    }
-
-    // If we got here, schedule was created
+    // Verify schedule was created
     const finalCount = await scheduler.getScheduleCount()
     expect(finalCount).toBeGreaterThanOrEqual(initialCount)
 
@@ -320,23 +308,21 @@ test.describe('Scheduler Schedules', () => {
     await scheduler.fillScheduleName(testName)
     await scheduler.fillScheduleDescription('E2E CRUD test')
 
-    // Attempt save
+    // Select an event pattern (required)
+    const patternSelected = await scheduler.selectFirstEventPattern()
+    expect(patternSelected, 'Event patterns should be available in library').toBeTruthy()
+
+    // Save
     await scheduler.clickSave()
     await page.waitForTimeout(1000)
 
-    // If editor still open, skip (pattern required)
-    if (await scheduler.isEditorOpen()) {
-      await scheduler.clickCancel()
-      test.skip(true, 'Schedule creation requires event pattern selection')
-      return
-    }
+    // Verify save succeeded (editor should close)
+    const editorStillOpen = await scheduler.isEditorOpen()
+    expect(editorStillOpen, 'Editor should close after successful save').toBeFalsy()
 
     // Verify creation
-    let scheduleExists = await scheduler.hasScheduleWithName(testName)
-    if (!scheduleExists) {
-      test.skip(true, 'Failed to create test schedule')
-      return
-    }
+    const scheduleExists = await scheduler.hasScheduleWithName(testName)
+    expect(scheduleExists, 'Schedule should appear in list after creation').toBeTruthy()
 
     // Edit schedule
     const card = scheduler.getScheduleCardByName(testName)

--- a/Firmware/webui/frontend/src/components/common/ConfirmDialog.jsx
+++ b/Firmware/webui/frontend/src/components/common/ConfirmDialog.jsx
@@ -117,6 +117,7 @@ export default function ConfirmDialog({
         aria-modal="true"
         aria-labelledby="confirm-dialog-title"
         aria-describedby="confirm-dialog-message"
+        data-testid="confirm-dialog"
         className="relative bg-white dark:bg-gray-800 rounded-lg shadow-xl
                    w-full max-w-md p-6 mx-4"
         onClick={(e) => e.stopPropagation()}
@@ -153,6 +154,7 @@ export default function ConfirmDialog({
             type="button"
             onClick={onClose}
             disabled={isLoading}
+            data-testid="confirm-dialog-cancel"
             className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md
                        hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-900 dark:text-gray-100
                        disabled:opacity-50 disabled:cursor-not-allowed"
@@ -164,6 +166,7 @@ export default function ConfirmDialog({
             type="button"
             onClick={handleConfirm}
             disabled={isLoading}
+            data-testid="confirm-dialog-confirm"
             className={`flex-1 px-4 py-2 rounded-md font-medium
                        disabled:opacity-50 disabled:cursor-not-allowed ${styles.confirmButton}`}
           >

--- a/Firmware/webui/frontend/src/components/scheduler/CalendarView/CalendarHeader.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/CalendarView/CalendarHeader.jsx
@@ -58,6 +58,7 @@ export default function CalendarHeader({
             onClick={() => onNavigate('prev')}
             className="p-1 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200"
             aria-label="Previous"
+            data-testid="calendar-nav-previous"
             type="button"
           >
             <ChevronLeftIcon className="h-5 w-5" />
@@ -75,6 +76,7 @@ export default function CalendarHeader({
             onClick={() => onNavigate('next')}
             className="p-1 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200"
             aria-label="Next"
+            data-testid="calendar-nav-next"
             type="button"
           >
             <ChevronRightIcon className="h-5 w-5" />

--- a/Firmware/webui/frontend/src/components/scheduler/PatternLibrary/PatternCard.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/PatternLibrary/PatternCard.jsx
@@ -57,6 +57,7 @@ function PatternCard({ pattern, onClick, onSelect, isSelected = false }) {
     <article
       role="article"
       tabIndex={0}
+      data-testid={`pattern-card-${pattern.pattern_id}`}
       className={`
         bg-white dark:bg-gray-800
         border dark:border-gray-700

--- a/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/EventPatternSelector.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/EventPatternSelector.jsx
@@ -164,7 +164,10 @@ const EventPatternSelector = ({
 
       {/* Selected Pattern Summary */}
       {activeTab === 'library' && (
-        <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-4">
+        <div
+          className="bg-gray-50 dark:bg-gray-800 rounded-lg p-4"
+          data-testid="selected-pattern-summary"
+        >
           {pattern ? (
             <div className="flex items-center justify-between">
               <div>

--- a/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/EventPatternSelector.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/EventPatternSelector.jsx
@@ -123,6 +123,7 @@ const EventPatternSelector = ({
             aria-selected={activeTab === 'library'}
             disabled={disabled}
             onClick={() => handleTabChange('library')}
+            data-testid="pattern-tab-library"
             className={`
               px-4 py-2 text-sm font-medium border-b-2 transition-colors
               focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2
@@ -143,6 +144,7 @@ const EventPatternSelector = ({
             aria-selected={activeTab === 'custom'}
             disabled={disabled}
             onClick={() => handleTabChange('custom')}
+            data-testid="pattern-tab-custom"
             className={`
               px-4 py-2 text-sm font-medium border-b-2 transition-colors
               focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2


### PR DESCRIPTION
## Summary

Add Playwright E2E tests for the scheduler UI covering schedule CRUD workflows, activation/deactivation, and calendar navigation.

**Closes #234**

## Changes

### New Files

- **`e2e/pages/scheduler.page.js`** - Page object encapsulating all scheduler UI interactions
  - Navigation methods (goto, tab switching)
  - Schedule list operations (count, edit, activate, deactivate, delete)
  - Active banner operations
  - Editor drawer operations
  - Calendar operations (view modes, navigation, schedule selection)
  - Utility methods (test name generation, toast waiting)

- **`e2e/tests/scheduler-schedules.spec.js`** - Schedule CRUD workflow tests (14 tests)
  - Page loading and tab navigation
  - Editor drawer operations
  - Cancel discards changes
  - Edit existing schedule
  - Delete confirmation dialog
  - Activate/deactivate from card
  - Deactivate from active banner
  - Full CRUD workflow integration

### Modified Files

- **`e2e/tests/scheduler-calendar.spec.js`** - Added 8 new tests
  - Schedule selection in dropdown
  - Navigation (previous/next period)
  - Today button
  - View mode persistence after navigation

## Test Coverage

| File | Tests | Type |
|------|-------|------|
| scheduler-schedules.spec.js | 14 | New |
| scheduler-calendar.spec.js | 15 (8 new) | Modified |
| **Total** | **29** | |

## Test plan

- [x] Lint passes (`npm run lint -- e2e/`)
- [x] Tests follow existing patterns from gallery.page.js
- [x] Rate limiting handled (tests skip when rate limited)
- [x] Graceful skip for missing data
- [x] Unique test names with timestamps for CRUD tests
- [ ] E2E tests pass on Mothbox Pi (requires manual verification)

## Dependencies

- Requires: #224 (Main Page) - ✅ Complete
- Requires: #228 (Calendar View) - ✅ Complete