### PR TITLE
fix(presets): Improve error messages for missing settings (#69)

### DIFF
--- a/Firmware/webui/backend/routes/presets.py
+++ b/Firmware/webui/backend/routes/presets.py
@@ -213,7 +213,11 @@ def apply_preset(name):
                     ), 400
                 else:
                     return jsonify(
-                        {"error": f'Preset "{name}" has no camera settings for capture workflow'}
+                        {
+                            "error": f'Preset "{name}" has no camera settings. '
+                            f'This may indicate a corrupted preset file. '
+                            f'Try re-saving the preset using "Save As" to recreate it.'
+                        }
                     ), 400
         elif apply_to == "liveview":
             if not liveview_settings:
@@ -225,7 +229,11 @@ def apply_preset(name):
                     ), 400
                 else:
                     return jsonify(
-                        {"error": f'Preset "{name}" has no liveview settings for liveview workflow'}
+                        {
+                            "error": f'Preset "{name}" has no liveview settings. '
+                            f'This may indicate a corrupted preset file. '
+                            f'Try re-saving the preset using "Save As" to recreate it.'
+                        }
                     ), 400
         elif apply_to == "both" and not camera_settings and not liveview_settings:
             return jsonify(


### PR DESCRIPTION
## Summary
Improve error messages when presets have missing liveview or camera settings to help users understand the cause and how to fix it.

Closes #69

## Changes
Updated error messages in `webui/backend/routes/presets.py`:

**Before:**
```
Preset "my_preset" has no liveview settings for liveview workflow
```

**After:**
```
Preset "my_preset" has no liveview settings. This may indicate a corrupted preset file. Try re-saving the preset using "Save As" to recreate it.
```

Same improvement applied for missing camera settings.

**Note:** The workflow-specific messages ("Cannot apply liveview-only preset to capture workflow...") were left unchanged as they already provide clear context.

## Test plan
- [x] All 34 preset route tests pass
- [x] Existing tests use flexible assertions that accommodate new messages
- [x] Ruff linting passes