### PR TITLE
refactor: Replace repetitive type conversion with safe_convert() helper (#81)

### DIFF
--- a/Firmware/Tests/unit/test_config_routes.py
+++ b/Firmware/Tests/unit/test_config_routes.py
@@ -828,3 +828,39 @@ class TestConfigErrorRecovery:
         assert response.status_code == 200
         data = response.get_json()
         assert 'jpeg_quality' in data  # Has defaults
+
+
+class TestSafeConvert:
+    """Tests for safe_convert() helper function (Issue #81)."""
+
+    def test_successful_int_conversion(self):
+        """Test successful integer conversion."""
+        from routes.config import safe_convert
+        assert safe_convert("123", int, 0) == 123
+        assert safe_convert("0", int, -1) == 0
+        assert safe_convert("-42", int, 0) == -42
+
+    def test_successful_float_conversion(self):
+        """Test successful float conversion."""
+        from routes.config import safe_convert
+        assert safe_convert("1.5", float, 0.0) == 1.5
+        assert safe_convert("0.0", float, 1.0) == 0.0
+        assert safe_convert("-3.14", float, 0.0) == -3.14
+
+    def test_failed_conversion_returns_default(self):
+        """Test that invalid values return the default."""
+        from routes.config import safe_convert
+        assert safe_convert("invalid", int, 99) == 99
+        assert safe_convert("not_a_number", float, 1.5) == 1.5
+
+    def test_none_value_returns_default(self):
+        """Test that None returns the default."""
+        from routes.config import safe_convert
+        assert safe_convert(None, int, 42) == 42
+        assert safe_convert(None, float, 3.14) == 3.14
+
+    def test_empty_string_returns_default(self):
+        """Test that empty string returns the default."""
+        from routes.config import safe_convert
+        assert safe_convert("", int, 100) == 100
+        assert safe_convert("", float, 2.0) == 2.0

--- a/Firmware/webui/backend/routes/config.py
+++ b/Firmware/webui/backend/routes/config.py
@@ -2,7 +2,8 @@
 
 import csv
 import shutil
-from contextlib import suppress
+from collections.abc import Callable
+from typing import Any
 
 # Setup path to import mothbox_paths
 # Import camera control mapping
@@ -194,6 +195,23 @@ def update_schedule_settings():
         return jsonify({"error": str(e)}), 500
 
 
+def safe_convert(value: Any, converter: Callable, default: Any) -> Any:
+    """Safely convert a value, returning default on failure.
+
+    Args:
+        value: Value to convert (typically string from config file)
+        converter: Conversion function (int, float, etc.)
+        default: Value to return if conversion fails
+
+    Returns:
+        Converted value on success, default on ValueError/TypeError
+    """
+    try:
+        return converter(value)
+    except (ValueError, TypeError):
+        return default
+
+
 @config_bp.route("/webui", methods=["GET"])
 def get_webui_settings():
     """Get WebUI stream settings"""
@@ -264,8 +282,7 @@ def get_webui_settings():
                         "analogue_gain",
                     ]:
                         # Float values
-                        with suppress(ValueError):
-                            defaults[key] = float(settings[key])
+                        defaults[key] = safe_convert(settings[key], float, defaults[key])
                     elif key in [
                         "noise_reduction_mode",
                         "ae_metering_mode",
@@ -273,12 +290,10 @@ def get_webui_settings():
                         "focus_peaking_intensity",
                     ]:
                         # Integer values (noise_reduction_mode: 0-2, ae_metering_mode: 0-2, exposure_time: microseconds, focus_peaking_intensity: 50-200)
-                        with suppress(ValueError):
-                            defaults[key] = int(settings[key])
+                        defaults[key] = safe_convert(settings[key], int, defaults[key])
                     else:
                         # Other integer values
-                        with suppress(ValueError):
-                            defaults[key] = int(settings[key])
+                        defaults[key] = safe_convert(settings[key], int, defaults[key])
 
         return jsonify(defaults)
     except Exception as e:


### PR DESCRIPTION
## Summary
Replace repetitive type conversion logic in `get_webui_settings()` with a reusable `safe_convert()` helper function.

Closes #81

## Changes
- Added `safe_convert(value, converter, default)` helper function
- Replaced 3 repetitive `with suppress(ValueError)` blocks with calls to helper
- Updated imports: removed unused `suppress`, added `Callable` and `Any`

## Benefits
- **DRY**: Eliminated code duplication
- **Testable**: Helper function can be unit tested independently
- **Maintainable**: Error handling logic in one place
- **Type Safe**: Added proper type hints

## Test plan
- [x] Added 5 new tests in `TestSafeConvert` class
- [x] All 46 config route tests pass
- [x] Ruff linting clean