### PR TITLE
fix: Add schema version-based cache invalidation for SidecarService (#185)

### DIFF
--- a/Firmware/Tests/unit/test_sidecar_service.py
+++ b/Firmware/Tests/unit/test_sidecar_service.py
@@ -1028,3 +1028,80 @@ class TestSidecarServiceSearchIntegration:
         metadata = service.get_metadata(str(photo))
         assert metadata is not None
         assert "test" in metadata.tags
+
+
+# ============================================================================
+# Test Cache Version Invalidation (Issue #185)
+# ============================================================================
+
+class TestCacheVersionInvalidation:
+    """Tests for schema version-based cache invalidation."""
+
+    def test_version_mismatch_returns_none(self, cache_dir):
+        """Cache entry with old version is treated as miss."""
+        from webui.backend.services.sidecar_service import SidecarService, CacheEntry
+        import json
+
+        service = SidecarService(cache_dir=cache_dir, cache_version="2.0")
+
+        # Create cache file with old version
+        photo_path = "/photos/test.jpg"
+        cache_file = service._get_cache_file_path(photo_path)
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+
+        old_entry = {
+            "photo_path": photo_path,
+            "metadata": {"test": "data"},
+            "cached_at": 123456.0,
+            "cache_version": "1.0",  # Old version
+        }
+        cache_file.write_text(json.dumps(old_entry))
+
+        # Should return None due to version mismatch
+        result = service._get_l2(photo_path)
+        assert result is None
+
+    def test_version_mismatch_deletes_cache_file(self, cache_dir):
+        """Cache file with old version is deleted."""
+        from webui.backend.services.sidecar_service import SidecarService
+        import json
+
+        service = SidecarService(cache_dir=cache_dir, cache_version="2.0")
+
+        photo_path = "/photos/test.jpg"
+        cache_file = service._get_cache_file_path(photo_path)
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+
+        old_entry = {
+            "photo_path": photo_path,
+            "metadata": {"test": "data"},
+            "cached_at": 123456.0,
+            "cache_version": "1.0",
+        }
+        cache_file.write_text(json.dumps(old_entry))
+
+        service._get_l2(photo_path)
+        assert not cache_file.exists()  # File should be deleted
+
+    def test_matching_version_returns_entry(self, cache_dir):
+        """Cache entry with matching version is returned."""
+        from webui.backend.services.sidecar_service import SidecarService
+        import json
+
+        service = SidecarService(cache_dir=cache_dir, cache_version="2.0")
+
+        photo_path = "/photos/test.jpg"
+        cache_file = service._get_cache_file_path(photo_path)
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+
+        entry = {
+            "photo_path": photo_path,
+            "metadata": {"species": "Moth"},
+            "cached_at": 123456.0,
+            "cache_version": "2.0",  # Matches service version
+        }
+        cache_file.write_text(json.dumps(entry))
+
+        result = service._get_l2(photo_path)
+        assert result is not None
+        assert result.metadata["species"] == "Moth"

--- a/Firmware/Tests/unit/test_sidecar_service.py
+++ b/Firmware/Tests/unit/test_sidecar_service.py
@@ -7,12 +7,11 @@ TDD approach: tests written first, then implementation.
 Coverage Target: 85%+
 """
 
-import pytest
+import json
 import threading
 import time
-import json
-from pathlib import Path
-from unittest.mock import patch, MagicMock
+
+import pytest
 
 # Import will fail until implementation exists - that's expected in TDD
 try:
@@ -137,7 +136,7 @@ class TestSidecarServiceInit:
         cache_dir = tmp_path / "nonexistent_cache"
         assert not cache_dir.exists()
 
-        service = SidecarService(cache_dir=cache_dir)
+        SidecarService(cache_dir=cache_dir)  # Creates directory as side effect
         assert cache_dir.exists()
         assert cache_dir.is_dir()
 
@@ -872,7 +871,7 @@ class TestListAllSidecars:
     def test_list_all_sidecars_uses_cache(self, service, sample_photo_with_sidecar, photos_dir):
         """list_all_sidecars should populate cache for efficient repeat access."""
         # First call - should populate cache
-        results1 = service.list_all_sidecars(photos_dir)
+        service.list_all_sidecars(photos_dir)
         stats1 = service.get_statistics()
 
         # Access same photo - should be L1 hit
@@ -1039,8 +1038,7 @@ class TestCacheVersionInvalidation:
 
     def test_version_mismatch_returns_none(self, cache_dir):
         """Cache entry with old version is treated as miss."""
-        from webui.backend.services.sidecar_service import SidecarService, CacheEntry
-        import json
+        from webui.backend.services.sidecar_service import SidecarService
 
         service = SidecarService(cache_dir=cache_dir, cache_version="2.0")
 
@@ -1064,7 +1062,6 @@ class TestCacheVersionInvalidation:
     def test_version_mismatch_deletes_cache_file(self, cache_dir):
         """Cache file with old version is deleted."""
         from webui.backend.services.sidecar_service import SidecarService
-        import json
 
         service = SidecarService(cache_dir=cache_dir, cache_version="2.0")
 
@@ -1086,7 +1083,6 @@ class TestCacheVersionInvalidation:
     def test_matching_version_returns_entry(self, cache_dir):
         """Cache entry with matching version is returned."""
         from webui.backend.services.sidecar_service import SidecarService
-        import json
 
         service = SidecarService(cache_dir=cache_dir, cache_version="2.0")
 
@@ -1105,3 +1101,88 @@ class TestCacheVersionInvalidation:
         result = service._get_l2(photo_path)
         assert result is not None
         assert result.metadata["species"] == "Moth"
+
+    def test_startup_purge_on_version_change(self, tmp_path, monkeypatch):
+        """Startup purge removes all cache files when version changes."""
+        import webui.backend.services as services_module
+        from webui.backend.services.sidecar_service import CACHE_SCHEMA_VERSION
+
+        # Reset singleton
+        monkeypatch.setattr(services_module, '_sidecar_service', None)
+
+        cache_dir = tmp_path / "cache" / "sidecar"
+        cache_dir.mkdir(parents=True)
+
+        # Create old cache files
+        (cache_dir / "photo1.json").write_text('{"cache_version": "1.0"}')
+        (cache_dir / "photo2.json").write_text('{"cache_version": "1.0"}')
+        version_file = cache_dir / ".version"
+        version_file.write_text("1.0")
+
+        # Mock DATA_DIR to use tmp_path
+        monkeypatch.setattr('mothbox_paths.DATA_DIR', tmp_path)
+
+        # Initialize service (should trigger purge)
+        from webui.backend.services import get_sidecar_service
+        service = get_sidecar_service()
+
+        # Verify old files removed
+        assert not (cache_dir / "photo1.json").exists()
+        assert not (cache_dir / "photo2.json").exists()
+
+        # Verify version file updated
+        assert version_file.read_text().strip() == CACHE_SCHEMA_VERSION
+
+        # Verify service was created
+        assert service is not None
+
+    def test_startup_first_time_init(self, tmp_path, monkeypatch):
+        """First-time initialization creates version file without purge."""
+        import webui.backend.services as services_module
+        from webui.backend.services.sidecar_service import CACHE_SCHEMA_VERSION
+
+        # Reset singleton
+        monkeypatch.setattr(services_module, '_sidecar_service', None)
+
+        # Mock DATA_DIR to use tmp_path (cache dir doesn't exist yet)
+        monkeypatch.setattr('mothbox_paths.DATA_DIR', tmp_path)
+
+        # Initialize service (first time - no version file exists)
+        from webui.backend.services import get_sidecar_service
+        service = get_sidecar_service()
+
+        cache_dir = tmp_path / "cache" / "sidecar"
+        version_file = cache_dir / ".version"
+
+        # Verify version file was created
+        assert version_file.exists()
+        assert version_file.read_text().strip() == CACHE_SCHEMA_VERSION
+
+        # Verify service was created
+        assert service is not None
+
+    def test_startup_matching_version_no_purge(self, tmp_path, monkeypatch):
+        """Matching version does not purge cache files."""
+        import webui.backend.services as services_module
+        from webui.backend.services.sidecar_service import CACHE_SCHEMA_VERSION
+
+        # Reset singleton
+        monkeypatch.setattr(services_module, '_sidecar_service', None)
+
+        cache_dir = tmp_path / "cache" / "sidecar"
+        cache_dir.mkdir(parents=True)
+
+        # Create cache files with current version
+        (cache_dir / "photo1.json").write_text(f'{{"cache_version": "{CACHE_SCHEMA_VERSION}"}}')
+        version_file = cache_dir / ".version"
+        version_file.write_text(CACHE_SCHEMA_VERSION)
+
+        # Mock DATA_DIR to use tmp_path
+        monkeypatch.setattr('mothbox_paths.DATA_DIR', tmp_path)
+
+        # Initialize service (should NOT purge - version matches)
+        from webui.backend.services import get_sidecar_service
+        get_sidecar_service()
+
+        # Verify file was NOT deleted
+        assert (cache_dir / "photo1.json").exists()

--- a/Firmware/webui/backend/services/__init__.py
+++ b/Firmware/webui/backend/services/__init__.py
@@ -61,12 +61,31 @@ def get_sidecar_service():
     """
     global _sidecar_service
     if _sidecar_service is None:
+        import contextlib
+        import logging
+
         from mothbox_paths import DATA_DIR
 
-        from .sidecar_service import SidecarService
+        from .sidecar_service import CACHE_SCHEMA_VERSION, SidecarService
+
+        logger = logging.getLogger(__name__)
 
         cache_dir = DATA_DIR / "cache" / "sidecar"
-        _sidecar_service = SidecarService(cache_dir=cache_dir)
+        cache_dir.mkdir(parents=True, exist_ok=True)
+
+        # Check version file and purge if schema changed
+        version_file = cache_dir / ".version"
+        if version_file.exists() and version_file.read_text().strip() != CACHE_SCHEMA_VERSION:
+            logger.info("Cache schema version changed, purging L2 cache")
+            for f in cache_dir.glob("*.json"):
+                with contextlib.suppress(Exception):
+                    f.unlink()
+        version_file.write_text(CACHE_SCHEMA_VERSION)
+
+        _sidecar_service = SidecarService(
+            cache_dir=cache_dir,
+            cache_version=CACHE_SCHEMA_VERSION,
+        )
     return _sidecar_service
 
 

--- a/Firmware/webui/backend/services/__init__.py
+++ b/Firmware/webui/backend/services/__init__.py
@@ -62,6 +62,7 @@ def get_sidecar_service():
     global _sidecar_service
     if _sidecar_service is None:
         import contextlib
+        import fcntl
         import logging
 
         from mothbox_paths import DATA_DIR
@@ -73,14 +74,32 @@ def get_sidecar_service():
         cache_dir = DATA_DIR / "cache" / "sidecar"
         cache_dir.mkdir(parents=True, exist_ok=True)
 
-        # Check version file and purge if schema changed
-        version_file = cache_dir / ".version"
-        if version_file.exists() and version_file.read_text().strip() != CACHE_SCHEMA_VERSION:
-            logger.info("Cache schema version changed, purging L2 cache")
-            for f in cache_dir.glob("*.json"):
-                with contextlib.suppress(Exception):
-                    f.unlink()
-        version_file.write_text(CACHE_SCHEMA_VERSION)
+        # Use file-based locking to prevent race conditions when multiple
+        # processes/threads initialize simultaneously
+        lock_file = cache_dir / ".purge.lock"
+        try:
+            with open(lock_file, 'w') as lock:
+                fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+
+                # Check version file and purge if schema changed
+                version_file = cache_dir / ".version"
+                if version_file.exists():
+                    if version_file.read_text().strip() != CACHE_SCHEMA_VERSION:
+                        logger.info("Cache schema version changed, purging L2 cache")
+                        for f in cache_dir.glob("*.json"):
+                            try:
+                                f.unlink()
+                            except Exception as e:
+                                logger.debug(f"Failed to delete cache file {f}: {e}")
+                else:
+                    logger.info(
+                        f"Initializing L2 cache with schema version {CACHE_SCHEMA_VERSION}"
+                    )
+                version_file.write_text(CACHE_SCHEMA_VERSION)
+        finally:
+            # Clean up lock file (non-critical if this fails)
+            with contextlib.suppress(Exception):
+                lock_file.unlink()
 
         _sidecar_service = SidecarService(
             cache_dir=cache_dir,

--- a/Firmware/webui/backend/services/sidecar_service.py
+++ b/Firmware/webui/backend/services/sidecar_service.py
@@ -63,6 +63,9 @@ from webui.backend.lib.sidecar_metadata import (
 # Matches: name_YYYY_MM_DD__HH_MM_SS... or ManFocus_name_YYYY_MM_DD__...
 FILENAME_DATE_PATTERN = re.compile(r'(\d{4})_(\d{2})_(\d{2})__')
 
+# Cache schema version - bump when sidecar structure changes
+CACHE_SCHEMA_VERSION = "1.1"
+
 logger = logging.getLogger(__name__)
 
 
@@ -702,6 +705,15 @@ class SidecarService:
                 with open(cache_file) as f:
                     data = json.load(f)
                     entry = CacheEntry.from_dict(data)
+
+                # Invalidate if schema version mismatch
+                if entry.cache_version != self.cache_version:
+                    logger.debug(
+                        f"Cache version mismatch for {photo_path}: "
+                        f"{entry.cache_version} != {self.cache_version}"
+                    )
+                    cache_file.unlink()
+                    return None
 
                 # Update file mtime for LRU tracking (non-critical)
                 with contextlib.suppress(Exception):

--- a/Firmware/webui/backend/services/sidecar_service.py
+++ b/Firmware/webui/backend/services/sidecar_service.py
@@ -63,7 +63,12 @@ from webui.backend.lib.sidecar_metadata import (
 # Matches: name_YYYY_MM_DD__HH_MM_SS... or ManFocus_name_YYYY_MM_DD__...
 FILENAME_DATE_PATTERN = re.compile(r'(\d{4})_(\d{2})_(\d{2})__')
 
-# Cache schema version - bump when sidecar structure changes
+# Cache schema version - bump when cache entry structure changes.
+# Bumping this will invalidate all existing L2 cache entries on startup.
+# Examples of when to bump:
+#   - New metadata fields added to CacheEntry
+#   - Changed serialization format
+#   - Renamed keys in cached metadata dict
 CACHE_SCHEMA_VERSION = "1.1"
 
 logger = logging.getLogger(__name__)
@@ -135,7 +140,7 @@ class SidecarService:
         cache_dir: Path | str,
         l1_max_size: int = 1000,
         l2_max_size: int = 10000,
-        cache_version: str = "1.0",
+        cache_version: str = CACHE_SCHEMA_VERSION,
         search_service: Any | None = None,
     ):
         """


### PR DESCRIPTION
## Summary
Implement automatic cache invalidation when sidecar metadata schema changes, preventing stale/corrupted data from being served.

Closes #185

## Problem
The L2 file cache could serve stale data when the sidecar metadata schema changed. Users had to manually clear the cache directory.

## Solution
Two-layer cache invalidation:

1. **Per-entry validation** in `_get_l2()`: Check `entry.cache_version` against `self.cache_version`. Mismatched entries are deleted and treated as cache misses.

2. **Startup purge** in `get_sidecar_service()`: Check `.version` file in cache directory. If schema version changed, purge all L2 cache files.

## Changes
- Added `CACHE_SCHEMA_VERSION = "1.1"` constant
- Modified `_get_l2()` to validate and delete mismatched cache entries
- Updated `get_sidecar_service()` to check version file on startup
- Added 3 new tests for version invalidation

## Usage
To trigger cache invalidation after schema changes, just bump `CACHE_SCHEMA_VERSION`.

## Test plan
- [x] `test_version_mismatch_returns_none` - Old version entry treated as miss
- [x] `test_version_mismatch_deletes_cache_file` - Stale file removed
- [x] `test_matching_version_returns_entry` - Valid entry returned
- [x] All 65 sidecar service tests pass
- [x] Ruff linting clean