### PR TITLE
feat(gps): Add coordinate precision control (#158)

### DIFF
--- a/Firmware/Tests/unit/test_gps_coordinates.py
+++ b/Firmware/Tests/unit/test_gps_coordinates.py
@@ -1127,3 +1127,241 @@ class TestFormatCoordinatePair:
             format_coordinate_pair(0.0, 181.0)
 
         print("✓ Invalid longitude rejected")
+
+
+# ============================================================================
+# TestPrecisionControl: Test configurable precision for DMS seconds
+# ============================================================================
+
+class TestPrecisionControl:
+    """
+    Test seconds_precision parameter for coordinate formatting precision control.
+
+    Tests configurable precision (0-6 decimal places) for seconds in DMS format,
+    allowing users to control coordinate accuracy display.
+
+    Related to Issue #158: Coordinate Precision Control
+    """
+
+    def test_precision_0_no_decimals(self):
+        """
+        Test precision=0 (whole seconds, ±30m accuracy).
+
+        Scenario: San Francisco latitude with 0 decimal places
+        Expected: Seconds rounded to nearest whole number
+        """
+        from utils.gps_coordinates import decimal_to_dms
+
+        # Act: Convert with precision=0
+        degrees, minutes, seconds, ref = decimal_to_dms(37.7749, is_latitude=True, seconds_precision=0)
+
+        # Assert: Seconds should be integer (30 or 29)
+        assert ref == 'N'
+        assert degrees == 37
+        assert minutes == 46
+        assert isinstance(seconds, float), "Seconds should be float type"
+        assert seconds == int(seconds), f"Seconds {seconds} should be whole number"
+        assert 29 <= seconds <= 30, f"Seconds should be 29 or 30, got {seconds}"
+
+        print(f"\n✓ Precision 0: {degrees}° {minutes}' {seconds:.0f}\" {ref}")
+
+    def test_precision_1_one_decimal(self):
+        """
+        Test precision=1 (1 decimal place, ±3m accuracy).
+
+        Scenario: San Francisco latitude with 1 decimal place
+        Expected: Seconds rounded to 1 decimal place
+        """
+        from utils.gps_coordinates import decimal_to_dms
+
+        # Act: Convert with precision=1
+        degrees, minutes, seconds, ref = decimal_to_dms(37.7749, is_latitude=True, seconds_precision=1)
+
+        # Assert: Verify 1 decimal place
+        assert ref == 'N'
+        assert degrees == 37
+        assert minutes == 46
+        # 29.64 → 29.6 with 1 decimal
+        assert abs(seconds - 29.6) < 0.05, f"Expected ~29.6, got {seconds}"
+
+        print(f"✓ Precision 1: {degrees}° {minutes}' {seconds:.1f}\" {ref}")
+
+    def test_precision_2_default(self):
+        """
+        Test precision=2 (2 decimal places, ±30cm accuracy) - DEFAULT.
+
+        Scenario: San Francisco latitude with default precision
+        Expected: Seconds with 2 decimal places (backward compatible)
+        """
+        from utils.gps_coordinates import decimal_to_dms
+
+        # Act: Convert with default precision (should be 2)
+        degrees, minutes, seconds, ref = decimal_to_dms(37.7749, is_latitude=True)
+
+        # Assert: Verify 2 decimal places (default behavior)
+        assert ref == 'N'
+        assert degrees == 37
+        assert minutes == 46
+        assert abs(seconds - 29.64) < 0.01, f"Expected ~29.64, got {seconds}"
+
+        print(f"✓ Precision 2 (default): {degrees}° {minutes}' {seconds:.2f}\" {ref}")
+
+    def test_precision_4_high_accuracy(self):
+        """
+        Test precision=4 (4 decimal places, ±3mm accuracy).
+
+        Scenario: San Francisco latitude with 4 decimal places
+        Expected: High-precision seconds
+        """
+        from utils.gps_coordinates import decimal_to_dms
+
+        # Act: Convert with precision=4
+        degrees, minutes, seconds, ref = decimal_to_dms(37.7749, is_latitude=True, seconds_precision=4)
+
+        # Assert: Verify 4 decimal places
+        assert ref == 'N'
+        assert degrees == 37
+        assert minutes == 46
+        # Should preserve 4 decimal places
+        assert abs(seconds - 29.64) < 0.0001, f"Expected ~29.6400, got {seconds}"
+
+        print(f"✓ Precision 4: {degrees}° {minutes}' {seconds:.4f}\" {ref}")
+
+    def test_precision_6_maximum(self):
+        """
+        Test precision=6 (6 decimal places, ±0.03mm accuracy) - MAXIMUM.
+
+        Scenario: San Francisco latitude with maximum precision
+        Expected: Ultra-high-precision seconds
+        """
+        from utils.gps_coordinates import decimal_to_dms
+
+        # Act: Convert with precision=6
+        degrees, minutes, seconds, ref = decimal_to_dms(37.7749, is_latitude=True, seconds_precision=6)
+
+        # Assert: Verify 6 decimal places
+        assert ref == 'N'
+        assert degrees == 37
+        assert minutes == 46
+        assert abs(seconds - 29.64) < 0.000001, f"Expected ~29.640000, got {seconds}"
+
+        print(f"✓ Precision 6: {degrees}° {minutes}' {seconds:.6f}\" {ref}")
+
+    def test_format_coordinate_display_precision(self):
+        """
+        Test format_coordinate_display() with different precision values.
+
+        Scenario: Format same coordinate with varying precision
+        Expected: Different seconds precision in output strings
+        """
+        from utils.gps_coordinates import format_coordinate_display
+
+        # Act: Format with different precisions
+        fmt_0 = format_coordinate_display(37.7749, is_latitude=True, format='dms', seconds_precision=0)
+        fmt_2 = format_coordinate_display(37.7749, is_latitude=True, format='dms', seconds_precision=2)
+        fmt_4 = format_coordinate_display(37.7749, is_latitude=True, format='dms', seconds_precision=4)
+
+        # Assert: Verify different format strings
+        assert '37°46\'' in fmt_0, "Should contain degrees and minutes"
+        assert '37°46\'' in fmt_2, "Should contain degrees and minutes"
+        assert '37°46\'' in fmt_4, "Should contain degrees and minutes"
+
+        # Check that precision affects output
+        assert '"N' in fmt_0, "Should end with reference"
+        assert '"N' in fmt_2, "Should end with reference"
+        assert '"N' in fmt_4, "Should end with reference"
+
+        print(f"✓ Format precision 0: {fmt_0}")
+        print(f"✓ Format precision 2: {fmt_2}")
+        print(f"✓ Format precision 4: {fmt_4}")
+
+    def test_format_coordinate_pair_precision(self):
+        """
+        Test format_coordinate_pair() with precision parameter.
+
+        Scenario: Format coordinate pair with custom precision
+        Expected: Both lat/lon use specified precision
+        """
+        from utils.gps_coordinates import format_coordinate_pair
+
+        # Act: Format with precision=4
+        result = format_coordinate_pair(37.7749, -122.4194, format='dms', seconds_precision=4)
+
+        # Assert: Verify both coordinates present
+        assert '37°46\'' in result, "Should contain latitude"
+        assert '122°25\'' in result, "Should contain longitude"
+        assert 'N' in result, "Should contain North reference"
+        assert 'W' in result, "Should contain West reference"
+
+        print(f"✓ Coordinate pair (precision 4): {result}")
+
+    def test_invalid_precision_negative(self):
+        """
+        Test rejection of negative precision.
+
+        Scenario: seconds_precision = -1
+        Expected: ValueError
+        """
+        from utils.gps_coordinates import decimal_to_dms
+
+        # Act & Assert: Should raise ValueError
+        with pytest.raises(ValueError, match="seconds_precision.*range"):
+            decimal_to_dms(37.7749, is_latitude=True, seconds_precision=-1)
+
+        print("✓ Negative precision rejected")
+
+    def test_invalid_precision_too_high(self):
+        """
+        Test rejection of precision > 6.
+
+        Scenario: seconds_precision = 7
+        Expected: ValueError
+        """
+        from utils.gps_coordinates import decimal_to_dms
+
+        # Act & Assert: Should raise ValueError
+        with pytest.raises(ValueError, match="seconds_precision.*range"):
+            decimal_to_dms(37.7749, is_latitude=True, seconds_precision=7)
+
+        print("✓ Precision > 6 rejected")
+
+    def test_invalid_precision_float(self):
+        """
+        Test rejection of non-integer precision.
+
+        Scenario: seconds_precision = 2.5 (float)
+        Expected: ValueError
+        """
+        from utils.gps_coordinates import decimal_to_dms
+
+        # Act & Assert: Should raise ValueError
+        with pytest.raises(ValueError, match="seconds_precision"):
+            decimal_to_dms(37.7749, is_latitude=True, seconds_precision=2.5)
+
+        print("✓ Float precision rejected")
+
+    @pytest.mark.parametrize("precision,expected_range", [
+        (0, (29, 30)),      # ±30m accuracy
+        (1, (29.6, 29.7)),  # ±3m accuracy
+        (2, (29.63, 29.65)),  # ±30cm accuracy
+        (3, (29.639, 29.641)),  # ±3cm accuracy
+        (4, (29.6399, 29.6401)),  # ±3mm accuracy
+    ])
+    def test_precision_accuracy_parametrized(self, precision, expected_range):
+        """
+        Parametrized test for different precision levels.
+
+        Tests that different precision values produce appropriately rounded results.
+        """
+        from utils.gps_coordinates import decimal_to_dms
+
+        # Act: Convert with specified precision
+        degrees, minutes, seconds, ref = decimal_to_dms(
+            37.7749, is_latitude=True, seconds_precision=precision
+        )
+
+        # Assert: Verify seconds in expected range
+        assert expected_range[0] <= seconds <= expected_range[1], \
+            f"Precision {precision}: expected {expected_range}, got {seconds}"
+
+        print(f"✓ Precision {precision}: {degrees}° {minutes}' {seconds:.{precision}f}\" {ref}")

--- a/Firmware/webui/frontend/e2e/tests/gps-settings.spec.js
+++ b/Firmware/webui/frontend/e2e/tests/gps-settings.spec.js
@@ -1,0 +1,150 @@
+/**
+ * GPS Settings Tests
+ *
+ * Tests for GPS precision dropdown and localStorage persistence
+ */
+
+import { test, expect } from '@playwright/test'
+import { isRateLimited, TIMEOUTS } from '../fixtures/test-helpers.js'
+
+test.describe('GPS Settings', () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to settings page
+    await page.goto('/settings')
+    await page.waitForLoadState('networkidle')
+
+    // Check for rate limiting before each test
+    if (await isRateLimited(page)) {
+      test.skip(true, 'Rate limited by server (50/hour)')
+    }
+  })
+
+  test('settings page loads and GPS Settings card is visible', async ({ page }) => {
+    // Wait for GPS Settings card to be visible
+    const gpsCard = page.locator('text=🛰️ GPS Module Configuration')
+    await expect(gpsCard).toBeVisible({ timeout: TIMEOUTS.NETWORK })
+  })
+
+  test('GPS precision dropdown is present with all options', async ({ page }) => {
+    // Locate the GPS precision dropdown
+    const precisionDropdown = page.locator('select[aria-label="GPS Coordinate Precision"]')
+    await expect(precisionDropdown).toBeVisible({ timeout: TIMEOUTS.NETWORK })
+
+    // Verify all 7 options are present (0-6 decimal places)
+    const options = precisionDropdown.locator('option')
+    const optionCount = await options.count()
+    expect(optionCount).toBe(7)
+
+    // Verify each option value exists
+    for (let i = 0; i <= 6; i++) {
+      const option = options.nth(i)
+      const value = await option.getAttribute('value')
+      expect(value).toBe(String(i))
+    }
+  })
+
+  test('selecting a precision value updates the dropdown', async ({ page }) => {
+    const precisionDropdown = page.locator('select[aria-label="GPS Coordinate Precision"]')
+    await expect(precisionDropdown).toBeVisible({ timeout: TIMEOUTS.NETWORK })
+
+    // Select precision value 4 (4 decimals)
+    await precisionDropdown.selectOption('4')
+
+    // Verify dropdown shows selected value
+    const selectedValue = await precisionDropdown.inputValue()
+    expect(selectedValue).toBe('4')
+  })
+
+  test('precision value is saved to localStorage', async ({ page }) => {
+    const precisionDropdown = page.locator('select[aria-label="GPS Coordinate Precision"]')
+    await expect(precisionDropdown).toBeVisible({ timeout: TIMEOUTS.NETWORK })
+
+    // Select precision value 3
+    await precisionDropdown.selectOption('3')
+
+    // Wait briefly for localStorage write to complete
+    await page.waitForTimeout(TIMEOUTS.TRANSITION)
+
+    // Check localStorage value
+    const storedValue = await page.evaluate(() => {
+      return localStorage.getItem('mothbox_gps_precision')
+    })
+    expect(storedValue).toBe('3')
+  })
+
+  test('precision persists after page reload', async ({ page }) => {
+    const precisionDropdown = page.locator('select[aria-label="GPS Coordinate Precision"]')
+    await expect(precisionDropdown).toBeVisible({ timeout: TIMEOUTS.NETWORK })
+
+    // Set precision to 5
+    await precisionDropdown.selectOption('5')
+
+    // Wait for state to save
+    await page.waitForTimeout(TIMEOUTS.TRANSITION)
+
+    // Reload the page
+    await page.reload()
+    await page.waitForLoadState('networkidle')
+
+    // Check that dropdown still shows value 5
+    const reloadedDropdown = page.locator('select[aria-label="GPS Coordinate Precision"]')
+    await expect(reloadedDropdown).toBeVisible({ timeout: TIMEOUTS.NETWORK })
+
+    const selectedValue = await reloadedDropdown.inputValue()
+    expect(selectedValue).toBe('5')
+  })
+
+  test('default precision is 2 decimals when no preference is stored', async ({ page }) => {
+    // Clear localStorage before test
+    await page.evaluate(() => {
+      localStorage.removeItem('mothbox_gps_precision')
+    })
+
+    // Reload to apply cleared state
+    await page.reload()
+    await page.waitForLoadState('networkidle')
+
+    // Check default value
+    const precisionDropdown = page.locator('select[aria-label="GPS Coordinate Precision"]')
+    await expect(precisionDropdown).toBeVisible({ timeout: TIMEOUTS.NETWORK })
+
+    const defaultValue = await precisionDropdown.inputValue()
+    expect(defaultValue).toBe('2')
+  })
+
+  test('each precision option has descriptive label', async ({ page }) => {
+    const precisionDropdown = page.locator('select[aria-label="GPS Coordinate Precision"]')
+    await expect(precisionDropdown).toBeVisible({ timeout: TIMEOUTS.NETWORK })
+
+    // Verify option text includes both label and description
+    const options = precisionDropdown.locator('option')
+
+    // Check a few specific options to verify format
+    const option0 = await options.nth(0).textContent()
+    expect(option0).toContain('0 decimals')
+    expect(option0).toContain('Coarse location')
+
+    const option2 = await options.nth(2).textContent()
+    expect(option2).toContain('2 decimals')
+    expect(option2).toContain('Standard GPS')
+
+    const option6 = await options.nth(6).textContent()
+    expect(option6).toContain('6 decimals')
+    expect(option6).toContain('Maximum')
+  })
+
+  test('precision dropdown is part of GPS Settings card', async ({ page }) => {
+    // Verify the dropdown is within the GPS Settings card
+    const gpsCard = page.locator('text=🛰️ GPS Module Configuration').locator('..')
+    const precisionDropdown = gpsCard.locator('select[aria-label="GPS Coordinate Precision"]')
+
+    await expect(precisionDropdown).toBeVisible({ timeout: TIMEOUTS.NETWORK })
+  })
+
+  test('precision setting has descriptive help text', async ({ page }) => {
+    // Look for help text near the precision dropdown
+    const helpText = page.locator('text=Controls decimal places shown for GPS coordinates')
+
+    await expect(helpText).toBeVisible({ timeout: TIMEOUTS.NETWORK })
+  })
+})

--- a/Firmware/webui/frontend/e2e/tests/gps-settings.spec.js
+++ b/Firmware/webui/frontend/e2e/tests/gps-settings.spec.js
@@ -142,8 +142,9 @@ test.describe('GPS Settings', () => {
   })
 
   test('precision setting has descriptive help text', async ({ page }) => {
-    // Look for help text near the precision dropdown
-    const helpText = page.locator('text=Controls decimal places shown for GPS coordinates')
+    // Use structural selector that's less prone to text changes
+    const precisionSection = page.locator('select[aria-label="GPS Coordinate Precision"]').locator('..')
+    const helpText = precisionSection.locator('.text-xs.text-gray-500')
 
     await expect(helpText).toBeVisible({ timeout: TIMEOUTS.NETWORK })
   })

--- a/Firmware/webui/frontend/src/components/GPSSettings.jsx
+++ b/Firmware/webui/frontend/src/components/GPSSettings.jsx
@@ -5,7 +5,7 @@ import { validateDevicePath, validateBaudrate } from '../utils/gpsValidation'
 import { formatCoordinateDisplay } from '../utils/gpsCoordinates'
 import { GPS_PRECISION_OPTIONS, getGpsPrecision, setGpsPrecision } from '../utils/gpsPrecision'
 import { QUERY_KEYS } from '../utils/queryKeys'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import toast from 'react-hot-toast'
 import CollapsibleCard from './CollapsibleCard'
 import ConfirmDialog from './common/ConfirmDialog'
@@ -45,6 +45,35 @@ export default function GPSSettings() {
     // Pause polling during sync to avoid spam, otherwise poll every 15s
     refetchInterval: () => syncing ? false : 15000,
   })
+
+  // Memoize formatted coordinates to avoid unnecessary re-renders
+  const formattedCurrentLat = useMemo(
+    () => gpsStatus?.latitude
+      ? formatCoordinateDisplay(parseFloat(gpsStatus.latitude), true, 'dms', gpsPrecision)
+      : null,
+    [gpsStatus?.latitude, gpsPrecision]
+  )
+
+  const formattedCurrentLon = useMemo(
+    () => gpsStatus?.longitude
+      ? formatCoordinateDisplay(parseFloat(gpsStatus.longitude), false, 'dms', gpsPrecision)
+      : null,
+    [gpsStatus?.longitude, gpsPrecision]
+  )
+
+  const formattedLastLat = useMemo(
+    () => gpsStatus?.last_known_lat
+      ? formatCoordinateDisplay(parseFloat(gpsStatus.last_known_lat), true, 'dms', gpsPrecision)
+      : null,
+    [gpsStatus?.last_known_lat, gpsPrecision]
+  )
+
+  const formattedLastLon = useMemo(
+    () => gpsStatus?.last_known_lon
+      ? formatCoordinateDisplay(parseFloat(gpsStatus.last_known_lon), false, 'dms', gpsPrecision)
+      : null,
+    [gpsStatus?.last_known_lon, gpsPrecision]
+  )
 
   const updateConfigMutation = useMutation({
     mutationFn: updateGpsConfig,
@@ -301,11 +330,11 @@ export default function GPSSettings() {
                       <>
                         <p className="text-blue-700 text-xs">
                           <span className="font-medium">Lat:</span>{' '}
-                          {formatCoordinateDisplay(parseFloat(gpsStatus.latitude), true, 'dms', gpsPrecision)}
+                          {formattedCurrentLat}
                         </p>
                         <p className="text-blue-700 text-xs">
                           <span className="font-medium">Lon:</span>{' '}
-                          {formatCoordinateDisplay(parseFloat(gpsStatus.longitude), false, 'dms', gpsPrecision)}
+                          {formattedCurrentLon}
                         </p>
                         <p className="text-blue-700 text-xs">
                           <span className="font-medium">UTC Offset:</span> {gpsStatus.utc_offset}h
@@ -321,8 +350,8 @@ export default function GPSSettings() {
                       <div className="mt-2 pt-2 border-t border-blue-300">
                         <p className="text-blue-700 font-medium mb-1 text-xs">Last Known Position:</p>
                         <p className="text-blue-700 text-xs">
-                          📍 {formatCoordinateDisplay(parseFloat(gpsStatus.last_known_lat), true, 'dms', gpsPrecision)},{' '}
-                          {formatCoordinateDisplay(parseFloat(gpsStatus.last_known_lon), false, 'dms', gpsPrecision)}
+                          📍 {formattedLastLat},{' '}
+                          {formattedLastLon}
                         </p>
                         <p className="text-blue-700 text-xs">
                           <span className="font-medium">Acquired:</span> {formatTimestamp(gpsStatus.last_position_time)}
@@ -461,7 +490,7 @@ export default function GPSSettings() {
                   ))}
                 </select>
                 <p className="text-xs text-gray-500 mt-1">
-                  Controls decimal places shown for GPS coordinates throughout the UI
+                  Controls decimal places shown for GPS coordinates throughout the UI (display only - does not affect GPS accuracy)
                 </p>
               </div>
 

--- a/Firmware/webui/frontend/src/components/GPSSettings.jsx
+++ b/Firmware/webui/frontend/src/components/GPSSettings.jsx
@@ -2,6 +2,8 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { getGpsConfig, updateGpsConfig, getGpsStatus, syncGps } from '../utils/api'
 import { formatTimestamp } from '../utils/helpers'
 import { validateDevicePath, validateBaudrate } from '../utils/gpsValidation'
+import { formatCoordinateDisplay } from '../utils/gpsCoordinates'
+import { GPS_PRECISION_OPTIONS, getGpsPrecision, setGpsPrecision } from '../utils/gpsPrecision'
 import { QUERY_KEYS } from '../utils/queryKeys'
 import { useState, useEffect } from 'react'
 import toast from 'react-hot-toast'
@@ -16,6 +18,14 @@ export default function GPSSettings() {
   const [localConfig, setLocalConfig] = useState(null)
   const [validationErrors, setValidationErrors] = useState({})
   const [showRestartConfirm, setShowRestartConfirm] = useState(false)
+  const [gpsPrecision, setGpsPrecisionState] = useState(() => getGpsPrecision())
+
+  // Handle precision change
+  const handlePrecisionChange = (newPrecision) => {
+    const precision = parseInt(newPrecision, 10)
+    setGpsPrecisionState(precision)
+    setGpsPrecision(precision)
+  }
 
   const { data: gpsConfig, isLoading: configLoading } = useQuery({
     queryKey: QUERY_KEYS.GPS_CONFIG,
@@ -290,10 +300,12 @@ export default function GPSSettings() {
                     {gpsStatus.has_fix && (
                       <>
                         <p className="text-blue-700 text-xs">
-                          <span className="font-medium">Lat:</span> {gpsStatus.latitude}
+                          <span className="font-medium">Lat:</span>{' '}
+                          {formatCoordinateDisplay(parseFloat(gpsStatus.latitude), true, 'dms', gpsPrecision)}
                         </p>
                         <p className="text-blue-700 text-xs">
-                          <span className="font-medium">Lon:</span> {gpsStatus.longitude}
+                          <span className="font-medium">Lon:</span>{' '}
+                          {formatCoordinateDisplay(parseFloat(gpsStatus.longitude), false, 'dms', gpsPrecision)}
                         </p>
                         <p className="text-blue-700 text-xs">
                           <span className="font-medium">UTC Offset:</span> {gpsStatus.utc_offset}h
@@ -309,7 +321,8 @@ export default function GPSSettings() {
                       <div className="mt-2 pt-2 border-t border-blue-300">
                         <p className="text-blue-700 font-medium mb-1 text-xs">Last Known Position:</p>
                         <p className="text-blue-700 text-xs">
-                          📍 {gpsStatus.last_known_lat}, {gpsStatus.last_known_lon}
+                          📍 {formatCoordinateDisplay(parseFloat(gpsStatus.last_known_lat), true, 'dms', gpsPrecision)},{' '}
+                          {formatCoordinateDisplay(parseFloat(gpsStatus.last_known_lon), false, 'dms', gpsPrecision)}
                         </p>
                         <p className="text-blue-700 text-xs">
                           <span className="font-medium">Acquired:</span> {formatTimestamp(gpsStatus.last_position_time)}
@@ -428,6 +441,28 @@ export default function GPSSettings() {
                     Serial communication speed (9600 is default for NEO-M8N)
                   </p>
                 )}
+              </div>
+
+              {/* GPS Coordinate Precision */}
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Coordinate Display Precision
+                </label>
+                <select
+                  value={gpsPrecision}
+                  onChange={(e) => handlePrecisionChange(e.target.value)}
+                  aria-label="GPS Coordinate Precision"
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                >
+                  {GPS_PRECISION_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label} - {option.description}
+                    </option>
+                  ))}
+                </select>
+                <p className="text-xs text-gray-500 mt-1">
+                  Controls decimal places shown for GPS coordinates throughout the UI
+                </p>
               </div>
 
               {/* Advanced Timeout Configuration */}

--- a/Firmware/webui/frontend/src/components/GPSSettings.jsx
+++ b/Firmware/webui/frontend/src/components/GPSSettings.jsx
@@ -47,33 +47,26 @@ export default function GPSSettings() {
   })
 
   // Memoize formatted coordinates to avoid unnecessary re-renders
-  const formattedCurrentLat = useMemo(
-    () => gpsStatus?.latitude
-      ? formatCoordinateDisplay(parseFloat(gpsStatus.latitude), true, 'dms', gpsPrecision)
-      : null,
-    [gpsStatus?.latitude, gpsPrecision]
-  )
+  // Defensive: parseFloat("N/A") returns NaN, which would throw in formatCoordinateDisplay
+  const formattedCurrentLat = useMemo(() => {
+    const val = parseFloat(gpsStatus?.latitude)
+    return !Number.isNaN(val) ? formatCoordinateDisplay(val, true, 'dms', gpsPrecision) : null
+  }, [gpsStatus?.latitude, gpsPrecision])
 
-  const formattedCurrentLon = useMemo(
-    () => gpsStatus?.longitude
-      ? formatCoordinateDisplay(parseFloat(gpsStatus.longitude), false, 'dms', gpsPrecision)
-      : null,
-    [gpsStatus?.longitude, gpsPrecision]
-  )
+  const formattedCurrentLon = useMemo(() => {
+    const val = parseFloat(gpsStatus?.longitude)
+    return !Number.isNaN(val) ? formatCoordinateDisplay(val, false, 'dms', gpsPrecision) : null
+  }, [gpsStatus?.longitude, gpsPrecision])
 
-  const formattedLastLat = useMemo(
-    () => gpsStatus?.last_known_lat
-      ? formatCoordinateDisplay(parseFloat(gpsStatus.last_known_lat), true, 'dms', gpsPrecision)
-      : null,
-    [gpsStatus?.last_known_lat, gpsPrecision]
-  )
+  const formattedLastLat = useMemo(() => {
+    const val = parseFloat(gpsStatus?.last_known_lat)
+    return !Number.isNaN(val) ? formatCoordinateDisplay(val, true, 'dms', gpsPrecision) : null
+  }, [gpsStatus?.last_known_lat, gpsPrecision])
 
-  const formattedLastLon = useMemo(
-    () => gpsStatus?.last_known_lon
-      ? formatCoordinateDisplay(parseFloat(gpsStatus.last_known_lon), false, 'dms', gpsPrecision)
-      : null,
-    [gpsStatus?.last_known_lon, gpsPrecision]
-  )
+  const formattedLastLon = useMemo(() => {
+    const val = parseFloat(gpsStatus?.last_known_lon)
+    return !Number.isNaN(val) ? formatCoordinateDisplay(val, false, 'dms', gpsPrecision) : null
+  }, [gpsStatus?.last_known_lon, gpsPrecision])
 
   const updateConfigMutation = useMutation({
     mutationFn: updateGpsConfig,

--- a/Firmware/webui/frontend/src/components/GPSSettings.jsx
+++ b/Firmware/webui/frontend/src/components/GPSSettings.jsx
@@ -24,7 +24,9 @@ export default function GPSSettings() {
   const handlePrecisionChange = (newPrecision) => {
     const precision = parseInt(newPrecision, 10)
     setGpsPrecisionState(precision)
-    setGpsPrecision(precision)
+    if (!setGpsPrecision(precision)) {
+      toast.error('Precision changed but could not be saved (private browsing?)', { duration: 4000 })
+    }
   }
 
   const { data: gpsConfig, isLoading: configLoading } = useQuery({

--- a/Firmware/webui/frontend/src/components/__tests__/GPSSettings.test.jsx
+++ b/Firmware/webui/frontend/src/components/__tests__/GPSSettings.test.jsx
@@ -95,8 +95,9 @@ describe('GPSSettings', () => {
     })
 
     expect(screen.getByText(/GPS Fix/i)).toBeInTheDocument()
-    expect(screen.getByText(/37.7749/)).toBeInTheDocument()
-    expect(screen.getByText(/-122.4194/)).toBeInTheDocument()
+    // Coordinates are displayed in DMS format (e.g., 37°46'29.64"N)
+    expect(screen.getByText(/37°46/)).toBeInTheDocument()  // Latitude: 37.7749 → 37°46'
+    expect(screen.getByText(/122°25/)).toBeInTheDocument() // Longitude: -122.4194 → 122°25'
   })
 
   it('displays "No GPS Fix" when GPS has no fix', async () => {

--- a/Firmware/webui/frontend/src/utils/__tests__/gpsCoordinates.test.ts
+++ b/Firmware/webui/frontend/src/utils/__tests__/gpsCoordinates.test.ts
@@ -636,3 +636,160 @@ describe('formatCoordinatePair', () => {
     });
   });
 });
+
+// ============================================================================
+// TestPrecisionControl: Test configurable precision for DMS seconds
+// ============================================================================
+
+describe('precision control', () => {
+  describe('decimalToDMS with seconds precision', () => {
+    test('precision=0 (whole seconds, ±30m accuracy)', () => {
+      // Act: Convert with precision=0
+      const result = decimalToDMS(37.7749, true, 0);
+
+      // Assert: Seconds should be whole number
+      expect(result.reference).toBe('N');
+      expect(result.degrees).toBe(37);
+      expect(result.minutes).toBe(46);
+      expect(Number.isInteger(result.seconds)).toBe(true);
+      expect(result.seconds).toBeGreaterThanOrEqual(29);
+      expect(result.seconds).toBeLessThanOrEqual(30);
+    });
+
+    test('precision=1 (1 decimal place, ±3m accuracy)', () => {
+      // Act: Convert with precision=1
+      const result = decimalToDMS(37.7749, true, 1);
+
+      // Assert: Verify 1 decimal place
+      expect(result.reference).toBe('N');
+      expect(result.degrees).toBe(37);
+      expect(result.minutes).toBe(46);
+      expect(Math.abs(result.seconds - 29.6)).toBeLessThan(0.05);
+    });
+
+    test('precision=2 (2 decimal places, ±30cm accuracy) - DEFAULT', () => {
+      // Act: Convert with default precision (should be 2)
+      const result = decimalToDMS(37.7749, true);
+
+      // Assert: Verify 2 decimal places (default behavior)
+      expect(result.reference).toBe('N');
+      expect(result.degrees).toBe(37);
+      expect(result.minutes).toBe(46);
+      expect(Math.abs(result.seconds - 29.64)).toBeLessThan(0.01);
+    });
+
+    test('precision=4 (4 decimal places, ±3mm accuracy)', () => {
+      // Act: Convert with precision=4
+      const result = decimalToDMS(37.7749, true, 4);
+
+      // Assert: Verify 4 decimal places
+      expect(result.reference).toBe('N');
+      expect(result.degrees).toBe(37);
+      expect(result.minutes).toBe(46);
+      expect(Math.abs(result.seconds - 29.64)).toBeLessThan(0.0001);
+    });
+
+    test('precision=6 (6 decimal places, ±0.03mm accuracy) - MAXIMUM', () => {
+      // Act: Convert with precision=6
+      const result = decimalToDMS(37.7749, true, 6);
+
+      // Assert: Verify 6 decimal places
+      expect(result.reference).toBe('N');
+      expect(result.degrees).toBe(37);
+      expect(result.minutes).toBe(46);
+      expect(Math.abs(result.seconds - 29.64)).toBeLessThan(0.000001);
+    });
+
+    test('throws error for negative precision', () => {
+      expect(() => decimalToDMS(37.7749, true, -1)).toThrow(/secondsPrecision.*range/i);
+    });
+
+    test('throws error for precision > 6', () => {
+      expect(() => decimalToDMS(37.7749, true, 7)).toThrow(/secondsPrecision.*range/i);
+    });
+
+    test('throws error for non-integer precision', () => {
+      expect(() => decimalToDMS(37.7749, true, 2.5)).toThrow(/secondsPrecision/i);
+    });
+
+    test.each([
+      [0, 29, 30],           // ±30m accuracy
+      [1, 29.6, 29.7],       // ±3m accuracy
+      [2, 29.63, 29.65],     // ±30cm accuracy
+      [3, 29.639, 29.641],   // ±3cm accuracy
+      [4, 29.6399, 29.6401], // ±3mm accuracy
+    ])(
+      'precision=%i produces seconds in range [%f, %f]',
+      (precision, expectedMin, expectedMax) => {
+        // Act: Convert with specified precision
+        const result = decimalToDMS(37.7749, true, precision);
+
+        // Assert: Verify seconds in expected range
+        expect(result.seconds).toBeGreaterThanOrEqual(expectedMin);
+        expect(result.seconds).toBeLessThanOrEqual(expectedMax);
+      }
+    );
+  });
+
+  describe('formatCoordinateDisplay with precision', () => {
+    test('formats with different precision values', () => {
+      // Act: Format with different precisions
+      const fmt0 = formatCoordinateDisplay(37.7749, true, 'dms', 0);
+      const fmt2 = formatCoordinateDisplay(37.7749, true, 'dms', 2);
+      const fmt4 = formatCoordinateDisplay(37.7749, true, 'dms', 4);
+
+      // Assert: Verify different format strings
+      expect(fmt0).toContain("37°46'");
+      expect(fmt0).toContain('"N');
+      expect(fmt2).toContain("37°46'");
+      expect(fmt2).toContain('"N');
+      expect(fmt4).toContain("37°46'");
+      expect(fmt4).toContain('"N');
+
+      // Verify precision affects decimal places in output
+      // precision=0: "30\"N" or "29\"N"
+      expect(fmt0).toMatch(/\d+"N/);
+      // precision=2: "29.64\"N"
+      expect(fmt2).toMatch(/\d+\.\d{2}"N/);
+      // precision=4: "29.6400\"N"
+      expect(fmt4).toMatch(/\d+\.\d{4}"N/);
+    });
+
+    test('precision only affects DMS format, not decimal or short', () => {
+      // Act: Format with different formats
+      const dms = formatCoordinateDisplay(37.7749, true, 'dms', 4);
+      const decimal = formatCoordinateDisplay(37.7749, true, 'decimal', 4);
+      const short = formatCoordinateDisplay(37.7749, true, 'short', 4);
+
+      // Assert: DMS should be affected, others should not
+      expect(dms).toContain("37°46'");
+      expect(decimal).toContain('37.774900°N'); // Always 6 decimal places
+      expect(short).toContain('37.77°N'); // Always 2 decimal places
+    });
+  });
+
+  describe('formatCoordinatePair with precision', () => {
+    test('formats coordinate pair with custom precision', () => {
+      // Act: Format with precision=4
+      const result = formatCoordinatePair(37.7749, -122.4194, 'dms', 4);
+
+      // Assert: Verify both coordinates present
+      expect(result).toContain("37°46'");
+      expect(result).toContain("122°25'");
+      expect(result).toContain('N');
+      expect(result).toContain('W');
+
+      // Verify 4 decimal places in seconds
+      expect(result).toMatch(/\d+\.\d{4}"/);
+    });
+
+    test('uses default precision=2 when not specified', () => {
+      // Act: Format without precision parameter
+      const result = formatCoordinatePair(37.7749, -122.4194);
+
+      // Assert: Should use default precision=2
+      expect(result).toContain("37°46'");
+      expect(result).toMatch(/\d+\.\d{2}"/); // 2 decimal places
+    });
+  });
+});

--- a/Firmware/webui/frontend/src/utils/__tests__/gpsPrecision.test.js
+++ b/Firmware/webui/frontend/src/utils/__tests__/gpsPrecision.test.js
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  GPS_PRECISION_OPTIONS,
+  getGpsPrecision,
+  setGpsPrecision,
+} from '../gpsPrecision'
+
+describe('gpsPrecision', () => {
+  beforeEach(() => {
+    // Clear localStorage before each test
+    localStorage.clear()
+  })
+
+  describe('GPS_PRECISION_OPTIONS', () => {
+    it('has 7 precision levels (0-6)', () => {
+      expect(GPS_PRECISION_OPTIONS).toHaveLength(7)
+    })
+
+    it('includes all required precision values', () => {
+      const values = GPS_PRECISION_OPTIONS.map(o => o.value)
+      expect(values).toEqual([0, 1, 2, 3, 4, 5, 6])
+    })
+
+    it('has label and description for each option', () => {
+      GPS_PRECISION_OPTIONS.forEach(option => {
+        expect(option.label).toBeDefined()
+        expect(option.description).toBeDefined()
+        expect(typeof option.label).toBe('string')
+        expect(typeof option.description).toBe('string')
+      })
+    })
+  })
+
+  describe('getGpsPrecision', () => {
+    it('returns default value of 2 when localStorage is empty', () => {
+      expect(getGpsPrecision()).toBe(2)
+    })
+
+    it('returns stored value from localStorage', () => {
+      localStorage.setItem('mothbox_gps_precision', '4')
+      expect(getGpsPrecision()).toBe(4)
+    })
+
+    it('returns default value for invalid stored values', () => {
+      localStorage.setItem('mothbox_gps_precision', 'invalid')
+      expect(getGpsPrecision()).toBe(2)
+    })
+
+    it('returns default value for out-of-range values (negative)', () => {
+      localStorage.setItem('mothbox_gps_precision', '-1')
+      expect(getGpsPrecision()).toBe(2)
+    })
+
+    it('returns default value for out-of-range values (> 6)', () => {
+      localStorage.setItem('mothbox_gps_precision', '7')
+      expect(getGpsPrecision()).toBe(2)
+    })
+
+    it('handles all valid precision values', () => {
+      for (let i = 0; i <= 6; i++) {
+        localStorage.setItem('mothbox_gps_precision', String(i))
+        expect(getGpsPrecision()).toBe(i)
+      }
+    })
+  })
+
+  describe('setGpsPrecision', () => {
+    it('stores precision value in localStorage', () => {
+      setGpsPrecision(3)
+      expect(localStorage.getItem('mothbox_gps_precision')).toBe('3')
+    })
+
+    it('stores precision as string', () => {
+      setGpsPrecision(5)
+      const stored = localStorage.getItem('mothbox_gps_precision')
+      expect(typeof stored).toBe('string')
+      expect(stored).toBe('5')
+    })
+
+    it('overwrites previous value', () => {
+      setGpsPrecision(1)
+      expect(localStorage.getItem('mothbox_gps_precision')).toBe('1')
+      setGpsPrecision(4)
+      expect(localStorage.getItem('mothbox_gps_precision')).toBe('4')
+    })
+
+    it('can be retrieved by getGpsPrecision', () => {
+      setGpsPrecision(6)
+      expect(getGpsPrecision()).toBe(6)
+    })
+  })
+
+  describe('localStorage unavailable', () => {
+    it('getGpsPrecision returns default when localStorage throws', () => {
+      const originalGetItem = localStorage.getItem
+      localStorage.getItem = vi.fn(() => {
+        throw new Error('localStorage disabled')
+      })
+
+      expect(getGpsPrecision()).toBe(2)
+
+      localStorage.getItem = originalGetItem
+    })
+
+    it('setGpsPrecision handles localStorage errors gracefully', () => {
+      const originalSetItem = localStorage.setItem
+      localStorage.setItem = vi.fn(() => {
+        throw new Error('localStorage disabled')
+      })
+
+      // Should not throw
+      expect(() => setGpsPrecision(3)).not.toThrow()
+
+      localStorage.setItem = originalSetItem
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/utils/gpsCoordinates.ts
+++ b/Firmware/webui/frontend/src/utils/gpsCoordinates.ts
@@ -56,8 +56,9 @@ export type CoordinateType = 'latitude' | 'longitude';
  *
  * @param decimal - Decimal degrees (e.g., 37.7749 or -122.4194)
  * @param isLatitude - True if latitude, False if longitude
+ * @param secondsPrecision - Number of decimal places for seconds (0-6, default 2)
  * @returns DMS coordinate with degrees, minutes, seconds, and reference
- * @throws Error if coordinate is invalid (out of range, NaN, infinity)
+ * @throws Error if coordinate is invalid (out of range, NaN, infinity) or secondsPrecision is invalid
  *
  * @example
  * ```typescript
@@ -66,9 +67,23 @@ export type CoordinateType = 'latitude' | 'longitude';
  *
  * decimalToDMS(-122.4194, false);
  * // Returns: { degrees: 122, minutes: 25, seconds: 9.84, reference: 'W' }
+ *
+ * decimalToDMS(37.7749, true, 4);
+ * // Returns: { degrees: 37, minutes: 46, seconds: 29.6400, reference: 'N' }
  * ```
  */
-export function decimalToDMS(decimal: number, isLatitude: boolean): DMSCoordinate {
+export function decimalToDMS(
+  decimal: number,
+  isLatitude: boolean,
+  secondsPrecision: number = 2
+): DMSCoordinate {
+  // 0. Validate secondsPrecision
+  if (!Number.isInteger(secondsPrecision) || secondsPrecision < 0 || secondsPrecision > 6) {
+    throw new Error(
+      `Invalid secondsPrecision: ${secondsPrecision} (must be integer in range [0, 6])`
+    );
+  }
+
   // 1. Validate input is not null/undefined
   if (decimal === null || decimal === undefined) {
     throw new Error('Coordinate cannot be null or undefined');
@@ -113,8 +128,9 @@ export function decimalToDMS(decimal: number, isLatitude: boolean): DMSCoordinat
   // 9. Extract seconds (remaining fractional minutes * 60)
   const secondsDecimal = (minutesDecimal - minutes) * 60;
 
-  // 10. Round to 2 decimal places (matching Python's round(x, 2))
-  let seconds = Math.round(secondsDecimal * 100) / 100;
+  // 10. Round to specified precision
+  const multiplier = Math.pow(10, secondsPrecision);
+  let seconds = Math.round(secondsDecimal * multiplier) / multiplier;
 
   // 11. Handle seconds overflow (rounding 59.995 -> 60.00)
   if (seconds >= 60.0) {
@@ -252,8 +268,9 @@ export function validateCoordinate(
  * @param decimal - Decimal degrees
  * @param isLatitude - True if latitude, False if longitude
  * @param format - Display format ('dms', 'decimal', or 'short')
+ * @param secondsPrecision - Number of decimal places for seconds in DMS format (0-6, default 2)
  * @returns Formatted coordinate string
- * @throws Error if coordinate is invalid or format is invalid
+ * @throws Error if coordinate is invalid, format is invalid, or secondsPrecision is invalid
  *
  * @example
  * ```typescript
@@ -265,17 +282,25 @@ export function validateCoordinate(
  *
  * formatCoordinateDisplay(37.7749, true, 'short');
  * // Returns: "37.77°N"
+ *
+ * formatCoordinateDisplay(37.7749, true, 'dms', 4);
+ * // Returns: "37°46'29.6400\"N"
  * ```
  */
 export function formatCoordinateDisplay(
   decimal: number,
   isLatitude: boolean,
-  format: CoordinateFormat = 'dms'
+  format: CoordinateFormat = 'dms',
+  secondsPrecision: number = 2
 ): string {
   if (format === 'dms') {
     // DMS format: "37°46'29.64\"N"
-    const { degrees, minutes, seconds, reference } = decimalToDMS(decimal, isLatitude);
-    return `${degrees}°${minutes}'${seconds.toFixed(2)}"${reference}`;
+    const { degrees, minutes, seconds, reference } = decimalToDMS(
+      decimal,
+      isLatitude,
+      secondsPrecision
+    );
+    return `${degrees}°${minutes}'${seconds.toFixed(secondsPrecision)}"${reference}`;
   } else if (format === 'decimal') {
     // Decimal format: "37.774900°N" (6 decimal places)
     const reference = isLatitude
@@ -302,8 +327,9 @@ export function formatCoordinateDisplay(
  * @param latitude - Latitude in decimal degrees (-90.0 to 90.0)
  * @param longitude - Longitude in decimal degrees (-180.0 to 180.0)
  * @param format - Display format ('dms', 'decimal', or 'short')
+ * @param secondsPrecision - Number of decimal places for seconds in DMS format (0-6, default 2)
  * @returns Formatted string: "LAT_STRING LON_STRING"
- * @throws Error if either coordinate is invalid
+ * @throws Error if either coordinate is invalid or secondsPrecision is invalid
  *
  * @example
  * ```typescript
@@ -315,12 +341,16 @@ export function formatCoordinateDisplay(
  *
  * formatCoordinatePair(37.7749, -122.4194, 'short');
  * // Returns: "37.77°N 122.42°W"
+ *
+ * formatCoordinatePair(37.7749, -122.4194, 'dms', 4);
+ * // Returns: "37°46'29.6400\"N 122°25'9.8400\"W"
  * ```
  */
 export function formatCoordinatePair(
   latitude: number,
   longitude: number,
-  format: CoordinateFormat = 'dms'
+  format: CoordinateFormat = 'dms',
+  secondsPrecision: number = 2
 ): string {
   // Validate latitude
   const latValidation = validateCoordinate(latitude, 'latitude');
@@ -335,8 +365,8 @@ export function formatCoordinatePair(
   }
 
   // Format both coordinates
-  const latStr = formatCoordinateDisplay(latitude, true, format);
-  const lonStr = formatCoordinateDisplay(longitude, false, format);
+  const latStr = formatCoordinateDisplay(latitude, true, format, secondsPrecision);
+  const lonStr = formatCoordinateDisplay(longitude, false, format, secondsPrecision);
 
   return `${latStr} ${lonStr}`;
 }

--- a/Firmware/webui/frontend/src/utils/gpsPrecision.js
+++ b/Firmware/webui/frontend/src/utils/gpsPrecision.js
@@ -1,0 +1,49 @@
+/**
+ * GPS Precision Preference Utilities
+ *
+ * Manages the user's GPS coordinate precision preference stored in localStorage.
+ * Used by GPSSettings component and other components that display GPS coordinates.
+ */
+
+// GPS Precision options with accuracy descriptions
+export const GPS_PRECISION_OPTIONS = [
+  { value: 0, label: '0 decimals (±30m)', description: 'Coarse location' },
+  { value: 1, label: '1 decimal (±3m)', description: 'City block' },
+  { value: 2, label: '2 decimals (±30cm)', description: 'Standard GPS' },
+  { value: 3, label: '3 decimals (±3cm)', description: 'High precision' },
+  { value: 4, label: '4 decimals (±3mm)', description: 'Survey grade' },
+  { value: 5, label: '5 decimals (±0.3mm)', description: 'Scientific' },
+  { value: 6, label: '6 decimals (±0.03mm)', description: 'Maximum' },
+]
+
+// LocalStorage key for GPS precision preference
+const GPS_PRECISION_KEY = 'mothbox_gps_precision'
+
+/**
+ * Get stored GPS precision or default to 2 decimal places
+ * @returns {number} Precision value (0-6)
+ */
+export function getGpsPrecision() {
+  try {
+    const stored = localStorage.getItem(GPS_PRECISION_KEY)
+    if (stored !== null) {
+      const value = parseInt(stored, 10)
+      if (value >= 0 && value <= 6) return value
+    }
+  } catch {
+    // localStorage not available
+  }
+  return 2 // Default precision
+}
+
+/**
+ * Set GPS precision preference in localStorage
+ * @param {number} precision - Precision value (0-6)
+ */
+export function setGpsPrecision(precision) {
+  try {
+    localStorage.setItem(GPS_PRECISION_KEY, String(precision))
+  } catch {
+    // localStorage not available
+  }
+}

--- a/Firmware/webui/frontend/src/utils/gpsPrecision.js
+++ b/Firmware/webui/frontend/src/utils/gpsPrecision.js
@@ -39,11 +39,14 @@ export function getGpsPrecision() {
 /**
  * Set GPS precision preference in localStorage
  * @param {number} precision - Precision value (0-6)
+ * @returns {boolean} True if saved successfully, false if localStorage unavailable
  */
 export function setGpsPrecision(precision) {
   try {
     localStorage.setItem(GPS_PRECISION_KEY, String(precision))
-  } catch {
-    // localStorage not available
+    return true
+  } catch (error) {
+    console.warn('Failed to save GPS precision preference:', error)
+    return false
   }
 }

--- a/Firmware/webui/shared/gps_coordinates.py
+++ b/Firmware/webui/shared/gps_coordinates.py
@@ -9,9 +9,29 @@ core coordinate math from the EXIF-specific implementation in webui/backend/lib/
 """
 
 import math
-from typing import Literal
+from typing import Literal, NamedTuple
+
+
+class DMSCoordinate(NamedTuple):
+    """Represents a coordinate in Degrees, Minutes, Seconds format.
+
+    This NamedTuple provides named field access for better IDE support while
+    remaining fully backward-compatible with tuple unpacking and indexing.
+
+    Attributes:
+        degrees: Integer degrees (0-180)
+        minutes: Integer minutes (0-59)
+        seconds: Float seconds (0.0-59.999...)
+        reference: Cardinal direction ('N', 'S', 'E', or 'W')
+    """
+
+    degrees: int
+    minutes: int
+    seconds: float
+    reference: str
 
 __all__ = [
+    "DMSCoordinate",
     "decimal_to_dms",
     "dms_to_decimal",
     "format_coordinate_display",
@@ -59,7 +79,7 @@ def validate_coordinate(decimal: float, is_latitude: bool) -> bool:
 
 def decimal_to_dms(
     decimal: float, is_latitude: bool, seconds_precision: int = 2
-) -> tuple[int, int, float, str]:
+) -> DMSCoordinate:
     """Convert decimal degrees to DMS format.
 
     Args:
@@ -68,7 +88,7 @@ def decimal_to_dms(
         seconds_precision: Number of decimal places for seconds (0-6, default 2)
 
     Returns:
-        Tuple of (degrees, minutes, seconds, reference)
+        DMSCoordinate with named fields:
         - degrees: Integer degrees (0-180)
         - minutes: Integer minutes (0-59)
         - seconds: Float seconds (0.0-59.999...)
@@ -80,11 +100,11 @@ def decimal_to_dms(
 
     Example:
         >>> decimal_to_dms(37.7749, is_latitude=True)
-        (37, 46, 29.64, 'N')
+        DMSCoordinate(degrees=37, minutes=46, seconds=29.64, reference='N')
         >>> decimal_to_dms(-122.4194, is_latitude=False)
-        (122, 25, 9.84, 'W')
+        DMSCoordinate(degrees=122, minutes=25, seconds=9.84, reference='W')
         >>> decimal_to_dms(37.7749, is_latitude=True, seconds_precision=4)
-        (37, 46, 29.6400, 'N')
+        DMSCoordinate(degrees=37, minutes=46, seconds=29.64, reference='N')
     """
     # Validate seconds_precision
     if not isinstance(seconds_precision, int) or not (0 <= seconds_precision <= 6):
@@ -140,7 +160,7 @@ def decimal_to_dms(
         degrees += 1
         minutes = 0
 
-    return (degrees, minutes, seconds, ref)
+    return DMSCoordinate(degrees, minutes, seconds, ref)
 
 
 def dms_to_decimal(degrees: int, minutes: int, seconds: float, ref: str) -> float:

--- a/Firmware/webui/shared/gps_coordinates.py
+++ b/Firmware/webui/shared/gps_coordinates.py
@@ -57,12 +57,15 @@ def validate_coordinate(decimal: float, is_latitude: bool) -> bool:
         return -180 <= decimal <= 180
 
 
-def decimal_to_dms(decimal: float, is_latitude: bool) -> tuple[int, int, float, str]:
+def decimal_to_dms(
+    decimal: float, is_latitude: bool, seconds_precision: int = 2
+) -> tuple[int, int, float, str]:
     """Convert decimal degrees to DMS format.
 
     Args:
         decimal: Decimal degrees (e.g., 37.7749 or -122.4194)
         is_latitude: True if latitude, False if longitude
+        seconds_precision: Number of decimal places for seconds (0-6, default 2)
 
     Returns:
         Tuple of (degrees, minutes, seconds, reference)
@@ -72,14 +75,23 @@ def decimal_to_dms(decimal: float, is_latitude: bool) -> tuple[int, int, float, 
         - reference: 'N', 'S', 'E', or 'W'
 
     Raises:
-        ValueError: If coordinate is invalid (out of range, NaN, infinity)
+        ValueError: If coordinate is invalid (out of range, NaN, infinity) or
+                    if seconds_precision is out of range
 
     Example:
         >>> decimal_to_dms(37.7749, is_latitude=True)
         (37, 46, 29.64, 'N')
         >>> decimal_to_dms(-122.4194, is_latitude=False)
         (122, 25, 9.84, 'W')
+        >>> decimal_to_dms(37.7749, is_latitude=True, seconds_precision=4)
+        (37, 46, 29.6400, 'N')
     """
+    # Validate seconds_precision
+    if not isinstance(seconds_precision, int) or not (0 <= seconds_precision <= 6):
+        raise ValueError(
+            f"Invalid seconds_precision: {seconds_precision} (must be integer in range [0, 6])"
+        )
+
     # Validate input coordinate
     if decimal is None:
         raise ValueError("Coordinate cannot be None")
@@ -115,8 +127,8 @@ def decimal_to_dms(decimal: float, is_latitude: bool) -> tuple[int, int, float, 
     # Extract seconds (remaining fractional minutes * 60)
     seconds_decimal = (minutes_decimal - minutes) * 60
 
-    # Round to 2 decimal places
-    seconds = round(seconds_decimal, 2)
+    # Round to specified precision
+    seconds = round(seconds_decimal, seconds_precision)
 
     # Handle seconds overflow (rounding 59.995 -> 60.00)
     if seconds >= 60.0:
@@ -167,7 +179,10 @@ def dms_to_decimal(degrees: int, minutes: int, seconds: float, ref: str) -> floa
 
 
 def format_coordinate_display(
-    decimal: float, is_latitude: bool, format: Literal["dms", "decimal", "short"] = "dms"
+    decimal: float,
+    is_latitude: bool,
+    format: Literal["dms", "decimal", "short"] = "dms",
+    seconds_precision: int = 2,
 ) -> str:
     """Format a coordinate for display.
 
@@ -178,12 +193,13 @@ def format_coordinate_display(
             - 'dms': Degrees, minutes, seconds with symbols (e.g., "37°46'29.64\"N")
             - 'decimal': Decimal degrees with direction (e.g., "37.774900°N")
             - 'short': Short decimal with direction (e.g., "37.77°N")
+        seconds_precision: Number of decimal places for seconds in DMS format (0-6, default 2)
 
     Returns:
         Formatted coordinate string
 
     Raises:
-        ValueError: If coordinate is invalid
+        ValueError: If coordinate is invalid or seconds_precision is out of range
 
     Example:
         >>> format_coordinate_display(37.7749, is_latitude=True, format="dms")
@@ -192,10 +208,12 @@ def format_coordinate_display(
         '37.774900°N'
         >>> format_coordinate_display(37.7749, is_latitude=True, format="short")
         '37.77°N'
+        >>> format_coordinate_display(37.7749, is_latitude=True, format="dms", seconds_precision=4)
+        "37°46'29.6400\\"N"
     """
     if format == "dms":
-        deg, min, sec, ref = decimal_to_dms(decimal, is_latitude)
-        return f"{deg}°{min}'{sec:.2f}\"{ref}"
+        deg, min, sec, ref = decimal_to_dms(decimal, is_latitude, seconds_precision)
+        return f"{deg}°{min}'{sec:.{seconds_precision}f}\"{ref}"
     elif format == "decimal":
         # Determine reference
         if is_latitude:  # noqa: SIM108  # More readable than nested ternary
@@ -217,7 +235,8 @@ def format_coordinate_display(
 def format_coordinate_pair(
     latitude: float,
     longitude: float,
-    format: Literal["dms", "decimal", "short"] = "dms"
+    format: Literal["dms", "decimal", "short"] = "dms",
+    seconds_precision: int = 2,
 ) -> str:
     """Format a coordinate pair (latitude, longitude) for display.
 
@@ -228,6 +247,7 @@ def format_coordinate_pair(
         latitude: Latitude in decimal degrees (-90.0 to 90.0)
         longitude: Longitude in decimal degrees (-180.0 to 180.0)
         format: Display format ('dms', 'decimal', or 'short')
+        seconds_precision: Number of decimal places for seconds in DMS format (0-6, default 2)
 
     Returns:
         Formatted string: "LAT_STRING LON_STRING"
@@ -237,7 +257,7 @@ def format_coordinate_pair(
             - Short: "37.77°N 122.42°W"
 
     Raises:
-        ValueError: If either coordinate is invalid
+        ValueError: If either coordinate is invalid or seconds_precision is out of range
 
     Example:
         >>> format_coordinate_pair(37.7749, -122.4194)
@@ -246,6 +266,8 @@ def format_coordinate_pair(
         '37.774900°N 122.419400°W'
         >>> format_coordinate_pair(37.7749, -122.4194, format='short')
         '37.77°N 122.42°W'
+        >>> format_coordinate_pair(37.7749, -122.4194, seconds_precision=4)
+        '37°46\\'29.6400"N 122°25\\'9.8400"W'
     """
     # Validate latitude
     if not validate_coordinate(latitude, is_latitude=True):
@@ -256,7 +278,11 @@ def format_coordinate_pair(
         raise ValueError(f"Invalid longitude: {longitude} (must be in range [-180, 180])")
 
     # Format both coordinates
-    lat_str = format_coordinate_display(latitude, is_latitude=True, format=format)
-    lon_str = format_coordinate_display(longitude, is_latitude=False, format=format)
+    lat_str = format_coordinate_display(
+        latitude, is_latitude=True, format=format, seconds_precision=seconds_precision
+    )
+    lon_str = format_coordinate_display(
+        longitude, is_latitude=False, format=format, seconds_precision=seconds_precision
+    )
 
     return f"{lat_str} {lon_str}"


### PR DESCRIPTION
## Summary

Adds configurable precision (0-6 decimal places) to GPS coordinate formatting functions and a UI dropdown in GPS Settings for user control.

### Changes

- **Core API (Python + TypeScript)**: Add `seconds_precision` parameter to `decimal_to_dms()`, `format_coordinate_display()`, and `format_coordinate_pair()`
- **GPS Settings UI**: Add precision dropdown with 7 levels from ±30m to ±0.03mm accuracy
- **Persistence**: Store user preference in localStorage (`mothbox_gps_precision`)
- **Tests**: 15 unit tests for precision utility, 107 TypeScript tests, 92 Python tests, 9 Playwright E2E tests

### Precision Levels

| Value | Accuracy | Use Case |
|-------|----------|----------|
| 0 | ±30m | Coarse location |
| 1 | ±3m | City block |
| 2 (default) | ±30cm | Standard GPS |
| 3 | ±3cm | High precision |
| 4 | ±3mm | Survey grade |
| 5 | ±0.3mm | Scientific |
| 6 | ±0.03mm | Maximum |

### Files Changed

- `webui/shared/gps_coordinates.py` - Python implementation
- `webui/frontend/src/utils/gpsCoordinates.ts` - TypeScript implementation
- `webui/frontend/src/utils/gpsPrecision.js` - Precision utility
- `webui/frontend/src/components/GPSSettings.jsx` - UI dropdown
- Test files for all components

Closes #158

## Test Plan

- [x] Python tests pass (92/92)
- [x] TypeScript tests pass (107/107)
- [x] GPS precision utility tests pass (15/15)
- [x] ESLint passes
- [x] Ruff passes
- [ ] Playwright E2E tests (require Pi hardware)