### PR TITLE
fix(scheduler): Add frontend JSON format support to Schedule.from_dict() (#280)

### DIFF
--- a/Firmware/Tests/unit/test_schedule_schema.py
+++ b/Firmware/Tests/unit/test_schedule_schema.py
@@ -1462,14 +1462,7 @@ class TestScheduleFromDictFrontendFormat:
 class TestFrontendFormatValidation:
     """Tests for validation of malformed frontend data."""
 
-    @pytest.fixture
-    def sample_event_pattern(self):
-        """Create a sample event pattern for testing."""
-        return EventPattern(
-            pattern_id="pattern-123",
-            name="Test Pattern",
-            actions=[PatternAction(action_type="gpio", action_name="attract_on")],
-        )
+    # Uses module-level sample_event_pattern fixture
 
     def test_missing_trigger_type(self, sample_event_pattern):
         """Empty trigger object should raise ValueError."""
@@ -1640,19 +1633,7 @@ class TestFrontendFormatValidation:
 class TestDeepCopyDefensiveProgramming:
     """Tests that verify deepcopy is used to prevent input mutation."""
 
-    @pytest.fixture
-    def sample_event_pattern(self):
-        """A sample event pattern for testing."""
-        return EventPattern(
-            pattern_id=str(uuid.uuid4()),
-            name="Test Pattern",
-            actions=[
-                PatternAction(
-                    action_type="gpio",
-                    action_name="attract_on",
-                )
-            ],
-        )
+    # Uses module-level sample_event_pattern fixture
 
     def test_from_dict_does_not_mutate_input(self, sample_event_pattern):
         """Schedule.from_dict should not mutate the input data."""

--- a/Firmware/Tests/unit/test_schedule_schema.py
+++ b/Firmware/Tests/unit/test_schedule_schema.py
@@ -1270,3 +1270,190 @@ class TestScheduleWithCronTrigger:
         restored = Schedule.from_dict(data)
         assert restored.trigger_type == "cron"
         assert restored.cron_trigger.cron_expression == "0 */2 * * *"
+
+
+# =============================================================================
+# FRONTEND FORMAT CONVERSION TESTS (Issue #280)
+# =============================================================================
+
+
+class TestScheduleFromDictFrontendFormat:
+    """Test Schedule.from_dict() with frontend JSON format conversion."""
+
+    def test_is_frontend_format_with_trigger_object(self):
+        """Returns True when 'trigger' key exists."""
+        data = {
+            "name": "Test",
+            "trigger": {"trigger_type": "interval", "interval_minutes": 60},
+        }
+        assert Schedule._is_frontend_format(data) is True
+
+    def test_is_frontend_format_without_trigger_object(self):
+        """Returns False for backend format."""
+        data = {
+            "name": "Test",
+            "trigger_type": "interval",
+            "interval_trigger": {"interval_minutes": 60},
+        }
+        assert Schedule._is_frontend_format(data) is False
+
+    def test_parse_frontend_interval_trigger(self):
+        """Converts flat interval fields."""
+        trigger_data = {
+            "trigger_type": "interval",
+            "interval_minutes": 60,
+            "time_window_start": "21:00",
+            "time_window_end": "05:00",
+            "days_of_week": [0, 1, 2, 3, 4, 5, 6],
+        }
+        result = Schedule._parse_interval_trigger_frontend(trigger_data)
+        assert isinstance(result, IntervalTrigger)
+        assert result.interval_minutes == 60
+        assert result.time_window.start_time == "21:00"
+        assert result.time_window.end_time == "05:00"
+        assert result.days_of_week == [0, 1, 2, 3, 4, 5, 6]
+
+    def test_parse_frontend_solar_trigger(self):
+        """Converts solar trigger."""
+        trigger_data = {
+            "trigger_type": "solar",
+            "solar_event": "sunset",
+            "offset_minutes": 30,
+            "days_of_week": [0, 1, 2, 3, 4],
+        }
+        result = Schedule._parse_solar_trigger_frontend(trigger_data)
+        assert isinstance(result, SolarTrigger)
+        assert result.solar_event == "sunset"
+        assert result.offset_minutes == 30
+        assert result.days_of_week == [0, 1, 2, 3, 4]
+
+    def test_parse_frontend_moon_phase_trigger(self):
+        """Converts moon_phase (string to list)."""
+        trigger_data = {
+            "trigger_type": "moon_phase",
+            "moon_phase": "full",
+            "time_of_day": "21:00",
+            "offset_days": 2,
+        }
+        result = Schedule._parse_moon_phase_trigger_frontend(trigger_data)
+        assert isinstance(result, MoonPhaseTrigger)
+        assert result.phases == ["full"]
+        assert result.offset_days == 2
+        assert result.time_window.start_time == "21:00"
+
+    def test_parse_frontend_fixed_time_trigger(self):
+        """Converts time_of_day to time."""
+        trigger_data = {
+            "trigger_type": "fixed_time",
+            "time_of_day": "21:00",
+            "days_of_week": [0, 1, 2, 3, 4, 5, 6],
+        }
+        result = Schedule._parse_fixed_time_trigger_frontend(trigger_data)
+        assert isinstance(result, FixedTimeTrigger)
+        assert result.time == "21:00"
+        assert result.days_of_week == [0, 1, 2, 3, 4, 5, 6]
+
+    def test_parse_frontend_sensor_trigger(self):
+        """Converts sensor fields."""
+        trigger_data = {
+            "trigger_type": "sensor",
+            "sensor_type": "motion",
+            "threshold": 0.0,
+            "comparison": "gt",
+            "cooldown_minutes": 5,
+        }
+        result = Schedule._parse_sensor_trigger_frontend(trigger_data)
+        assert isinstance(result, SensorTrigger)
+        assert result.sensor_type == "motion"
+        assert result.threshold == 0.0
+        assert result.comparison == "gt"
+        assert result.cooldown_minutes == 5
+
+    def test_parse_frontend_cron_trigger(self):
+        """Converts cron_expression."""
+        trigger_data = {
+            "trigger_type": "cron",
+            "cron_expression": "0 21 * * *",
+        }
+        result = Schedule._parse_cron_trigger_frontend(trigger_data)
+        assert isinstance(result, CronTrigger)
+        assert result.cron_expression == "0 21 * * *"
+
+    def test_from_dict_frontend_interval_full(self, sample_event_pattern):
+        """Full Schedule creation with interval."""
+        data = {
+            "schedule_id": "test-uuid-1234",
+            "name": "My Schedule",
+            "trigger": {
+                "trigger_type": "interval",
+                "interval_minutes": 60,
+                "time_window_start": "21:00",
+                "time_window_end": "05:00",
+                "days_of_week": [0, 1, 2, 3, 4, 5, 6],
+            },
+            "event_patterns": [sample_event_pattern.to_dict()],
+            "date_range": {"start_date": "2024-06-01", "end_date": "2024-08-31"},
+        }
+        schedule = Schedule.from_dict(data)
+        assert schedule.schedule_id == "test-uuid-1234"
+        assert schedule.name == "My Schedule"
+        assert schedule.trigger_type == "interval"
+        assert schedule.interval_trigger.interval_minutes == 60
+        assert schedule.interval_trigger.time_window.start_time == "21:00"
+        assert schedule.start_date == "2024-06-01"
+        assert schedule.end_date == "2024-08-31"
+
+    def test_from_dict_frontend_solar_full(self, sample_event_pattern):
+        """Full Schedule creation with solar."""
+        data = {
+            "schedule_id": "test-uuid-5678",
+            "name": "Solar Schedule",
+            "trigger": {
+                "trigger_type": "solar",
+                "solar_event": "sunset",
+                "offset_minutes": 30,
+                "days_of_week": [0, 1, 2, 3, 4],
+            },
+            "event_patterns": [sample_event_pattern.to_dict()],
+        }
+        schedule = Schedule.from_dict(data)
+        assert schedule.trigger_type == "solar"
+        assert schedule.solar_trigger.solar_event == "sunset"
+        assert schedule.solar_trigger.offset_minutes == 30
+        assert schedule.solar_trigger.days_of_week == [0, 1, 2, 3, 4]
+
+    def test_from_dict_frontend_with_date_range(self, sample_event_pattern):
+        """Unwraps date_range object."""
+        data = {
+            "name": "Date Range Test",
+            "trigger": {"trigger_type": "interval", "interval_minutes": 60},
+            "event_patterns": [sample_event_pattern.to_dict()],
+            "date_range": {"start_date": "2024-01-01", "end_date": "2024-12-31"},
+        }
+        schedule = Schedule.from_dict(data)
+        assert schedule.start_date == "2024-01-01"
+        assert schedule.end_date == "2024-12-31"
+
+    def test_from_dict_backend_format_still_works(
+        self, sample_event_pattern, sample_time_window
+    ):
+        """Backward compatibility."""
+        data = {
+            "schedule_id": "backend-uuid",
+            "name": "Backend Format Schedule",
+            "event_patterns": [sample_event_pattern.to_dict()],
+            "trigger_type": "interval",
+            "interval_trigger": {
+                "interval_minutes": 30,
+                "time_window": sample_time_window.to_dict(),
+                "days_of_week": [5, 6],
+            },
+            "start_date": "2024-01-01",
+            "end_date": "2024-12-31",
+        }
+        schedule = Schedule.from_dict(data)
+        assert schedule.schedule_id == "backend-uuid"
+        assert schedule.name == "Backend Format Schedule"
+        assert schedule.trigger_type == "interval"
+        assert schedule.interval_trigger.interval_minutes == 30
+        assert schedule.start_date == "2024-01-01"

--- a/Firmware/Tests/unit/test_schedule_schema.py
+++ b/Firmware/Tests/unit/test_schedule_schema.py
@@ -1612,6 +1612,30 @@ class TestFrontendFormatValidation:
         assert schedule.interval_trigger.time_window.start_time == "21:00"
         assert schedule.interval_trigger.time_window.end_time == "05:00"
 
+    def test_interval_trigger_nested_time_window_takes_priority(self, sample_event_pattern):
+        """Nested time_window object takes priority over flat time_window_start/end fields.
+
+        When both formats are present, the nested object wins. This documents
+        the expected behavior for conflicting inputs.
+        """
+        data = {
+            "name": "Test Schedule",
+            "trigger": {
+                "trigger_type": "interval",
+                "interval_minutes": 60,
+                # Nested object - should take priority
+                "time_window": {"start_time": "20:00", "end_time": "06:00"},
+                # Flat fields - should be ignored
+                "time_window_start": "21:00",
+                "time_window_end": "05:00",
+            },
+            "event_patterns": [sample_event_pattern.to_dict()],
+        }
+        schedule = Schedule.from_dict(data)
+        # Nested object wins
+        assert schedule.interval_trigger.time_window.start_time == "20:00"
+        assert schedule.interval_trigger.time_window.end_time == "06:00"
+
 
 class TestDeepCopyDefensiveProgramming:
     """Tests that verify deepcopy is used to prevent input mutation."""

--- a/Firmware/Tests/unit/test_schedule_schema.py
+++ b/Firmware/Tests/unit/test_schedule_schema.py
@@ -1547,8 +1547,8 @@ class TestFrontendFormatValidation:
         assert schedule.start_date is None
         assert schedule.end_date is None
 
-    def test_fixed_time_trigger_defaults_to_midnight(self, sample_event_pattern):
-        """Fixed time trigger defaults to 00:00 when time_of_day is missing."""
+    def test_missing_time_of_day(self, sample_event_pattern):
+        """Fixed time trigger without time_of_day should raise ValueError."""
         data = {
             "name": "Test Schedule",
             "trigger": {
@@ -1557,8 +1557,8 @@ class TestFrontendFormatValidation:
             },
             "event_patterns": [sample_event_pattern.to_dict()],
         }
-        schedule = Schedule.from_dict(data)
-        assert schedule.fixed_time_trigger.time == "00:00"
+        with pytest.raises(ValueError, match="time_of_day is required"):
+            Schedule.from_dict(data)
 
     def test_moon_phase_empty_string(self, sample_event_pattern):
         """Empty string moon_phase should raise ValueError."""

--- a/Firmware/Tests/unit/test_schedule_schema.py
+++ b/Firmware/Tests/unit/test_schedule_schema.py
@@ -1553,3 +1553,104 @@ class TestFrontendFormatValidation:
         schedule = Schedule.from_dict(data)
         assert schedule.start_date is None
         assert schedule.end_date is None
+
+    def test_fixed_time_trigger_defaults_to_midnight(self, sample_event_pattern):
+        """Fixed time trigger defaults to 00:00 when time_of_day is missing."""
+        data = {
+            "name": "Test Schedule",
+            "trigger": {
+                "trigger_type": "fixed_time",
+                "days_of_week": [0, 1, 2, 3, 4, 5, 6],
+            },
+            "event_patterns": [sample_event_pattern.to_dict()],
+        }
+        schedule = Schedule.from_dict(data)
+        assert schedule.fixed_time_trigger.time == "00:00"
+
+    def test_moon_phase_empty_string(self, sample_event_pattern):
+        """Empty string moon_phase should raise ValueError."""
+        data = {
+            "name": "Test Schedule",
+            "trigger": {"trigger_type": "moon_phase", "moon_phase": ""},
+            "event_patterns": [sample_event_pattern.to_dict()],
+        }
+        with pytest.raises(ValueError, match="moon_phase or phases is required"):
+            Schedule.from_dict(data)
+
+    def test_moon_phase_empty_list(self, sample_event_pattern):
+        """Empty list phases should raise ValueError."""
+        data = {
+            "name": "Test Schedule",
+            "trigger": {"trigger_type": "moon_phase", "phases": []},
+            "event_patterns": [sample_event_pattern.to_dict()],
+        }
+        with pytest.raises(ValueError, match="moon_phase or phases is required"):
+            Schedule.from_dict(data)
+
+    def test_moon_phase_none_value(self, sample_event_pattern):
+        """None moon_phase should raise ValueError."""
+        data = {
+            "name": "Test Schedule",
+            "trigger": {"trigger_type": "moon_phase", "moon_phase": None},
+            "event_patterns": [sample_event_pattern.to_dict()],
+        }
+        with pytest.raises(ValueError, match="moon_phase or phases is required"):
+            Schedule.from_dict(data)
+
+    def test_interval_trigger_nested_time_window(self, sample_event_pattern):
+        """Interval trigger with nested time_window format."""
+        data = {
+            "name": "Test Schedule",
+            "trigger": {
+                "trigger_type": "interval",
+                "interval_minutes": 60,
+                "time_window": {"start_time": "21:00", "end_time": "05:00"},
+            },
+            "event_patterns": [sample_event_pattern.to_dict()],
+        }
+        schedule = Schedule.from_dict(data)
+        assert schedule.interval_trigger.time_window.start_time == "21:00"
+        assert schedule.interval_trigger.time_window.end_time == "05:00"
+
+
+class TestDeepCopyDefensiveProgramming:
+    """Tests that verify deepcopy is used to prevent input mutation."""
+
+    @pytest.fixture
+    def sample_event_pattern(self):
+        """A sample event pattern for testing."""
+        return EventPattern(
+            pattern_id=str(uuid.uuid4()),
+            name="Test Pattern",
+            actions=[
+                PatternAction(
+                    action_type="gpio",
+                    action_name="attract_on",
+                )
+            ],
+        )
+
+    def test_from_dict_does_not_mutate_input(self, sample_event_pattern):
+        """Schedule.from_dict should not mutate the input data."""
+        original_trigger = {
+            "trigger_type": "interval",
+            "interval_minutes": 60,
+            "time_window": {"start_time": "20:00", "end_time": "06:00"},
+        }
+        data = {
+            "name": "Test Schedule",
+            "trigger": original_trigger.copy(),
+            "event_patterns": [sample_event_pattern.to_dict()],
+            "date_range": {"start_date": "2025-01-01", "end_date": "2025-12-31"},
+        }
+
+        # Make a deep copy to compare after
+        import copy
+
+        original_data = copy.deepcopy(data)
+
+        # Parse the schedule
+        Schedule.from_dict(data)
+
+        # Input should not be mutated
+        assert data == original_data

--- a/Firmware/Tests/unit/test_schedule_schema.py
+++ b/Firmware/Tests/unit/test_schedule_schema.py
@@ -1457,3 +1457,99 @@ class TestScheduleFromDictFrontendFormat:
         assert schedule.trigger_type == "interval"
         assert schedule.interval_trigger.interval_minutes == 30
         assert schedule.start_date == "2024-01-01"
+
+
+class TestFrontendFormatValidation:
+    """Tests for validation of malformed frontend data."""
+
+    @pytest.fixture
+    def sample_event_pattern(self):
+        """Create a sample event pattern for testing."""
+        return EventPattern(
+            pattern_id="pattern-123",
+            name="Test Pattern",
+            actions=[PatternAction(action_type="gpio", action_name="attract_on")],
+        )
+
+    def test_missing_trigger_type(self, sample_event_pattern):
+        """Empty trigger object should raise ValueError."""
+        data = {
+            "name": "Test Schedule",
+            "trigger": {},
+            "event_patterns": [sample_event_pattern.to_dict()],
+        }
+        with pytest.raises(ValueError, match="trigger_type is required"):
+            Schedule.from_dict(data)
+
+    def test_invalid_trigger_type(self, sample_event_pattern):
+        """Unknown trigger type should raise ValueError."""
+        data = {
+            "name": "Test Schedule",
+            "trigger": {"trigger_type": "unknown_type"},
+            "event_patterns": [sample_event_pattern.to_dict()],
+        }
+        with pytest.raises(ValueError, match="Unknown trigger_type"):
+            Schedule.from_dict(data)
+
+    def test_missing_interval_minutes(self, sample_event_pattern):
+        """Interval trigger without interval_minutes should raise ValueError."""
+        data = {
+            "name": "Test Schedule",
+            "trigger": {"trigger_type": "interval"},
+            "event_patterns": [sample_event_pattern.to_dict()],
+        }
+        with pytest.raises(ValueError, match="interval_minutes is required"):
+            Schedule.from_dict(data)
+
+    def test_missing_solar_event(self, sample_event_pattern):
+        """Solar trigger without solar_event should raise ValueError."""
+        data = {
+            "name": "Test Schedule",
+            "trigger": {"trigger_type": "solar"},
+            "event_patterns": [sample_event_pattern.to_dict()],
+        }
+        with pytest.raises(ValueError, match="solar_event is required"):
+            Schedule.from_dict(data)
+
+    def test_missing_moon_phase(self, sample_event_pattern):
+        """Moon phase trigger without phases should raise ValueError."""
+        data = {
+            "name": "Test Schedule",
+            "trigger": {"trigger_type": "moon_phase"},
+            "event_patterns": [sample_event_pattern.to_dict()],
+        }
+        with pytest.raises(ValueError, match="moon_phase or phases is required"):
+            Schedule.from_dict(data)
+
+    def test_missing_sensor_type(self, sample_event_pattern):
+        """Sensor trigger without sensor_type should raise ValueError."""
+        data = {
+            "name": "Test Schedule",
+            "trigger": {"trigger_type": "sensor"},
+            "event_patterns": [sample_event_pattern.to_dict()],
+        }
+        with pytest.raises(ValueError, match="sensor_type is required"):
+            Schedule.from_dict(data)
+
+    def test_missing_cron_expression(self, sample_event_pattern):
+        """Cron trigger without cron_expression should raise ValueError."""
+        data = {
+            "name": "Test Schedule",
+            "trigger": {"trigger_type": "cron"},
+            "event_patterns": [sample_event_pattern.to_dict()],
+        }
+        with pytest.raises(ValueError, match="cron_expression is required"):
+            Schedule.from_dict(data)
+
+    def test_null_date_range(self, sample_event_pattern):
+        """Null date_range should not cause errors."""
+        data = {
+            "name": "Test Schedule",
+            "trigger": {"trigger_type": "interval", "interval_minutes": 60},
+            "event_patterns": [sample_event_pattern.to_dict()],
+            "date_range": None,
+        }
+        # Should not raise - None date_range is valid
+        schedule = Schedule.from_dict(data)
+        assert schedule.start_date is None
+        assert schedule.end_date is None

--- a/Firmware/webui/backend/lib/schedule_schema.py
+++ b/Firmware/webui/backend/lib/schedule_schema.py
@@ -739,6 +739,9 @@ class Schedule:
                 end_offset_minutes=data.get('end_offset_minutes', 0),
             )
 
+        if 'interval_minutes' not in data:
+            raise ValueError("interval_minutes is required for interval trigger")
+
         return IntervalTrigger(
             interval_minutes=data['interval_minutes'],
             time_window=time_window,
@@ -748,6 +751,9 @@ class Schedule:
     @staticmethod
     def _parse_solar_trigger_frontend(data: dict) -> SolarTrigger:
         """Parse frontend solar trigger format."""
+        if 'solar_event' not in data:
+            raise ValueError("solar_event is required for solar trigger")
+
         return SolarTrigger(
             solar_event=data['solar_event'],
             offset_minutes=data.get('offset_minutes', 0),
@@ -766,6 +772,9 @@ class Schedule:
         # Wrap single phase in list
         phase = data.get('moon_phase')
         phases = [phase] if isinstance(phase, str) else data.get('phases', [])
+
+        if not phases:
+            raise ValueError("moon_phase or phases is required for moon phase trigger")
 
         # Convert time_of_day to time_window
         time_window = None
@@ -800,6 +809,9 @@ class Schedule:
     @staticmethod
     def _parse_sensor_trigger_frontend(data: dict) -> SensorTrigger:
         """Parse frontend sensor trigger format."""
+        if 'sensor_type' not in data:
+            raise ValueError("sensor_type is required for sensor trigger")
+
         time_window = None
         if 'time_window' in data and data['time_window']:
             time_window = TimeWindow.from_dict(data['time_window'])
@@ -815,6 +827,9 @@ class Schedule:
     @staticmethod
     def _parse_cron_trigger_frontend(data: dict) -> CronTrigger:
         """Parse frontend cron trigger format."""
+        if 'cron_expression' not in data:
+            raise ValueError("cron_expression is required for cron trigger")
+
         return CronTrigger(
             cron_expression=data['cron_expression'],
         )
@@ -830,6 +845,13 @@ class Schedule:
             Dict with trigger_type and corresponding typed trigger object
         """
         trigger_type = trigger_data.get('trigger_type')
+
+        if not trigger_type:
+            raise ValueError("trigger_type is required")
+
+        valid_types = {'interval', 'solar', 'moon_phase', 'fixed_time', 'sensor', 'cron'}
+        if trigger_type not in valid_types:
+            raise ValueError(f"Unknown trigger_type: {trigger_type}")
 
         result = {'trigger_type': trigger_type}
 
@@ -875,7 +897,7 @@ class Schedule:
         # Unwrap date_range if present
         if 'date_range' in converted:
             date_range = converted.pop('date_range')
-            if isinstance(date_range, dict):
+            if date_range and isinstance(date_range, dict):
                 converted['start_date'] = date_range.get('start_date')
                 converted['end_date'] = date_range.get('end_date')
 

--- a/Firmware/webui/backend/lib/schedule_schema.py
+++ b/Firmware/webui/backend/lib/schedule_schema.py
@@ -710,9 +710,194 @@ class Schedule:
             "modified_by": self.modified_by,
         }
 
+    @staticmethod
+    def _is_frontend_format(data: dict) -> bool:
+        """Detect if data uses frontend JSON format.
+
+        Frontend format has a nested 'trigger' object containing trigger_type and all config.
+        Backend format has trigger_type at top level with separate trigger objects.
+        """
+        return 'trigger' in data and isinstance(data.get('trigger'), dict)
+
+    @staticmethod
+    def _parse_interval_trigger_frontend(data: dict) -> IntervalTrigger:
+        """Parse frontend interval trigger format.
+
+        Frontend sends:
+        - interval_minutes
+        - time_window_start, time_window_end (or nested time_window)
+        - days_of_week
+        """
+        # Handle both flat and nested time_window formats
+        if 'time_window' in data and isinstance(data['time_window'], dict):
+            time_window = TimeWindow.from_dict(data['time_window'])
+        else:
+            time_window = TimeWindow(
+                start_time=data.get('time_window_start', '00:00'),
+                end_time=data.get('time_window_end', '23:59'),
+                start_offset_minutes=data.get('start_offset_minutes', 0),
+                end_offset_minutes=data.get('end_offset_minutes', 0),
+            )
+
+        return IntervalTrigger(
+            interval_minutes=data['interval_minutes'],
+            time_window=time_window,
+            days_of_week=data.get('days_of_week'),
+        )
+
+    @staticmethod
+    def _parse_solar_trigger_frontend(data: dict) -> SolarTrigger:
+        """Parse frontend solar trigger format."""
+        return SolarTrigger(
+            solar_event=data['solar_event'],
+            offset_minutes=data.get('offset_minutes', 0),
+            days_of_week=data.get('days_of_week'),
+        )
+
+    @staticmethod
+    def _parse_moon_phase_trigger_frontend(data: dict) -> MoonPhaseTrigger:
+        """Parse frontend moon phase trigger format.
+
+        Frontend sends:
+        - moon_phase: single string (wrap in list for backend)
+        - time_of_day: single time string (convert to time_window)
+        - offset_days
+        """
+        # Wrap single phase in list
+        phase = data.get('moon_phase')
+        phases = [phase] if isinstance(phase, str) else data.get('phases', [])
+
+        # Convert time_of_day to time_window
+        time_window = None
+        if 'time_of_day' in data:
+            time_of_day = data['time_of_day']
+            time_window = TimeWindow(
+                start_time=time_of_day,
+                end_time=time_of_day,
+            )
+        elif 'time_window' in data and data['time_window']:
+            time_window = TimeWindow.from_dict(data['time_window'])
+
+        return MoonPhaseTrigger(
+            phases=phases,
+            offset_days=data.get('offset_days', 0),
+            time_window=time_window,
+        )
+
+    @staticmethod
+    def _parse_fixed_time_trigger_frontend(data: dict) -> FixedTimeTrigger:
+        """Parse frontend fixed time trigger format.
+
+        Frontend sends:
+        - time_of_day (maps to 'time')
+        - days_of_week
+        """
+        return FixedTimeTrigger(
+            time=data.get('time_of_day', data.get('time', '00:00')),
+            days_of_week=data.get('days_of_week'),
+        )
+
+    @staticmethod
+    def _parse_sensor_trigger_frontend(data: dict) -> SensorTrigger:
+        """Parse frontend sensor trigger format."""
+        time_window = None
+        if 'time_window' in data and data['time_window']:
+            time_window = TimeWindow.from_dict(data['time_window'])
+
+        return SensorTrigger(
+            sensor_type=data['sensor_type'],
+            threshold=data.get('threshold', 0.0),
+            comparison=data.get('comparison', 'gt'),
+            cooldown_minutes=data.get('cooldown_minutes', 5),
+            time_window=time_window,
+        )
+
+    @staticmethod
+    def _parse_cron_trigger_frontend(data: dict) -> CronTrigger:
+        """Parse frontend cron trigger format."""
+        return CronTrigger(
+            cron_expression=data['cron_expression'],
+        )
+
+    @staticmethod
+    def _parse_frontend_trigger(trigger_data: dict) -> dict:
+        """Convert frontend trigger format to backend trigger objects.
+
+        Args:
+            trigger_data: Frontend trigger object with trigger_type and config
+
+        Returns:
+            Dict with trigger_type and corresponding typed trigger object
+        """
+        trigger_type = trigger_data.get('trigger_type')
+
+        result = {'trigger_type': trigger_type}
+
+        # Parse based on trigger type
+        if trigger_type == 'interval':
+            result['interval_trigger'] = Schedule._parse_interval_trigger_frontend(trigger_data)
+        elif trigger_type == 'solar':
+            result['solar_trigger'] = Schedule._parse_solar_trigger_frontend(trigger_data)
+        elif trigger_type == 'moon_phase':
+            result['moon_phase_trigger'] = Schedule._parse_moon_phase_trigger_frontend(trigger_data)
+        elif trigger_type == 'fixed_time':
+            result['fixed_time_trigger'] = Schedule._parse_fixed_time_trigger_frontend(trigger_data)
+        elif trigger_type == 'sensor':
+            result['sensor_trigger'] = Schedule._parse_sensor_trigger_frontend(trigger_data)
+        elif trigger_type == 'cron':
+            result['cron_trigger'] = Schedule._parse_cron_trigger_frontend(trigger_data)
+
+        return result
+
+    @classmethod
+    def _convert_frontend_format(cls, data: dict) -> dict:
+        """Convert frontend JSON format to backend format.
+
+        Converts:
+        - trigger object → trigger_type + specific trigger objects
+        - date_range object → start_date/end_date at top level
+
+        Args:
+            data: Frontend format dict
+
+        Returns:
+            Backend format dict
+        """
+        # Create copy to avoid mutating input
+        converted = data.copy()
+
+        # Extract and convert trigger
+        if 'trigger' in converted:
+            trigger_data = converted.pop('trigger')
+            trigger_fields = cls._parse_frontend_trigger(trigger_data)
+            converted.update(trigger_fields)
+
+        # Unwrap date_range if present
+        if 'date_range' in converted:
+            date_range = converted.pop('date_range')
+            if isinstance(date_range, dict):
+                converted['start_date'] = date_range.get('start_date')
+                converted['end_date'] = date_range.get('end_date')
+
+        return converted
+
     @classmethod
     def from_dict(cls, data: dict) -> "Schedule":
-        """Create from dictionary."""
+        """Create from dictionary. Supports both frontend and backend formats."""
+        # Detect and convert frontend format
+        if cls._is_frontend_format(data):
+            data = cls._convert_frontend_format(data)
+
+        # Helper to handle both dict and object types for triggers
+        def _process_trigger(trigger_data, trigger_class):
+            if trigger_data is None:
+                return None
+            # If already an instance, return as-is (from frontend conversion)
+            if isinstance(trigger_data, trigger_class):
+                return trigger_data
+            # Otherwise parse from dict (backend format)
+            return trigger_class.from_dict(trigger_data)
+
         return cls(
             schedule_id=data.get("schedule_id", ""),
             name=data["name"],
@@ -721,36 +906,12 @@ class Schedule:
                 EventPattern.from_dict(p) for p in data.get("event_patterns", [])
             ],
             trigger_type=data.get("trigger_type", "interval"),
-            interval_trigger=(
-                IntervalTrigger.from_dict(data["interval_trigger"])
-                if data.get("interval_trigger")
-                else None
-            ),
-            solar_trigger=(
-                SolarTrigger.from_dict(data["solar_trigger"])
-                if data.get("solar_trigger")
-                else None
-            ),
-            moon_phase_trigger=(
-                MoonPhaseTrigger.from_dict(data["moon_phase_trigger"])
-                if data.get("moon_phase_trigger")
-                else None
-            ),
-            fixed_time_trigger=(
-                FixedTimeTrigger.from_dict(data["fixed_time_trigger"])
-                if data.get("fixed_time_trigger")
-                else None
-            ),
-            sensor_trigger=(
-                SensorTrigger.from_dict(data["sensor_trigger"])
-                if data.get("sensor_trigger")
-                else None
-            ),
-            cron_trigger=(
-                CronTrigger.from_dict(data["cron_trigger"])
-                if data.get("cron_trigger")
-                else None
-            ),
+            interval_trigger=_process_trigger(data.get("interval_trigger"), IntervalTrigger),
+            solar_trigger=_process_trigger(data.get("solar_trigger"), SolarTrigger),
+            moon_phase_trigger=_process_trigger(data.get("moon_phase_trigger"), MoonPhaseTrigger),
+            fixed_time_trigger=_process_trigger(data.get("fixed_time_trigger"), FixedTimeTrigger),
+            sensor_trigger=_process_trigger(data.get("sensor_trigger"), SensorTrigger),
+            cron_trigger=_process_trigger(data.get("cron_trigger"), CronTrigger),
             start_date=data.get("start_date"),
             end_date=data.get("end_date"),
             deployment_id=data.get("deployment_id"),

--- a/Firmware/webui/backend/lib/schedule_schema.py
+++ b/Firmware/webui/backend/lib/schedule_schema.py
@@ -52,7 +52,7 @@ import re
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Final
+from typing import Final, TypeVar
 
 logger = logging.getLogger(__name__)
 
@@ -718,7 +718,7 @@ class Schedule:
         Frontend format has a nested 'trigger' object containing trigger_type and all config.
         Backend format has trigger_type at top level with separate trigger objects.
         """
-        return 'trigger' in data and isinstance(data.get('trigger'), dict)
+        return "trigger" in data and isinstance(data.get("trigger"), dict)
 
     @staticmethod
     def _parse_interval_trigger_frontend(data: dict) -> IntervalTrigger:
@@ -728,37 +728,41 @@ class Schedule:
         - interval_minutes
         - time_window_start, time_window_end (or nested time_window)
         - days_of_week
+
+        Note: Value validation (type, range) is handled by IntervalTrigger's
+        __post_init__ and validate_interval_trigger(). This method only checks
+        for required field presence.
         """
         # Handle both flat and nested time_window formats
-        if 'time_window' in data and isinstance(data['time_window'], dict):
-            time_window = TimeWindow.from_dict(data['time_window'])
+        if "time_window" in data and isinstance(data["time_window"], dict):
+            time_window = TimeWindow.from_dict(data["time_window"])
         else:
             time_window = TimeWindow(
-                start_time=data.get('time_window_start', '00:00'),
-                end_time=data.get('time_window_end', '23:59'),
-                start_offset_minutes=data.get('start_offset_minutes', 0),
-                end_offset_minutes=data.get('end_offset_minutes', 0),
+                start_time=data.get("time_window_start", "00:00"),
+                end_time=data.get("time_window_end", "23:59"),
+                start_offset_minutes=data.get("start_offset_minutes", 0),
+                end_offset_minutes=data.get("end_offset_minutes", 0),
             )
 
-        if 'interval_minutes' not in data:
+        if "interval_minutes" not in data:
             raise ValueError("interval_minutes is required for interval trigger")
 
         return IntervalTrigger(
-            interval_minutes=data['interval_minutes'],
+            interval_minutes=data["interval_minutes"],
             time_window=time_window,
-            days_of_week=data.get('days_of_week'),
+            days_of_week=data.get("days_of_week"),
         )
 
     @staticmethod
     def _parse_solar_trigger_frontend(data: dict) -> SolarTrigger:
         """Parse frontend solar trigger format."""
-        if 'solar_event' not in data:
+        if "solar_event" not in data:
             raise ValueError("solar_event is required for solar trigger")
 
         return SolarTrigger(
-            solar_event=data['solar_event'],
-            offset_minutes=data.get('offset_minutes', 0),
-            days_of_week=data.get('days_of_week'),
+            solar_event=data["solar_event"],
+            offset_minutes=data.get("offset_minutes", 0),
+            days_of_week=data.get("days_of_week"),
         )
 
     @staticmethod
@@ -770,27 +774,29 @@ class Schedule:
         - time_of_day: single time string (convert to time_window)
         - offset_days
         """
-        # Wrap single phase in list (only if non-empty string)
-        phase = data.get('moon_phase')
-        phases = [phase] if isinstance(phase, str) and phase else data.get('phases', [])
+        # Wrap single phase in list (only if non-empty string).
+        # Empty string "" is falsy, so falls back to phases key - this is intentional
+        # to handle cases where frontend sends moon_phase="" with phases=[...].
+        phase = data.get("moon_phase")
+        phases = [phase] if isinstance(phase, str) and phase else data.get("phases", [])
 
         if not phases:
             raise ValueError("moon_phase or phases is required for moon phase trigger")
 
         # Convert time_of_day to time_window
         time_window = None
-        if 'time_of_day' in data:
-            time_of_day = data['time_of_day']
+        if "time_of_day" in data:
+            time_of_day = data["time_of_day"]
             time_window = TimeWindow(
                 start_time=time_of_day,
                 end_time=time_of_day,
             )
-        elif 'time_window' in data and data['time_window']:
-            time_window = TimeWindow.from_dict(data['time_window'])
+        elif "time_window" in data and data["time_window"]:
+            time_window = TimeWindow.from_dict(data["time_window"])
 
         return MoonPhaseTrigger(
             phases=phases,
-            offset_days=data.get('offset_days', 0),
+            offset_days=data.get("offset_days", 0),
             time_window=time_window,
         )
 
@@ -803,36 +809,36 @@ class Schedule:
         - days_of_week
         """
         return FixedTimeTrigger(
-            time=data.get('time_of_day', data.get('time', '00:00')),
-            days_of_week=data.get('days_of_week'),
+            time=data.get("time_of_day", data.get("time", "00:00")),
+            days_of_week=data.get("days_of_week"),
         )
 
     @staticmethod
     def _parse_sensor_trigger_frontend(data: dict) -> SensorTrigger:
         """Parse frontend sensor trigger format."""
-        if 'sensor_type' not in data:
+        if "sensor_type" not in data:
             raise ValueError("sensor_type is required for sensor trigger")
 
         time_window = None
-        if 'time_window' in data and data['time_window']:
-            time_window = TimeWindow.from_dict(data['time_window'])
+        if "time_window" in data and data["time_window"]:
+            time_window = TimeWindow.from_dict(data["time_window"])
 
         return SensorTrigger(
-            sensor_type=data['sensor_type'],
-            threshold=data.get('threshold', 0.0),
-            comparison=data.get('comparison', 'gt'),
-            cooldown_minutes=data.get('cooldown_minutes', 5),
+            sensor_type=data["sensor_type"],
+            threshold=data.get("threshold", 0.0),
+            comparison=data.get("comparison", "gt"),
+            cooldown_minutes=data.get("cooldown_minutes", 5),
             time_window=time_window,
         )
 
     @staticmethod
     def _parse_cron_trigger_frontend(data: dict) -> CronTrigger:
         """Parse frontend cron trigger format."""
-        if 'cron_expression' not in data:
+        if "cron_expression" not in data:
             raise ValueError("cron_expression is required for cron trigger")
 
         return CronTrigger(
-            cron_expression=data['cron_expression'],
+            cron_expression=data["cron_expression"],
         )
 
     @staticmethod
@@ -845,30 +851,30 @@ class Schedule:
         Returns:
             Dict with trigger_type and corresponding typed trigger object
         """
-        trigger_type = trigger_data.get('trigger_type')
+        trigger_type = trigger_data.get("trigger_type")
 
         if not trigger_type:
             raise ValueError("trigger_type is required")
 
-        valid_types = {'interval', 'solar', 'moon_phase', 'fixed_time', 'sensor', 'cron'}
+        valid_types = {"interval", "solar", "moon_phase", "fixed_time", "sensor", "cron"}
         if trigger_type not in valid_types:
             raise ValueError(f"Unknown trigger_type: {trigger_type}")
 
-        result = {'trigger_type': trigger_type}
+        result = {"trigger_type": trigger_type}
 
         # Parse based on trigger type
-        if trigger_type == 'interval':
-            result['interval_trigger'] = Schedule._parse_interval_trigger_frontend(trigger_data)
-        elif trigger_type == 'solar':
-            result['solar_trigger'] = Schedule._parse_solar_trigger_frontend(trigger_data)
-        elif trigger_type == 'moon_phase':
-            result['moon_phase_trigger'] = Schedule._parse_moon_phase_trigger_frontend(trigger_data)
-        elif trigger_type == 'fixed_time':
-            result['fixed_time_trigger'] = Schedule._parse_fixed_time_trigger_frontend(trigger_data)
-        elif trigger_type == 'sensor':
-            result['sensor_trigger'] = Schedule._parse_sensor_trigger_frontend(trigger_data)
-        elif trigger_type == 'cron':
-            result['cron_trigger'] = Schedule._parse_cron_trigger_frontend(trigger_data)
+        if trigger_type == "interval":
+            result["interval_trigger"] = Schedule._parse_interval_trigger_frontend(trigger_data)
+        elif trigger_type == "solar":
+            result["solar_trigger"] = Schedule._parse_solar_trigger_frontend(trigger_data)
+        elif trigger_type == "moon_phase":
+            result["moon_phase_trigger"] = Schedule._parse_moon_phase_trigger_frontend(trigger_data)
+        elif trigger_type == "fixed_time":
+            result["fixed_time_trigger"] = Schedule._parse_fixed_time_trigger_frontend(trigger_data)
+        elif trigger_type == "sensor":
+            result["sensor_trigger"] = Schedule._parse_sensor_trigger_frontend(trigger_data)
+        elif trigger_type == "cron":
+            result["cron_trigger"] = Schedule._parse_cron_trigger_frontend(trigger_data)
 
         return result
 
@@ -890,17 +896,17 @@ class Schedule:
         converted = copy.deepcopy(data)
 
         # Extract and convert trigger
-        if 'trigger' in converted:
-            trigger_data = converted.pop('trigger')
+        if "trigger" in converted:
+            trigger_data = converted.pop("trigger")
             trigger_fields = cls._parse_frontend_trigger(trigger_data)
             converted.update(trigger_fields)
 
         # Unwrap date_range if present
-        if 'date_range' in converted:
-            date_range = converted.pop('date_range')
+        if "date_range" in converted:
+            date_range = converted.pop("date_range")
             if date_range and isinstance(date_range, dict):
-                converted['start_date'] = date_range.get('start_date')
-                converted['end_date'] = date_range.get('end_date')
+                converted["start_date"] = date_range.get("start_date")
+                converted["end_date"] = date_range.get("end_date")
 
         return converted
 
@@ -912,7 +918,11 @@ class Schedule:
             data = cls._convert_frontend_format(data)
 
         # Helper to handle both dict and object types for triggers
-        def _process_trigger(trigger_data, trigger_class):
+        T = TypeVar("T")
+
+        def _process_trigger(
+            trigger_data: dict | T | None, trigger_class: type[T]
+        ) -> T | None:
             if trigger_data is None:
                 return None
             # If already an instance, return as-is (from frontend conversion)

--- a/Firmware/webui/backend/lib/schedule_schema.py
+++ b/Firmware/webui/backend/lib/schedule_schema.py
@@ -807,18 +807,12 @@ class Schedule:
         """Parse frontend fixed time trigger format.
 
         Frontend sends:
-        - time_of_day (maps to 'time')
+        - time_of_day (maps to 'time') - required
         - days_of_week
-
-        Note: time_of_day defaults to "00:00" if not provided. This maintains
-        backward compatibility but may indicate a frontend bug if unintentional.
         """
         time_value = data.get("time_of_day") or data.get("time")
         if not time_value:
-            logger.warning(
-                "fixed_time trigger missing time_of_day, defaulting to 00:00"
-            )
-            time_value = "00:00"
+            raise ValueError("time_of_day is required for fixed_time trigger")
 
         return FixedTimeTrigger(
             time=time_value,

--- a/Firmware/webui/backend/lib/schedule_schema.py
+++ b/Firmware/webui/backend/lib/schedule_schema.py
@@ -733,7 +733,9 @@ class Schedule:
         __post_init__ and validate_interval_trigger(). This method only checks
         for required field presence.
         """
-        # Handle both flat and nested time_window formats
+        # Handle both flat and nested time_window formats.
+        # Priority: nested time_window object takes precedence over flat fields
+        # (time_window_start/end). If both are present, nested object wins.
         if "time_window" in data and isinstance(data["time_window"], dict):
             time_window = TimeWindow.from_dict(data["time_window"])
         else:
@@ -807,9 +809,19 @@ class Schedule:
         Frontend sends:
         - time_of_day (maps to 'time')
         - days_of_week
+
+        Note: time_of_day defaults to "00:00" if not provided. This maintains
+        backward compatibility but may indicate a frontend bug if unintentional.
         """
+        time_value = data.get("time_of_day") or data.get("time")
+        if not time_value:
+            logger.warning(
+                "fixed_time trigger missing time_of_day, defaulting to 00:00"
+            )
+            time_value = "00:00"
+
         return FixedTimeTrigger(
-            time=data.get("time_of_day", data.get("time", "00:00")),
+            time=time_value,
             days_of_week=data.get("days_of_week"),
         )
 

--- a/Firmware/webui/backend/lib/schedule_schema.py
+++ b/Firmware/webui/backend/lib/schedule_schema.py
@@ -46,6 +46,7 @@ Usage:
 Issue #208 - Scheduler Phase 1: Schedule Schema
 """
 
+import copy
 import logging
 import re
 import uuid
@@ -769,9 +770,9 @@ class Schedule:
         - time_of_day: single time string (convert to time_window)
         - offset_days
         """
-        # Wrap single phase in list
+        # Wrap single phase in list (only if non-empty string)
         phase = data.get('moon_phase')
-        phases = [phase] if isinstance(phase, str) else data.get('phases', [])
+        phases = [phase] if isinstance(phase, str) and phase else data.get('phases', [])
 
         if not phases:
             raise ValueError("moon_phase or phases is required for moon phase trigger")
@@ -885,8 +886,8 @@ class Schedule:
         Returns:
             Backend format dict
         """
-        # Create copy to avoid mutating input
-        converted = data.copy()
+        # Deep copy to avoid mutating nested input structures
+        converted = copy.deepcopy(data)
 
         # Extract and convert trigger
         if 'trigger' in converted:


### PR DESCRIPTION
## Summary

Fixes #280 - The Visual Scheduler frontend sends trigger data in a different JSON format than the backend expected, causing all scheduler CRUD operations to fail.

**Problem:**
- Frontend format: `{ trigger: { trigger_type, ...fields }, date_range: {...} }`
- Backend expected: `{ trigger_type, *_trigger: {...}, start_date, end_date }`

**Solution:**
- Add format detection via `_is_frontend_format()` 
- Add conversion layer with `_convert_frontend_format()` orchestrator
- Add 6 trigger-specific parsers for all trigger types
- Unwrap `date_range` wrapper to flat `start_date/end_date`
- Full backward compatibility with existing backend format

## Changes

- `webui/backend/lib/schedule_schema.py`: Added 9 helper methods for frontend format detection and conversion
- `Tests/unit/test_schedule_schema.py`: Added `TestScheduleFromDictFrontendFormat` class with 12 TDD tests

## Trigger Mappings

| Trigger Type | Frontend Field | Backend Field |
|--------------|----------------|---------------|
| interval | `time_window_start/end` | `time_window.start_time/end_time` |
| solar | direct mapping | direct mapping |
| moon_phase | `moon_phase` (string) | `phases` (list) |
| fixed_time | `time_of_day` | `time` |
| sensor | direct mapping | direct mapping |
| cron | direct mapping | direct mapping |

## Test Plan

- [x] All 116 schedule schema tests pass
- [x] All 12 new frontend format tests pass
- [x] Backward compatibility: existing backend format still works
- [x] Ruff linting passes
- [ ] Manual test: Create schedule via Visual Scheduler UI