### PR TITLE
feat(system): Implement INA260 power monitoring (#73)

### DIFF
--- a/Firmware/Tests/unit/test_system_routes.py
+++ b/Firmware/Tests/unit/test_system_routes.py
@@ -231,20 +231,70 @@ class TestSystemPower:
             data = json.loads(response.data)
             assert data['enabled'] is False
 
-    def test_power_ina260_enabled_but_not_implemented(self, system_client, mock_paths):
-        """GET /power returns TODO status when INA260 is enabled"""
-        with patch('routes.system.get_hardware_config', return_value={'ina260_enabled': True}):
+    def test_power_returns_sensor_readings_when_available(self, system_client, mock_paths):
+        """GET /power returns actual sensor readings when INA260 connected"""
+        # Mock sensor object with realistic values
+        mock_ina260 = MagicMock()
+        mock_ina260.voltage = 12.45  # 12.45V
+        mock_ina260.current = 350.5  # 350.5mA
+        mock_ina260.power = 4360.0   # 4360mW
+
+        with patch('routes.system.get_hardware_config', return_value={
+            'ina260_enabled': True,
+            'ina260_address': 0x40
+        }), \
+             patch('routes.system._read_ina260_sensor', return_value=mock_ina260):
+
             response = system_client.get('/api/system/power')
 
             assert response.status_code == 200
             data = json.loads(response.data)
+
             assert data['enabled'] is True
-            # Implementation is TODO (issue #73)
+            assert data['voltage'] == 12.45
+            assert data['current'] == 350.5
+            assert data['power'] == 4360.0
+
+    def test_power_returns_null_when_sensor_not_connected(self, system_client, mock_paths):
+        """GET /power returns null values when sensor not connected"""
+        with patch('routes.system.get_hardware_config', return_value={
+            'ina260_enabled': True,
+            'ina260_address': 0x40
+        }), \
+             patch('routes.system._read_ina260_sensor', return_value=None):
+
+            response = system_client.get('/api/system/power')
+
+            assert response.status_code == 200
+            data = json.loads(response.data)
+
+            assert data['enabled'] is True
             assert data['voltage'] is None
             assert data['current'] is None
             assert data['power'] is None
+            assert 'error' in data  # Should indicate sensor not available
 
-    def test_power_handles_error(self, system_client, mock_paths):
+    def test_power_handles_sensor_oserror(self, system_client, mock_paths):
+        """GET /power handles OSError when I2C bus unavailable"""
+        with patch('routes.system.get_hardware_config', return_value={
+            'ina260_enabled': True,
+            'ina260_address': 0x40
+        }), \
+             patch('routes.system._read_ina260_sensor', side_effect=OSError("I2C bus error")):
+
+            response = system_client.get('/api/system/power')
+
+            assert response.status_code == 200
+            data = json.loads(response.data)
+
+            # Should return enabled but with null values and error message
+            assert data['enabled'] is True
+            assert data['voltage'] is None
+            assert data['current'] is None
+            assert data['power'] is None
+            assert 'error' in data
+
+    def test_power_handles_config_error(self, system_client, mock_paths):
         """GET /power handles errors gracefully"""
         with patch('routes.system.get_hardware_config', side_effect=Exception("Config error")):
             response = system_client.get('/api/system/power')
@@ -252,6 +302,28 @@ class TestSystemPower:
             assert response.status_code == 500
             data = json.loads(response.data)
             assert 'error' in data
+
+    def test_power_rounds_values_to_two_decimals(self, system_client, mock_paths):
+        """GET /power rounds sensor readings to 2 decimal places"""
+        mock_ina260 = MagicMock()
+        mock_ina260.voltage = 12.456789
+        mock_ina260.current = 350.123456
+        mock_ina260.power = 4360.987654
+
+        with patch('routes.system.get_hardware_config', return_value={
+            'ina260_enabled': True,
+            'ina260_address': 0x40
+        }), \
+             patch('routes.system._read_ina260_sensor', return_value=mock_ina260):
+
+            response = system_client.get('/api/system/power')
+
+            assert response.status_code == 200
+            data = json.loads(response.data)
+
+            assert data['voltage'] == 12.46  # Rounded
+            assert data['current'] == 350.12  # Rounded
+            assert data['power'] == 4360.99  # Rounded
 
 
 # ============================================================================

--- a/Firmware/Tests/unit/test_system_routes.py
+++ b/Firmware/Tests/unit/test_system_routes.py
@@ -233,17 +233,18 @@ class TestSystemPower:
 
     def test_power_returns_sensor_readings_when_available(self, system_client, mock_paths):
         """GET /power returns actual sensor readings when INA260 connected"""
-        # Mock sensor object with realistic values
-        mock_ina260 = MagicMock()
-        mock_ina260.voltage = 12.45  # 12.45V
-        mock_ina260.current = 350.5  # 350.5mA
-        mock_ina260.power = 4360.0   # 4360mW
+        # Mock sensor readings as dict (matching new return type)
+        mock_readings = {
+            "voltage": 12.45,  # 12.45V
+            "current": 350.5,  # 350.5mA
+            "power": 4360.0    # 4360mW
+        }
 
         with patch('routes.system.get_hardware_config', return_value={
             'ina260_enabled': True,
             'ina260_address': 0x40
         }), \
-             patch('routes.system._read_ina260_sensor', return_value=mock_ina260):
+             patch('routes.system._read_ina260_sensor', return_value=mock_readings):
 
             response = system_client.get('/api/system/power')
 
@@ -295,7 +296,7 @@ class TestSystemPower:
             assert 'error' in data
 
     def test_power_handles_config_error(self, system_client, mock_paths):
-        """GET /power handles errors gracefully"""
+        """GET /power returns 500 when hardware config fails"""
         with patch('routes.system.get_hardware_config', side_effect=Exception("Config error")):
             response = system_client.get('/api/system/power')
 
@@ -305,16 +306,17 @@ class TestSystemPower:
 
     def test_power_rounds_values_to_two_decimals(self, system_client, mock_paths):
         """GET /power rounds sensor readings to 2 decimal places"""
-        mock_ina260 = MagicMock()
-        mock_ina260.voltage = 12.456789
-        mock_ina260.current = 350.123456
-        mock_ina260.power = 4360.987654
+        mock_readings = {
+            "voltage": 12.456789,
+            "current": 350.123456,
+            "power": 4360.987654
+        }
 
         with patch('routes.system.get_hardware_config', return_value={
             'ina260_enabled': True,
             'ina260_address': 0x40
         }), \
-             patch('routes.system._read_ina260_sensor', return_value=mock_ina260):
+             patch('routes.system._read_ina260_sensor', return_value=mock_readings):
 
             response = system_client.get('/api/system/power')
 
@@ -324,6 +326,26 @@ class TestSystemPower:
             assert data['voltage'] == 12.46  # Rounded
             assert data['current'] == 350.12  # Rounded
             assert data['power'] == 4360.99  # Rounded
+
+    def test_power_uses_correct_address_from_config(self, system_client, mock_paths):
+        """GET /power passes correct I2C address from config to sensor"""
+        mock_readings = {
+            "voltage": 12.0,
+            "current": 100.0,
+            "power": 1200.0
+        }
+
+        with patch('routes.system.get_hardware_config', return_value={
+            'ina260_enabled': True,
+            'ina260_address': 0x41  # Non-default address
+        }), \
+             patch('routes.system._read_ina260_sensor', return_value=mock_readings) as mock_sensor:
+
+            response = system_client.get('/api/system/power')
+
+            assert response.status_code == 200
+            # Verify sensor was called with the correct address from config
+            mock_sensor.assert_called_once_with(0x41)
 
 
 # ============================================================================

--- a/Firmware/Tests/unit/test_system_routes.py
+++ b/Firmware/Tests/unit/test_system_routes.py
@@ -256,8 +256,8 @@ class TestSystemPower:
             assert data['current'] == 350.5
             assert data['power'] == 4360.0
 
-    def test_power_returns_null_when_sensor_not_connected(self, system_client, mock_paths):
-        """GET /power returns null values when sensor not connected"""
+    def test_power_returns_null_when_sensor_unavailable(self, system_client, mock_paths):
+        """GET /power returns null values when sensor returns None (not connected or error)"""
         with patch('routes.system.get_hardware_config', return_value={
             'ina260_enabled': True,
             'ina260_address': 0x40
@@ -273,27 +273,7 @@ class TestSystemPower:
             assert data['voltage'] is None
             assert data['current'] is None
             assert data['power'] is None
-            assert 'error' in data  # Should indicate sensor not available
-
-    def test_power_handles_sensor_oserror(self, system_client, mock_paths):
-        """GET /power handles OSError when I2C bus unavailable"""
-        with patch('routes.system.get_hardware_config', return_value={
-            'ina260_enabled': True,
-            'ina260_address': 0x40
-        }), \
-             patch('routes.system._read_ina260_sensor', side_effect=OSError("I2C bus error")):
-
-            response = system_client.get('/api/system/power')
-
-            assert response.status_code == 200
-            data = json.loads(response.data)
-
-            # Should return enabled but with null values and error message
-            assert data['enabled'] is True
-            assert data['voltage'] is None
-            assert data['current'] is None
-            assert data['power'] is None
-            assert 'error' in data
+            assert data['error'] == "Sensor not available"
 
     def test_power_handles_config_error(self, system_client, mock_paths):
         """GET /power returns 500 when hardware config fails"""

--- a/Firmware/Tests/unit/test_system_routes.py
+++ b/Firmware/Tests/unit/test_system_routes.py
@@ -327,6 +327,20 @@ class TestSystemPower:
             # Verify sensor was called with the correct address from config
             mock_sensor.assert_called_once_with(0x41)
 
+    def test_read_ina260_sensor_handles_i2c_init_failure(self, mock_paths):
+        """_read_ina260_sensor returns None when I2C bus initialization fails"""
+        mock_board = MagicMock()
+        mock_board.I2C.side_effect = OSError("I2C bus not available")
+
+        with patch.dict('sys.modules', {
+            'board': mock_board,
+            'adafruit_ina260': MagicMock()
+        }):
+            from routes.system import _read_ina260_sensor
+            result = _read_ina260_sensor(0x40)
+
+            assert result is None
+
 
 # ============================================================================
 # Test System Info Endpoint

--- a/Firmware/Tests/unit/test_system_routes.py
+++ b/Firmware/Tests/unit/test_system_routes.py
@@ -341,6 +341,49 @@ class TestSystemPower:
 
             assert result is None
 
+    def test_read_ina260_sensor_cleans_up_i2c_on_success(self, mock_paths):
+        """_read_ina260_sensor calls i2c.deinit() after successful read"""
+        mock_i2c = MagicMock()
+        mock_board = MagicMock()
+        mock_board.I2C.return_value = mock_i2c
+
+        mock_sensor = MagicMock()
+        mock_sensor.voltage = 12.0
+        mock_sensor.current = 100.0
+        mock_sensor.power = 1200.0
+
+        mock_ina260 = MagicMock()
+        mock_ina260.INA260.return_value = mock_sensor
+
+        with patch.dict('sys.modules', {
+            'board': mock_board,
+            'adafruit_ina260': mock_ina260
+        }):
+            from routes.system import _read_ina260_sensor
+            result = _read_ina260_sensor(0x40)
+
+            assert result is not None
+            mock_i2c.deinit.assert_called_once()
+
+    def test_read_ina260_sensor_cleans_up_i2c_on_sensor_failure(self, mock_paths):
+        """_read_ina260_sensor calls i2c.deinit() even when sensor init fails"""
+        mock_i2c = MagicMock()
+        mock_board = MagicMock()
+        mock_board.I2C.return_value = mock_i2c
+
+        mock_ina260 = MagicMock()
+        mock_ina260.INA260.side_effect = ValueError("No sensor at address")
+
+        with patch.dict('sys.modules', {
+            'board': mock_board,
+            'adafruit_ina260': mock_ina260
+        }):
+            from routes.system import _read_ina260_sensor
+            result = _read_ina260_sensor(0x40)
+
+            assert result is None
+            mock_i2c.deinit.assert_called_once()
+
 
 # ============================================================================
 # Test System Info Endpoint

--- a/Firmware/webui/backend/routes/system.py
+++ b/Firmware/webui/backend/routes/system.py
@@ -156,7 +156,7 @@ def _read_ina260_sensor(address: int) -> dict | None:
         or None if sensor not available
 
     Raises:
-        OSError: If I2C bus communication fails
+        OSError: If I2C bus communication fails (caught by caller)
     """
     try:
         import adafruit_ina260
@@ -172,9 +172,12 @@ def _read_ina260_sensor(address: int) -> dict | None:
             }
         finally:
             i2c.deinit()
-    except (ImportError, ValueError):
-        # ImportError: adafruit libraries not installed
+    except ImportError:
+        # adafruit libraries not installed
+        return None
+    except (ValueError, OSError):
         # ValueError: Sensor not found at address
+        # OSError: I2C bus initialization or communication failed
         return None
 
 

--- a/Firmware/webui/backend/routes/system.py
+++ b/Firmware/webui/backend/routes/system.py
@@ -141,6 +141,32 @@ def get_system_status():
         return jsonify({"error": "Failed to get storage info"}), 500
 
 
+def _read_ina260_sensor(address: int):
+    """
+    Read INA260 power sensor from I2C bus.
+
+    Args:
+        address: I2C address for the sensor (typically 0x40)
+
+    Returns:
+        INA260 sensor object with voltage, current, power properties,
+        or None if sensor not available
+
+    Raises:
+        OSError: If I2C bus communication fails
+    """
+    try:
+        import adafruit_ina260
+        import board
+
+        i2c = board.I2C()
+        return adafruit_ina260.INA260(i2c, address=address)
+    except (ImportError, ValueError):
+        # ImportError: adafruit libraries not installed
+        # ValueError: Sensor not found at address
+        return None
+
+
 @system_bp.route("/power", methods=["GET"])
 def get_power_status():
     """Get power metrics from INA260 if available"""
@@ -149,9 +175,34 @@ def get_power_status():
         if not hw_config.get("ina260_enabled"):
             return jsonify({"enabled": False})
 
-        # TODO: Implement power monitoring
-        # See: https://github.com/zane-lazare/Mothbox/issues/73
-        return jsonify({"enabled": True, "voltage": None, "current": None, "power": None})
+        # Read from INA260 sensor
+        address = hw_config.get("ina260_address", 0x40)
+        try:
+            sensor = _read_ina260_sensor(address)
+            if sensor is None:
+                return jsonify({
+                    "enabled": True,
+                    "voltage": None,
+                    "current": None,
+                    "power": None,
+                    "error": "Sensor not available"
+                })
+
+            return jsonify({
+                "enabled": True,
+                "voltage": round(sensor.voltage, 2),
+                "current": round(sensor.current, 2),
+                "power": round(sensor.power, 2)
+            })
+        except OSError as e:
+            print(f"INA260 I2C error: {e}")
+            return jsonify({
+                "enabled": True,
+                "voltage": None,
+                "current": None,
+                "power": None,
+                "error": "I2C communication error"
+            })
     except Exception as e:
         print(f"Error getting power status: {e}")
         return jsonify({"error": "Failed to get power status"}), 500

--- a/Firmware/webui/backend/routes/system.py
+++ b/Firmware/webui/backend/routes/system.py
@@ -141,15 +141,18 @@ def get_system_status():
         return jsonify({"error": "Failed to get storage info"}), 500
 
 
-def _read_ina260_sensor(address: int):
+def _read_ina260_sensor(address: int) -> dict | None:
     """
     Read INA260 power sensor from I2C bus.
+
+    Reads sensor values immediately and closes the I2C bus to avoid
+    resource leaks.
 
     Args:
         address: I2C address for the sensor (typically 0x40)
 
     Returns:
-        INA260 sensor object with voltage, current, power properties,
+        dict with keys 'voltage', 'current', 'power' containing float values,
         or None if sensor not available
 
     Raises:
@@ -160,7 +163,15 @@ def _read_ina260_sensor(address: int):
         import board
 
         i2c = board.I2C()
-        return adafruit_ina260.INA260(i2c, address=address)
+        try:
+            sensor = adafruit_ina260.INA260(i2c, address=address)
+            return {
+                "voltage": sensor.voltage,
+                "current": sensor.current,
+                "power": sensor.power,
+            }
+        finally:
+            i2c.deinit()
     except (ImportError, ValueError):
         # ImportError: adafruit libraries not installed
         # ValueError: Sensor not found at address
@@ -169,7 +180,25 @@ def _read_ina260_sensor(address: int):
 
 @system_bp.route("/power", methods=["GET"])
 def get_power_status():
-    """Get power metrics from INA260 if available"""
+    """
+    Get power metrics from INA260 sensor if available.
+
+    Reads voltage, current, and power from the INA260 power monitor
+    connected via I2C. The sensor must be enabled in hardware configuration.
+
+    Returns:
+        200: Power status (may include 'error' field if sensor unavailable)
+        500: Configuration error
+
+    Response schema:
+        {
+            "enabled": bool,
+            "voltage": float | null,  # Volts (V)
+            "current": float | null,  # Milliamps (mA)
+            "power": float | null,    # Milliwatts (mW)
+            "error": str | undefined  # Present when sensor unavailable
+        }
+    """
     try:
         hw_config = get_hardware_config()
         if not hw_config.get("ina260_enabled"):
@@ -178,8 +207,8 @@ def get_power_status():
         # Read from INA260 sensor
         address = hw_config.get("ina260_address", 0x40)
         try:
-            sensor = _read_ina260_sensor(address)
-            if sensor is None:
+            readings = _read_ina260_sensor(address)
+            if readings is None:
                 return jsonify({
                     "enabled": True,
                     "voltage": None,
@@ -190,9 +219,9 @@ def get_power_status():
 
             return jsonify({
                 "enabled": True,
-                "voltage": round(sensor.voltage, 2),
-                "current": round(sensor.current, 2),
-                "power": round(sensor.power, 2)
+                "voltage": round(readings["voltage"], 2),
+                "current": round(readings["current"], 2),
+                "power": round(readings["power"], 2)
             })
         except OSError as e:
             print(f"INA260 I2C error: {e}")

--- a/Firmware/webui/backend/routes/system.py
+++ b/Firmware/webui/backend/routes/system.py
@@ -153,10 +153,7 @@ def _read_ina260_sensor(address: int) -> dict | None:
 
     Returns:
         dict with keys 'voltage', 'current', 'power' containing float values,
-        or None if sensor not available
-
-    Raises:
-        OSError: If I2C bus communication fails (caught by caller)
+        or None if sensor not available or any error occurs
     """
     try:
         import adafruit_ina260
@@ -209,32 +206,22 @@ def get_power_status():
 
         # Read from INA260 sensor
         address = hw_config.get("ina260_address", 0x40)
-        try:
-            readings = _read_ina260_sensor(address)
-            if readings is None:
-                return jsonify({
-                    "enabled": True,
-                    "voltage": None,
-                    "current": None,
-                    "power": None,
-                    "error": "Sensor not available"
-                })
-
-            return jsonify({
-                "enabled": True,
-                "voltage": round(readings["voltage"], 2),
-                "current": round(readings["current"], 2),
-                "power": round(readings["power"], 2)
-            })
-        except OSError as e:
-            print(f"INA260 I2C error: {e}")
+        readings = _read_ina260_sensor(address)
+        if readings is None:
             return jsonify({
                 "enabled": True,
                 "voltage": None,
                 "current": None,
                 "power": None,
-                "error": "I2C communication error"
+                "error": "Sensor not available"
             })
+
+        return jsonify({
+            "enabled": True,
+            "voltage": round(readings["voltage"], 2),
+            "current": round(readings["current"], 2),
+            "power": round(readings["power"], 2)
+        })
     except Exception as e:
         print(f"Error getting power status: {e}")
         return jsonify({"error": "Failed to get power status"}), 500

--- a/Firmware/webui/backend/routes/system.py
+++ b/Firmware/webui/backend/routes/system.py
@@ -155,20 +155,18 @@ def _read_ina260_sensor(address: int) -> dict | None:
         dict with keys 'voltage', 'current', 'power' containing float values,
         or None if sensor not available or any error occurs
     """
+    i2c = None
     try:
         import adafruit_ina260
         import board
 
         i2c = board.I2C()
-        try:
-            sensor = adafruit_ina260.INA260(i2c, address=address)
-            return {
-                "voltage": sensor.voltage,
-                "current": sensor.current,
-                "power": sensor.power,
-            }
-        finally:
-            i2c.deinit()
+        sensor = adafruit_ina260.INA260(i2c, address=address)
+        return {
+            "voltage": sensor.voltage,
+            "current": sensor.current,
+            "power": sensor.power,
+        }
     except ImportError:
         # adafruit libraries not installed
         return None
@@ -176,6 +174,9 @@ def _read_ina260_sensor(address: int) -> dict | None:
         # ValueError: Sensor not found at address
         # OSError: I2C bus initialization or communication failed
         return None
+    finally:
+        if i2c is not None:
+            i2c.deinit()
 
 
 @system_bp.route("/power", methods=["GET"])


### PR DESCRIPTION
## Summary

Fixes #73 - Implements actual INA260 sensor reading for the `/api/system/power` endpoint.

**Before:** Endpoint returned placeholder `null` values
**After:** Returns actual voltage, current, power readings from INA260 sensor

## Changes

- `webui/backend/routes/system.py`:
  - Add `_read_ina260_sensor()` helper for I2C communication
  - Update `get_power_status()` to read from sensor
  - Handle sensor unavailability and I2C errors gracefully

- `Tests/unit/test_system_routes.py`:
  - Add 4 new tests for sensor reading scenarios
  - Update existing test for actual implementation

## API Response

```json
// When sensor connected
{
  "enabled": true,
  "voltage": 12.45,
  "current": 350.5,
  "power": 4360.0
}

// When sensor not available
{
  "enabled": true,
  "voltage": null,
  "current": null,
  "power": null,
  "error": "Sensor not available"
}
```

## Test Plan

- [x] All 26 system route tests pass
- [x] Ruff linting passes
- [ ] Manual test on Raspberry Pi with INA260 sensor connected