### PR TITLE
refactor(cron-bridge): Rename get_next_events() to preview_schedule() (#305)

### DIFF
--- a/Firmware/Tests/unit/test_cron_bridge.py
+++ b/Firmware/Tests/unit/test_cron_bridge.py
@@ -13,11 +13,11 @@ from webui.backend.lib.cron_bridge import (
     calculate_next_waketime,
     clear_rtc_wakealarm,
     fixed_time_trigger_to_cron,
-    get_next_events,
     get_solar_execution_time,
     interval_trigger_to_cron,
     is_moon_phase_active,
     moon_phase_trigger_to_cron,
+    preview_schedule,
     remove_from_system,
     routine_to_cron_entries,
     schedule_to_cron,
@@ -947,11 +947,11 @@ class TestRemoveFromSystem:
             mock_crontab_class.assert_called_once_with(user="testuser")
 
 
-class TestGetNextEvents:
-    """Test get_next_events function (Schema 3.0)."""
+class TestPreviewSchedule:
+    """Test preview_schedule function (Schema 3.0)."""
 
     def test_returns_list_of_events(self):
-        """get_next_events returns list of event dicts."""
+        """preview_schedule returns list of event dicts."""
         # Create simple schedule with interval trigger routine
         action = Action(action_type="camera", action_name="takephoto", offset_minutes=0)
         window = TimeWindow(start_time="21:00", end_time="22:00")
@@ -969,7 +969,7 @@ class TestGetNextEvents:
             routines=[routine],
         )
 
-        events = get_next_events(schedule, count=10, from_time=datetime(2024, 6, 15, 20, 0, 0))
+        events = preview_schedule(schedule, count=10, from_time=datetime(2024, 6, 15, 20, 0, 0))
         assert isinstance(events, list)
         assert len(events) <= 10
 
@@ -990,7 +990,7 @@ class TestGetNextEvents:
             routines=[routine],
         )
 
-        events = get_next_events(schedule, count=5, from_time=datetime(2024, 6, 15, 20, 0, 0))
+        events = preview_schedule(schedule, count=5, from_time=datetime(2024, 6, 15, 20, 0, 0))
         assert len(events) >= 1
         event = events[0]
         assert "datetime" in event
@@ -1020,7 +1020,7 @@ class TestGetNextEvents:
             routines=[routine],
         )
 
-        events = get_next_events(schedule, count=10, from_time=datetime(2024, 6, 15, 20, 0, 0))
+        events = preview_schedule(schedule, count=10, from_time=datetime(2024, 6, 15, 20, 0, 0))
         datetimes = [e["datetime"] for e in events]
         assert datetimes == sorted(datetimes)
 
@@ -1042,7 +1042,7 @@ class TestGetNextEvents:
             routines=[routine],
         )
 
-        events = get_next_events(schedule, count=20, from_time=datetime(2024, 6, 15, 20, 0, 0))
+        events = preview_schedule(schedule, count=20, from_time=datetime(2024, 6, 15, 20, 0, 0))
         action_names = {e["action_name"] for e in events}
         assert "attract_on" in action_names
         assert "takephoto" in action_names
@@ -1067,7 +1067,7 @@ class TestGetNextEvents:
             routines=[routine],
         )
 
-        events = get_next_events(schedule, count=10, from_time=datetime(2024, 6, 15, 0, 0, 0))
+        events = preview_schedule(schedule, count=10, from_time=datetime(2024, 6, 15, 0, 0, 0))
         assert len(events) >= 1
 
     def test_returns_empty_for_disabled_schedule(self):
@@ -1088,11 +1088,11 @@ class TestGetNextEvents:
             enabled=False,
         )
 
-        events = get_next_events(schedule, count=10)
+        events = preview_schedule(schedule, count=10)
         assert events == []
 
     def test_respects_count_limit(self):
-        """get_next_events respects count parameter."""
+        """preview_schedule respects count parameter."""
         action = Action(action_type="camera", action_name="takephoto", offset_minutes=0)
         trigger = FixedTimeTrigger(time="21:00", days_of_week=None)
         routine = Routine(
@@ -1108,8 +1108,8 @@ class TestGetNextEvents:
             routines=[routine],
         )
 
-        events5 = get_next_events(schedule, count=5, from_time=datetime(2024, 6, 15, 20, 0, 0))
-        events10 = get_next_events(schedule, count=10, from_time=datetime(2024, 6, 15, 20, 0, 0))
+        events5 = preview_schedule(schedule, count=5, from_time=datetime(2024, 6, 15, 20, 0, 0))
+        events10 = preview_schedule(schedule, count=10, from_time=datetime(2024, 6, 15, 20, 0, 0))
         assert len(events5) == 5
         assert len(events10) == 10
 

--- a/Firmware/webui/backend/lib/cron_bridge.py
+++ b/Firmware/webui/backend/lib/cron_bridge.py
@@ -1383,11 +1383,11 @@ def schedule_to_cron(
 
 
 # =============================================================================
-# EVENT PREVIEW
+# SCHEDULE PREVIEW
 # =============================================================================
 
 
-def get_next_events(
+def preview_schedule(
     schedule: Schedule,
     count: int = 10,
     from_time: datetime | None = None,
@@ -1395,22 +1395,22 @@ def get_next_events(
     longitude: float | None = None,
     timezone_name: str = "UTC",
 ) -> list[dict]:
-    """Preview next N scheduled events without modifying system (Schema 3.0).
+    """Preview upcoming schedule executions (Schema 3.0).
 
-    Iterates over each routine in the schedule, calculates upcoming event
+    Iterates over each routine in the schedule, calculates upcoming
     execution times based on the routine's embedded trigger, and aggregates
-    all events.
+    all results.
 
     Args:
         schedule: Schedule object to preview
-        count: Maximum number of events to return (default 10)
-        from_time: Calculate events from this time (defaults to now)
+        count: Maximum number of executions to return (default 10)
+        from_time: Calculate executions from this time (defaults to now)
         latitude: Observer latitude (required for solar triggers)
         longitude: Observer longitude (required for solar triggers)
         timezone_name: Timezone for calculations
 
     Returns:
-        List of event dicts with:
+        List of dicts with:
         - datetime: ISO 8601 string
         - action_type: str (gpio, camera, etc.)
         - action_name: str (attract_on, takephoto, etc.)

--- a/Firmware/webui/docs/dev/api/cron-bridge.md
+++ b/Firmware/webui/docs/dev/api/cron-bridge.md
@@ -240,27 +240,29 @@ def remove_from_system(
 
 **Safety**: Only removes jobs matching `is_mothbox_command()` heuristic.
 
-## Event Preview
+## Schedule Preview
 
-### get_next_events
+### preview_schedule
 
-Preview next scheduled executions without modifying system.
+Preview upcoming schedule executions without modifying system.
 
 ```python
-def get_next_events(
+def preview_schedule(
     schedule: Schedule,
     count: int = 10,
-    latitude: float = 0.0,
-    longitude: float = 0.0,
+    from_time: datetime | None = None,
+    latitude: float | None = None,
+    longitude: float | None = None,
     timezone_name: str = "UTC",
 ) -> list[dict]
 ```
 
-**Returns**: List of event dicts with:
+**Returns**: List of dicts with:
 - `datetime`: ISO 8601 timestamp
 - `action_type`: Action type (gpio, camera, etc.)
 - `action_name`: Specific action (takephoto, attract_on, etc.)
-- `pattern_name`: Source pattern name
+- `routine_name`: Source routine name
+- `routine_id`: Source routine ID
 
 ## Integration with SchedulerService
 


### PR DESCRIPTION
## Summary

- Rename `get_next_events()` to `preview_schedule()` per Scheduler Terminology Refactor
- Update test class name and all function calls
- Update API documentation

## Changes

| File | Changes |
|------|---------|
| `webui/backend/lib/cron_bridge.py` | Rename function, update section header and docstring |
| `Tests/unit/test_cron_bridge.py` | Update import, rename test class, update function calls |
| `webui/docs/dev/api/cron-bridge.md` | Update documentation with new function name and signature |

## Test plan

- [x] All 121 cron_bridge tests pass
- [x] Ruff linter passes
- [x] No breaking changes (function only used in tests, routes use `generate_preview()` from `schedule_preview.py`)

Closes #305