### PR TITLE
refactor(scheduler): Rename PatternExecution to RoutineExecution (#307)

### DIFF
--- a/Firmware/Tests/unit/test_schedule_conflict_lib.py
+++ b/Firmware/Tests/unit/test_schedule_conflict_lib.py
@@ -144,8 +144,8 @@ def sample_conflict():
         start_time=datetime(2024, 6, 15, 21, 5, 0),
         end_time=datetime(2024, 6, 15, 21, 5, 30),
         resource="camera",
-        message="Camera resource conflict between patterns",
-        suggested_resolution="Increase interval between pattern triggers",
+        message="Camera resource conflict between routines",
+        suggested_resolution="Increase interval between routine triggers",
         severity="error",
     )
 
@@ -543,8 +543,8 @@ class TestTimeOverlapDetection:
         assert start == datetime(2024, 6, 15, 21, 10, 0)  # exec1 start
         assert end == datetime(2024, 6, 15, 21, 15, 0)    # exec2 end
 
-    def test_adjacent_patterns_no_overlap(self):
-        """Adjacent patterns (end == start) should NOT overlap."""
+    def test_adjacent_routines_no_overlap(self):
+        """Adjacent routines (end == start) should NOT overlap."""
         exec1 = RoutineExecution(
             routine_id="p1",
             routine_name="P1",
@@ -612,8 +612,8 @@ class TestTimeOverlapDetection:
         assert start == datetime(2024, 6, 15, 21, 15, 0)
         assert end == datetime(2024, 6, 15, 21, 45, 0)
 
-    def test_zero_duration_pattern(self):
-        """Zero-duration patterns (start == end) should still be detected."""
+    def test_zero_duration_routine(self):
+        """Zero-duration routines (start == end) should still be detected."""
         instant = RoutineExecution(
             routine_id="instant",
             routine_name="Instant",
@@ -954,7 +954,7 @@ class TestResourceContention:
 
 
 # ============================================================================
-# Test Pattern Execution Generation
+# Test Routine Execution Generation
 # ============================================================================
 
 class TestRoutineExecutionGeneration:
@@ -1006,8 +1006,8 @@ class TestRoutineExecutionGeneration:
         assert "camera" in resource_types   # takephoto
         # attract_off is also 'attract' type
 
-    def test_execution_duration_matches_pattern(self, sample_schedule):
-        """Execution end_time should reflect pattern duration."""
+    def test_execution_duration_matches_routine(self, sample_schedule):
+        """Execution end_time should reflect routine duration."""
         start_date = date(2024, 6, 15)
         end_date = date(2024, 6, 15)
 
@@ -1023,7 +1023,7 @@ class TestRoutineExecutionGeneration:
         first_exec = executions[0]
         duration = (first_exec.end_time - first_exec.start_time).total_seconds() / 60
 
-        # Pattern has actions at 0, 5, and 15 minutes, so duration is 15 minutes
+        # Routine has actions at 0, 5, and 15 minutes, so duration is 15 minutes
         assert duration == 15
 
     def test_empty_execution_list_outside_window(self, sample_schedule):
@@ -1094,8 +1094,8 @@ class TestRoutineExecutionGeneration:
 class TestDetectConflicts:
     """Tests for detect_conflicts() main function."""
 
-    def test_no_conflicts_single_pattern(self, sample_schedule):
-        """Single pattern with adequate interval should have no conflicts."""
+    def test_no_conflicts_single_routine(self, sample_schedule):
+        """Single routine with adequate interval should have no conflicts."""
         report = detect_conflicts(
             sample_schedule,
             preview_days=1,
@@ -1109,7 +1109,7 @@ class TestDetectConflicts:
         assert len(report.conflicts) == 0
 
     def test_time_overlap_conflict_detected(self, conflicting_schedule):
-        """Schedule with overlapping patterns should detect time overlap."""
+        """Schedule with overlapping routines should detect time overlap."""
         report = detect_conflicts(
             conflicting_schedule,
             preview_days=1,
@@ -1118,7 +1118,7 @@ class TestDetectConflicts:
             timezone_name="UTC",
         )
 
-        # With 15-min interval and 20-min pattern duration, patterns will overlap
+        # With 15-min interval and 20-min routine duration, routines will overlap
         time_overlaps = [c for c in report.conflicts if c.conflict_type == "time_overlap"]
         assert len(time_overlaps) > 0
 
@@ -1132,7 +1132,7 @@ class TestDetectConflicts:
             timezone_name="UTC",
         )
 
-        # Both patterns use camera at offset 10, should conflict
+        # Both routines use camera at offset 10, should conflict
         resource_conflicts = [c for c in report.conflicts if c.conflict_type == "resource_contention"]
         assert len(resource_conflicts) > 0
 

--- a/Firmware/Tests/unit/test_schedule_conflict_lib.py
+++ b/Firmware/Tests/unit/test_schedule_conflict_lib.py
@@ -2,13 +2,13 @@
 Unit tests for schedule conflict detection library.
 
 Tests cover:
-- Data structure serialization (ResourceUsage, PatternExecution, Conflict, ConflictReport)
+- Data structure serialization (ResourceUsage, RoutineExecution, Conflict, ConflictReport)
 - Time overlap detection
 - Resource contention detection (camera, GPS, GPIO)
 - GPIO state conflict detection
-- Pattern execution generation
+- Routine execution generation
 - Conflict report generation
-- Edge cases (adjacent patterns, same start time, overnight windows)
+- Edge cases (adjacent routines, same start time, overnight windows)
 
 Coverage target: 85%+
 Test count target: 35+
@@ -62,14 +62,16 @@ try:
         SINGLE_RESOURCES,
         Conflict,
         ConflictReport,
-        PatternExecution,
+        GPIOStateWarning,
         ResourceUsage,
+        RoutineExecution,
         TimeCollision,
         check_resource_contention,
         check_time_overlap,
         detect_conflicts,
+        detect_gpio_conflicts,
         detect_time_collisions,
-        generate_pattern_executions,
+        generate_routine_executions,
         get_resource_type,
         validate_schedule_conflicts,
     )
@@ -96,17 +98,17 @@ def sample_resource_usage():
         resource_name="takephoto",
         start_time=datetime(2024, 6, 15, 21, 5, 0),
         end_time=datetime(2024, 6, 15, 21, 5, 30),
-        pattern_id="pattern-1",
+        routine_id="routine-1",
         action_index=1,
     )
 
 
 @pytest.fixture
-def sample_pattern_execution():
-    """Create a sample PatternExecution for testing."""
-    return PatternExecution(
-        pattern_id="pattern-1",
-        pattern_name="UV Capture",
+def sample_routine_execution():
+    """Create a sample RoutineExecution for testing."""
+    return RoutineExecution(
+        routine_id="routine-1",
+        routine_name="UV Capture",
         start_time=datetime(2024, 6, 15, 21, 0, 0),
         end_time=datetime(2024, 6, 15, 21, 15, 0),
         resource_usages=[
@@ -115,7 +117,7 @@ def sample_pattern_execution():
                 resource_name="attract_on",
                 start_time=datetime(2024, 6, 15, 21, 0, 0),
                 end_time=datetime(2024, 6, 15, 21, 0, 0),
-                pattern_id="pattern-1",
+                routine_id="routine-1",
                 action_index=0,
             ),
             ResourceUsage(
@@ -123,7 +125,7 @@ def sample_pattern_execution():
                 resource_name="takephoto",
                 start_time=datetime(2024, 6, 15, 21, 5, 0),
                 end_time=datetime(2024, 6, 15, 21, 5, 30),
-                pattern_id="pattern-1",
+                routine_id="routine-1",
                 action_index=1,
             ),
         ],
@@ -165,10 +167,10 @@ def sample_conflict_report(sample_conflict):
 
 @pytest.fixture
 def overlapping_executions():
-    """Create two overlapping PatternExecutions."""
-    exec1 = PatternExecution(
-        pattern_id="pattern-1",
-        pattern_name="Pattern 1",
+    """Create two overlapping RoutineExecutions."""
+    exec1 = RoutineExecution(
+        routine_id="pattern-1",
+        routine_name="Pattern 1",
         start_time=datetime(2024, 6, 15, 21, 0, 0),
         end_time=datetime(2024, 6, 15, 21, 15, 0),
         resource_usages=[
@@ -177,14 +179,14 @@ def overlapping_executions():
                 resource_name="takephoto",
                 start_time=datetime(2024, 6, 15, 21, 5, 0),
                 end_time=datetime(2024, 6, 15, 21, 5, 30),
-                pattern_id="pattern-1",
+                routine_id="pattern-1",
                 action_index=0,
             )
         ],
     )
-    exec2 = PatternExecution(
-        pattern_id="pattern-2",
-        pattern_name="Pattern 2",
+    exec2 = RoutineExecution(
+        routine_id="pattern-2",
+        routine_name="Pattern 2",
         start_time=datetime(2024, 6, 15, 21, 10, 0),
         end_time=datetime(2024, 6, 15, 21, 25, 0),
         resource_usages=[
@@ -193,7 +195,7 @@ def overlapping_executions():
                 resource_name="takephoto",
                 start_time=datetime(2024, 6, 15, 21, 15, 0),
                 end_time=datetime(2024, 6, 15, 21, 15, 30),
-                pattern_id="pattern-2",
+                routine_id="pattern-2",
                 action_index=0,
             )
         ],
@@ -203,17 +205,17 @@ def overlapping_executions():
 
 @pytest.fixture
 def non_overlapping_executions():
-    """Create two non-overlapping PatternExecutions."""
-    exec1 = PatternExecution(
-        pattern_id="pattern-1",
-        pattern_name="Pattern 1",
+    """Create two non-overlapping RoutineExecutions."""
+    exec1 = RoutineExecution(
+        routine_id="pattern-1",
+        routine_name="Pattern 1",
         start_time=datetime(2024, 6, 15, 21, 0, 0),
         end_time=datetime(2024, 6, 15, 21, 15, 0),
         resource_usages=[],
     )
-    exec2 = PatternExecution(
-        pattern_id="pattern-2",
-        pattern_name="Pattern 2",
+    exec2 = RoutineExecution(
+        routine_id="pattern-2",
+        routine_name="Pattern 2",
         start_time=datetime(2024, 6, 15, 22, 0, 0),
         end_time=datetime(2024, 6, 15, 22, 15, 0),
         resource_usages=[],
@@ -225,9 +227,9 @@ def non_overlapping_executions():
 def sample_schedule():
     """Create a valid Schedule for conflict testing (Schema 3.0)."""
     from webui.backend.lib.schedule_schema import (
-        Routine,
-        IntervalTrigger,
         Action,
+        IntervalTrigger,
+        Routine,
         Schedule,
         TimeWindow,
     )
@@ -281,9 +283,9 @@ def sample_schedule():
 def conflicting_schedule():
     """Create a Schedule with routines that will conflict (Schema 3.0)."""
     from webui.backend.lib.schedule_schema import (
-        Routine,
-        IntervalTrigger,
         Action,
+        IntervalTrigger,
+        Routine,
         Schedule,
         TimeWindow,
     )
@@ -374,7 +376,7 @@ class TestConflictDataclasses:
         assert data["resource_name"] == "takephoto"
         assert data["start_time"] == "2024-06-15T21:05:00"
         assert data["end_time"] == "2024-06-15T21:05:30"
-        assert data["pattern_id"] == "pattern-1"
+        assert data["routine_id"] == "routine-1"
         assert data["action_index"] == 1
 
     def test_resource_usage_from_dict(self, sample_resource_usage):
@@ -386,30 +388,30 @@ class TestConflictDataclasses:
         assert restored.resource_name == sample_resource_usage.resource_name
         assert restored.start_time == sample_resource_usage.start_time
         assert restored.end_time == sample_resource_usage.end_time
-        assert restored.pattern_id == sample_resource_usage.pattern_id
+        assert restored.routine_id == sample_resource_usage.routine_id
         assert restored.action_index == sample_resource_usage.action_index
 
-    def test_pattern_execution_to_dict(self, sample_pattern_execution):
-        """PatternExecution.to_dict() should serialize including nested resource_usages."""
-        data = sample_pattern_execution.to_dict()
+    def test_routine_execution_to_dict(self, sample_routine_execution):
+        """RoutineExecution.to_dict() should serialize including nested resource_usages."""
+        data = sample_routine_execution.to_dict()
 
-        assert data["pattern_id"] == "pattern-1"
-        assert data["pattern_name"] == "UV Capture"
+        assert data["routine_id"] == "routine-1"
+        assert data["routine_name"] == "UV Capture"
         assert data["start_time"] == "2024-06-15T21:00:00"
         assert data["end_time"] == "2024-06-15T21:15:00"
         assert len(data["resource_usages"]) == 2
         assert data["resource_usages"][0]["resource_type"] == "gpio"
         assert data["resource_usages"][1]["resource_type"] == "camera"
 
-    def test_pattern_execution_from_dict(self, sample_pattern_execution):
-        """PatternExecution.from_dict() should deserialize including nested usages."""
-        data = sample_pattern_execution.to_dict()
-        restored = PatternExecution.from_dict(data)
+    def test_routine_execution_from_dict(self, sample_routine_execution):
+        """RoutineExecution.from_dict() should deserialize including nested usages."""
+        data = sample_routine_execution.to_dict()
+        restored = RoutineExecution.from_dict(data)
 
-        assert restored.pattern_id == sample_pattern_execution.pattern_id
-        assert restored.pattern_name == sample_pattern_execution.pattern_name
-        assert restored.start_time == sample_pattern_execution.start_time
-        assert restored.end_time == sample_pattern_execution.end_time
+        assert restored.routine_id == sample_routine_execution.routine_id
+        assert restored.routine_name == sample_routine_execution.routine_name
+        assert restored.start_time == sample_routine_execution.start_time
+        assert restored.end_time == sample_routine_execution.end_time
         assert len(restored.resource_usages) == 2
         assert restored.resource_usages[0].resource_type == "gpio"
         assert restored.resource_usages[1].resource_type == "camera"
@@ -487,16 +489,16 @@ class TestTimeOverlapDetection:
 
     def test_fully_overlapping_executions(self):
         """Fully overlapping executions should return True with overlap period."""
-        exec1 = PatternExecution(
-            pattern_id="p1",
-            pattern_name="P1",
+        exec1 = RoutineExecution(
+            routine_id="p1",
+            routine_name="P1",
             start_time=datetime(2024, 6, 15, 21, 0, 0),
             end_time=datetime(2024, 6, 15, 21, 30, 0),
             resource_usages=[],
         )
-        exec2 = PatternExecution(
-            pattern_id="p2",
-            pattern_name="P2",
+        exec2 = RoutineExecution(
+            routine_id="p2",
+            routine_name="P2",
             start_time=datetime(2024, 6, 15, 21, 5, 0),
             end_time=datetime(2024, 6, 15, 21, 20, 0),
             resource_usages=[],
@@ -520,16 +522,16 @@ class TestTimeOverlapDetection:
 
     def test_partial_overlap_end_inside(self):
         """Partial overlap where exec1 ends during exec2."""
-        exec1 = PatternExecution(
-            pattern_id="p1",
-            pattern_name="P1",
+        exec1 = RoutineExecution(
+            routine_id="p1",
+            routine_name="P1",
             start_time=datetime(2024, 6, 15, 21, 10, 0),
             end_time=datetime(2024, 6, 15, 21, 25, 0),
             resource_usages=[],
         )
-        exec2 = PatternExecution(
-            pattern_id="p2",
-            pattern_name="P2",
+        exec2 = RoutineExecution(
+            routine_id="p2",
+            routine_name="P2",
             start_time=datetime(2024, 6, 15, 21, 0, 0),
             end_time=datetime(2024, 6, 15, 21, 15, 0),
             resource_usages=[],
@@ -543,16 +545,16 @@ class TestTimeOverlapDetection:
 
     def test_adjacent_patterns_no_overlap(self):
         """Adjacent patterns (end == start) should NOT overlap."""
-        exec1 = PatternExecution(
-            pattern_id="p1",
-            pattern_name="P1",
+        exec1 = RoutineExecution(
+            routine_id="p1",
+            routine_name="P1",
             start_time=datetime(2024, 6, 15, 21, 0, 0),
             end_time=datetime(2024, 6, 15, 21, 15, 0),
             resource_usages=[],
         )
-        exec2 = PatternExecution(
-            pattern_id="p2",
-            pattern_name="P2",
+        exec2 = RoutineExecution(
+            routine_id="p2",
+            routine_name="P2",
             start_time=datetime(2024, 6, 15, 21, 15, 0),  # Starts exactly when exec1 ends
             end_time=datetime(2024, 6, 15, 21, 30, 0),
             resource_usages=[],
@@ -566,16 +568,16 @@ class TestTimeOverlapDetection:
 
     def test_same_start_time(self):
         """Executions starting at same time should overlap."""
-        exec1 = PatternExecution(
-            pattern_id="p1",
-            pattern_name="P1",
+        exec1 = RoutineExecution(
+            routine_id="p1",
+            routine_name="P1",
             start_time=datetime(2024, 6, 15, 21, 0, 0),
             end_time=datetime(2024, 6, 15, 21, 15, 0),
             resource_usages=[],
         )
-        exec2 = PatternExecution(
-            pattern_id="p2",
-            pattern_name="P2",
+        exec2 = RoutineExecution(
+            routine_id="p2",
+            routine_name="P2",
             start_time=datetime(2024, 6, 15, 21, 0, 0),
             end_time=datetime(2024, 6, 15, 21, 10, 0),
             resource_usages=[],
@@ -589,16 +591,16 @@ class TestTimeOverlapDetection:
 
     def test_one_contains_other(self):
         """One execution fully contains another."""
-        outer = PatternExecution(
-            pattern_id="outer",
-            pattern_name="Outer",
+        outer = RoutineExecution(
+            routine_id="outer",
+            routine_name="Outer",
             start_time=datetime(2024, 6, 15, 21, 0, 0),
             end_time=datetime(2024, 6, 15, 22, 0, 0),
             resource_usages=[],
         )
-        inner = PatternExecution(
-            pattern_id="inner",
-            pattern_name="Inner",
+        inner = RoutineExecution(
+            routine_id="inner",
+            routine_name="Inner",
             start_time=datetime(2024, 6, 15, 21, 15, 0),
             end_time=datetime(2024, 6, 15, 21, 45, 0),
             resource_usages=[],
@@ -612,16 +614,16 @@ class TestTimeOverlapDetection:
 
     def test_zero_duration_pattern(self):
         """Zero-duration patterns (start == end) should still be detected."""
-        instant = PatternExecution(
-            pattern_id="instant",
-            pattern_name="Instant",
+        instant = RoutineExecution(
+            routine_id="instant",
+            routine_name="Instant",
             start_time=datetime(2024, 6, 15, 21, 10, 0),
             end_time=datetime(2024, 6, 15, 21, 10, 0),  # Same as start
             resource_usages=[],
         )
-        normal = PatternExecution(
-            pattern_id="normal",
-            pattern_name="Normal",
+        normal = RoutineExecution(
+            routine_id="normal",
+            routine_name="Normal",
             start_time=datetime(2024, 6, 15, 21, 5, 0),
             end_time=datetime(2024, 6, 15, 21, 20, 0),
             resource_usages=[],
@@ -708,7 +710,7 @@ class TestResourceContention:
             resource_name="takephoto",
             start_time=datetime(2024, 6, 15, 21, 5, 0),
             end_time=datetime(2024, 6, 15, 21, 5, 30),
-            pattern_id="p1",
+            routine_id="p1",
             action_index=0,
         )
         usage2 = ResourceUsage(
@@ -716,7 +718,7 @@ class TestResourceContention:
             resource_name="takephoto",
             start_time=datetime(2024, 6, 15, 21, 5, 15),
             end_time=datetime(2024, 6, 15, 21, 5, 45),
-            pattern_id="p2",
+            routine_id="p2",
             action_index=0,
         )
 
@@ -732,7 +734,7 @@ class TestResourceContention:
             resource_name="sync",
             start_time=datetime(2024, 6, 15, 21, 0, 0),
             end_time=datetime(2024, 6, 15, 21, 0, 30),
-            pattern_id="p1",
+            routine_id="p1",
             action_index=0,
         )
         usage2 = ResourceUsage(
@@ -740,7 +742,7 @@ class TestResourceContention:
             resource_name="sync",
             start_time=datetime(2024, 6, 15, 21, 0, 15),
             end_time=datetime(2024, 6, 15, 21, 0, 45),
-            pattern_id="p2",
+            routine_id="p2",
             action_index=0,
         )
 
@@ -756,7 +758,7 @@ class TestResourceContention:
             resource_name="attract_on",
             start_time=datetime(2024, 6, 15, 21, 0, 0),
             end_time=datetime(2024, 6, 15, 21, 0, 0),
-            pattern_id="p1",
+            routine_id="p1",
             action_index=0,
         )
         usage2 = ResourceUsage(
@@ -764,7 +766,7 @@ class TestResourceContention:
             resource_name="attract_off",
             start_time=datetime(2024, 6, 15, 21, 0, 0),
             end_time=datetime(2024, 6, 15, 21, 0, 0),
-            pattern_id="p2",
+            routine_id="p2",
             action_index=0,
         )
 
@@ -780,7 +782,7 @@ class TestResourceContention:
             resource_name="attract_on",
             start_time=datetime(2024, 6, 15, 21, 0, 0),
             end_time=datetime(2024, 6, 15, 21, 0, 0),
-            pattern_id="p1",
+            routine_id="p1",
             action_index=0,
         )
         usage2 = ResourceUsage(
@@ -788,7 +790,7 @@ class TestResourceContention:
             resource_name="attract_on",
             start_time=datetime(2024, 6, 15, 21, 0, 0),
             end_time=datetime(2024, 6, 15, 21, 0, 0),
-            pattern_id="p2",
+            routine_id="p2",
             action_index=0,
         )
 
@@ -804,7 +806,7 @@ class TestResourceContention:
             resource_name="takephoto",
             start_time=datetime(2024, 6, 15, 21, 5, 0),
             end_time=datetime(2024, 6, 15, 21, 5, 30),
-            pattern_id="p1",
+            routine_id="p1",
             action_index=0,
         )
         usage2 = ResourceUsage(
@@ -812,7 +814,7 @@ class TestResourceContention:
             resource_name="attract_on",
             start_time=datetime(2024, 6, 15, 21, 5, 0),
             end_time=datetime(2024, 6, 15, 21, 5, 0),
-            pattern_id="p2",
+            routine_id="p2",
             action_index=0,
         )
 
@@ -828,7 +830,7 @@ class TestResourceContention:
             resource_name="takephoto",
             start_time=datetime(2024, 6, 15, 21, 5, 0),
             end_time=datetime(2024, 6, 15, 21, 5, 30),
-            pattern_id="p1",
+            routine_id="p1",
             action_index=0,
         )
         usage2 = ResourceUsage(
@@ -836,7 +838,7 @@ class TestResourceContention:
             resource_name="takephoto",
             start_time=datetime(2024, 6, 15, 21, 10, 0),
             end_time=datetime(2024, 6, 15, 21, 10, 30),
-            pattern_id="p2",
+            routine_id="p2",
             action_index=0,
         )
 
@@ -852,7 +854,7 @@ class TestResourceContention:
             resource_name="backup",
             start_time=datetime(2024, 6, 15, 21, 0, 0),
             end_time=datetime(2024, 6, 15, 21, 5, 0),
-            pattern_id="p1",
+            routine_id="p1",
             action_index=0,
         )
         usage2 = ResourceUsage(
@@ -860,7 +862,7 @@ class TestResourceContention:
             resource_name="backup",
             start_time=datetime(2024, 6, 15, 21, 2, 0),
             end_time=datetime(2024, 6, 15, 21, 7, 0),
-            pattern_id="p2",
+            routine_id="p2",
             action_index=0,
         )
 
@@ -877,7 +879,7 @@ class TestResourceContention:
             resource_name="takephoto",
             start_time=datetime(2024, 6, 15, 21, 5, 0),
             end_time=datetime(2024, 6, 15, 21, 5, 30),
-            pattern_id="p1",
+            routine_id="p1",
             action_index=0,
         )
         # Instant camera action at exactly 21:05:30 (end time of duration_usage)
@@ -886,7 +888,7 @@ class TestResourceContention:
             resource_name="takephoto",
             start_time=datetime(2024, 6, 15, 21, 5, 30),
             end_time=datetime(2024, 6, 15, 21, 5, 30),  # Instant (start == end)
-            pattern_id="p2",
+            routine_id="p2",
             action_index=0,
         )
 
@@ -904,7 +906,7 @@ class TestResourceContention:
             resource_name="takephoto",
             start_time=datetime(2024, 6, 15, 21, 5, 0),
             end_time=datetime(2024, 6, 15, 21, 5, 30),
-            pattern_id="p1",
+            routine_id="p1",
             action_index=0,
         )
         # Instant camera action at exactly 21:05:00 (start time of duration_usage)
@@ -913,7 +915,7 @@ class TestResourceContention:
             resource_name="takephoto",
             start_time=datetime(2024, 6, 15, 21, 5, 0),
             end_time=datetime(2024, 6, 15, 21, 5, 0),  # Instant (start == end)
-            pattern_id="p2",
+            routine_id="p2",
             action_index=0,
         )
 
@@ -931,7 +933,7 @@ class TestResourceContention:
             resource_name="takephoto",
             start_time=datetime(2024, 6, 15, 21, 5, 0),
             end_time=datetime(2024, 6, 15, 21, 5, 30),
-            pattern_id="p1",
+            routine_id="p1",
             action_index=0,
         )
         # Instant camera action at 21:05:31 (1 second after end time)
@@ -940,7 +942,7 @@ class TestResourceContention:
             resource_name="takephoto",
             start_time=datetime(2024, 6, 15, 21, 5, 31),
             end_time=datetime(2024, 6, 15, 21, 5, 31),  # Instant (start == end)
-            pattern_id="p2",
+            routine_id="p2",
             action_index=0,
         )
 
@@ -955,15 +957,15 @@ class TestResourceContention:
 # Test Pattern Execution Generation
 # ============================================================================
 
-class TestPatternExecutionGeneration:
-    """Tests for generate_pattern_executions() function."""
+class TestRoutineExecutionGeneration:
+    """Tests for generate_routine_executions() function."""
 
     def test_interval_trigger_generation(self, sample_schedule):
         """Interval trigger should generate executions at correct times."""
         start_date = date(2024, 6, 15)
         end_date = date(2024, 6, 15)
 
-        executions = generate_pattern_executions(
+        executions = generate_routine_executions(
             sample_schedule,
             start_date,
             end_date,
@@ -976,7 +978,7 @@ class TestPatternExecutionGeneration:
         assert len(executions) == 4
 
         # Check first execution
-        assert executions[0].pattern_name == "UV Capture Cycle"
+        assert executions[0].routine_name == "UV Capture Cycle"
         assert executions[0].start_time.hour == 21
         assert executions[0].start_time.minute == 0
 
@@ -985,7 +987,7 @@ class TestPatternExecutionGeneration:
         start_date = date(2024, 6, 15)
         end_date = date(2024, 6, 15)
 
-        executions = generate_pattern_executions(
+        executions = generate_routine_executions(
             sample_schedule,
             start_date,
             end_date,
@@ -1009,7 +1011,7 @@ class TestPatternExecutionGeneration:
         start_date = date(2024, 6, 15)
         end_date = date(2024, 6, 15)
 
-        executions = generate_pattern_executions(
+        executions = generate_routine_executions(
             sample_schedule,
             start_date,
             end_date,
@@ -1039,7 +1041,7 @@ class TestPatternExecutionGeneration:
         start_date = date(2024, 6, 15)
         end_date = date(2024, 6, 15)
 
-        executions = generate_pattern_executions(
+        executions = generate_routine_executions(
             sample_schedule,
             start_date,
             end_date,
@@ -1055,7 +1057,7 @@ class TestPatternExecutionGeneration:
         start_date = date(2024, 6, 15)
         end_date = date(2024, 6, 17)  # 3 days
 
-        executions = generate_pattern_executions(
+        executions = generate_routine_executions(
             sample_schedule,
             start_date,
             end_date,
@@ -1072,7 +1074,7 @@ class TestPatternExecutionGeneration:
         start_date = date(2024, 6, 15)
         end_date = date(2024, 6, 17)
 
-        executions = generate_pattern_executions(
+        executions = generate_routine_executions(
             sample_schedule,
             start_date,
             end_date,
@@ -1255,14 +1257,14 @@ class TestConstants:
 # ============================================================================
 
 class TestTriggerTypeHandling:
-    """Tests for different trigger types in generate_pattern_executions()."""
+    """Tests for different trigger types in generate_routine_executions()."""
 
     def test_routine_with_days_of_week(self):
         """Routine with day restrictions should skip other days (Schema 3.0)."""
         from webui.backend.lib.schedule_schema import (
-            Routine,
-            IntervalTrigger,
             Action,
+            IntervalTrigger,
+            Routine,
             Schedule,
             TimeWindow,
         )
@@ -1290,7 +1292,7 @@ class TestTriggerTypeHandling:
             enabled=True,
         )
 
-        executions = generate_pattern_executions(
+        executions = generate_routine_executions(
             schedule,
             date(2024, 6, 15),  # Saturday
             date(2024, 6, 15),
@@ -1305,9 +1307,9 @@ class TestTriggerTypeHandling:
     def test_routine_on_valid_day(self):
         """Routine should generate executions on valid days (Schema 3.0)."""
         from webui.backend.lib.schedule_schema import (
-            Routine,
-            IntervalTrigger,
             Action,
+            IntervalTrigger,
+            Routine,
             Schedule,
             TimeWindow,
         )
@@ -1335,7 +1337,7 @@ class TestTriggerTypeHandling:
             enabled=True,
         )
 
-        executions = generate_pattern_executions(
+        executions = generate_routine_executions(
             schedule,
             date(2024, 6, 17),  # Monday
             date(2024, 6, 17),
@@ -1350,9 +1352,9 @@ class TestTriggerTypeHandling:
     def test_fixed_time_trigger_generation(self):
         """Fixed time trigger should generate single execution per day (Schema 3.0)."""
         from webui.backend.lib.schedule_schema import (
-            Routine,
-            FixedTimeTrigger,
             Action,
+            FixedTimeTrigger,
+            Routine,
             Schedule,
         )
 
@@ -1374,7 +1376,7 @@ class TestTriggerTypeHandling:
             enabled=True,
         )
 
-        executions = generate_pattern_executions(
+        executions = generate_routine_executions(
             schedule,
             date(2024, 6, 15),
             date(2024, 6, 17),  # 3 days
@@ -1394,9 +1396,9 @@ class TestTriggerTypeHandling:
     def test_fixed_time_with_days_of_week(self):
         """Fixed time with day restrictions should skip other days (Schema 3.0)."""
         from webui.backend.lib.schedule_schema import (
-            Routine,
-            FixedTimeTrigger,
             Action,
+            FixedTimeTrigger,
+            Routine,
             Schedule,
         )
 
@@ -1422,7 +1424,7 @@ class TestTriggerTypeHandling:
             enabled=True,
         )
 
-        executions = generate_pattern_executions(
+        executions = generate_routine_executions(
             schedule,
             date(2024, 6, 15),  # Saturday
             date(2024, 6, 15),
@@ -1437,8 +1439,8 @@ class TestTriggerTypeHandling:
     def test_sensor_trigger_generation(self):
         """Sensor trigger with time window should generate placeholder execution (Schema 3.0)."""
         from webui.backend.lib.schedule_schema import (
-            Routine,
             Action,
+            Routine,
             Schedule,
             SensorTrigger,
             TimeWindow,
@@ -1466,7 +1468,7 @@ class TestTriggerTypeHandling:
             enabled=True,
         )
 
-        executions = generate_pattern_executions(
+        executions = generate_routine_executions(
             schedule,
             date(2024, 6, 15),
             date(2024, 6, 15),
@@ -1483,9 +1485,9 @@ class TestTriggerTypeHandling:
     def test_overnight_window_handling(self):
         """Interval trigger with overnight window should work correctly (Schema 3.0)."""
         from webui.backend.lib.schedule_schema import (
-            Routine,
-            IntervalTrigger,
             Action,
+            IntervalTrigger,
+            Routine,
             Schedule,
             TimeWindow,
         )
@@ -1512,7 +1514,7 @@ class TestTriggerTypeHandling:
             enabled=True,
         )
 
-        executions = generate_pattern_executions(
+        executions = generate_routine_executions(
             schedule,
             date(2024, 6, 15),
             date(2024, 6, 15),
@@ -1545,7 +1547,7 @@ class TestConflictMessageGeneration:
             resource_name="takephoto",
             start_time=datetime(2024, 6, 15, 21, 0, 0),
             end_time=datetime(2024, 6, 15, 21, 0, 30),
-            pattern_id="p1",
+            routine_id="p1",
             action_index=0,
         )
         usage2 = ResourceUsage(
@@ -1553,7 +1555,7 @@ class TestConflictMessageGeneration:
             resource_name="takephoto",
             start_time=datetime(2024, 6, 15, 21, 0, 0),
             end_time=datetime(2024, 6, 15, 21, 0, 30),
-            pattern_id="p2",
+            routine_id="p2",
             action_index=0,
         )
 
@@ -1577,7 +1579,7 @@ class TestConflictMessageGeneration:
             resource_name="attract_on",
             start_time=datetime(2024, 6, 15, 21, 0, 0),
             end_time=datetime(2024, 6, 15, 21, 0, 0),
-            pattern_id="p1",
+            routine_id="p1",
             action_index=0,
         )
         usage2 = ResourceUsage(
@@ -1585,7 +1587,7 @@ class TestConflictMessageGeneration:
             resource_name="attract_off",
             start_time=datetime(2024, 6, 15, 21, 0, 0),
             end_time=datetime(2024, 6, 15, 21, 0, 0),
-            pattern_id="p2",
+            routine_id="p2",
             action_index=0,
         )
 
@@ -1607,7 +1609,7 @@ class TestConflictMessageGeneration:
             resource_name="test",
             start_time=datetime(2024, 6, 15, 21, 0, 0),
             end_time=datetime(2024, 6, 15, 21, 0, 30),
-            pattern_id="p1",
+            routine_id="p1",
             action_index=0,
         )
         usage2 = ResourceUsage(
@@ -1615,7 +1617,7 @@ class TestConflictMessageGeneration:
             resource_name="test",
             start_time=datetime(2024, 6, 15, 21, 0, 0),
             end_time=datetime(2024, 6, 15, 21, 0, 30),
-            pattern_id="p2",
+            routine_id="p2",
             action_index=0,
         )
 
@@ -1670,8 +1672,8 @@ class TestSolarTriggerGeneration:
     def test_solar_trigger_with_valid_location(self):
         """Solar trigger should generate execution at solar event time."""
         from webui.backend.lib.schedule_schema import (
-            Routine,
             Action,
+            Routine,
             Schedule,
             SolarTrigger,
         )
@@ -1698,7 +1700,7 @@ class TestSolarTriggerGeneration:
         )
 
         # Use Panama coordinates where solar_time library works
-        executions = generate_pattern_executions(
+        executions = generate_routine_executions(
             schedule,
             date(2024, 6, 15),
             date(2024, 6, 15),
@@ -1715,8 +1717,8 @@ class TestSolarTriggerGeneration:
     def test_solar_trigger_with_days_of_week(self):
         """Solar trigger with day restrictions should skip other days."""
         from webui.backend.lib.schedule_schema import (
-            Routine,
             Action,
+            Routine,
             Schedule,
             SolarTrigger,
         )
@@ -1744,7 +1746,7 @@ class TestSolarTriggerGeneration:
             enabled=True,
         )
 
-        executions = generate_pattern_executions(
+        executions = generate_routine_executions(
             schedule,
             date(2024, 6, 15),  # Saturday
             date(2024, 6, 15),
@@ -1763,9 +1765,9 @@ class TestMoonPhaseTriggerGeneration:
     def test_moon_phase_trigger_with_time_window(self):
         """Moon phase trigger with time_window should use window start time."""
         from webui.backend.lib.schedule_schema import (
-            Routine,
-            MoonPhaseTrigger,
             Action,
+            MoonPhaseTrigger,
+            Routine,
             Schedule,
             TimeWindow,
         )
@@ -1793,7 +1795,7 @@ class TestMoonPhaseTriggerGeneration:
         )
 
         # Find a full moon date (approximately June 22, 2024)
-        executions = generate_pattern_executions(
+        executions = generate_routine_executions(
             schedule,
             date(2024, 6, 21),
             date(2024, 6, 23),  # Around full moon
@@ -1809,9 +1811,9 @@ class TestMoonPhaseTriggerGeneration:
     def test_moon_phase_trigger_without_time_window(self):
         """Moon phase trigger without time_window should default to noon."""
         from webui.backend.lib.schedule_schema import (
-            Routine,
-            MoonPhaseTrigger,
             Action,
+            MoonPhaseTrigger,
+            Routine,
             Schedule,
         )
 
@@ -1837,7 +1839,7 @@ class TestMoonPhaseTriggerGeneration:
         )
 
         # Find a full moon date
-        executions = generate_pattern_executions(
+        executions = generate_routine_executions(
             schedule,
             date(2024, 6, 21),
             date(2024, 6, 23),
@@ -2195,3 +2197,285 @@ class TestDetectTimeCollisions:
         collision = collisions[0]
         # Should use routine_id when name is None
         assert "routine-abc" in collision.message or "routine-xyz" in collision.message
+
+
+# ============================================================================
+# Test GPIOStateWarning and detect_gpio_conflicts
+# ============================================================================
+
+class TestGPIOStateWarning:
+    """Tests for GPIOStateWarning dataclass."""
+
+    def test_gpio_state_warning_creation(self):
+        """GPIOStateWarning should be creatable with all fields."""
+        warning = GPIOStateWarning(
+            resource_type="attract",
+            routine_id="routine-1",
+            routine_name="UV Capture",
+            issue="Attract turned on 1 time(s) but off 0 time(s)",
+            suggested_fix="Add attract_off action at end of routine",
+        )
+
+        assert warning.resource_type == "attract"
+        assert warning.routine_id == "routine-1"
+        assert warning.routine_name == "UV Capture"
+        assert "on 1" in warning.issue
+        assert "attract_off" in warning.suggested_fix
+
+    def test_gpio_state_warning_to_dict(self):
+        """GPIOStateWarning.to_dict() should serialize all fields."""
+        warning = GPIOStateWarning(
+            resource_type="flash",
+            routine_id="routine-2",
+            routine_name="Flash Test",
+            issue="Flash turned off 2 time(s) but on 1 time(s)",
+            suggested_fix="Verify flash_on action exists before flash_off",
+        )
+
+        data = warning.to_dict()
+
+        assert data["type"] == "gpio_state_warning"
+        assert data["resource_type"] == "flash"
+        assert data["routine_id"] == "routine-2"
+        assert data["routine_name"] == "Flash Test"
+        assert "off 2" in data["issue"]
+        assert "flash_on" in data["suggested_fix"]
+
+    def test_gpio_state_warning_from_dict(self):
+        """GPIOStateWarning.from_dict() should deserialize correctly."""
+        warning = GPIOStateWarning(
+            resource_type="attract",
+            routine_id="routine-3",
+            routine_name="Test Routine",
+            issue="Test issue",
+            suggested_fix="Test fix",
+        )
+
+        data = warning.to_dict()
+        restored = GPIOStateWarning.from_dict(data)
+
+        assert restored.resource_type == warning.resource_type
+        assert restored.routine_id == warning.routine_id
+        assert restored.routine_name == warning.routine_name
+        assert restored.issue == warning.issue
+        assert restored.suggested_fix == warning.suggested_fix
+
+
+class TestDetectGPIOConflicts:
+    """Tests for detect_gpio_conflicts() function."""
+
+    def test_no_gpio_conflicts_balanced(self):
+        """Balanced on/off actions should not generate warnings."""
+        from webui.backend.lib.schedule_schema import (
+            Action,
+            FixedTimeTrigger,
+            Routine,
+            Schedule,
+        )
+
+        routine = Routine(
+            routine_id="balanced",
+            name="Balanced GPIO",
+            trigger=FixedTimeTrigger(time="21:00"),
+            actions=[
+                Action(action_type="gpio", action_name="attract_on", offset_minutes=0),
+                Action(action_type="camera", action_name="takephoto", offset_minutes=5),
+                Action(action_type="gpio", action_name="attract_off", offset_minutes=10),
+            ],
+        )
+
+        schedule = Schedule(
+            schedule_id="balanced-schedule",
+            name="Balanced Schedule",
+            routines=[routine],
+            enabled=True,
+        )
+
+        warnings = detect_gpio_conflicts(schedule)
+
+        assert len(warnings) == 0
+
+    def test_gpio_conflict_missing_off(self):
+        """attract_on without attract_off should generate warning."""
+        from webui.backend.lib.schedule_schema import (
+            Action,
+            FixedTimeTrigger,
+            Routine,
+            Schedule,
+        )
+
+        routine = Routine(
+            routine_id="missing-off",
+            name="Missing Off",
+            trigger=FixedTimeTrigger(time="21:00"),
+            actions=[
+                Action(action_type="gpio", action_name="attract_on", offset_minutes=0),
+                Action(action_type="camera", action_name="takephoto", offset_minutes=5),
+                # Missing attract_off
+            ],
+        )
+
+        schedule = Schedule(
+            schedule_id="missing-off-schedule",
+            name="Missing Off Schedule",
+            routines=[routine],
+            enabled=True,
+        )
+
+        warnings = detect_gpio_conflicts(schedule)
+
+        assert len(warnings) == 1
+        assert warnings[0].resource_type == "attract"
+        assert warnings[0].routine_id == "missing-off"
+        assert "on 1" in warnings[0].issue
+        assert "off 0" in warnings[0].issue
+        assert "attract_off" in warnings[0].suggested_fix
+
+    def test_gpio_conflict_missing_on(self):
+        """flash_off without flash_on should generate warning."""
+        from webui.backend.lib.schedule_schema import (
+            Action,
+            FixedTimeTrigger,
+            Routine,
+            Schedule,
+        )
+
+        routine = Routine(
+            routine_id="missing-on",
+            name="Missing On",
+            trigger=FixedTimeTrigger(time="21:00"),
+            actions=[
+                Action(action_type="gpio", action_name="flash_off", offset_minutes=0),
+                # Missing flash_on
+            ],
+        )
+
+        schedule = Schedule(
+            schedule_id="missing-on-schedule",
+            name="Missing On Schedule",
+            routines=[routine],
+            enabled=True,
+        )
+
+        warnings = detect_gpio_conflicts(schedule)
+
+        assert len(warnings) == 1
+        assert warnings[0].resource_type == "flash"
+        assert "off 1" in warnings[0].issue
+        assert "on 0" in warnings[0].issue
+        assert "flash_on" in warnings[0].suggested_fix
+
+    def test_gpio_conflict_multiple_routines(self):
+        """Multiple routines can each have their own GPIO warnings."""
+        from webui.backend.lib.schedule_schema import (
+            Action,
+            FixedTimeTrigger,
+            Routine,
+            Schedule,
+        )
+
+        routine1 = Routine(
+            routine_id="routine-1",
+            name="Attract Only On",
+            trigger=FixedTimeTrigger(time="21:00"),
+            actions=[
+                Action(action_type="gpio", action_name="attract_on", offset_minutes=0),
+            ],
+        )
+        routine2 = Routine(
+            routine_id="routine-2",
+            name="Flash Only On",
+            trigger=FixedTimeTrigger(time="22:00"),
+            actions=[
+                Action(action_type="gpio", action_name="flash_on", offset_minutes=0),
+            ],
+        )
+
+        schedule = Schedule(
+            schedule_id="multi-gpio",
+            name="Multiple GPIO Issues",
+            routines=[routine1, routine2],
+            enabled=True,
+        )
+
+        warnings = detect_gpio_conflicts(schedule)
+
+        assert len(warnings) == 2
+        resource_types = {w.resource_type for w in warnings}
+        assert "attract" in resource_types
+        assert "flash" in resource_types
+
+    def test_empty_schedule_no_warnings(self):
+        """Empty schedule should generate no warnings."""
+        from webui.backend.lib.schedule_schema import Schedule
+
+        schedule = Schedule(
+            schedule_id="empty",
+            name="Empty Schedule",
+            routines=[],
+            enabled=True,
+        )
+
+        warnings = detect_gpio_conflicts(schedule)
+
+        assert len(warnings) == 0
+
+    def test_non_gpio_actions_ignored(self):
+        """Non-GPIO actions should be ignored."""
+        from webui.backend.lib.schedule_schema import (
+            Action,
+            FixedTimeTrigger,
+            Routine,
+            Schedule,
+        )
+
+        routine = Routine(
+            routine_id="camera-only",
+            name="Camera Only",
+            trigger=FixedTimeTrigger(time="21:00"),
+            actions=[
+                Action(action_type="camera", action_name="takephoto", offset_minutes=0),
+                Action(action_type="gps_sync", action_name="sync", offset_minutes=5),
+            ],
+        )
+
+        schedule = Schedule(
+            schedule_id="camera-schedule",
+            name="Camera Schedule",
+            routines=[routine],
+            enabled=True,
+        )
+
+        warnings = detect_gpio_conflicts(schedule)
+
+        assert len(warnings) == 0
+
+    def test_routine_name_fallback_to_id(self):
+        """Warning uses routine_id if name is None."""
+        from webui.backend.lib.schedule_schema import (
+            Action,
+            FixedTimeTrigger,
+            Routine,
+            Schedule,
+        )
+
+        routine = Routine(
+            routine_id="routine-abc-123",
+            name=None,  # No name
+            trigger=FixedTimeTrigger(time="21:00"),
+            actions=[
+                Action(action_type="gpio", action_name="attract_on", offset_minutes=0),
+            ],
+        )
+
+        schedule = Schedule(
+            schedule_id="nameless",
+            name="Nameless Routine",
+            routines=[routine],
+            enabled=True,
+        )
+
+        warnings = detect_gpio_conflicts(schedule)
+
+        assert len(warnings) == 1
+        assert warnings[0].routine_name == "routine-abc-123"

--- a/Firmware/Tests/unit/test_schedule_preview.py
+++ b/Firmware/Tests/unit/test_schedule_preview.py
@@ -42,10 +42,10 @@ except ImportError:
 # Import schema classes
 try:
     from webui.backend.lib.schedule_schema import (
+        Action,
         FixedTimeTrigger,
         IntervalTrigger,
         MoonPhaseTrigger,
-        Action,
         Routine,
         Schedule,
         SensorTrigger,
@@ -345,8 +345,8 @@ class TestPreviewExecution:
         execution = PreviewExecution(
             start_time=datetime(2025, 6, 15, 21, 0, 0, tzinfo=UTC),
             end_time=datetime(2025, 6, 15, 21, 15, 0, tzinfo=UTC),
-            pattern_id="uv-cycle",
-            pattern_name="UV Capture Cycle",
+            routine_id="uv-cycle",
+            routine_name="UV Capture Cycle",
             trigger_info="interval:60m",
             actions=actions,
         )
@@ -355,8 +355,8 @@ class TestPreviewExecution:
 
         assert result["start_time"] == "2025-06-15T21:00:00+00:00"
         assert result["end_time"] == "2025-06-15T21:15:00+00:00"
-        assert result["pattern_id"] == "uv-cycle"
-        assert result["pattern_name"] == "UV Capture Cycle"
+        assert result["routine_id"] == "uv-cycle"
+        assert result["routine_name"] == "UV Capture Cycle"
         assert result["trigger_info"] == "interval:60m"
         assert len(result["actions"]) == 1
 
@@ -365,8 +365,8 @@ class TestPreviewExecution:
         execution = PreviewExecution(
             start_time=datetime(2025, 6, 15, 21, 0, 0, tzinfo=UTC),
             end_time=datetime(2025, 6, 15, 21, 0, 0, tzinfo=UTC),
-            pattern_id="empty",
-            pattern_name="Empty Pattern",
+            routine_id="empty",
+            routine_name="Empty Pattern",
             trigger_info="fixed",
             actions=[],
         )
@@ -458,8 +458,8 @@ class TestPreviewResult:
                 {
                     "start_time": "2025-06-15T21:00:00+00:00",
                     "end_time": "2025-06-15T21:15:00+00:00",
-                    "pattern_id": "uv-cycle",
-                    "pattern_name": "UV Capture Cycle",
+                    "routine_id": "uv-cycle",
+                    "routine_name": "UV Capture Cycle",
                     "trigger_info": "interval:60m",
                     "actions": [
                         {
@@ -488,7 +488,7 @@ class TestPreviewResult:
         assert result.total_actions == 1
         assert result.total_executions == 1
         assert len(result.executions) == 1
-        assert result.executions[0].pattern_id == "uv-cycle"
+        assert result.executions[0].routine_id == "uv-cycle"
         assert len(result.executions[0].actions) == 1
         assert result.executions[0].actions[0].action_name == "attract_on"
         assert result.moon_phases == {"2025-06-15": {"phase": "full", "illumination": 1.0}}
@@ -504,8 +504,8 @@ class TestPreviewResult:
                 PreviewExecution(
                     start_time=datetime(2025, 6, 15, 21, 0, 0, tzinfo=UTC),
                     end_time=datetime(2025, 6, 15, 21, 15, 0, tzinfo=UTC),
-                    pattern_id="test-pattern",
-                    pattern_name="Test Pattern",
+                    routine_id="test-pattern",
+                    routine_name="Test Pattern",
                     trigger_info="interval:30m",
                     actions=[
                         ActionExecution(
@@ -535,7 +535,7 @@ class TestPreviewResult:
         assert restored.total_executions == original.total_executions
         assert restored.generated_at == original.generated_at
         assert len(restored.executions) == len(original.executions)
-        assert restored.executions[0].pattern_id == original.executions[0].pattern_id
+        assert restored.executions[0].routine_id == original.executions[0].routine_id
         assert len(restored.executions[0].actions) == len(original.executions[0].actions)
 
 
@@ -751,7 +751,7 @@ class TestConflictIntegration:
     """Tests for conflict detection integration."""
 
     @patch("webui.backend.lib.schedule_preview.detect_conflicts")
-    @patch("webui.backend.lib.schedule_preview.generate_pattern_executions")
+    @patch("webui.backend.lib.schedule_preview.generate_routine_executions")
     def test_conflicts_included_in_result(
         self, mock_gen_exec, mock_detect, sample_interval_schedule
     ):
@@ -775,7 +775,7 @@ class TestConflictIntegration:
         assert len(result.conflicts) == 1
 
     @patch("webui.backend.lib.schedule_preview.detect_conflicts")
-    @patch("webui.backend.lib.schedule_preview.generate_pattern_executions")
+    @patch("webui.backend.lib.schedule_preview.generate_routine_executions")
     def test_no_conflicts_empty_list(self, mock_gen_exec, mock_detect, sample_interval_schedule):
         """Test empty conflict list when no conflicts."""
         mock_gen_exec.return_value = []
@@ -789,7 +789,7 @@ class TestConflictIntegration:
         assert result.conflicts == []
 
     @patch("webui.backend.lib.schedule_preview.detect_conflicts")
-    @patch("webui.backend.lib.schedule_preview.generate_pattern_executions")
+    @patch("webui.backend.lib.schedule_preview.generate_routine_executions")
     def test_conflict_report_called_with_correct_params(
         self, mock_gen_exec, mock_detect, sample_interval_schedule
     ):
@@ -956,7 +956,7 @@ class TestLocationFallback:
 
     @patch("webui.backend.lib.schedule_preview._get_default_location")
     @patch("webui.backend.lib.schedule_preview.detect_conflicts")
-    @patch("webui.backend.lib.schedule_preview.generate_pattern_executions")
+    @patch("webui.backend.lib.schedule_preview.generate_routine_executions")
     def test_location_from_params_priority(
         self, mock_gen_exec, mock_detect, mock_default_loc, sample_interval_schedule
     ):
@@ -976,14 +976,14 @@ class TestLocationFallback:
             longitude=-80.0,
         )
 
-        # generate_pattern_executions should be called with explicit params
+        # generate_routine_executions should be called with explicit params
         call_args = mock_gen_exec.call_args
         assert call_args.kwargs["latitude"] == 35.0
         assert call_args.kwargs["longitude"] == -80.0
 
     @patch("webui.backend.lib.schedule_preview._get_default_location")
     @patch("webui.backend.lib.schedule_preview.detect_conflicts")
-    @patch("webui.backend.lib.schedule_preview.generate_pattern_executions")
+    @patch("webui.backend.lib.schedule_preview.generate_routine_executions")
     def test_location_from_controls_fallback(
         self, mock_gen_exec, mock_detect, mock_default_loc, sample_interval_schedule
     ):
@@ -998,14 +998,14 @@ class TestLocationFallback:
         # Call without explicit params
         generate_preview(sample_interval_schedule, days=1)
 
-        # generate_pattern_executions should be called with default location
+        # generate_routine_executions should be called with default location
         call_args = mock_gen_exec.call_args
         assert call_args.kwargs["latitude"] == 10.0
         assert call_args.kwargs["longitude"] == 20.0
 
     @patch("webui.backend.lib.schedule_preview._get_default_location")
     @patch("webui.backend.lib.schedule_preview.detect_conflicts")
-    @patch("webui.backend.lib.schedule_preview.generate_pattern_executions")
+    @patch("webui.backend.lib.schedule_preview.generate_routine_executions")
     def test_default_location_warning_included(
         self, mock_gen_exec, mock_detect, mock_default_loc, sample_interval_schedule
     ):
@@ -1028,7 +1028,7 @@ class TestLocationFallback:
 
     @patch("webui.backend.lib.schedule_preview._get_default_location")
     @patch("webui.backend.lib.schedule_preview.detect_conflicts")
-    @patch("webui.backend.lib.schedule_preview.generate_pattern_executions")
+    @patch("webui.backend.lib.schedule_preview.generate_routine_executions")
     def test_explicit_location_no_warning(
         self, mock_gen_exec, mock_detect, mock_default_loc, sample_interval_schedule
     ):
@@ -1053,7 +1053,7 @@ class TestLocationFallback:
 
     @patch("webui.backend.lib.schedule_preview._get_default_location")
     @patch("webui.backend.lib.schedule_preview.detect_conflicts")
-    @patch("webui.backend.lib.schedule_preview.generate_pattern_executions")
+    @patch("webui.backend.lib.schedule_preview.generate_routine_executions")
     def test_controls_location_no_warning(
         self, mock_gen_exec, mock_detect, mock_default_loc, sample_interval_schedule
     ):
@@ -1074,7 +1074,7 @@ class TestLocationFallback:
 
     @patch("webui.backend.lib.schedule_preview._get_default_location")
     @patch("webui.backend.lib.schedule_preview.detect_conflicts")
-    @patch("webui.backend.lib.schedule_preview.generate_pattern_executions")
+    @patch("webui.backend.lib.schedule_preview.generate_routine_executions")
     def test_sensor_trigger_warning_included(
         self, mock_gen_exec, mock_detect, mock_default_loc, sample_sensor_schedule
     ):
@@ -1104,7 +1104,7 @@ class TestPreviewGeneration:
     """Integration tests for full preview generation."""
 
     @patch("webui.backend.lib.schedule_preview.detect_conflicts")
-    @patch("webui.backend.lib.schedule_preview.generate_pattern_executions")
+    @patch("webui.backend.lib.schedule_preview.generate_routine_executions")
     def test_generate_preview_returns_result(
         self, mock_gen_exec, mock_detect, sample_interval_schedule
     ):
@@ -1124,24 +1124,24 @@ class TestPreviewGeneration:
         assert result.total_actions == 0
 
     @patch("webui.backend.lib.schedule_preview.detect_conflicts")
-    @patch("webui.backend.lib.schedule_preview.generate_pattern_executions")
+    @patch("webui.backend.lib.schedule_preview.generate_routine_executions")
     def test_generate_preview_counts_actions(
         self, mock_gen_exec, mock_detect, sample_interval_schedule
     ):
         """Test generate_preview correctly counts actions."""
-        from webui.backend.lib.schedule_conflict import PatternExecution
+        from webui.backend.lib.schedule_conflict import RoutineExecution
 
-        # Mock 2 routine executions (pattern_id is routine_id in Schema 3.0)
-        mock_exec_1 = PatternExecution(
-            pattern_id="uv-capture-cycle",
-            pattern_name="UV Capture Cycle",
+        # Mock 2 routine executions (routine_id is routine_id in Schema 3.0)
+        mock_exec_1 = RoutineExecution(
+            routine_id="uv-capture-cycle",
+            routine_name="UV Capture Cycle",
             start_time=datetime(2025, 6, 15, 21, 0, 0, tzinfo=UTC),
             end_time=datetime(2025, 6, 15, 21, 15, 0, tzinfo=UTC),
             resource_usages=[],
         )
-        mock_exec_2 = PatternExecution(
-            pattern_id="uv-capture-cycle",
-            pattern_name="UV Capture Cycle",
+        mock_exec_2 = RoutineExecution(
+            routine_id="uv-capture-cycle",
+            routine_name="UV Capture Cycle",
             start_time=datetime(2025, 6, 15, 22, 0, 0, tzinfo=UTC),
             end_time=datetime(2025, 6, 15, 22, 15, 0, tzinfo=UTC),
             resource_usages=[],
@@ -1159,7 +1159,7 @@ class TestPreviewGeneration:
         assert result.total_actions == 6
 
     @patch("webui.backend.lib.schedule_preview.detect_conflicts")
-    @patch("webui.backend.lib.schedule_preview.generate_pattern_executions")
+    @patch("webui.backend.lib.schedule_preview.generate_routine_executions")
     def test_preview_boundaries_use_timezone(
         self, mock_gen_exec, mock_detect, sample_interval_schedule
     ):
@@ -1200,7 +1200,7 @@ class TestPreviewGeneration:
         assert result_utc.preview_start.minute == 0
 
     @patch("webui.backend.lib.schedule_preview.detect_conflicts")
-    @patch("webui.backend.lib.schedule_preview.generate_pattern_executions")
+    @patch("webui.backend.lib.schedule_preview.generate_routine_executions")
     def test_preview_boundaries_timezone_offset(
         self, mock_gen_exec, mock_detect, sample_interval_schedule
     ):

--- a/Firmware/webui/backend/lib/schedule_conflict.py
+++ b/Firmware/webui/backend/lib/schedule_conflict.py
@@ -66,15 +66,15 @@ class ResourceUsage:
         resource_name: Specific action name (e.g., "takephoto", "attract_on")
         start_time: When resource is acquired
         end_time: When resource is released
-        pattern_id: Source pattern ID
-        action_index: Index within pattern's actions list
+        routine_id: Source routine ID
+        action_index: Index within routine's actions list
     """
 
     resource_type: str
     resource_name: str
     start_time: datetime
     end_time: datetime
-    pattern_id: str
+    routine_id: str
     action_index: int
 
     def to_dict(self) -> dict:
@@ -84,7 +84,7 @@ class ResourceUsage:
             "resource_name": self.resource_name,
             "start_time": self.start_time.isoformat(),
             "end_time": self.end_time.isoformat(),
-            "pattern_id": self.pattern_id,
+            "routine_id": self.routine_id,
             "action_index": self.action_index,
         }
 
@@ -96,26 +96,26 @@ class ResourceUsage:
             resource_name=data["resource_name"],
             start_time=datetime.fromisoformat(data["start_time"]),
             end_time=datetime.fromisoformat(data["end_time"]),
-            pattern_id=data["pattern_id"],
+            routine_id=data["routine_id"],
             action_index=data["action_index"],
         )
 
 
 @dataclass
-class PatternExecution:
+class RoutineExecution:
     """
     Represents a single execution of a Routine at a specific time.
 
     Attributes:
-        pattern_id: The Routine ID
-        pattern_name: Human-readable routine name
+        routine_id: The Routine ID
+        routine_name: Human-readable routine name
         start_time: Absolute start time of routine execution
         end_time: When routine completes (start + duration)
         resource_usages: List of resources used during execution
     """
 
-    pattern_id: str
-    pattern_name: str
+    routine_id: str
+    routine_name: str
     start_time: datetime
     end_time: datetime
     resource_usages: list[ResourceUsage] = field(default_factory=list)
@@ -123,19 +123,19 @@ class PatternExecution:
     def to_dict(self) -> dict:
         """Serialize to dictionary."""
         return {
-            "pattern_id": self.pattern_id,
-            "pattern_name": self.pattern_name,
+            "routine_id": self.routine_id,
+            "routine_name": self.routine_name,
             "start_time": self.start_time.isoformat(),
             "end_time": self.end_time.isoformat(),
             "resource_usages": [r.to_dict() for r in self.resource_usages],
         }
 
     @classmethod
-    def from_dict(cls, data: dict) -> "PatternExecution":
+    def from_dict(cls, data: dict) -> "RoutineExecution":
         """Deserialize from dictionary."""
         return cls(
-            pattern_id=data["pattern_id"],
-            pattern_name=data["pattern_name"],
+            routine_id=data["routine_id"],
+            routine_name=data["routine_name"],
             start_time=datetime.fromisoformat(data["start_time"]),
             end_time=datetime.fromisoformat(data["end_time"]),
             resource_usages=[ResourceUsage.from_dict(r) for r in data.get("resource_usages", [])],
@@ -289,8 +289,8 @@ class ConflictReport:
 
 
 def check_time_overlap(
-    exec1: PatternExecution,
-    exec2: PatternExecution,
+    exec1: RoutineExecution,
+    exec2: RoutineExecution,
 ) -> tuple[bool, datetime | None, datetime | None]:
     """
     Check if two pattern executions overlap in time.
@@ -623,11 +623,11 @@ def _get_routine_trigger_times_for_day(
 
 def _create_resource_usage(
     action: Action,
-    pattern_id: str,
+    routine_id: str,
     action_index: int,
     execution_start: datetime,
 ) -> ResourceUsage:
-    """Create ResourceUsage from a Action."""
+    """Create ResourceUsage from an Action."""
     resource_type = get_resource_type(action)
 
     # Calculate actual times
@@ -644,16 +644,16 @@ def _create_resource_usage(
         resource_name=action.action_name,
         start_time=action_start,
         end_time=action_end,
-        pattern_id=pattern_id,
+        routine_id=routine_id,
         action_index=action_index,
     )
 
 
-def _create_pattern_execution(
+def _create_routine_execution(
     routine: Routine,
     trigger_time: datetime,
-) -> PatternExecution:
-    """Create PatternExecution from Routine at trigger time (Schema 3.0)."""
+) -> RoutineExecution:
+    """Create RoutineExecution from Routine at trigger time (Schema 3.0)."""
     # Calculate execution duration from max action offset
     duration_minutes = routine.duration_minutes if routine.actions else 0
     end_time = trigger_time + timedelta(minutes=duration_minutes)
@@ -664,25 +664,25 @@ def _create_pattern_execution(
         for i, action in enumerate(routine.actions)
     ]
 
-    return PatternExecution(
-        pattern_id=routine.routine_id,
-        pattern_name=routine.name,
+    return RoutineExecution(
+        routine_id=routine.routine_id,
+        routine_name=routine.name,
         start_time=trigger_time,
         end_time=end_time,
         resource_usages=resource_usages,
     )
 
 
-def generate_pattern_executions(
+def generate_routine_executions(
     schedule: Schedule,
     start_date: date,
     end_date: date,
     latitude: float,
     longitude: float,
     timezone_name: str = "UTC",
-) -> list[PatternExecution]:
+) -> list[RoutineExecution]:
     """
-    Generate all pattern executions for a schedule within a date range (Schema 3.0).
+    Generate all routine executions for a schedule within a date range (Schema 3.0).
 
     Each routine has its own trigger, so we generate executions per-routine.
 
@@ -695,7 +695,7 @@ def generate_pattern_executions(
         timezone_name: Timezone for time resolution
 
     Returns:
-        List of PatternExecution objects sorted by start_time
+        List of RoutineExecution objects sorted by start_time
     """
     executions = []
 
@@ -719,7 +719,7 @@ def generate_pattern_executions(
 
             # Create execution for each trigger time
             for trigger_time in routine_trigger_times:
-                execution = _create_pattern_execution(routine, trigger_time)
+                execution = _create_routine_execution(routine, trigger_time)
                 executions.append(execution)
 
             current += timedelta(days=1)
@@ -787,7 +787,7 @@ def detect_conflicts(
     """
     Detect all conflicts in a schedule over a preview period.
 
-    Analyzes time overlaps and resource contention for all pattern
+    Analyzes time overlaps and resource contention for all routine
     executions within the preview window.
 
     Args:
@@ -805,8 +805,8 @@ def detect_conflicts(
     start_date = date.today()
     end_date = start_date + timedelta(days=preview_days - 1)
 
-    # Generate all pattern executions
-    executions = generate_pattern_executions(
+    # Generate all routine executions
+    executions = generate_routine_executions(
         schedule, start_date, end_date, latitude, longitude, timezone_name
     )
 
@@ -822,35 +822,35 @@ def detect_conflicts(
                 # Create time overlap conflict (warning severity)
                 time_conflict = Conflict(
                     conflict_type=CONFLICT_TIME_OVERLAP,
-                    event1_id=exec1.pattern_id,
-                    event1_name=exec1.pattern_name,
-                    event2_id=exec2.pattern_id,
-                    event2_name=exec2.pattern_name,
+                    event1_id=exec1.routine_id,
+                    event1_name=exec1.routine_name,
+                    event2_id=exec2.routine_id,
+                    event2_name=exec2.routine_name,
                     start_time=overlap_start,
                     end_time=overlap_end,
                     message=(
-                        f"Patterns '{exec1.pattern_name}' and '{exec2.pattern_name}' "
+                        f"Routines '{exec1.routine_name}' and '{exec2.routine_name}' "
                         f"overlap from {overlap_start.strftime('%H:%M:%S')} to "
                         f"{overlap_end.strftime('%H:%M:%S')}"
                     ),
                     suggested_resolution=(
-                        "Adjust pattern offsets or increase interval between triggers"
+                        "Adjust routine offsets or increase interval between triggers"
                     ),
                     severity=SEVERITY_WARNING,
                 )
                 conflicts.append(time_conflict)
 
-                # Check resource contention within overlapping patterns
+                # Check resource contention within overlapping routines
                 for usage1 in exec1.resource_usages:
                     for usage2 in exec2.resource_usages:
                         contends, conflict_type = check_resource_contention(usage1, usage2)
                         if contends:
                             resource_conflict = Conflict(
                                 conflict_type=conflict_type,
-                                event1_id=exec1.pattern_id,
-                                event1_name=exec1.pattern_name,
-                                event2_id=exec2.pattern_id,
-                                event2_name=exec2.pattern_name,
+                                event1_id=exec1.routine_id,
+                                event1_name=exec1.routine_name,
+                                event2_id=exec2.routine_id,
+                                event2_name=exec2.routine_name,
                                 start_time=max(usage1.start_time, usage2.start_time),
                                 end_time=min(usage1.end_time, usage2.end_time),
                                 resource=usage1.resource_type,
@@ -937,7 +937,7 @@ def detect_time_collisions(
     """
     Detect when two or more routines execute at exactly the same time.
 
-    Uses generate_pattern_executions() to get all routine execution times
+    Uses generate_routine_executions() to get all routine execution times
     over the preview period, then identifies exact time matches.
 
     Time collisions are blocking errors because hardware resources
@@ -963,8 +963,8 @@ def detect_time_collisions(
     lat = latitude if latitude is not None else 0.0
     lon = longitude if longitude is not None else 0.0
 
-    # Generate all pattern executions
-    executions = generate_pattern_executions(
+    # Generate all routine executions
+    executions = generate_routine_executions(
         schedule, start_date, end_date, lat, lon, timezone_name
     )
 
@@ -972,7 +972,7 @@ def detect_time_collisions(
         return []
 
     # Group executions by start_time
-    by_time: dict[datetime, list[PatternExecution]] = {}
+    by_time: dict[datetime, list[RoutineExecution]] = {}
     for execution in executions:
         by_time.setdefault(execution.start_time, []).append(execution)
 
@@ -980,8 +980,8 @@ def detect_time_collisions(
     collisions = []
     for exec_time, execs in by_time.items():
         if len(execs) >= 2:
-            routine_ids = [e.pattern_id for e in execs]
-            routine_names = [e.pattern_name or e.pattern_id for e in execs]
+            routine_ids = [e.routine_id for e in execs]
+            routine_names = [e.routine_name or e.routine_id for e in execs]
 
             # Generate human-readable message
             if len(routine_names) == 2:
@@ -1004,3 +1004,130 @@ def detect_time_collisions(
         )
 
     return collisions
+
+
+# ============================================================================
+# GPIO State Warning Detection
+# ============================================================================
+
+
+@dataclass
+class GPIOStateWarning:
+    """
+    Warning for unbalanced GPIO states (non-blocking).
+
+    Represents a warning when GPIO resources (attract, flash) are
+    left in an inconsistent state, such as turning on without
+    a corresponding off action within the same routine.
+
+    These warnings are advisory and do not block schedule activation.
+
+    Attributes:
+        resource_type: GPIO resource type ("attract" or "flash")
+        routine_id: Source routine ID
+        routine_name: Human-readable routine name
+        issue: Description of the state imbalance
+        suggested_fix: Recommended action to resolve
+    """
+
+    resource_type: str
+    routine_id: str
+    routine_name: str
+    issue: str
+    suggested_fix: str
+
+    def to_dict(self) -> dict:
+        """Serialize to dictionary."""
+        return {
+            "type": "gpio_state_warning",
+            "resource_type": self.resource_type,
+            "routine_id": self.routine_id,
+            "routine_name": self.routine_name,
+            "issue": self.issue,
+            "suggested_fix": self.suggested_fix,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "GPIOStateWarning":
+        """Deserialize from dictionary."""
+        return cls(
+            resource_type=data["resource_type"],
+            routine_id=data["routine_id"],
+            routine_name=data["routine_name"],
+            issue=data["issue"],
+            suggested_fix=data["suggested_fix"],
+        )
+
+
+def detect_gpio_conflicts(schedule: Schedule) -> list[GPIOStateWarning]:
+    """
+    Detect unbalanced GPIO states in a schedule.
+
+    Analyzes routines for GPIO actions that may leave hardware
+    in an inconsistent state (e.g., attract_on without attract_off).
+
+    These are non-blocking warnings that don't prevent schedule
+    activation but alert users to potential issues.
+
+    Args:
+        schedule: Schedule to analyze
+
+    Returns:
+        List of GPIOStateWarning objects. Empty if no issues detected.
+    """
+    warnings: list[GPIOStateWarning] = []
+
+    for routine in schedule.routines:
+        # Track GPIO state changes within routine
+        gpio_states: dict[str, list[str]] = {"attract": [], "flash": []}
+
+        for action in routine.actions:
+            if action.action_type == "gpio":
+                if action.action_name.startswith("attract"):
+                    state = "on" if action.action_name.endswith("_on") else "off"
+                    gpio_states["attract"].append(state)
+                elif action.action_name.startswith("flash"):
+                    state = "on" if action.action_name.endswith("_on") else "off"
+                    gpio_states["flash"].append(state)
+
+        # Check for imbalanced states
+        for resource, states in gpio_states.items():
+            if states:
+                on_count = states.count("on")
+                off_count = states.count("off")
+
+                if on_count > off_count:
+                    warnings.append(
+                        GPIOStateWarning(
+                            resource_type=resource,
+                            routine_id=routine.routine_id,
+                            routine_name=routine.name or routine.routine_id,
+                            issue=(
+                                f"{resource.title()} turned on {on_count} time(s) "
+                                f"but off {off_count} time(s)"
+                            ),
+                            suggested_fix=f"Add {resource}_off action at end of routine",
+                        )
+                    )
+                elif off_count > on_count:
+                    warnings.append(
+                        GPIOStateWarning(
+                            resource_type=resource,
+                            routine_id=routine.routine_id,
+                            routine_name=routine.name or routine.routine_id,
+                            issue=(
+                                f"{resource.title()} turned off {off_count} time(s) "
+                                f"but on {on_count} time(s)"
+                            ),
+                            suggested_fix=(
+                                f"Verify {resource}_on action exists before {resource}_off"
+                            ),
+                        )
+                    )
+
+    if warnings:
+        logger.debug(
+            f"Found {len(warnings)} GPIO state warning(s) in schedule {schedule.schedule_id}"
+        )
+
+    return warnings

--- a/Firmware/webui/backend/lib/schedule_conflict.py
+++ b/Firmware/webui/backend/lib/schedule_conflict.py
@@ -1,8 +1,8 @@
 """
 Schedule conflict detection library.
 
-Provides conflict detection for Mothbox scheduler patterns, detecting:
-- Time overlaps between pattern executions
+Provides conflict detection for Mothbox scheduler routines, detecting:
+- Time overlaps between routine executions
 - Resource contention (camera, GPS single-instance resources)
 - GPIO state conflicts (on vs off for same GPIO resource)
 
@@ -145,14 +145,14 @@ class RoutineExecution:
 @dataclass
 class Conflict:
     """
-    Describes a detected conflict between pattern executions.
+    Describes a detected conflict between routine executions.
 
     Attributes:
         conflict_type: "time_overlap", "resource_contention", "gpio_state_conflict"
-        event1_id: First pattern execution ID
-        event1_name: First pattern name
-        event2_id: Second pattern execution ID
-        event2_name: Second pattern name
+        event1_id: First routine execution ID
+        event1_name: First routine name
+        event2_id: Second routine execution ID
+        event2_name: Second routine name
         start_time: Conflict start (overlap beginning)
         end_time: Conflict end (overlap ending)
         resource: Conflicting resource name (if resource contention)
@@ -254,7 +254,7 @@ class ConflictReport:
         schedule_name: Schedule name
         preview_start: Analysis start date
         preview_end: Analysis end date
-        total_executions: Number of pattern executions in preview period
+        total_executions: Number of routine executions in preview period
         conflicts: List of detected conflicts
         has_blocking_conflicts: True if any severity="error" conflicts
         analyzed_at: Timestamp of analysis
@@ -293,27 +293,27 @@ def check_time_overlap(
     exec2: RoutineExecution,
 ) -> tuple[bool, datetime | None, datetime | None]:
     """
-    Check if two pattern executions overlap in time.
+    Check if two routine executions overlap in time.
 
     Two intervals [a1, a2] and [b1, b2] overlap if a1 < b2 AND b1 < a2.
-    Adjacent patterns (a2 == b1) are NOT considered overlapping.
+    Adjacent routines (a2 == b1) are NOT considered overlapping.
 
     Args:
-        exec1: First pattern execution
-        exec2: Second pattern execution
+        exec1: First routine execution
+        exec2: Second routine execution
 
     Returns:
         Tuple of (overlaps: bool, overlap_start: datetime | None, overlap_end: datetime | None)
 
     Note:
-        Zero-duration patterns (start == end) return False because a point in
+        Zero-duration routines (start == end) return False because a point in
         time has no duration to overlap. However, check_resource_contention()
         uses different logic - instant actions CAN conflict with resources they
-        touch, even at boundaries. This is intentional: pattern overlap is about
-        scheduling (do patterns run simultaneously?), while resource contention
+        touch, even at boundaries. This is intentional: routine overlap is about
+        scheduling (do routines run simultaneously?), while resource contention
         is about hardware access (can two actions use the same resource?).
     """
-    # Handle zero-duration patterns (start == end)
+    # Handle zero-duration routines (start == end)
     # A point in time doesn't have duration, so can't truly overlap
     if exec1.start_time == exec1.end_time or exec2.start_time == exec2.end_time:
         return False, None, None
@@ -748,14 +748,14 @@ def _generate_conflict_message(
     if conflict_type == CONFLICT_RESOURCE_CONTENTION:
         return (
             f"{usage1.resource_type.title()} resource conflict: "
-            f"both patterns use {usage1.resource_name} at the same time"
+            f"both routines use {usage1.resource_name} at the same time"
         )
     elif conflict_type == CONFLICT_GPIO_STATE:
         return (
             f"GPIO state conflict: {usage1.resource_name} and "
             f"{usage2.resource_name} cannot be active simultaneously"
         )
-    return "Pattern execution conflict detected"
+    return "Routine execution conflict detected"
 
 
 def _generate_resolution(
@@ -767,14 +767,14 @@ def _generate_resolution(
     if conflict_type == CONFLICT_RESOURCE_CONTENTION:
         return (
             f"Adjust action timing so {usage1.resource_type} is not used "
-            f"simultaneously, or increase interval between pattern triggers"
+            f"simultaneously, or increase interval between routine triggers"
         )
     elif conflict_type == CONFLICT_GPIO_STATE:
         return (
             f"Ensure {usage1.resource_type} state changes don't overlap: "
             f"add delay between {usage1.resource_name} and {usage2.resource_name}"
         )
-    return "Adjust pattern timing or increase trigger interval"
+    return "Adjust routine timing or increase trigger interval"
 
 
 def detect_conflicts(

--- a/Firmware/webui/backend/lib/schedule_preview.py
+++ b/Firmware/webui/backend/lib/schedule_preview.py
@@ -20,9 +20,9 @@ from typing import Final
 from webui.backend.lib.moon_phase import get_moon_phases_for_range
 from webui.backend.lib.schedule_conflict import (
     Conflict,
-    PatternExecution,
+    RoutineExecution,
     detect_conflicts,
-    generate_pattern_executions,
+    generate_routine_executions,
 )
 from webui.backend.lib.schedule_schema import (
     FixedTimeTrigger,
@@ -116,25 +116,25 @@ class ActionExecution:
 @dataclass
 class PreviewExecution:
     """
-    A single pattern execution with expanded actions.
+    A single routine execution with expanded actions.
 
-    Wraps PatternExecution from schedule_conflict.py, adding:
+    Wraps RoutineExecution from schedule_conflict.py, adding:
     - Expanded action list with absolute times
     - Trigger description for display
 
     Attributes:
-        start_time: When pattern execution begins
-        end_time: When pattern execution completes
-        pattern_id: Source pattern identifier
-        pattern_name: Human-readable pattern name
+        start_time: When routine execution begins
+        end_time: When routine execution completes
+        routine_id: Source routine identifier
+        routine_name: Human-readable routine name
         trigger_info: Trigger description (e.g., "interval:60m", "sunset+30")
         actions: Expanded actions with absolute times
     """
 
     start_time: datetime
     end_time: datetime
-    pattern_id: str
-    pattern_name: str
+    routine_id: str
+    routine_name: str
     trigger_info: str
     actions: list[ActionExecution] = field(default_factory=list)
 
@@ -143,8 +143,8 @@ class PreviewExecution:
         return {
             "start_time": self.start_time.isoformat(),
             "end_time": self.end_time.isoformat(),
-            "pattern_id": self.pattern_id,
-            "pattern_name": self.pattern_name,
+            "routine_id": self.routine_id,
+            "routine_name": self.routine_name,
             "trigger_info": self.trigger_info,
             "actions": [a.to_dict() for a in self.actions],
         }
@@ -155,8 +155,8 @@ class PreviewExecution:
         return cls(
             start_time=datetime.fromisoformat(data["start_time"]),
             end_time=datetime.fromisoformat(data["end_time"]),
-            pattern_id=data["pattern_id"],
-            pattern_name=data["pattern_name"],
+            routine_id=data["routine_id"],
+            routine_name=data["routine_name"],
             trigger_info=data["trigger_info"],
             actions=[ActionExecution.from_dict(a) for a in data.get("actions", [])],
         )
@@ -168,7 +168,7 @@ class PreviewResult:
     Complete preview result for a schedule.
 
     Contains:
-    - All pattern executions with expanded actions
+    - All routine executions with expanded actions
     - Conflicts detected over preview period
     - Moon phases for calendar display
     - Summary statistics
@@ -179,11 +179,11 @@ class PreviewResult:
         schedule_name: Human-readable schedule name
         preview_start: Preview period start (midnight UTC)
         preview_end: Preview period end (midnight UTC)
-        executions: List of pattern executions
+        executions: List of routine executions
         conflicts: List of detected conflicts
         moon_phases: Moon phase by date {ISO date string: phase dict}
         total_actions: Total count of individual actions
-        total_executions: Total count of pattern executions
+        total_executions: Total count of routine executions
         warnings: List of warning messages (e.g., default location used)
         generated_at: Timestamp when preview was generated
     """
@@ -360,15 +360,15 @@ def _expand_actions(
 
 
 def _convert_execution(
-    execution: PatternExecution,
+    execution: RoutineExecution,
     trigger_info: str,
     routine_cache: dict[str, Routine],
 ) -> PreviewExecution:
     """
-    Convert PatternExecution to PreviewExecution with expanded actions (Schema 3.0).
+    Convert RoutineExecution to PreviewExecution with expanded actions (Schema 3.0).
 
     Args:
-        execution: PatternExecution from schedule_conflict.py
+        execution: RoutineExecution from schedule_conflict.py
         trigger_info: Trigger description string
         routine_cache: Dict mapping routine_id to Routine for O(1) lookup
 
@@ -376,7 +376,7 @@ def _convert_execution(
         PreviewExecution with expanded actions
     """
     # Look up routine from cache - O(1) instead of O(n) linear search
-    routine = routine_cache.get(execution.pattern_id)
+    routine = routine_cache.get(execution.routine_id)
 
     actions = []
     if routine:
@@ -385,8 +385,8 @@ def _convert_execution(
     return PreviewExecution(
         start_time=execution.start_time,
         end_time=execution.end_time,
-        pattern_id=execution.pattern_id,
-        pattern_name=execution.pattern_name,
+        routine_id=execution.routine_id,
+        routine_name=execution.routine_name,
         trigger_info=trigger_info,
         actions=actions,
     )
@@ -481,8 +481,8 @@ def generate_preview(
         logger.info(warning_msg)
         warnings.append(warning_msg)
 
-    # Generate pattern executions using schedule_conflict.py
-    raw_executions = generate_pattern_executions(
+    # Generate routine executions using schedule_conflict.py
+    raw_executions = generate_routine_executions(
         schedule=schedule,
         start_date=start_date,
         end_date=end_date,


### PR DESCRIPTION
## Summary
- Rename `PatternExecution` class to `RoutineExecution`
- Rename `pattern_id` field to `routine_id` throughout
- Rename `pattern_name` field to `routine_name` throughout
- Rename `generate_pattern_executions()` to `generate_routine_executions()`
- Add `GPIOStateWarning` dataclass for unbalanced GPIO state detection
- Add `detect_gpio_conflicts()` function (non-blocking warnings)

## Test plan
- [x] All 85 conflict detection tests pass
- [x] All 64 preview tests pass
- [x] ruff check passes
- [x] bandit security scan passes

Closes #307