### PR TITLE
refactor(scheduler): Update schedule_storage test terminology (#308)

### DIFF
--- a/Firmware/Tests/unit/test_schedule_storage.py
+++ b/Firmware/Tests/unit/test_schedule_storage.py
@@ -743,10 +743,10 @@ class TestEdgeCases:
         valid_data["schedule_id"] = _test_uuid("valid-schedule")
         (temp_schedules_dir / "valid-schedule.json").write_text(json.dumps(valid_data))
 
-        # Create invalid schedule (empty event_patterns after initial parse)
+        # Create invalid schedule (empty routines)
         invalid_data = json.loads(sample_schedule_json)
         invalid_data["schedule_id"] = _test_uuid("invalid-schedule")
-        invalid_data["event_patterns"] = []  # Invalid: no patterns
+        invalid_data["routines"] = []  # Invalid: no routines
         (temp_schedules_dir / "invalid-schedule.json").write_text(json.dumps(invalid_data))
 
         # Only valid schedule should be returned


### PR DESCRIPTION
## Summary
- Update `test_list_schedules_skips_invalid_schedules` to use the new `routines` field name instead of the old `event_patterns` field

## Details
The `schedule_storage.py` module itself was already updated as it is JSON-agnostic and relies on `Schedule.from_dict()`/`to_dict()`. Only the test file had a stale reference to the old Schema 2.0 field name.

This aligns the test with Schema 3.0 where `event_patterns` was renamed to `routines` as part of the Scheduler Terminology Refactor (#296).

## Test plan
- [x] Unit tests pass (38/38)
- [x] Integration tests pass (8/8)
- [x] ruff check passes

Closes #308