### PR TITLE
feat(scheduler): Add WebSocket progress feedback during activation (#309)

### DIFF
--- a/Firmware/Tests/unit/test_scheduler_service.py
+++ b/Firmware/Tests/unit/test_scheduler_service.py
@@ -995,6 +995,125 @@ class TestActivateSchedule:
 
 
 # ============================================================================
+# Test Activation Progress Callback (Issue #309)
+# ============================================================================
+
+
+class TestActivationProgressCallback:
+    """Tests for progress_callback parameter in activate_schedule() (Issue #309)."""
+
+    def test_progress_callback_called_with_phases(
+        self, scheduler_service, temp_schedules_dir, sample_schedule
+    ):
+        """Progress callback should be called with expected phases."""
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        # Create enabled schedule
+        sample_schedule.schedule_id = _test_uuid("progress-phases")
+        sample_schedule.enabled = True
+        create_schedule(sample_schedule)
+
+        # Track progress calls
+        progress_calls = []
+
+        def track_progress(phase: str, progress: int) -> None:
+            progress_calls.append((phase, progress))
+
+        # Activate with progress callback
+        scheduler_service.activate_schedule(
+            _test_uuid("progress-phases"),
+            check_conflicts=True,
+            progress_callback=track_progress,
+        )
+
+        # Verify expected phases were called
+        phases = [p[0] for p in progress_calls]
+        assert "checking_conflicts" in phases
+        assert "generating_cron" in phases
+        assert "applying_cron" in phases
+        assert "updating_state" in phases
+        assert "complete" in phases
+
+        # Verify progress values are ascending
+        progress_values = [p[1] for p in progress_calls]
+        assert progress_values == sorted(progress_values)
+
+        # Verify final progress is 100
+        assert progress_calls[-1] == ("complete", 100)
+
+    def test_progress_callback_skips_conflict_check_when_disabled(
+        self, scheduler_service, temp_schedules_dir, sample_schedule
+    ):
+        """Progress should skip checking_conflicts phase when check_conflicts=False."""
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        # Create enabled schedule
+        sample_schedule.schedule_id = _test_uuid("progress-no-conflict")
+        sample_schedule.enabled = True
+        create_schedule(sample_schedule)
+
+        # Track progress calls
+        progress_calls = []
+
+        def track_progress(phase: str, progress: int) -> None:
+            progress_calls.append((phase, progress))
+
+        # Activate without conflict check
+        scheduler_service.activate_schedule(
+            _test_uuid("progress-no-conflict"),
+            check_conflicts=False,
+            progress_callback=track_progress,
+        )
+
+        # Verify checking_conflicts was NOT called
+        phases = [p[0] for p in progress_calls]
+        assert "checking_conflicts" not in phases
+        # But other phases should still be called
+        assert "generating_cron" in phases
+        assert "complete" in phases
+
+    def test_activation_works_without_callback(
+        self, scheduler_service, temp_schedules_dir, sample_schedule
+    ):
+        """Activation should work when no progress callback is provided."""
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        # Create enabled schedule
+        sample_schedule.schedule_id = _test_uuid("progress-none")
+        sample_schedule.enabled = True
+        create_schedule(sample_schedule)
+
+        # Activate without callback (should not raise)
+        scheduler_service.activate_schedule(_test_uuid("progress-none"))
+
+        assert scheduler_service._active_schedule_id == _test_uuid("progress-none")
+
+    def test_progress_callback_error_does_not_block_activation(
+        self, scheduler_service, temp_schedules_dir, sample_schedule
+    ):
+        """A failing progress callback should not block activation."""
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        # Create enabled schedule
+        sample_schedule.schedule_id = _test_uuid("progress-error")
+        sample_schedule.enabled = True
+        create_schedule(sample_schedule)
+
+        # Create a callback that raises an exception
+        def failing_callback(phase: str, progress: int) -> None:
+            raise RuntimeError("Callback failed intentionally")
+
+        # Activate with failing callback - should not raise
+        scheduler_service.activate_schedule(
+            _test_uuid("progress-error"),
+            progress_callback=failing_callback,
+        )
+
+        # Activation should still succeed
+        assert scheduler_service._active_schedule_id == _test_uuid("progress-error")
+
+
+# ============================================================================
 # Test Deactivate Schedule
 # ============================================================================
 

--- a/Firmware/webui/backend/routes/scheduler_ui.py
+++ b/Firmware/webui/backend/routes/scheduler_ui.py
@@ -20,7 +20,7 @@ from datetime import datetime
 from functools import wraps
 from pathlib import Path
 
-from flask import Blueprint, Response, jsonify, request
+from flask import Blueprint, Response, current_app, jsonify, request
 from werkzeug.exceptions import BadRequest
 
 from webui.backend.constants import MAX_BUILTIN_SCHEDULE_FILES
@@ -752,6 +752,21 @@ def activate_schedule(schedule_id: str) -> tuple[Response, int]:
 
         service = get_scheduler_service()
 
+        # Get socketio for progress events (may be None in tests)
+        socketio = current_app.extensions.get("socketio")
+
+        def emit_progress(phase: str, progress: int) -> None:
+            """Emit activation progress event via WebSocket."""
+            if socketio:
+                socketio.emit(
+                    "schedule:activation_progress",
+                    {
+                        "schedule_id": schedule_id,
+                        "phase": phase,
+                        "progress": progress,
+                    },
+                )
+
         # Activate via service (handles existence check internally)
         try:
             service.activate_schedule(
@@ -760,6 +775,7 @@ def activate_schedule(schedule_id: str) -> tuple[Response, int]:
                 latitude=latitude,
                 longitude=longitude,
                 timezone_name=timezone_name,
+                progress_callback=emit_progress,
             )
         except ScheduleConflictError as e:
             # Log conflict details, return generic message

--- a/Firmware/webui/backend/services/scheduler_service.py
+++ b/Firmware/webui/backend/services/scheduler_service.py
@@ -523,6 +523,7 @@ class SchedulerService:
         latitude: float = 0.0,
         longitude: float = 0.0,
         timezone_name: str = "UTC",
+        progress_callback: Any | None = None,
     ) -> None:
         """
         Activate a schedule (deactivates any currently active first).
@@ -538,6 +539,11 @@ class SchedulerService:
             latitude: Location latitude for solar calculations (default 0.0)
             longitude: Location longitude for solar calculations (default 0.0)
             timezone_name: Timezone for time resolution (default "UTC")
+            progress_callback: Optional callback(phase: str, progress: int) for
+                              progress updates during activation. Phases are:
+                              "checking_conflicts" (10%), "generating_cron" (30%),
+                              "applying_cron" (60%), "updating_state" (90%),
+                              "complete" (100%)
 
         Returns:
             None on success
@@ -547,6 +553,15 @@ class SchedulerService:
                 disabled, cron conversion failed, etc.)
             ScheduleConflictError: If schedule has blocking conflicts
         """
+
+        def _emit_progress(phase: str, progress: int) -> None:
+            """Emit progress if callback provided."""
+            if progress_callback:
+                try:
+                    progress_callback(phase, progress)
+                except Exception as e:
+                    logger.warning(f"Progress callback failed: {e}")
+
         # Get the schedule
         schedule = self.get_schedule(schedule_id)
         if not schedule:
@@ -563,6 +578,7 @@ class SchedulerService:
         # Check for conflicts before activation (Issue #213)
         # Uses cached conflict report to avoid redundant computation
         if check_conflicts:
+            _emit_progress("checking_conflicts", 10)
             try:
                 from webui.backend.lib.schedule_conflict import SEVERITY_ERROR
 
@@ -612,6 +628,7 @@ class SchedulerService:
         # Apply schedule to system cron FIRST (Issue #215, Fix #4 atomic operation)
         # We apply cron before updating is_active to avoid inconsistent state
         # if cron application fails. This eliminates the need for rollback.
+        _emit_progress("generating_cron", 30)
         try:
             result = schedule_to_cron(
                 schedule,
@@ -622,6 +639,7 @@ class SchedulerService:
             if result.errors:
                 raise ScheduleActivationError(f"Cron conversion failed: {'; '.join(result.errors)}")
 
+            _emit_progress("applying_cron", 60)
             apply_to_system(
                 entries=result.entries,
                 schedule_id=schedule_id,
@@ -639,6 +657,7 @@ class SchedulerService:
 
         # Update is_active flag in storage AFTER cron succeeds
         # For built-in schedules, we only update the in-memory state
+        _emit_progress("updating_state", 90)
         try:
             if not is_builtin_schedule(schedule_id):
                 self.update_schedule(schedule_id, {"is_active": True})
@@ -655,6 +674,7 @@ class SchedulerService:
         with self._cache_lock:
             self._active_schedule_id = schedule_id
 
+        _emit_progress("complete", 100)
         logger.info(f"Activated schedule: {schedule_id}")
 
     def deactivate_schedule(self) -> bool:


### PR DESCRIPTION
## Summary
- Add `progress_callback` parameter to `activate_schedule()` for WebSocket progress events
- Emit `schedule:activation_progress` events during 5-year cron pre-computation
- Add 4 tests for progress callback functionality

## Progress Phases
| Phase | Progress | Description |
|-------|----------|-------------|
| `checking_conflicts` | 10% | Before conflict detection |
| `generating_cron` | 30% | Before cron entry generation |
| `applying_cron` | 60% | Before applying to system crontab |
| `updating_state` | 90% | Before updating is_active flag |
| `complete` | 100% | After successful activation |

## Test plan
- [x] All 4 new progress callback tests pass
- [x] All 7 existing activation tests pass
- [x] All 11 activation route tests pass
- [x] Ruff linting passes
- [x] Bandit security scan passes

Closes #309