### PR TITLE
feat(test): Add trigger fixtures for all 7 types (#313)

### DIFF
--- a/Firmware/Tests/conftest.py
+++ b/Firmware/Tests/conftest.py
@@ -3091,3 +3091,373 @@ def mock_sensor_hardware(monkeypatch):
         "smbus": mock_smbus_instance,
         "hw_config": hw_config,
     }
+
+
+# =============================================================================
+# TRIGGER FIXTURES (Issue #313)
+# =============================================================================
+
+
+@pytest.fixture
+def solar_trigger():
+    """SolarTrigger fixture for testing.
+
+    Creates a SolarTrigger that fires at dusk with no offset.
+    """
+    from webui.backend.lib.schedule_schema import SolarTrigger
+
+    return SolarTrigger(solar_event="dusk", offset_minutes=0)
+
+
+@pytest.fixture
+def interval_trigger():
+    """IntervalTrigger with time window fixture.
+
+    Creates an IntervalTrigger that fires every 15 minutes
+    within a 22:00-06:00 time window.
+    """
+    from webui.backend.lib.schedule_schema import IntervalTrigger, TimeWindow
+
+    return IntervalTrigger(
+        interval_minutes=15,
+        time_window=TimeWindow(start_time="22:00", end_time="06:00"),
+    )
+
+
+@pytest.fixture
+def fixed_time_trigger():
+    """FixedTimeTrigger fixture for testing.
+
+    Creates a FixedTimeTrigger that fires at 09:00 daily.
+    """
+    from webui.backend.lib.schedule_schema import FixedTimeTrigger
+
+    return FixedTimeTrigger(time="09:00")
+
+
+@pytest.fixture
+def moon_phase_trigger():
+    """MoonPhaseTrigger fixture for testing.
+
+    Creates a MoonPhaseTrigger that fires on full and new moon nights
+    within a 22:00-04:00 time window.
+    """
+    from webui.backend.lib.schedule_schema import MoonPhaseTrigger, TimeWindow
+
+    return MoonPhaseTrigger(
+        phases=["full", "new"],
+        time_window=TimeWindow(start_time="22:00", end_time="04:00"),
+    )
+
+
+@pytest.fixture
+def recurring_days_trigger():
+    """RecurringDaysTrigger fixture for testing.
+
+    Creates a RecurringDaysTrigger that fires every 3 days at 21:00.
+    """
+    from webui.backend.lib.schedule_schema import RecurringDaysTrigger
+
+    return RecurringDaysTrigger(every_n_days=3, time="21:00")
+
+
+@pytest.fixture
+def sensor_trigger():
+    """SensorTrigger fixture for testing (used as pre_condition).
+
+    Creates a SensorTrigger that triggers when light is below 100 lux.
+    Note: SensorTriggers are only valid as pre_conditions, not primary triggers.
+    """
+    from webui.backend.lib.schedule_schema import SensorTrigger
+
+    return SensorTrigger(
+        sensor_type="light",
+        threshold=100,
+        comparison="lt",
+    )
+
+
+@pytest.fixture
+def cron_trigger():
+    """CronTrigger fixture for testing (expert mode).
+
+    Creates a CronTrigger that fires every 2 hours.
+    """
+    from webui.backend.lib.schedule_schema import CronTrigger
+
+    return CronTrigger(cron_expression="0 */2 * * *")
+
+
+# =============================================================================
+# ROUTINE FIXTURES (Issue #313)
+# =============================================================================
+
+
+@pytest.fixture
+def routine_solar(solar_trigger):
+    """Routine with SolarTrigger fixture.
+
+    Creates a routine that turns on attract lights at dusk.
+    Auto-generated name: "Attract On at Dusk"
+    """
+    from webui.backend.lib.schedule_schema import Action, Routine
+
+    return Routine(
+        routine_id="test-solar",
+        name=None,  # Auto-generated: "Attract On at Dusk"
+        trigger=solar_trigger,
+        actions=[Action(action_type="gpio", action_name="attract_on")],
+    )
+
+
+@pytest.fixture
+def routine_interval(interval_trigger):
+    """Routine with IntervalTrigger fixture.
+
+    Creates a routine that captures photos with flash every 15 minutes.
+    Auto-generated name contains "Flash" and "Photo" and "15min"
+    """
+    from webui.backend.lib.schedule_schema import Action, Routine
+
+    return Routine(
+        routine_id="test-interval",
+        name=None,  # Auto-generated: "Flash + Photo every 15min"
+        trigger=interval_trigger,
+        actions=[
+            Action(action_type="gpio", action_name="flash_on", offset_minutes=0),
+            Action(action_type="camera", action_name="takephoto", offset_minutes=1),
+            Action(action_type="gpio", action_name="flash_off", offset_minutes=2),
+        ],
+    )
+
+
+@pytest.fixture
+def routine_fixed_time(fixed_time_trigger):
+    """Routine with FixedTimeTrigger fixture.
+
+    Creates a routine that runs backup service at 09:00.
+    Auto-generated name: "Backup at 09:00"
+    """
+    from webui.backend.lib.schedule_schema import Action, Routine
+
+    return Routine(
+        routine_id="test-fixed",
+        name=None,  # Auto-generated: "Backup at 09:00"
+        trigger=fixed_time_trigger,
+        actions=[Action(action_type="service", action_name="backup")],
+    )
+
+
+@pytest.fixture
+def routine_moon_phase(moon_phase_trigger):
+    """Routine with MoonPhaseTrigger fixture.
+
+    Creates a routine that takes photos on full/new moon nights.
+    """
+    from webui.backend.lib.schedule_schema import Action, Routine
+
+    return Routine(
+        routine_id="test-moon",
+        name=None,
+        trigger=moon_phase_trigger,
+        actions=[Action(action_type="camera", action_name="takephoto")],
+    )
+
+
+@pytest.fixture
+def routine_recurring_days(recurring_days_trigger):
+    """Routine with RecurringDaysTrigger fixture.
+
+    Creates a routine that syncs GPS every 3 days at 21:00.
+    Auto-generated name: "GPS Sync every 3 days"
+    """
+    from webui.backend.lib.schedule_schema import Action, Routine
+
+    return Routine(
+        routine_id="test-recurring",
+        name=None,  # Auto-generated: "GPS Sync every 3 days"
+        trigger=recurring_days_trigger,
+        actions=[Action(action_type="gps_sync", action_name="gps_sync")],
+    )
+
+
+@pytest.fixture
+def routine_cron(cron_trigger):
+    """Routine with CronTrigger fixture.
+
+    Creates a routine that turns on attract lights every 2 hours (expert mode).
+    """
+    from webui.backend.lib.schedule_schema import Action, Routine
+
+    return Routine(
+        routine_id="test-cron",
+        name=None,
+        trigger=cron_trigger,
+        actions=[Action(action_type="gpio", action_name="attract_on")],
+    )
+
+
+@pytest.fixture
+def routine_with_precondition(interval_trigger, sensor_trigger):
+    """Routine with pre_condition (sensor check before executing).
+
+    Creates a routine that takes photos every 15 minutes, but only if
+    light sensor reads below 100 lux (it's dark enough).
+    """
+    from webui.backend.lib.schedule_schema import Action, Routine
+
+    return Routine(
+        routine_id="test-precondition",
+        name="Photo if Dark",
+        trigger=interval_trigger,
+        actions=[Action(action_type="camera", action_name="takephoto")],
+        pre_condition=sensor_trigger,  # Only run if light < 100
+    )
+
+
+# =============================================================================
+# ROUTINE FACTORY FUNCTION (Issue #313)
+# =============================================================================
+
+
+def _make_routine_impl(
+    trigger_type: str,
+    actions: list[dict] | None = None,
+    routine_id: str | None = None,
+    name: str | None = None,
+    pre_condition: dict | None = None,
+    **trigger_kwargs,
+):
+    """Factory function to create routines with any trigger type.
+
+    This factory allows creating routines dynamically for testing different
+    trigger types without needing separate fixtures for each combination.
+
+    Args:
+        trigger_type: One of "solar", "interval", "fixed_time", "moon_phase",
+                     "recurring_days", "sensor", "cron"
+        actions: List of action dicts, each with at least "action_type" and
+                "action_name". Defaults to [{"action_type": "gpio", "action_name": "attract_on"}]
+        routine_id: Optional routine ID. Defaults to "test-{trigger_type}"
+        name: Optional routine name. Defaults to None (auto-generated)
+        pre_condition: Optional dict for SensorTrigger pre_condition
+        **trigger_kwargs: Keyword arguments passed to trigger constructor
+
+    Returns:
+        Routine: A valid Routine instance
+
+    Raises:
+        ValueError: If trigger_type is unknown or required kwargs missing
+
+    Examples:
+        >>> routine = make_routine("solar", solar_event="dusk")
+        >>> routine.trigger.solar_event
+        'dusk'
+
+        >>> routine = make_routine(
+        ...     "interval",
+        ...     interval_minutes=30,
+        ...     actions=[{"action_type": "camera", "action_name": "takephoto"}]
+        ... )
+        >>> routine.trigger.interval_minutes
+        30
+
+    Related: Issue #313 - Add Trigger Fixtures for All 7 Types
+    """
+    from webui.backend.lib.schedule_schema import (
+        Action,
+        CronTrigger,
+        FixedTimeTrigger,
+        IntervalTrigger,
+        MoonPhaseTrigger,
+        RecurringDaysTrigger,
+        Routine,
+        SensorTrigger,
+        SolarTrigger,
+        TimeWindow,
+    )
+
+    # Mapping from trigger_type string to trigger class
+    trigger_classes = {
+        "solar": SolarTrigger,
+        "interval": IntervalTrigger,
+        "fixed_time": FixedTimeTrigger,
+        "moon_phase": MoonPhaseTrigger,
+        "recurring_days": RecurringDaysTrigger,
+        "sensor": SensorTrigger,
+        "cron": CronTrigger,
+    }
+
+    if trigger_type not in trigger_classes:
+        raise ValueError(
+            f"Unknown trigger_type: {trigger_type}. "
+            f"Valid types: {list(trigger_classes.keys())}"
+        )
+
+    trigger_cls = trigger_classes[trigger_type]
+
+    # Apply default required kwargs for certain trigger types
+    if trigger_type == "interval":
+        if "time_window" not in trigger_kwargs:
+            trigger_kwargs["time_window"] = TimeWindow(
+                start_time="22:00", end_time="06:00"
+            )
+        if "interval_minutes" not in trigger_kwargs:
+            trigger_kwargs["interval_minutes"] = 15
+    elif trigger_type == "moon_phase":
+        if "phases" not in trigger_kwargs:
+            raise ValueError("moon_phase trigger requires 'phases' argument")
+    elif trigger_type == "solar":
+        if "solar_event" not in trigger_kwargs:
+            trigger_kwargs["solar_event"] = "dusk"
+    elif trigger_type == "fixed_time":
+        if "time" not in trigger_kwargs:
+            trigger_kwargs["time"] = "21:00"
+    elif trigger_type == "recurring_days":
+        if "time" not in trigger_kwargs:
+            trigger_kwargs["time"] = "21:00"
+    elif trigger_type == "cron":
+        if "cron_expression" not in trigger_kwargs:
+            trigger_kwargs["cron_expression"] = "0 21 * * *"
+    elif trigger_type == "sensor":
+        if "sensor_type" not in trigger_kwargs:
+            trigger_kwargs["sensor_type"] = "motion"
+
+    # Create trigger
+    trigger = trigger_cls(**trigger_kwargs)
+
+    # Create actions
+    if actions is None:
+        actions = [{"action_type": "gpio", "action_name": "attract_on"}]
+    action_objects = [Action(**a) for a in actions]
+
+    # Create pre_condition if provided
+    pre_cond = None
+    if pre_condition:
+        pre_cond = SensorTrigger(**pre_condition)
+
+    # Create routine
+    return Routine(
+        routine_id=routine_id or f"test-{trigger_type}",
+        name=name,
+        trigger=trigger,
+        actions=action_objects,
+        pre_condition=pre_cond,
+    )
+
+
+@pytest.fixture
+def make_routine():
+    """Fixture that returns the make_routine factory function.
+
+    This fixture provides access to the make_routine() factory function
+    for creating routines with any trigger type dynamically in tests.
+
+    Usage:
+        def test_something(make_routine):
+            routine = make_routine("solar", solar_event="sunset")
+            assert routine.trigger.solar_event == "sunset"
+
+    Related: Issue #313 - Add Trigger Fixtures for All 7 Types
+    """
+    return _make_routine_impl

--- a/Firmware/Tests/conftest.py
+++ b/Firmware/Tests/conftest.py
@@ -10,12 +10,17 @@ Usage:
     - camera_streamer fixture handles proper resource cleanup
 """
 
-import pytest
-import sys
 import gc
-import time
 import os
+import sys
+import time
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from webui.backend.lib.schedule_schema import Routine
 
 # Setup path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent / 'webui' / 'backend'))
@@ -3166,7 +3171,11 @@ def sensor_trigger():
     """SensorTrigger fixture for testing (used as pre_condition).
 
     Creates a SensorTrigger that triggers when light is below 100 lux.
-    Note: SensorTriggers are only valid as pre_conditions, not primary triggers.
+
+    Note: SensorTriggers can only be used as pre_conditions, not primary triggers.
+    The schema validator (validate_routine) enforces this by checking against
+    PRIMARY_TRIGGER_TYPES and rejecting SensorTrigger as a primary trigger.
+    See: webui/backend/lib/schedule_schema.py:1141-1148
     """
     from webui.backend.lib.schedule_schema import SensorTrigger
 
@@ -3327,7 +3336,7 @@ def _make_routine_impl(
     name: str | None = None,
     pre_condition: dict | None = None,
     **trigger_kwargs,
-):
+) -> "Routine":
     """Factory function to create routines with any trigger type.
 
     This factory allows creating routines dynamically for testing different
@@ -3414,12 +3423,17 @@ def _make_routine_impl(
         if "time" not in trigger_kwargs:
             trigger_kwargs["time"] = "21:00"
     elif trigger_type == "recurring_days":
+        if "every_n_days" not in trigger_kwargs:
+            raise ValueError("recurring_days trigger requires 'every_n_days' argument")
         if "time" not in trigger_kwargs:
             trigger_kwargs["time"] = "21:00"
     elif trigger_type == "cron":
         if "cron_expression" not in trigger_kwargs:
             trigger_kwargs["cron_expression"] = "0 21 * * *"
     elif trigger_type == "sensor":
+        # Default to "motion" which doesn't require threshold/comparison.
+        # Other sensor types (temperature, light, humidity) require
+        # threshold and comparison parameters to be passed explicitly.
         if "sensor_type" not in trigger_kwargs:
             trigger_kwargs["sensor_type"] = "motion"
 

--- a/Firmware/Tests/unit/test_schedule_schema.py
+++ b/Firmware/Tests/unit/test_schedule_schema.py
@@ -2233,3 +2233,282 @@ class TestScheduleWithMixedTriggerTypes:
         valid, error = validate_schedule(schedule)
         assert valid is True
         assert error is None
+
+
+# =============================================================================
+# TRIGGER AND ROUTINE FIXTURE TESTS (Issue #313)
+# =============================================================================
+
+
+class TestTriggerFixtures:
+    """Test the 7 trigger fixtures produce valid instances."""
+
+    def test_solar_trigger_fixture(self, solar_trigger):
+        """solar_trigger fixture creates valid SolarTrigger."""
+        assert isinstance(solar_trigger, SolarTrigger)
+        assert solar_trigger.solar_event == "dusk"
+        assert solar_trigger.offset_minutes == 0
+
+    def test_interval_trigger_fixture(self, interval_trigger):
+        """interval_trigger fixture creates valid IntervalTrigger."""
+        assert isinstance(interval_trigger, IntervalTrigger)
+        assert interval_trigger.interval_minutes == 15
+        assert interval_trigger.time_window.start_time == "22:00"
+        assert interval_trigger.time_window.end_time == "06:00"
+
+    def test_fixed_time_trigger_fixture(self, fixed_time_trigger):
+        """fixed_time_trigger fixture creates valid FixedTimeTrigger."""
+        assert isinstance(fixed_time_trigger, FixedTimeTrigger)
+        assert fixed_time_trigger.time == "09:00"
+
+    def test_moon_phase_trigger_fixture(self, moon_phase_trigger):
+        """moon_phase_trigger fixture creates valid MoonPhaseTrigger."""
+        assert isinstance(moon_phase_trigger, MoonPhaseTrigger)
+        assert moon_phase_trigger.phases == ["full", "new"]
+        assert moon_phase_trigger.time_window is not None
+        assert moon_phase_trigger.time_window.start_time == "22:00"
+
+    def test_recurring_days_trigger_fixture(self, recurring_days_trigger):
+        """recurring_days_trigger fixture creates valid RecurringDaysTrigger."""
+        assert isinstance(recurring_days_trigger, RecurringDaysTrigger)
+        assert recurring_days_trigger.every_n_days == 3
+        assert recurring_days_trigger.time == "21:00"
+
+    def test_sensor_trigger_fixture(self, sensor_trigger):
+        """sensor_trigger fixture creates valid SensorTrigger."""
+        assert isinstance(sensor_trigger, SensorTrigger)
+        assert sensor_trigger.sensor_type == "light"
+        assert sensor_trigger.threshold == 100
+        assert sensor_trigger.comparison == "lt"
+
+    def test_cron_trigger_fixture(self, cron_trigger):
+        """cron_trigger fixture creates valid CronTrigger."""
+        assert isinstance(cron_trigger, CronTrigger)
+        assert cron_trigger.cron_expression == "0 */2 * * *"
+
+    def test_all_triggers_serialize(
+        self,
+        solar_trigger,
+        interval_trigger,
+        fixed_time_trigger,
+        moon_phase_trigger,
+        recurring_days_trigger,
+        sensor_trigger,
+        cron_trigger,
+    ):
+        """All trigger fixtures can serialize to dict."""
+        triggers = [
+            solar_trigger,
+            interval_trigger,
+            fixed_time_trigger,
+            moon_phase_trigger,
+            recurring_days_trigger,
+            sensor_trigger,
+            cron_trigger,
+        ]
+        for trigger in triggers:
+            d = trigger.to_dict()
+            assert isinstance(d, dict)
+
+
+class TestRoutineFixtures:
+    """Test the 7 routine fixtures produce valid instances."""
+
+    def test_routine_solar_fixture(self, routine_solar):
+        """routine_solar fixture creates valid Routine."""
+        assert isinstance(routine_solar, Routine)
+        assert routine_solar.routine_id == "test-solar"
+        assert isinstance(routine_solar.trigger, SolarTrigger)
+        assert len(routine_solar.actions) == 1
+        assert routine_solar.actions[0].action_name == "attract_on"
+
+    def test_routine_interval_fixture(self, routine_interval):
+        """routine_interval fixture creates valid Routine."""
+        assert isinstance(routine_interval, Routine)
+        assert routine_interval.routine_id == "test-interval"
+        assert isinstance(routine_interval.trigger, IntervalTrigger)
+        assert len(routine_interval.actions) == 3
+        # flash_on -> takephoto -> flash_off
+        assert routine_interval.actions[0].action_name == "flash_on"
+        assert routine_interval.actions[1].action_name == "takephoto"
+        assert routine_interval.actions[2].action_name == "flash_off"
+
+    def test_routine_fixed_time_fixture(self, routine_fixed_time):
+        """routine_fixed_time fixture creates valid Routine."""
+        assert isinstance(routine_fixed_time, Routine)
+        assert routine_fixed_time.routine_id == "test-fixed"
+        assert isinstance(routine_fixed_time.trigger, FixedTimeTrigger)
+        assert routine_fixed_time.actions[0].action_name == "backup"
+
+    def test_routine_moon_phase_fixture(self, routine_moon_phase):
+        """routine_moon_phase fixture creates valid Routine."""
+        assert isinstance(routine_moon_phase, Routine)
+        assert routine_moon_phase.routine_id == "test-moon"
+        assert isinstance(routine_moon_phase.trigger, MoonPhaseTrigger)
+        assert routine_moon_phase.actions[0].action_name == "takephoto"
+
+    def test_routine_recurring_days_fixture(self, routine_recurring_days):
+        """routine_recurring_days fixture creates valid Routine."""
+        assert isinstance(routine_recurring_days, Routine)
+        assert routine_recurring_days.routine_id == "test-recurring"
+        assert isinstance(routine_recurring_days.trigger, RecurringDaysTrigger)
+        assert routine_recurring_days.actions[0].action_name == "gps_sync"
+
+    def test_routine_cron_fixture(self, routine_cron):
+        """routine_cron fixture creates valid Routine."""
+        assert isinstance(routine_cron, Routine)
+        assert routine_cron.routine_id == "test-cron"
+        assert isinstance(routine_cron.trigger, CronTrigger)
+
+    def test_routine_with_precondition_fixture(self, routine_with_precondition):
+        """routine_with_precondition fixture creates valid Routine with pre_condition."""
+        assert isinstance(routine_with_precondition, Routine)
+        assert routine_with_precondition.name == "Photo if Dark"
+        assert routine_with_precondition.pre_condition is not None
+        assert isinstance(routine_with_precondition.pre_condition, SensorTrigger)
+        assert routine_with_precondition.pre_condition.sensor_type == "light"
+
+    def test_all_routines_serialize(
+        self,
+        routine_solar,
+        routine_interval,
+        routine_fixed_time,
+        routine_moon_phase,
+        routine_recurring_days,
+        routine_cron,
+        routine_with_precondition,
+    ):
+        """All routine fixtures can serialize and deserialize."""
+        routines = [
+            routine_solar,
+            routine_interval,
+            routine_fixed_time,
+            routine_moon_phase,
+            routine_recurring_days,
+            routine_cron,
+            routine_with_precondition,
+        ]
+        for routine in routines:
+            d = routine.to_dict()
+            restored = Routine.from_dict(d)
+            assert restored.routine_id == routine.routine_id
+
+
+class TestMakeRoutineFactory:
+    """Test the make_routine() factory function."""
+
+    def test_solar_routine(self, make_routine):
+        """make_routine creates solar trigger routine."""
+        routine = make_routine("solar", solar_event="dusk")
+        assert isinstance(routine.trigger, SolarTrigger)
+        assert routine.trigger.solar_event == "dusk"
+        assert routine.routine_id == "test-solar"
+
+    def test_interval_routine(self, make_routine):
+        """make_routine creates interval trigger routine with defaults."""
+        routine = make_routine("interval", interval_minutes=30)
+        assert isinstance(routine.trigger, IntervalTrigger)
+        assert routine.trigger.interval_minutes == 30
+        # Default time_window should be set
+        assert routine.trigger.time_window is not None
+
+    def test_fixed_time_routine(self, make_routine):
+        """make_routine creates fixed_time trigger routine."""
+        routine = make_routine("fixed_time", time="08:00")
+        assert isinstance(routine.trigger, FixedTimeTrigger)
+        assert routine.trigger.time == "08:00"
+
+    def test_moon_phase_routine(self, make_routine):
+        """make_routine creates moon_phase trigger routine."""
+        routine = make_routine("moon_phase", phases=["full", "waxing_gibbous"])
+        assert isinstance(routine.trigger, MoonPhaseTrigger)
+        assert routine.trigger.phases == ["full", "waxing_gibbous"]
+
+    def test_recurring_days_routine(self, make_routine):
+        """make_routine creates recurring_days trigger routine."""
+        routine = make_routine("recurring_days", every_n_days=7, time="06:00")
+        assert isinstance(routine.trigger, RecurringDaysTrigger)
+        assert routine.trigger.every_n_days == 7
+        assert routine.trigger.time == "06:00"
+
+    def test_sensor_routine(self, make_routine):
+        """make_routine creates sensor trigger routine."""
+        routine = make_routine(
+            "sensor", sensor_type="temperature", threshold=25, comparison="gte"
+        )
+        assert isinstance(routine.trigger, SensorTrigger)
+        assert routine.trigger.sensor_type == "temperature"
+        assert routine.trigger.threshold == 25
+
+    def test_cron_routine(self, make_routine):
+        """make_routine creates cron trigger routine."""
+        routine = make_routine("cron", cron_expression="30 4 * * *")
+        assert isinstance(routine.trigger, CronTrigger)
+        assert routine.trigger.cron_expression == "30 4 * * *"
+
+    def test_custom_actions(self, make_routine):
+        """make_routine accepts custom actions list."""
+        routine = make_routine(
+            "solar",
+            solar_event="sunset",
+            actions=[
+                {"action_type": "gpio", "action_name": "flash_on", "offset_minutes": 0},
+                {
+                    "action_type": "camera",
+                    "action_name": "takephoto",
+                    "offset_minutes": 1,
+                },
+            ],
+        )
+        assert len(routine.actions) == 2
+        assert routine.actions[0].action_name == "flash_on"
+        assert routine.actions[1].action_name == "takephoto"
+
+    def test_custom_routine_id(self, make_routine):
+        """make_routine accepts custom routine_id."""
+        routine = make_routine("solar", solar_event="dusk", routine_id="my-custom-id")
+        assert routine.routine_id == "my-custom-id"
+
+    def test_custom_name(self, make_routine):
+        """make_routine accepts custom name."""
+        routine = make_routine("solar", solar_event="dusk", name="My Custom Routine")
+        assert routine.name == "My Custom Routine"
+
+    def test_with_pre_condition(self, make_routine):
+        """make_routine accepts pre_condition dict."""
+        routine = make_routine(
+            "interval",
+            interval_minutes=15,
+            pre_condition={"sensor_type": "light", "threshold": 50, "comparison": "lt"},
+        )
+        assert routine.pre_condition is not None
+        assert routine.pre_condition.sensor_type == "light"
+        assert routine.pre_condition.threshold == 50
+
+    def test_unknown_trigger_type_raises_error(self, make_routine):
+        """make_routine raises ValueError for unknown trigger_type."""
+        with pytest.raises(ValueError, match="Unknown trigger_type"):
+            make_routine("unknown_trigger")
+
+    def test_moon_phase_without_phases_raises_error(self, make_routine):
+        """make_routine raises ValueError for moon_phase without phases."""
+        with pytest.raises(ValueError, match="phases"):
+            make_routine("moon_phase")
+
+    def test_default_values_applied(self, make_routine):
+        """make_routine applies sensible defaults for each trigger type."""
+        # Solar defaults to "dusk"
+        routine = make_routine("solar")
+        assert routine.trigger.solar_event == "dusk"
+
+        # fixed_time defaults to "21:00"
+        routine = make_routine("fixed_time")
+        assert routine.trigger.time == "21:00"
+
+        # cron defaults to "0 21 * * *"
+        routine = make_routine("cron")
+        assert routine.trigger.cron_expression == "0 21 * * *"
+
+        # sensor defaults to "motion"
+        routine = make_routine("sensor")
+        assert routine.trigger.sensor_type == "motion"

--- a/Firmware/Tests/unit/test_schedule_schema.py
+++ b/Firmware/Tests/unit/test_schedule_schema.py
@@ -2431,6 +2431,14 @@ class TestMakeRoutineFactory:
         assert routine.trigger.every_n_days == 7
         assert routine.trigger.time == "06:00"
 
+    def test_recurring_days_with_start_date(self, make_routine):
+        """make_routine handles custom start_date for recurring_days."""
+        routine = make_routine(
+            "recurring_days", every_n_days=7, time="06:00", start_date="2026-01-15"
+        )
+        assert isinstance(routine.trigger, RecurringDaysTrigger)
+        assert routine.trigger.start_date == "2026-01-15"
+
     def test_sensor_routine(self, make_routine):
         """make_routine creates sensor trigger routine."""
         routine = make_routine(
@@ -2494,6 +2502,11 @@ class TestMakeRoutineFactory:
         """make_routine raises ValueError for moon_phase without phases."""
         with pytest.raises(ValueError, match="phases"):
             make_routine("moon_phase")
+
+    def test_recurring_days_without_every_n_days_raises_error(self, make_routine):
+        """make_routine raises ValueError for recurring_days without every_n_days."""
+        with pytest.raises(ValueError, match="every_n_days"):
+            make_routine("recurring_days")
 
     def test_default_values_applied(self, make_routine):
         """make_routine applies sensible defaults for each trigger type."""

--- a/Firmware/webui/docs/dev/guides/scheduler/SCHEDULER_TERMINOLOGY_REFACTOR_TESTING.md
+++ b/Firmware/webui/docs/dev/guides/scheduler/SCHEDULER_TERMINOLOGY_REFACTOR_TESTING.md
@@ -274,7 +274,6 @@ from webui.backend.lib.schedule_schema import (
 def solar_trigger():
     """SolarTrigger fixture."""
     return SolarTrigger(
-        trigger_type="solar",
         solar_event="dusk",
         offset_minutes=0,
     )
@@ -284,7 +283,6 @@ def solar_trigger():
 def interval_trigger():
     """IntervalTrigger with time window fixture."""
     return IntervalTrigger(
-        trigger_type="interval",
         interval_minutes=15,
         time_window=TimeWindow(start_time="22:00", end_time="06:00"),
     )
@@ -294,7 +292,6 @@ def interval_trigger():
 def fixed_time_trigger():
     """FixedTimeTrigger fixture."""
     return FixedTimeTrigger(
-        trigger_type="fixed_time",
         time="09:00",
     )
 
@@ -303,7 +300,6 @@ def fixed_time_trigger():
 def moon_phase_trigger():
     """MoonPhaseTrigger fixture."""
     return MoonPhaseTrigger(
-        trigger_type="moon_phase",
         phases=["full", "new"],
         time_window=TimeWindow(start_time="22:00", end_time="04:00"),
     )
@@ -313,7 +309,6 @@ def moon_phase_trigger():
 def recurring_days_trigger():
     """RecurringDaysTrigger fixture."""
     return RecurringDaysTrigger(
-        trigger_type="recurring_days",
         every_n_days=3,
         time="21:00",
         start_date=None,  # Starts from today
@@ -324,9 +319,8 @@ def recurring_days_trigger():
 def sensor_trigger():
     """SensorTrigger fixture (used as pre_condition)."""
     return SensorTrigger(
-        trigger_type="sensor",
         sensor_type="light",
-        condition="below",
+        comparison="lt",
         threshold=100,
     )
 
@@ -335,7 +329,6 @@ def sensor_trigger():
 def cron_trigger():
     """CronTrigger fixture (expert mode)."""
     return CronTrigger(
-        trigger_type="cron",
         cron_expression="0 */2 * * *",  # Every 2 hours
     )
 
@@ -448,7 +441,7 @@ def make_routine(
     }
 
     trigger_cls = trigger_classes[trigger_type]
-    trigger = trigger_cls(trigger_type=trigger_type, **trigger_kwargs)
+    trigger = trigger_cls(**trigger_kwargs)
 
     if actions is None:
         actions = [{"action_type": "gpio", "action_name": "attract_on"}]
@@ -471,7 +464,7 @@ def test_all_trigger_types_serialize(
     for routine in [routine_solar, routine_interval, routine_fixed_time, routine_recurring_days]:
         d = routine.to_dict()
         restored = Routine.from_dict(d)
-        assert restored.trigger.trigger_type == routine.trigger.trigger_type
+        assert restored.routine_id == routine.routine_id
 
 
 def test_factory_creates_valid_routines():


### PR DESCRIPTION
## Summary
- Add 7 trigger fixtures: `solar_trigger`, `interval_trigger`, `fixed_time_trigger`, `moon_phase_trigger`, `recurring_days_trigger`, `sensor_trigger`, `cron_trigger`
- Add 7 routine fixtures: one for each trigger type plus `routine_with_precondition`
- Add `make_routine()` factory fixture for dynamic test data creation
- Add 30 new tests validating fixtures and factory function
- Fix incorrect trigger constructor syntax in testing documentation

## Test plan
- [x] All 205 schedule schema tests pass
- [x] 30 new fixture/factory tests pass
- [x] Ruff lint check passes on test file
- [x] Documentation examples now match actual class signatures

## Acceptance Criteria (from issue)
- [x] 7 trigger fixtures created
- [x] 7 routine fixtures created  
- [x] make_routine() factory function working

Closes #313

Part of Scheduler Terminology Refactor Phase 4 (#296)