### PR TITLE
feat(scheduler): Add schedule clone endpoint (#320)

### DIFF
--- a/Firmware/Tests/unit/test_scheduler_ui_routes.py
+++ b/Firmware/Tests/unit/test_scheduler_ui_routes.py
@@ -880,6 +880,184 @@ class TestDeleteScheduleEndpoint:
 
 
 # ============================================================================
+# Clone Schedule Endpoint Tests (Issue #320)
+# ============================================================================
+
+
+class TestCloneScheduleEndpoint:
+    """Tests for POST /api/scheduler/ui/schedules/{id}/clone."""
+
+    @pytest.fixture
+    def clone_schedule_mock(self):
+        """Create a mock schedule with all properties needed for cloning."""
+        schedule = MagicMock()
+        schedule.schedule_id = "original-schedule-id"
+        schedule.name = "Original Schedule"
+        schedule.description = "Original description"
+        schedule.enabled = True
+        schedule.is_active = False
+        schedule.create_deployment = False
+        schedule.deployment_id = None
+        schedule.routines = []
+        return schedule
+
+    def test_clone_schedule_success(self, client, mock_scheduler_service, clone_schedule_mock):
+        """Test successful schedule cloning with default name."""
+        # Add a routine with proper to_dict
+        routine_mock = MagicMock()
+        routine_mock.to_dict.return_value = {
+            "routine_id": "original-routine",
+            "name": "Test Routine",
+            "trigger": {"trigger_type": "fixed_time", "time": "21:00", "days_of_week": [0]},
+            "actions": [],
+            "pre_condition": None,
+            "description": "",
+        }
+        clone_schedule_mock.routines = [routine_mock]
+        mock_scheduler_service.get_schedule.return_value = clone_schedule_mock
+        mock_scheduler_service.create_schedule.return_value = True
+
+        response = client.post("/api/scheduler/ui/schedules/test-schedule/clone")
+
+        assert response.status_code == 201
+        data = response.get_json()
+        assert data["message"] == "Schedule cloned"
+        assert "schedule_id" in data
+        assert "schedule" in data
+        assert data["schedule"]["name"] == "Original Schedule (Copy)"
+        mock_scheduler_service.create_schedule.assert_called_once()
+
+    def test_clone_schedule_with_custom_name(
+        self, client, mock_scheduler_service, clone_schedule_mock
+    ):
+        """Test cloning with custom name."""
+        mock_scheduler_service.get_schedule.return_value = clone_schedule_mock
+        mock_scheduler_service.create_schedule.return_value = True
+
+        response = client.post(
+            "/api/scheduler/ui/schedules/test-schedule/clone",
+            json={"name": "My Custom Clone"},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 201
+        data = response.get_json()
+        assert data["schedule"]["name"] == "My Custom Clone"
+
+    def test_clone_schedule_not_found(self, client, mock_scheduler_service):
+        """Test cloning non-existent schedule."""
+        mock_scheduler_service.get_schedule.return_value = None
+
+        response = client.post("/api/scheduler/ui/schedules/nonexistent/clone")
+
+        assert response.status_code == 404
+        data = response.get_json()
+        assert "not found" in data["error"].lower()
+
+    def test_clone_builtin_schedule_success(
+        self, client, mock_scheduler_service, clone_schedule_mock
+    ):
+        """Test cloning a built-in schedule creates user-owned copy."""
+        mock_scheduler_service.get_schedule.return_value = clone_schedule_mock
+        mock_scheduler_service.create_schedule.return_value = True
+
+        response = client.post("/api/scheduler/ui/schedules/builtin-nightly/clone")
+
+        assert response.status_code == 201
+        # Verify create_schedule was called (creates new user schedule)
+        mock_scheduler_service.create_schedule.assert_called_once()
+
+    def test_clone_schedule_generates_new_ids(
+        self, client, mock_scheduler_service, clone_schedule_mock
+    ):
+        """Test that clone generates new schedule ID."""
+        clone_schedule_mock.schedule_id = "original-id"
+        mock_scheduler_service.get_schedule.return_value = clone_schedule_mock
+        mock_scheduler_service.create_schedule.return_value = True
+
+        response = client.post("/api/scheduler/ui/schedules/original-id/clone")
+
+        assert response.status_code == 201
+        data = response.get_json()
+        # New schedule_id should differ from original
+        assert data["schedule_id"] != "original-id"
+
+    def test_clone_schedule_is_not_active(
+        self, client, mock_scheduler_service, clone_schedule_mock
+    ):
+        """Test that cloned schedule is not active."""
+        clone_schedule_mock.is_active = True  # Original is active
+        mock_scheduler_service.get_schedule.return_value = clone_schedule_mock
+        mock_scheduler_service.create_schedule.return_value = True
+
+        response = client.post("/api/scheduler/ui/schedules/test-schedule/clone")
+
+        assert response.status_code == 201
+        data = response.get_json()
+        assert data["schedule"]["is_active"] is False
+
+    def test_clone_schedule_long_name_truncated(
+        self, client, mock_scheduler_service, clone_schedule_mock
+    ):
+        """Test that cloning with long original name truncates to fit suffix."""
+        clone_schedule_mock.name = "A" * 195  # 195 chars + " (Copy)" = 202 > 200
+        mock_scheduler_service.get_schedule.return_value = clone_schedule_mock
+        mock_scheduler_service.create_schedule.return_value = True
+
+        response = client.post("/api/scheduler/ui/schedules/test-schedule/clone")
+
+        assert response.status_code == 201
+        data = response.get_json()
+        assert len(data["schedule"]["name"]) <= 200
+        assert data["schedule"]["name"].endswith(" (Copy)")
+
+    def test_clone_schedule_empty_name_rejected(
+        self, client, mock_scheduler_service, clone_schedule_mock
+    ):
+        """Test that empty custom name is rejected."""
+        mock_scheduler_service.get_schedule.return_value = clone_schedule_mock
+
+        response = client.post(
+            "/api/scheduler/ui/schedules/test-schedule/clone",
+            json={"name": "   "},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "empty" in data["error"].lower()
+
+    def test_clone_schedule_name_too_long_rejected(
+        self, client, mock_scheduler_service, clone_schedule_mock
+    ):
+        """Test that overly long name is rejected."""
+        mock_scheduler_service.get_schedule.return_value = clone_schedule_mock
+
+        response = client.post(
+            "/api/scheduler/ui/schedules/test-schedule/clone",
+            json={"name": "A" * 201},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "200" in data["error"] or "characters" in data["error"].lower()
+
+    def test_clone_schedule_service_error(
+        self, client, mock_scheduler_service, clone_schedule_mock
+    ):
+        """Test when service fails to create clone."""
+        mock_scheduler_service.get_schedule.return_value = clone_schedule_mock
+        mock_scheduler_service.create_schedule.return_value = False
+
+        response = client.post("/api/scheduler/ui/schedules/test-schedule/clone")
+
+        assert response.status_code == 500
+        data = response.get_json()
+        assert "error" in data
+
+
+# ============================================================================
 # Activate Schedule Endpoint Tests (Issue #218)
 # ============================================================================
 

--- a/Firmware/webui/backend/routes/scheduler_ui.py
+++ b/Firmware/webui/backend/routes/scheduler_ui.py
@@ -17,6 +17,7 @@ Issue #310 - API terminology update (Schema 3.0)
 import logging
 from datetime import datetime
 from functools import wraps
+from uuid import uuid4
 
 from flask import Blueprint, Response, current_app, jsonify, request
 from werkzeug.exceptions import BadRequest
@@ -35,6 +36,8 @@ from webui.backend.lib.schedule_preview import (
     validate_timezone,
 )
 from webui.backend.lib.schedule_schema import (
+    MAX_PATTERN_NAME_LENGTH,
+    Routine,
     Schedule,
     ScheduleActivationError,
     ScheduleConflictError,
@@ -646,6 +649,145 @@ def delete_schedule(schedule_id: str) -> tuple[Response, int]:
 
     except Exception as e:
         logger.error(f"Error deleting schedule: {e}", exc_info=True)
+        return jsonify(
+            {
+                "error": "Internal server error",
+            }
+        ), 500
+
+
+@scheduler_ui_bp.route("/schedules/<schedule_id>/clone", methods=["POST"])
+@limiter.limit("30 per minute")
+def clone_schedule(schedule_id: str) -> tuple[Response, int]:
+    """
+    Clone a schedule to a new user-owned schedule.
+
+    POST /api/scheduler/ui/schedules/{id}/clone
+
+    Works for both built-in and user schedules. Creates a deep copy with:
+    - New schedule_id (UUID)
+    - New routine_id for each routine (UUID)
+    - Name with " (Copy)" suffix or custom name from request body
+    - is_active = False
+    - Fresh timestamps
+
+    Request Body (optional):
+        {
+            "name": "Custom name for the copy"
+        }
+
+    Returns:
+        201 Created: {
+            "message": "Schedule cloned",
+            "schedule_id": "new-uuid",
+            "schedule": {...}
+        }
+        400 Bad Request: Invalid name
+        404 Not Found: Schedule not found
+        500 Internal Server Error: Clone failed
+
+    Issue #320 - Built-in Schedule Immutability Enforcement
+    """
+    try:
+        service = get_scheduler_service()
+
+        # Get original schedule
+        original = service.get_schedule(schedule_id)
+        if original is None:
+            return jsonify(
+                {
+                    "error": "Schedule not found",
+                }
+            ), 404
+
+        # Parse optional request body for custom name
+        data = request.get_json(silent=True) or {}
+        custom_name = data.get("name")
+
+        # Validate custom name if provided
+        if custom_name is not None:
+            if not isinstance(custom_name, str):
+                return jsonify(
+                    {
+                        "error": "Name must be a string",
+                    }
+                ), 400
+            if not custom_name.strip():
+                return jsonify(
+                    {
+                        "error": "Name cannot be empty",
+                    }
+                ), 400
+            if len(custom_name) > MAX_PATTERN_NAME_LENGTH:
+                return jsonify(
+                    {
+                        "error": f"Name exceeds {MAX_PATTERN_NAME_LENGTH} characters",
+                    }
+                ), 400
+            new_name = custom_name.strip()
+        else:
+            new_name = f"{original.name} (Copy)"
+            # Truncate if default name exceeds max length
+            if len(new_name) > MAX_PATTERN_NAME_LENGTH:
+                suffix = " (Copy)"
+                max_original_len = MAX_PATTERN_NAME_LENGTH - len(suffix)
+                new_name = f"{original.name[:max_original_len]}{suffix}"
+
+        # Deep copy routines with new IDs
+        cloned_routines = []
+        for routine in original.routines:
+            routine_dict = routine.to_dict()
+            # Remove computed fields that get regenerated
+            routine_dict.pop("display_name", None)
+            routine_dict.pop("duration_minutes", None)
+            # Set empty routine_id to trigger UUID generation in __post_init__
+            routine_dict["routine_id"] = ""
+            cloned_routines.append(Routine.from_dict(routine_dict))
+
+        # Create new schedule with fresh IDs and timestamps
+        now = datetime.now().isoformat()
+        new_schedule = Schedule(
+            schedule_id=str(uuid4()),
+            name=new_name,
+            description=original.description,
+            routines=cloned_routines,
+            deployment_id=None,  # Clear deployment link
+            create_deployment=original.create_deployment,
+            enabled=original.enabled,
+            is_active=False,  # Clone is never active
+            created_at=now,
+            modified_at=now,
+            modified_by=None,
+        )
+
+        # Create via service
+        try:
+            success = service.create_schedule(new_schedule)
+        except ScheduleValidationError as e:
+            logger.warning(f"Cloned schedule validation failed: {e}")
+            return jsonify(
+                {
+                    "error": "Validation failed",
+                }
+            ), 400
+
+        if not success:
+            return jsonify(
+                {
+                    "error": "Failed to create cloned schedule",
+                }
+            ), 500
+
+        return jsonify(
+            {
+                "message": "Schedule cloned",
+                "schedule_id": new_schedule.schedule_id,
+                "schedule": new_schedule.to_dict(),
+            }
+        ), 201
+
+    except Exception as e:
+        logger.error(f"Error cloning schedule: {e}", exc_info=True)
         return jsonify(
             {
                 "error": "Internal server error",


### PR DESCRIPTION
## Summary
- Implement `POST /api/scheduler/ui/schedules/{id}/clone` endpoint for cloning schedules
- Enables copying built-in schedules (immutable) to create customizable user schedules
- Add 9 unit tests for clone endpoint

## Changes
### Clone Endpoint Features
- Clone any schedule (built-in or user) to a new user-owned schedule
- Optional custom name via request body `{"name": "Custom Name"}`, defaults to `{name} (Copy)`
- Generates new UUIDs for schedule and all routines
- Cloned schedule is always inactive (`is_active=False`)
- Fresh timestamps and cleared deployment link
- Name validation: max 200 chars, cannot be empty

### Files Modified
- `webui/backend/routes/scheduler_ui.py` - Added clone endpoint
- `Tests/unit/test_scheduler_ui_routes.py` - Added 9 unit tests

## Test plan
- [x] All 9 clone endpoint tests pass
- [x] All 75 scheduler UI route tests pass
- [x] Ruff check and format pass

## Acceptance Criteria (Issue #320)
- [x] Built-in schedules cannot be modified (PUT returns 403) - Already on dev
- [x] Built-in schedules cannot be deleted (DELETE returns 403) - Already on dev
- [x] Clone endpoint works for both built-in and user schedules

Closes #320