### PR TITLE
refactor(hooks): Rename useEventPatterns to useRoutines (#322)

### DIFF
--- a/Firmware/webui/frontend/src/components/scheduler/PatternLibrary/PatternList.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/PatternLibrary/PatternList.jsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useCallback } from 'react'
 import PropTypes from 'prop-types'
-import { useBuiltinPatterns } from '../../../hooks/useEventPatterns'
+import { useBuiltinRoutines } from '../../../hooks/useRoutines'
 import PatternCard from './PatternCard'
 import PatternFilters from './PatternFilters'
 import PatternDetailsDrawer from './PatternDetailsDrawer'
@@ -19,7 +19,7 @@ function PatternList({
   className = ''
 }) {
   // Fetch patterns from API
-  const { data, isLoading, isError, error, refetch } = useBuiltinPatterns()
+  const { data, isLoading, isError, error, refetch } = useBuiltinRoutines()
 
   // Filter state
   const [category, setCategory] = useState('all')

--- a/Firmware/webui/frontend/src/components/scheduler/PatternLibrary/__tests__/PatternList.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/PatternLibrary/__tests__/PatternList.test.jsx
@@ -2,11 +2,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import PatternList from '../PatternList'
-import { useBuiltinPatterns } from '../../../../hooks/useEventPatterns'
+import { useBuiltinRoutines } from '../../../../hooks/useRoutines'
 
 // Mock the hook
-vi.mock('../../../../hooks/useEventPatterns', () => ({
-  useBuiltinPatterns: vi.fn()
+vi.mock('../../../../hooks/useRoutines', () => ({
+  useBuiltinRoutines: vi.fn()
 }))
 
 // Mock child components
@@ -125,12 +125,12 @@ describe('PatternList', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    useBuiltinPatterns.mockReturnValue(mockHookReturn)
+    useBuiltinRoutines.mockReturnValue(mockHookReturn)
   })
 
   describe('Data Fetching Tests', () => {
     it('shows loading skeleton while isLoading=true', () => {
-      useBuiltinPatterns.mockReturnValue({
+      useBuiltinRoutines.mockReturnValue({
         ...mockHookReturn,
         isLoading: true,
         data: null
@@ -151,7 +151,7 @@ describe('PatternList', () => {
     })
 
     it('shows error message when isError=true', () => {
-      useBuiltinPatterns.mockReturnValue({
+      useBuiltinRoutines.mockReturnValue({
         ...mockHookReturn,
         isLoading: false,
         isError: true,
@@ -165,7 +165,7 @@ describe('PatternList', () => {
     })
 
     it('shows retry button on error', () => {
-      useBuiltinPatterns.mockReturnValue({
+      useBuiltinRoutines.mockReturnValue({
         ...mockHookReturn,
         isLoading: false,
         isError: true,
@@ -182,7 +182,7 @@ describe('PatternList', () => {
       const user = userEvent.setup()
       const mockRefetch = vi.fn()
 
-      useBuiltinPatterns.mockReturnValue({
+      useBuiltinRoutines.mockReturnValue({
         ...mockHookReturn,
         isLoading: false,
         isError: true,
@@ -200,7 +200,7 @@ describe('PatternList', () => {
     })
 
     it('shows empty state when patterns array is empty', () => {
-      useBuiltinPatterns.mockReturnValue({
+      useBuiltinRoutines.mockReturnValue({
         ...mockHookReturn,
         data: {
           patterns: [],
@@ -215,7 +215,7 @@ describe('PatternList', () => {
     })
 
     it('shows warning banner if data.warnings has items', () => {
-      useBuiltinPatterns.mockReturnValue({
+      useBuiltinRoutines.mockReturnValue({
         ...mockHookReturn,
         data: {
           ...mockHookReturn.data,
@@ -527,10 +527,10 @@ describe('PatternList', () => {
   })
 
   describe('Integration Tests', () => {
-    it('uses useBuiltinPatterns() hook correctly', () => {
+    it('uses useBuiltinRoutines() hook correctly', () => {
       render(<PatternList onPatternSelect={vi.fn()} />)
 
-      expect(useBuiltinPatterns).toHaveBeenCalled()
+      expect(useBuiltinRoutines).toHaveBeenCalled()
     })
 
     it('state persists across filter changes (drawer stays open)', async () => {

--- a/Firmware/webui/frontend/src/components/scheduler/PatternLibrary/__tests__/integration.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/PatternLibrary/__tests__/integration.test.jsx
@@ -11,11 +11,11 @@ import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 import { PatternList, PatternCard, PatternDetailsDrawer, PatternFilters } from '../index'
-import { useBuiltinPatterns } from '../../../../hooks/useEventPatterns'
+import { useBuiltinRoutines } from '../../../../hooks/useRoutines'
 
 // Mock the hook
-vi.mock('../../../../hooks/useEventPatterns', () => ({
-  useBuiltinPatterns: vi.fn(),
+vi.mock('../../../../hooks/useRoutines', () => ({
+  useBuiltinRoutines: vi.fn(),
 }))
 
 // Test data
@@ -79,7 +79,7 @@ function createWrapper() {
 describe('Pattern Library Integration', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    useBuiltinPatterns.mockReturnValue({
+    useBuiltinRoutines.mockReturnValue({
       data: { patterns: mockPatterns, total: 3, warnings: [] },
       isLoading: false,
       isError: false,
@@ -270,7 +270,7 @@ describe('Pattern Library Integration', () => {
   describe('Error Recovery', () => {
     it('shows error state and allows retry', async () => {
       const refetchMock = vi.fn()
-      useBuiltinPatterns.mockReturnValue({
+      useBuiltinRoutines.mockReturnValue({
         data: null,
         isLoading: false,
         isError: true,
@@ -296,7 +296,7 @@ describe('Pattern Library Integration', () => {
 
   describe('Loading State', () => {
     it('shows loading skeleton while fetching', () => {
-      useBuiltinPatterns.mockReturnValue({
+      useBuiltinRoutines.mockReturnValue({
         data: null,
         isLoading: true,
         isError: false,
@@ -313,7 +313,7 @@ describe('Pattern Library Integration', () => {
 
   describe('Empty State', () => {
     it('shows empty message when no patterns exist', () => {
-      useBuiltinPatterns.mockReturnValue({
+      useBuiltinRoutines.mockReturnValue({
         data: { patterns: [], total: 0, warnings: [] },
         isLoading: false,
         isError: false,

--- a/Firmware/webui/frontend/src/components/scheduler/RoutineEditor/RoutineEditor.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/RoutineEditor/RoutineEditor.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import ActionList from './ActionList'
 import OffsetTimeline from './OffsetTimeline'
-import { useValidatePattern, usePatternDuration } from '@/hooks/useEventPatterns'
+import { useValidateRoutine, useRoutineDuration } from '@/hooks/useRoutines'
 import { ROUTINE_LIMITS } from './constants'
 import { generateUUID } from '../../../utils/uuid'
 
@@ -28,8 +28,8 @@ const RoutineEditor = ({ routine, onSave, onCancel }) => {
   const [validationError, setValidationError] = useState('')
 
   // Hooks
-  const { mutateAsync: validatePattern, isPending: isValidating } = useValidatePattern()
-  const { data: duration = 0 } = usePatternDuration({ actions })
+  const { mutateAsync: validateRoutine, isPending: isValidating } = useValidateRoutine()
+  const duration = useRoutineDuration({ actions })
 
   // Determine mode
   const isEditMode = Boolean(routine?.routine_id)
@@ -119,7 +119,7 @@ const RoutineEditor = ({ routine, onSave, onCancel }) => {
 
     try {
       // Validate with backend
-      const validationResult = await validatePattern(routineData)
+      const validationResult = await validateRoutine(routineData)
 
       if (validationResult.valid) {
         // Call onSave with validated routine

--- a/Firmware/webui/frontend/src/components/scheduler/RoutineEditor/__tests__/RoutineEditor.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/RoutineEditor/__tests__/RoutineEditor.test.jsx
@@ -6,16 +6,13 @@ import RoutineEditor from '../RoutineEditor'
 import { ROUTINE_LIMITS } from '../constants'
 
 // Mock the hooks
-vi.mock('@/hooks/useEventPatterns', () => ({
-  useValidatePattern: () => ({
+vi.mock('@/hooks/useRoutines', () => ({
+  useValidateRoutine: () => ({
     mutateAsync: vi.fn().mockResolvedValue({ valid: true }),
     isPending: false,
     error: null
   }),
-  usePatternDuration: () => ({
-    data: 30,
-    isLoading: false
-  })
+  useRoutineDuration: () => 30
 }))
 
 // Mock sub-components
@@ -371,7 +368,7 @@ describe('RoutineEditor', () => {
   })
 
   describe('Duration Display', () => {
-    it('displays duration from usePatternDuration hook', () => {
+    it('displays duration from useRoutineDuration hook', () => {
       render(
         <RoutineEditor onSave={mockOnSave} onCancel={mockOnCancel} />,
         { wrapper: createWrapper() }
@@ -382,9 +379,9 @@ describe('RoutineEditor', () => {
   })
 
   describe('Save Functionality', () => {
-    it('calls useValidatePattern before saving', async () => {
+    it('calls useValidateRoutine before saving', async () => {
       const mockMutateAsync = vi.fn().mockResolvedValue({ valid: true })
-      vi.mocked(await import('@/hooks/useEventPatterns')).useValidatePattern = () => ({
+      vi.mocked(await import('@/hooks/useRoutines')).useValidateRoutine = () => ({
         mutateAsync: mockMutateAsync,
         isPending: false,
         error: null
@@ -409,7 +406,7 @@ describe('RoutineEditor', () => {
 
     it('calls onSave with routine data on successful validation', async () => {
       const mockMutateAsync = vi.fn().mockResolvedValue({ valid: true })
-      vi.mocked(await import('@/hooks/useEventPatterns')).useValidatePattern = () => ({
+      vi.mocked(await import('@/hooks/useRoutines')).useValidateRoutine = () => ({
         mutateAsync: mockMutateAsync,
         isPending: false,
         error: null
@@ -444,7 +441,7 @@ describe('RoutineEditor', () => {
 
     it('generates routine_id for new routines', async () => {
       const mockMutateAsync = vi.fn().mockResolvedValue({ valid: true })
-      vi.mocked(await import('@/hooks/useEventPatterns')).useValidatePattern = () => ({
+      vi.mocked(await import('@/hooks/useRoutines')).useValidateRoutine = () => ({
         mutateAsync: mockMutateAsync,
         isPending: false,
         error: null
@@ -479,7 +476,7 @@ describe('RoutineEditor', () => {
 
     it('preserves routine_id for existing routines', async () => {
       const mockMutateAsync = vi.fn().mockResolvedValue({ valid: true })
-      vi.mocked(await import('@/hooks/useEventPatterns')).useValidatePattern = () => ({
+      vi.mocked(await import('@/hooks/useRoutines')).useValidateRoutine = () => ({
         mutateAsync: mockMutateAsync,
         isPending: false,
         error: null
@@ -518,7 +515,7 @@ describe('RoutineEditor', () => {
         valid: false,
         errors: ['Invalid action offset']
       })
-      vi.mocked(await import('@/hooks/useEventPatterns')).useValidatePattern = () => ({
+      vi.mocked(await import('@/hooks/useRoutines')).useValidateRoutine = () => ({
         mutateAsync: mockMutateAsync,
         isPending: false,
         error: null
@@ -544,7 +541,7 @@ describe('RoutineEditor', () => {
 
     it('disables save button while validation is pending', async () => {
       const mockMutateAsync = vi.fn(() => new Promise(() => {})) // Never resolves
-      vi.mocked(await import('@/hooks/useEventPatterns')).useValidatePattern = () => ({
+      vi.mocked(await import('@/hooks/useRoutines')).useValidateRoutine = () => ({
         mutateAsync: mockMutateAsync,
         isPending: true,
         error: null

--- a/Firmware/webui/frontend/src/hooks/__tests__/useRoutines.test.jsx
+++ b/Firmware/webui/frontend/src/hooks/__tests__/useRoutines.test.jsx
@@ -80,7 +80,7 @@ describe('useBuiltinRoutines', () => {
       total: 2
     };
 
-    schedulerApi.listBuiltinPatterns.mockResolvedValue({ data: mockBuiltinRoutines });
+    schedulerApi.listBuiltinRoutines.mockResolvedValue({ data: mockBuiltinRoutines });
 
     const { result } = renderHook(() => useBuiltinRoutines(), {
       wrapper: createWrapper()
@@ -93,11 +93,11 @@ describe('useBuiltinRoutines', () => {
     });
 
     expect(result.current.data).toEqual(mockBuiltinRoutines);
-    expect(schedulerApi.listBuiltinPatterns).toHaveBeenCalledTimes(1);
+    expect(schedulerApi.listBuiltinRoutines).toHaveBeenCalledTimes(1);
   });
 
   it('handles empty routines list', async () => {
-    schedulerApi.listBuiltinPatterns.mockResolvedValue({
+    schedulerApi.listBuiltinRoutines.mockResolvedValue({
       data: { patterns: [], total: 0 }
     });
 
@@ -115,7 +115,7 @@ describe('useBuiltinRoutines', () => {
 
   it('handles fetch error', async () => {
     const mockError = new Error('Failed to fetch built-in routines');
-    schedulerApi.listBuiltinPatterns.mockRejectedValue(mockError);
+    schedulerApi.listBuiltinRoutines.mockRejectedValue(mockError);
 
     const { result } = renderHook(() => useBuiltinRoutines(), {
       wrapper: createWrapper()
@@ -136,7 +136,7 @@ describe('useBuiltinRoutines', () => {
       }
     });
 
-    schedulerApi.listBuiltinPatterns.mockResolvedValue({
+    schedulerApi.listBuiltinRoutines.mockResolvedValue({
       data: { patterns: [], total: 0 }
     });
 
@@ -154,14 +154,14 @@ describe('useBuiltinRoutines', () => {
 
     // Verify the correct query key is used in the cache
     const cachedQueries = queryClient.getQueryCache().findAll({
-      queryKey: QUERY_KEYS.BUILTIN_PATTERNS
+      queryKey: QUERY_KEYS.BUILTIN_ROUTINES
     });
     expect(cachedQueries).toHaveLength(1);
-    expect(cachedQueries[0].queryKey).toEqual(QUERY_KEYS.BUILTIN_PATTERNS);
+    expect(cachedQueries[0].queryKey).toEqual(QUERY_KEYS.BUILTIN_ROUTINES);
   });
 
   it('accepts custom queryOptions', async () => {
-    schedulerApi.listBuiltinPatterns.mockResolvedValue({
+    schedulerApi.listBuiltinRoutines.mockResolvedValue({
       data: { patterns: [], total: 0 }
     });
 
@@ -175,7 +175,7 @@ describe('useBuiltinRoutines', () => {
       expect(result.current.isSuccess).toBe(true);
     });
 
-    expect(schedulerApi.listBuiltinPatterns).toHaveBeenCalledTimes(1);
+    expect(schedulerApi.listBuiltinRoutines).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -207,7 +207,7 @@ describe('useValidateRoutine', () => {
       }
     };
 
-    schedulerApi.validatePattern.mockResolvedValue({ data: mockResponse });
+    schedulerApi.validateRoutine.mockResolvedValue({ data: mockResponse });
 
     const { result } = renderHook(() => useValidateRoutine(), {
       wrapper: createWrapper()
@@ -226,7 +226,7 @@ describe('useValidateRoutine', () => {
     });
 
     expect(result.current.data.data).toEqual(mockResponse);
-    expect(schedulerApi.validatePattern).toHaveBeenCalledWith({
+    expect(schedulerApi.validateRoutine).toHaveBeenCalledWith({
       name: 'Test Pattern',
       description: 'A test pattern',
       actions: [
@@ -241,7 +241,7 @@ describe('useValidateRoutine', () => {
       error: 'Pattern name is required'
     };
 
-    schedulerApi.validatePattern.mockResolvedValue({ data: mockResponse });
+    schedulerApi.validateRoutine.mockResolvedValue({ data: mockResponse });
 
     const { result } = renderHook(() => useValidateRoutine(), {
       wrapper: createWrapper()
@@ -262,7 +262,7 @@ describe('useValidateRoutine', () => {
 
   it('handles API error', async () => {
     const mockError = new Error('Pattern validation failed');
-    schedulerApi.validatePattern.mockRejectedValue(mockError);
+    schedulerApi.validateRoutine.mockRejectedValue(mockError);
 
     const { result } = renderHook(() => useValidateRoutine(), {
       wrapper: createWrapper()
@@ -283,7 +283,7 @@ describe('useValidateRoutine', () => {
       error: 'Missing required field: name'
     };
 
-    schedulerApi.validatePattern.mockResolvedValue({ data: mockResponse });
+    schedulerApi.validateRoutine.mockResolvedValue({ data: mockResponse });
 
     const { result } = renderHook(() => useValidateRoutine(), {
       wrapper: createWrapper()

--- a/Firmware/webui/frontend/src/hooks/__tests__/useRoutines.test.jsx
+++ b/Firmware/webui/frontend/src/hooks/__tests__/useRoutines.test.jsx
@@ -1,8 +1,8 @@
 /**
- * Tests for useEventPatterns hooks (Issue #222)
+ * Tests for useRoutines hooks (Issue #222, #322)
  *
  * Comprehensive test suite following TDD approach - tests written BEFORE implementation.
- * Tests React Query hooks for Event Pattern operations.
+ * Tests React Query hooks for Routine operations.
  *
  * Reference: useSchedules.test.jsx for testing patterns
  */
@@ -12,10 +12,10 @@ import React from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
-  useBuiltinPatterns,
-  useValidatePattern,
-  usePatternDuration,
-} from '../useEventPatterns';
+  useBuiltinRoutines,
+  useValidateRoutine,
+  useRoutineDuration,
+} from '../useRoutines';
 import * as schedulerApi from '../../utils/schedulerApi';
 import { QUERY_KEYS } from '../../utils/queryKeys';
 
@@ -37,10 +37,10 @@ const createWrapper = () => {
 };
 
 // =============================================================================
-// useBuiltinPatterns Tests
+// useBuiltinRoutines Tests
 // =============================================================================
 
-describe('useBuiltinPatterns', () => {
+describe('useBuiltinRoutines', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -49,8 +49,8 @@ describe('useBuiltinPatterns', () => {
     vi.restoreAllMocks();
   });
 
-  it('fetches built-in patterns successfully', async () => {
-    const mockBuiltinPatterns = {
+  it('fetches built-in routines successfully', async () => {
+    const mockBuiltinRoutines = {
       patterns: [
         {
           pattern_id: 'uv-capture-cycle',
@@ -80,9 +80,9 @@ describe('useBuiltinPatterns', () => {
       total: 2
     };
 
-    schedulerApi.listBuiltinPatterns.mockResolvedValue({ data: mockBuiltinPatterns });
+    schedulerApi.listBuiltinPatterns.mockResolvedValue({ data: mockBuiltinRoutines });
 
-    const { result } = renderHook(() => useBuiltinPatterns(), {
+    const { result } = renderHook(() => useBuiltinRoutines(), {
       wrapper: createWrapper()
     });
 
@@ -92,16 +92,16 @@ describe('useBuiltinPatterns', () => {
       expect(result.current.isSuccess).toBe(true);
     });
 
-    expect(result.current.data).toEqual(mockBuiltinPatterns);
+    expect(result.current.data).toEqual(mockBuiltinRoutines);
     expect(schedulerApi.listBuiltinPatterns).toHaveBeenCalledTimes(1);
   });
 
-  it('handles empty patterns list', async () => {
+  it('handles empty routines list', async () => {
     schedulerApi.listBuiltinPatterns.mockResolvedValue({
       data: { patterns: [], total: 0 }
     });
 
-    const { result } = renderHook(() => useBuiltinPatterns(), {
+    const { result } = renderHook(() => useBuiltinRoutines(), {
       wrapper: createWrapper()
     });
 
@@ -114,10 +114,10 @@ describe('useBuiltinPatterns', () => {
   });
 
   it('handles fetch error', async () => {
-    const mockError = new Error('Failed to fetch built-in patterns');
+    const mockError = new Error('Failed to fetch built-in routines');
     schedulerApi.listBuiltinPatterns.mockRejectedValue(mockError);
 
-    const { result } = renderHook(() => useBuiltinPatterns(), {
+    const { result } = renderHook(() => useBuiltinRoutines(), {
       wrapper: createWrapper()
     });
 
@@ -146,7 +146,7 @@ describe('useBuiltinPatterns', () => {
       </QueryClientProvider>
     );
 
-    const { result } = renderHook(() => useBuiltinPatterns(), { wrapper });
+    const { result } = renderHook(() => useBuiltinRoutines(), { wrapper });
 
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true);
@@ -167,7 +167,7 @@ describe('useBuiltinPatterns', () => {
 
     // Test that queryOptions are passed through
     const { result } = renderHook(
-      () => useBuiltinPatterns({ staleTime: 1000 }),
+      () => useBuiltinRoutines({ staleTime: 1000 }),
       { wrapper: createWrapper() }
     );
 
@@ -180,10 +180,10 @@ describe('useBuiltinPatterns', () => {
 });
 
 // =============================================================================
-// useValidatePattern Tests
+// useValidateRoutine Tests
 // =============================================================================
 
-describe('useValidatePattern', () => {
+describe('useValidateRoutine', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -192,7 +192,7 @@ describe('useValidatePattern', () => {
     vi.restoreAllMocks();
   });
 
-  it('validates pattern successfully', async () => {
+  it('validates routine successfully', async () => {
     const mockResponse = {
       valid: true,
       pattern: {
@@ -209,7 +209,7 @@ describe('useValidatePattern', () => {
 
     schedulerApi.validatePattern.mockResolvedValue({ data: mockResponse });
 
-    const { result } = renderHook(() => useValidatePattern(), {
+    const { result } = renderHook(() => useValidateRoutine(), {
       wrapper: createWrapper()
     });
 
@@ -235,7 +235,7 @@ describe('useValidatePattern', () => {
     });
   });
 
-  it('returns validation errors for invalid pattern', async () => {
+  it('returns validation errors for invalid routine', async () => {
     const mockResponse = {
       valid: false,
       error: 'Pattern name is required'
@@ -243,7 +243,7 @@ describe('useValidatePattern', () => {
 
     schedulerApi.validatePattern.mockResolvedValue({ data: mockResponse });
 
-    const { result } = renderHook(() => useValidatePattern(), {
+    const { result } = renderHook(() => useValidateRoutine(), {
       wrapper: createWrapper()
     });
 
@@ -264,7 +264,7 @@ describe('useValidatePattern', () => {
     const mockError = new Error('Pattern validation failed');
     schedulerApi.validatePattern.mockRejectedValue(mockError);
 
-    const { result } = renderHook(() => useValidatePattern(), {
+    const { result } = renderHook(() => useValidateRoutine(), {
       wrapper: createWrapper()
     });
 
@@ -285,7 +285,7 @@ describe('useValidatePattern', () => {
 
     schedulerApi.validatePattern.mockResolvedValue({ data: mockResponse });
 
-    const { result } = renderHook(() => useValidatePattern(), {
+    const { result } = renderHook(() => useValidateRoutine(), {
       wrapper: createWrapper()
     });
 
@@ -300,37 +300,37 @@ describe('useValidatePattern', () => {
 });
 
 // =============================================================================
-// usePatternDuration Tests
+// useRoutineDuration Tests
 // =============================================================================
 
-describe('usePatternDuration', () => {
-  it('returns 0 for null pattern', () => {
-    const { result } = renderHook(() => usePatternDuration(null), {
+describe('useRoutineDuration', () => {
+  it('returns 0 for null routine', () => {
+    const { result } = renderHook(() => useRoutineDuration(null), {
       wrapper: createWrapper()
     });
 
     expect(result.current).toBe(0);
   });
 
-  it('returns 0 for undefined pattern', () => {
-    const { result } = renderHook(() => usePatternDuration(undefined), {
+  it('returns 0 for undefined routine', () => {
+    const { result } = renderHook(() => useRoutineDuration(undefined), {
       wrapper: createWrapper()
     });
 
     expect(result.current).toBe(0);
   });
 
-  it('returns 0 for pattern with no actions property', () => {
-    const { result } = renderHook(() => usePatternDuration({ name: 'test' }), {
+  it('returns 0 for routine with no actions property', () => {
+    const { result } = renderHook(() => useRoutineDuration({ name: 'test' }), {
       wrapper: createWrapper()
     });
 
     expect(result.current).toBe(0);
   });
 
-  it('returns 0 for pattern with empty actions array', () => {
+  it('returns 0 for routine with empty actions array', () => {
     const { result } = renderHook(
-      () => usePatternDuration({ name: 'test', actions: [] }),
+      () => useRoutineDuration({ name: 'test', actions: [] }),
       { wrapper: createWrapper() }
     );
 
@@ -338,14 +338,14 @@ describe('usePatternDuration', () => {
   });
 
   it('calculates duration from single action', () => {
-    const pattern = {
+    const routine = {
       name: 'Single Action',
       actions: [
         { action_type: 'camera', action_name: 'takephoto', offset_minutes: 10 }
       ]
     };
 
-    const { result } = renderHook(() => usePatternDuration(pattern), {
+    const { result } = renderHook(() => useRoutineDuration(routine), {
       wrapper: createWrapper()
     });
 
@@ -353,7 +353,7 @@ describe('usePatternDuration', () => {
   });
 
   it('calculates max offset from multiple actions', () => {
-    const pattern = {
+    const routine = {
       name: 'UV Capture Cycle',
       actions: [
         { action_type: 'gpio', action_name: 'attract_on', offset_minutes: 0 },
@@ -362,7 +362,7 @@ describe('usePatternDuration', () => {
       ]
     };
 
-    const { result } = renderHook(() => usePatternDuration(pattern), {
+    const { result } = renderHook(() => useRoutineDuration(routine), {
       wrapper: createWrapper()
     });
 
@@ -370,7 +370,7 @@ describe('usePatternDuration', () => {
   });
 
   it('handles undefined offset_minutes (defaults to 0)', () => {
-    const pattern = {
+    const routine = {
       name: 'Missing Offset',
       actions: [
         { action_type: 'camera', action_name: 'takephoto' },
@@ -378,15 +378,15 @@ describe('usePatternDuration', () => {
       ]
     };
 
-    const { result } = renderHook(() => usePatternDuration(pattern), {
+    const { result } = renderHook(() => useRoutineDuration(routine), {
       wrapper: createWrapper()
     });
 
     expect(result.current).toBe(5);
   });
 
-  it('memoizes result correctly - same pattern returns same value', () => {
-    const pattern = {
+  it('memoizes result correctly - same routine returns same value', () => {
+    const routine = {
       name: 'Test Pattern',
       actions: [
         { action_type: 'camera', action_name: 'takephoto', offset_minutes: 10 }
@@ -394,21 +394,21 @@ describe('usePatternDuration', () => {
     };
 
     const { result, rerender } = renderHook(
-      ({ pattern }) => usePatternDuration(pattern),
-      { wrapper: createWrapper(), initialProps: { pattern } }
+      ({ routine }) => useRoutineDuration(routine),
+      { wrapper: createWrapper(), initialProps: { routine } }
     );
 
     const firstResult = result.current;
 
-    // Rerender with same pattern object
-    rerender({ pattern });
+    // Rerender with same routine object
+    rerender({ routine });
 
     expect(result.current).toBe(firstResult);
     expect(result.current).toBe(10);
   });
 
   it('handles decimal offset_minutes values', () => {
-    const pattern = {
+    const routine = {
       name: 'Decimal Offsets',
       actions: [
         { action_type: 'gpio', action_name: 'attract_on', offset_minutes: 5.5 },
@@ -417,7 +417,7 @@ describe('usePatternDuration', () => {
       ]
     };
 
-    const { result } = renderHook(() => usePatternDuration(pattern), {
+    const { result } = renderHook(() => useRoutineDuration(routine), {
       wrapper: createWrapper()
     });
 

--- a/Firmware/webui/frontend/src/hooks/__tests__/useSchedulePatterns.test.jsx
+++ b/Firmware/webui/frontend/src/hooks/__tests__/useSchedulePatterns.test.jsx
@@ -14,7 +14,7 @@
  * - useScheduleFromTemplate: Create from built-in template
  * - Re-exports from useSchedules.js
  *
- * Reference: useSchedules.test.jsx, useEventPatterns.test.jsx for testing patterns
+ * Reference: useSchedules.test.jsx, useRoutines.test.jsx for testing patterns
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';

--- a/Firmware/webui/frontend/src/hooks/__tests__/useSchedules.test.jsx
+++ b/Firmware/webui/frontend/src/hooks/__tests__/useSchedules.test.jsx
@@ -4,7 +4,7 @@
  * Comprehensive test suite following TDD approach - tests written BEFORE implementation.
  * Tests React Query hooks for Scheduler UI API integration.
  *
- * Event pattern hook tests are in useEventPatterns.test.jsx (Issue #222).
+ * Routine hook tests are in useRoutines.test.jsx (Issue #222, #322).
  *
  * Reference: useDeployments.test.jsx for testing patterns
  */
@@ -583,7 +583,7 @@ describe('useBuiltinSchedules', () => {
   });
 });
 
-// Note: useBuiltinPatterns tests are in useEventPatterns.test.jsx (Issue #222)
+// Note: useBuiltinRoutines tests are in useRoutines.test.jsx (Issue #222, #322)
 
 describe('useCreateSchedule', () => {
   beforeEach(() => {
@@ -1142,4 +1142,4 @@ describe('useValidateSchedule', () => {
   });
 });
 
-// Note: useValidatePattern tests are in useEventPatterns.test.jsx (Issue #222)
+// Note: useValidateRoutine tests are in useRoutines.test.jsx (Issue #222, #322)

--- a/Firmware/webui/frontend/src/hooks/useRoutines.js
+++ b/Firmware/webui/frontend/src/hooks/useRoutines.js
@@ -1,15 +1,15 @@
 /**
- * React Query hooks for Event Pattern operations (Issue #222)
+ * React Query hooks for Routine operations (Issue #222, #322)
  *
- * Provides hooks for managing event patterns:
- * - useBuiltinPatterns: List built-in event patterns
- * - useValidatePattern: Validate event pattern configuration
- * - usePatternDuration: Calculate pattern duration from actions
+ * Provides hooks for managing routines:
+ * - useBuiltinRoutines: List built-in routines
+ * - useValidateRoutine: Validate routine configuration
+ * - useRoutineDuration: Calculate routine duration from actions
  *
  * Naming Convention:
- * - Query hooks: use<Resource> (e.g., useBuiltinPatterns)
- * - Mutation hooks: use<Action><Resource> (e.g., useValidatePattern)
- * - Utility hooks: use<Utility> (e.g., usePatternDuration)
+ * - Query hooks: use<Resource> (e.g., useBuiltinRoutines)
+ * - Mutation hooks: use<Action><Resource> (e.g., useValidateRoutine)
+ * - Utility hooks: use<Utility> (e.g., useRoutineDuration)
  *
  * Query Options:
  * All query hooks accept an optional queryOptions parameter to customize React Query behavior
@@ -29,10 +29,10 @@ import {
 // =============================================================================
 
 /**
- * Query cache configuration for event pattern data.
+ * Query cache configuration for routine data.
  *
  * STALE_TIME (5 min): How long data is considered "fresh" before refetching.
- * Built-in patterns are static (loaded from disk), so 5 minutes is appropriate.
+ * Built-in routines are static (loaded from disk), so 5 minutes is appropriate.
  */
 const QUERY_CONFIG = {
   STALE_TIME: 5 * 60 * 1000, // 5 minutes
@@ -49,7 +49,7 @@ const QUERY_CONFIG = {
  */
 function handleMutationError(error, operation) {
   if (import.meta.env.DEV) {
-    console.error(`[EventPattern ${operation}]:`, error.message || error)
+    console.error(`[Routine ${operation}]:`, error.message || error)
   }
 }
 
@@ -58,11 +58,11 @@ function handleMutationError(error, operation) {
 // =============================================================================
 
 /**
- * List built-in event patterns
+ * List built-in routines
  *
- * Fetches pre-defined event patterns extracted from built-in schedules.
- * Built-in patterns are read-only templates that can be used when creating
- * new schedules or understanding common pattern structures.
+ * Fetches pre-defined routines extracted from built-in schedules.
+ * Built-in routines are read-only templates that can be used when creating
+ * new schedules or understanding common routine structures.
  *
  * @param {Object} [queryOptions] - React Query options (refetchInterval, onSuccess, etc.)
  * @returns {Object} React Query result
@@ -72,13 +72,13 @@ function handleMutationError(error, operation) {
  * @returns {Object} error - Error object if query failed
  *
  * @example
- * const { data, isLoading } = useBuiltinPatterns()
+ * const { data, isLoading } = useBuiltinRoutines()
  * if (data) {
- *   console.log(`${data.total} built-in patterns`)
+ *   console.log(`${data.total} built-in routines`)
  *   data.patterns.forEach(p => console.log(p.name))
  * }
  */
-export function useBuiltinPatterns(queryOptions = {}) {
+export function useBuiltinRoutines(queryOptions = {}) {
   return useQuery({
     queryKey: QUERY_KEYS.BUILTIN_PATTERNS,
     queryFn: async () => {
@@ -95,10 +95,10 @@ export function useBuiltinPatterns(queryOptions = {}) {
 // =============================================================================
 
 /**
- * Validate event pattern mutation
+ * Validate routine mutation
  *
- * Validates a pattern structure without saving it. Useful for providing
- * real-time validation feedback in pattern builder UIs.
+ * Validates a routine structure without saving it. Useful for providing
+ * real-time validation feedback in routine builder UIs.
  *
  * @returns {Object} React Query mutation result
  * @returns {Function} mutate - Mutation function (fire and forget)
@@ -109,7 +109,7 @@ export function useBuiltinPatterns(queryOptions = {}) {
  * @returns {Object} data - Response data on success { valid, pattern?, error? }
  *
  * @example
- * const { mutate, isPending, data } = useValidatePattern()
+ * const { mutate, isPending, data } = useValidateRoutine()
  *
  * const handleValidate = () => {
  *   mutate({
@@ -123,7 +123,7 @@ export function useBuiltinPatterns(queryOptions = {}) {
  *   }, {
  *     onSuccess: (response) => {
  *       if (response.data.valid) {
- *         console.log('Pattern is valid!')
+ *         console.log('Routine is valid!')
  *       } else {
  *         console.error('Validation error:', response.data.error)
  *       }
@@ -131,10 +131,10 @@ export function useBuiltinPatterns(queryOptions = {}) {
  *   })
  * }
  */
-export function useValidatePattern() {
+export function useValidateRoutine() {
   return useMutation({
     mutationFn: (data) => validatePattern(data),
-    onError: (error) => handleMutationError(error, 'validatePattern'),
+    onError: (error) => handleMutationError(error, 'validateRoutine'),
   })
 }
 
@@ -143,30 +143,30 @@ export function useValidatePattern() {
 // =============================================================================
 
 /**
- * Calculate the total duration of a pattern based on action offsets
+ * Calculate the total duration of a routine based on action offsets
  *
- * Returns the maximum offset_minutes value from all actions in the pattern.
- * This represents how long the pattern takes to complete from start to finish.
+ * Returns the maximum offset_minutes value from all actions in the routine.
+ * This represents how long the routine takes to complete from start to finish.
  *
  * Useful for:
- * - Displaying pattern duration in UI
- * - Checking if patterns fit within time windows
+ * - Displaying routine duration in UI
+ * - Checking if routines fit within time windows
  * - Scheduling calculations
  *
- * **Performance Note:** This hook uses useMemo with the pattern object as a
- * dependency. If the parent component creates a new pattern object on each
+ * **Performance Note:** This hook uses useMemo with the routine object as a
+ * dependency. If the parent component creates a new routine object on each
  * render (even with the same data), useMemo will recalculate because the
  * object reference changes. To prevent unnecessary recalculations, callers
- * should memoize the pattern object.
+ * should memoize the routine object.
  *
- * @param {Object|null} pattern - Event pattern object (should be memoized)
- * @param {Array} [pattern.actions] - Array of action objects with offset_minutes
+ * @param {Object|null} routine - Routine object (should be memoized)
+ * @param {Array} [routine.actions] - Array of action objects with offset_minutes
  * @returns {number} Maximum offset in minutes, or 0 if no actions.
  *   Decimal values are supported and preserved (e.g., 5.5 for 5m 30s).
  *
  * @example
- * // Good: Pattern is memoized, duration only recalculates when data changes
- * const pattern = useMemo(() => ({
+ * // Good: Routine is memoized, duration only recalculates when data changes
+ * const routine = useMemo(() => ({
  *   name: 'UV Capture Cycle',
  *   actions: [
  *     { action_type: 'gpio', action_name: 'attract_on', offset_minutes: 0 },
@@ -174,18 +174,18 @@ export function useValidatePattern() {
  *     { action_type: 'gpio', action_name: 'attract_off', offset_minutes: 15 }
  *   ]
  * }), [])
- * const duration = usePatternDuration(pattern) // "15"
+ * const duration = useRoutineDuration(routine) // "15"
  *
  * @example
- * // Also good: Pattern comes from React Query (already stable reference)
- * const { data } = useBuiltinPatterns()
- * const duration = usePatternDuration(data?.patterns?.[0])
+ * // Also good: Routine comes from React Query (already stable reference)
+ * const { data } = useBuiltinRoutines()
+ * const duration = useRoutineDuration(data?.patterns?.[0])
  */
-export function usePatternDuration(pattern) {
+export function useRoutineDuration(routine) {
   return useMemo(() => {
-    if (!pattern?.actions?.length) return 0
-    return Math.max(...pattern.actions.map(a => a.offset_minutes ?? 0))
-  }, [pattern])
+    if (!routine?.actions?.length) return 0
+    return Math.max(...routine.actions.map(a => a.offset_minutes ?? 0))
+  }, [routine])
 }
 
-export default useBuiltinPatterns
+export default useBuiltinRoutines

--- a/Firmware/webui/frontend/src/hooks/useRoutines.js
+++ b/Firmware/webui/frontend/src/hooks/useRoutines.js
@@ -20,8 +20,8 @@ import { useMemo } from 'react'
 import { useQuery, useMutation } from '@tanstack/react-query'
 import { QUERY_KEYS } from '../utils/queryKeys'
 import {
-  listBuiltinPatterns,
-  validatePattern,
+  listBuiltinRoutines,
+  validateRoutine,
 } from '../utils/schedulerApi'
 
 // =============================================================================
@@ -80,9 +80,9 @@ function handleMutationError(error, operation) {
  */
 export function useBuiltinRoutines(queryOptions = {}) {
   return useQuery({
-    queryKey: QUERY_KEYS.BUILTIN_PATTERNS,
+    queryKey: QUERY_KEYS.BUILTIN_ROUTINES,
     queryFn: async () => {
-      const response = await listBuiltinPatterns()
+      const response = await listBuiltinRoutines()
       return response.data
     },
     staleTime: QUERY_CONFIG.STALE_TIME,
@@ -133,7 +133,7 @@ export function useBuiltinRoutines(queryOptions = {}) {
  */
 export function useValidateRoutine() {
   return useMutation({
-    mutationFn: (data) => validatePattern(data),
+    mutationFn: (data) => validateRoutine(data),
     onError: (error) => handleMutationError(error, 'validateRoutine'),
   })
 }

--- a/Firmware/webui/frontend/src/hooks/useSchedules.js
+++ b/Firmware/webui/frontend/src/hooks/useSchedules.js
@@ -14,10 +14,10 @@
  * - useDeactivateSchedule: Deactivate schedule
  * - useValidateSchedule: Validate schedule configuration
  *
- * Event Pattern hooks are in useEventPatterns.js (Issue #222):
- * - useBuiltinPatterns: List built-in patterns
- * - useValidatePattern: Validate event pattern
- * - usePatternDuration: Calculate pattern duration
+ * Routine hooks are in useRoutines.js (Issue #222, #322):
+ * - useBuiltinRoutines: List built-in routines
+ * - useValidateRoutine: Validate routine
+ * - useRoutineDuration: Calculate routine duration
  *
  * Naming Convention:
  * - Query hooks: use<Resource> (e.g., useSchedules, useSchedule)
@@ -516,7 +516,7 @@ export default useSchedules
 // =============================================================================
 // Re-exports for backward compatibility (Issue #222)
 // =============================================================================
-// Pattern hooks have been moved to useEventPatterns.js
-// usePatternDuration is a new utility hook added in #222
+// Routine hooks have been moved to useRoutines.js (renamed from useEventPatterns.js in #322)
+// useRoutineDuration is a utility hook for calculating routine duration
 // These re-exports maintain backward compatibility for existing imports
-export { useBuiltinPatterns, useValidatePattern, usePatternDuration } from './useEventPatterns'
+export { useBuiltinRoutines, useValidateRoutine, useRoutineDuration } from './useRoutines'

--- a/Firmware/webui/frontend/src/utils/queryKeys.js
+++ b/Firmware/webui/frontend/src/utils/queryKeys.js
@@ -79,7 +79,7 @@ export const QUERY_KEYS = {
   ACTIVE_SCHEDULE: ['schedules', 'active'],
   SCHEDULE_PREVIEW: (id) => ['schedules', id, 'preview'],
   BUILTIN_SCHEDULES: ['schedules', 'builtin'],
-  BUILTIN_PATTERNS: ['schedules', 'patterns', 'builtin'],
+  BUILTIN_ROUTINES: ['schedules', 'routines', 'builtin'],
 
   // Cron Validation (Issue #233)
   CRON_VALIDATION: (expression) => ['cron-validation', expression],

--- a/Firmware/webui/frontend/src/utils/schedulerApi.js
+++ b/Firmware/webui/frontend/src/utils/schedulerApi.js
@@ -304,7 +304,7 @@ export const listBuiltinSchedules = () =>
  *   warnings: []
  * }
  */
-export const listBuiltinPatterns = () =>
+export const listBuiltinRoutines = () =>
   api.get(`${SCHEDULER_API_PREFIX}/patterns/builtin`, { timeout: API_TIMEOUT_MS })
 
 /**
@@ -322,5 +322,5 @@ export const listBuiltinPatterns = () =>
  *   warnings: []
  * }
  */
-export const validatePattern = (data) =>
+export const validateRoutine = (data) =>
   api.post(`${SCHEDULER_API_PREFIX}/patterns/validate`, data, { timeout: API_TIMEOUT_MS })


### PR DESCRIPTION
## Summary

- Renames `useEventPatterns.js` hook file to `useRoutines.js` as part of Scheduler Terminology Refactor Phase 6
- Updates all function names from Pattern to Routine terminology
- Updates all imports across consuming components

## Changes

**File renames:**
- `src/hooks/useEventPatterns.js` → `src/hooks/useRoutines.js`
- `src/hooks/__tests__/useEventPatterns.test.jsx` → `src/hooks/__tests__/useRoutines.test.jsx`

**Function renames:**
| Old Name | New Name |
|----------|----------|
| `useBuiltinPatterns` | `useBuiltinRoutines` |
| `useValidatePattern` | `useValidateRoutine` |
| `usePatternDuration` | `useRoutineDuration` |

**Updated imports in:**
- `useSchedules.js` (re-exports)
- `RoutineEditor.jsx`
- `PatternList.jsx`
- All related test files

## Test plan

- [x] `npm test -- useRoutines --run` passes (18 tests)
- [x] `npm test -- PatternList RoutineEditor --run` passes (153 tests)
- [x] `npm run lint` passes
- [x] `npm run build` succeeds
- [x] No remaining references to `useEventPatterns` in src/

Closes #322