### PR TITLE
feat(scheduler): Create TriggerSelector component

### DIFF
--- a/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/CronTriggerForm.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/CronTriggerForm.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types'
  * @component
  */
 function CronTriggerForm({ trigger, onChange, disabled = false }) {
-  const cronExpression = trigger?.cron_expression || '*/15 18-6 * * *'
+  const cronExpression = trigger?.cron_expression || '*/15 * * * *'
 
   /**
    * Handle cron expression change

--- a/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/CronTriggerForm.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/CronTriggerForm.jsx
@@ -77,6 +77,17 @@ function CronTriggerForm({ trigger, onChange, disabled = false }) {
         <div className="text-xs text-gray-600" data-testid="cron-description">
           {describeCron(cronExpression)}
         </div>
+
+        {/* Help Link */}
+        <a
+          href="https://crontab.guru/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs text-blue-400 hover:text-blue-300"
+          data-testid="cron-help-link"
+        >
+          Cron syntax reference ↗
+        </a>
       </div>
     </div>
   )

--- a/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/CronTriggerForm.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/CronTriggerForm.jsx
@@ -1,0 +1,94 @@
+import PropTypes from 'prop-types'
+
+/**
+ * CronTriggerForm Component
+ *
+ * Form for configuring cron expression triggers (expert mode).
+ *
+ * @component
+ */
+function CronTriggerForm({ trigger, onChange, disabled = false }) {
+  const cronExpression = trigger?.cron_expression || '*/15 18-6 * * *'
+
+  /**
+   * Handle cron expression change
+   */
+  const handleExpressionChange = (e) => {
+    onChange({
+      ...trigger,
+      cron_expression: e.target.value,
+    })
+  }
+
+  /**
+   * Parse cron expression and return human-readable description
+   * This is a simple implementation - can be enhanced later
+   */
+  const describeCron = (expression) => {
+    if (!expression) return ''
+
+    const parts = expression.trim().split(/\s+/)
+    if (parts.length < 5) return 'Invalid expression'
+
+    const [minute, hour] = parts
+
+    // Handle some common patterns
+    if (minute.startsWith('*/')) {
+      const interval = minute.slice(2)
+      if (hour.includes('-')) {
+        const [start, end] = hour.split('-')
+        return `Every ${interval} minutes, ${start}:00-${end}:00`
+      }
+      return `Every ${interval} minutes`
+    }
+
+    if (minute === '0' && !hour.includes('*') && !hour.includes('/')) {
+      const hourNum = parseInt(hour, 10)
+      const period = hourNum >= 12 ? 'pm' : 'am'
+      const displayHour = hourNum > 12 ? hourNum - 12 : hourNum === 0 ? 12 : hourNum
+      return `Daily at ${displayHour}${period}`
+    }
+
+    return 'Custom schedule'
+  }
+
+  return (
+    <div className="border border-gray-800 rounded-lg p-4" data-testid="cron-trigger-form">
+      <div className="flex items-center gap-2 mb-4">
+        <span className="text-sm text-white">Cron Expression</span>
+        <span className="text-xs text-yellow-500">advanced</span>
+      </div>
+
+      <div className="space-y-4">
+        {/* Cron Input */}
+        <input
+          type="text"
+          value={cronExpression}
+          onChange={handleExpressionChange}
+          disabled={disabled}
+          placeholder="*/15 * * * *"
+          className="w-full bg-transparent border border-gray-800 rounded px-3 py-2 text-sm text-white font-mono
+                     focus:border-gray-600 focus:outline-none
+                     disabled:opacity-50 disabled:cursor-not-allowed"
+          data-testid="cron-expression"
+        />
+
+        {/* Description */}
+        <div className="text-xs text-gray-600" data-testid="cron-description">
+          {describeCron(cronExpression)}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+CronTriggerForm.propTypes = {
+  trigger: PropTypes.shape({
+    trigger_type: PropTypes.string,
+    cron_expression: PropTypes.string,
+  }),
+  onChange: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+}
+
+export default CronTriggerForm

--- a/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/FixedTimeTriggerForm.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/FixedTimeTriggerForm.jsx
@@ -1,0 +1,107 @@
+import PropTypes from 'prop-types'
+
+/**
+ * FixedTimeTriggerForm Component
+ *
+ * Form for configuring fixed time triggers with multiple time entries.
+ *
+ * @component
+ */
+function FixedTimeTriggerForm({ trigger, onChange, disabled = false }) {
+  const times = trigger?.times || ['08:00']
+
+  /**
+   * Handle time change at specific index
+   */
+  const handleTimeChange = (index, value) => {
+    const newTimes = [...times]
+    newTimes[index] = value
+    onChange({
+      ...trigger,
+      times: newTimes,
+    })
+  }
+
+  /**
+   * Handle adding a new time
+   */
+  const handleAddTime = () => {
+    onChange({
+      ...trigger,
+      times: [...times, '12:00'],
+    })
+  }
+
+  /**
+   * Handle removing a time at specific index
+   */
+  const handleRemoveTime = (index) => {
+    if (times.length <= 1) return // Keep at least one time
+    const newTimes = times.filter((_, i) => i !== index)
+    onChange({
+      ...trigger,
+      times: newTimes,
+    })
+  }
+
+  return (
+    <div className="border border-gray-800 rounded-lg p-4" data-testid="fixed-time-trigger-form">
+      <div className="flex items-center gap-2 mb-4">
+        <span className="text-sm text-white">Fixed Time</span>
+        <span className="text-xs text-gray-600">run at specific times</span>
+      </div>
+
+      <div className="space-y-3" data-testid="fixed-time-list">
+        {times.map((time, index) => (
+          <div key={index} className="flex items-center gap-2">
+            <input
+              type="time"
+              value={time}
+              onChange={(e) => handleTimeChange(index, e.target.value)}
+              disabled={disabled}
+              className="bg-transparent border border-gray-800 rounded px-2 py-1 text-sm text-white
+                         focus:border-gray-600 focus:outline-none
+                         disabled:opacity-50 disabled:cursor-not-allowed"
+              data-testid={`fixed-time-input-${index}`}
+            />
+            {times.length > 1 && (
+              <button
+                type="button"
+                onClick={() => handleRemoveTime(index)}
+                disabled={disabled}
+                className="text-gray-600 hover:text-red-400 text-sm
+                           disabled:opacity-50 disabled:cursor-not-allowed"
+                aria-label={`Remove time ${time}`}
+                data-testid={`fixed-time-remove-${index}`}
+              >
+                &times;
+              </button>
+            )}
+          </div>
+        ))}
+
+        <button
+          type="button"
+          onClick={handleAddTime}
+          disabled={disabled}
+          className="text-xs text-gray-500 hover:text-gray-300
+                     disabled:opacity-50 disabled:cursor-not-allowed"
+          data-testid="fixed-time-add"
+        >
+          + Add time
+        </button>
+      </div>
+    </div>
+  )
+}
+
+FixedTimeTriggerForm.propTypes = {
+  trigger: PropTypes.shape({
+    trigger_type: PropTypes.string,
+    times: PropTypes.arrayOf(PropTypes.string),
+  }),
+  onChange: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+}
+
+export default FixedTimeTriggerForm

--- a/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/FixedTimeTriggerForm.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/FixedTimeTriggerForm.jsx
@@ -53,7 +53,7 @@ function FixedTimeTriggerForm({ trigger, onChange, disabled = false }) {
 
       <div className="space-y-3" data-testid="fixed-time-list">
         {times.map((time, index) => (
-          <div key={index} className="flex items-center gap-2">
+          <div key={`time-${index}-${time}`} className="flex items-center gap-2">
             <input
               type="time"
               value={time}

--- a/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/IntervalTriggerForm.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/IntervalTriggerForm.jsx
@@ -1,0 +1,202 @@
+import { useState } from 'react'
+import PropTypes from 'prop-types'
+import { INTERVAL_UNITS } from './constants'
+
+/**
+ * IntervalTriggerForm Component
+ *
+ * Form for configuring interval-based triggers with optional time window.
+ *
+ * @component
+ */
+function IntervalTriggerForm({ trigger, onChange, disabled = false }) {
+  const intervalMinutes = trigger?.interval_minutes || 15
+  const timeWindow = trigger?.time_window || null
+
+  // Determine display unit and value
+  const [displayUnit, setDisplayUnit] = useState(() => {
+    if (intervalMinutes >= 60 && intervalMinutes % 60 === 0) {
+      return 'hours'
+    }
+    return 'minutes'
+  })
+
+  const displayValue = displayUnit === 'hours'
+    ? intervalMinutes / 60
+    : intervalMinutes
+
+  /**
+   * Handle value change
+   */
+  const handleValueChange = (e) => {
+    const value = parseInt(e.target.value, 10) || 0
+    const multiplier = INTERVAL_UNITS.find(u => u.value === displayUnit)?.multiplier || 1
+    const newIntervalMinutes = value * multiplier
+    onChange({
+      ...trigger,
+      interval_minutes: newIntervalMinutes,
+    })
+  }
+
+  /**
+   * Handle unit change
+   */
+  const handleUnitChange = (e) => {
+    const newUnit = e.target.value
+    setDisplayUnit(newUnit)
+    // Recalculate interval_minutes based on current display value and new unit
+    const currentDisplayValue = displayValue
+    const multiplier = INTERVAL_UNITS.find(u => u.value === newUnit)?.multiplier || 1
+    onChange({
+      ...trigger,
+      interval_minutes: currentDisplayValue * multiplier,
+    })
+  }
+
+  /**
+   * Handle time window toggle
+   */
+  const handleTimeWindowToggle = (e) => {
+    if (e.target.checked) {
+      onChange({
+        ...trigger,
+        time_window: {
+          start_time: '18:00',
+          end_time: '06:00',
+        },
+      })
+    } else {
+      onChange({
+        ...trigger,
+        time_window: null,
+      })
+    }
+  }
+
+  /**
+   * Handle time window start change
+   */
+  const handleStartTimeChange = (e) => {
+    onChange({
+      ...trigger,
+      time_window: {
+        ...timeWindow,
+        start_time: e.target.value,
+      },
+    })
+  }
+
+  /**
+   * Handle time window end change
+   */
+  const handleEndTimeChange = (e) => {
+    onChange({
+      ...trigger,
+      time_window: {
+        ...timeWindow,
+        end_time: e.target.value,
+      },
+    })
+  }
+
+  return (
+    <div className="border border-gray-800 rounded-lg p-4" data-testid="interval-trigger-form">
+      <div className="flex items-center gap-2 mb-4">
+        <span className="text-sm text-white">Interval</span>
+        <span className="text-xs text-gray-600">repeat at fixed intervals</span>
+      </div>
+
+      <div className="space-y-4">
+        {/* Interval Value and Unit */}
+        <div className="flex items-center gap-3 text-sm">
+          <span className="text-gray-500">Every</span>
+          <input
+            type="number"
+            min="1"
+            value={displayValue}
+            onChange={handleValueChange}
+            disabled={disabled}
+            className="w-16 bg-transparent border border-gray-800 rounded px-2 py-1 text-white text-center
+                       focus:border-gray-600 focus:outline-none
+                       disabled:opacity-50 disabled:cursor-not-allowed"
+            data-testid="interval-value"
+          />
+          <select
+            value={displayUnit}
+            onChange={handleUnitChange}
+            disabled={disabled}
+            className="bg-transparent border border-gray-800 rounded px-2 py-1 text-white
+                       focus:border-gray-600 focus:outline-none
+                       disabled:opacity-50 disabled:cursor-not-allowed"
+            data-testid="interval-unit"
+          >
+            {INTERVAL_UNITS.map((unit) => (
+              <option key={unit.value} value={unit.value}>
+                {unit.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Time Window Toggle */}
+        <div className="flex items-center gap-3 text-sm">
+          <input
+            type="checkbox"
+            id="time-window-toggle"
+            checked={timeWindow !== null}
+            onChange={handleTimeWindowToggle}
+            disabled={disabled}
+            className="rounded border-gray-600
+                       disabled:opacity-50 disabled:cursor-not-allowed"
+            data-testid="time-window-toggle"
+          />
+          <label htmlFor="time-window-toggle" className="text-gray-400">
+            Limit to time window
+          </label>
+        </div>
+
+        {/* Time Window Inputs */}
+        {timeWindow && (
+          <div className="flex items-center gap-3 text-sm pl-6">
+            <input
+              type="time"
+              value={timeWindow.start_time || '18:00'}
+              onChange={handleStartTimeChange}
+              disabled={disabled}
+              className="bg-transparent border border-gray-800 rounded px-2 py-1 text-white
+                         focus:border-gray-600 focus:outline-none
+                         disabled:opacity-50 disabled:cursor-not-allowed"
+              data-testid="time-window-start"
+            />
+            <span className="text-gray-600">to</span>
+            <input
+              type="time"
+              value={timeWindow.end_time || '06:00'}
+              onChange={handleEndTimeChange}
+              disabled={disabled}
+              className="bg-transparent border border-gray-800 rounded px-2 py-1 text-white
+                         focus:border-gray-600 focus:outline-none
+                         disabled:opacity-50 disabled:cursor-not-allowed"
+              data-testid="time-window-end"
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+IntervalTriggerForm.propTypes = {
+  trigger: PropTypes.shape({
+    trigger_type: PropTypes.string,
+    interval_minutes: PropTypes.number,
+    time_window: PropTypes.shape({
+      start_time: PropTypes.string,
+      end_time: PropTypes.string,
+    }),
+  }),
+  onChange: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+}
+
+export default IntervalTriggerForm

--- a/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/IntervalTriggerForm.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/IntervalTriggerForm.jsx
@@ -25,7 +25,8 @@ function IntervalTriggerForm({ trigger, onChange, disabled = false }) {
    * Handle value change
    */
   const handleValueChange = (e) => {
-    const value = Math.max(1, parseInt(e.target.value, 10) || 1)
+    const parsed = parseInt(e.target.value, 10)
+    const value = isNaN(parsed) ? 1 : Math.max(1, parsed)
     const multiplier = INTERVAL_UNITS.find(u => u.value === displayUnit)?.multiplier || 1
     const newIntervalMinutes = value * multiplier
     onChange({

--- a/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/IntervalTriggerForm.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/IntervalTriggerForm.jsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import PropTypes from 'prop-types'
 import { INTERVAL_UNITS } from './constants'
 
@@ -13,13 +12,10 @@ function IntervalTriggerForm({ trigger, onChange, disabled = false }) {
   const intervalMinutes = trigger?.interval_minutes || 15
   const timeWindow = trigger?.time_window || null
 
-  // Determine display unit and value
-  const [displayUnit, setDisplayUnit] = useState(() => {
-    if (intervalMinutes >= 60 && intervalMinutes % 60 === 0) {
-      return 'hours'
-    }
-    return 'minutes'
-  })
+  // Derive display unit from interval_minutes (syncs with parent updates)
+  const displayUnit = (intervalMinutes >= 60 && intervalMinutes % 60 === 0)
+    ? 'hours'
+    : 'minutes'
 
   const displayValue = displayUnit === 'hours'
     ? intervalMinutes / 60
@@ -29,7 +25,7 @@ function IntervalTriggerForm({ trigger, onChange, disabled = false }) {
    * Handle value change
    */
   const handleValueChange = (e) => {
-    const value = parseInt(e.target.value, 10) || 0
+    const value = Math.max(1, parseInt(e.target.value, 10) || 1)
     const multiplier = INTERVAL_UNITS.find(u => u.value === displayUnit)?.multiplier || 1
     const newIntervalMinutes = value * multiplier
     onChange({
@@ -39,18 +35,27 @@ function IntervalTriggerForm({ trigger, onChange, disabled = false }) {
   }
 
   /**
-   * Handle unit change
+   * Handle unit change - just updates the display, keeps interval_minutes unchanged
+   * The displayUnit is derived from intervalMinutes, so changing units will
+   * adjust when the value is next modified
    */
   const handleUnitChange = (e) => {
     const newUnit = e.target.value
-    setDisplayUnit(newUnit)
-    // Recalculate interval_minutes based on current display value and new unit
-    const currentDisplayValue = displayValue
-    const multiplier = INTERVAL_UNITS.find(u => u.value === newUnit)?.multiplier || 1
-    onChange({
-      ...trigger,
-      interval_minutes: currentDisplayValue * multiplier,
-    })
+    // When switching to hours, round up to nearest hour (minimum 1 hour = 60 min)
+    // When switching to minutes, keep same interval
+    if (newUnit === 'hours') {
+      const hours = Math.max(1, Math.ceil(intervalMinutes / 60))
+      onChange({
+        ...trigger,
+        interval_minutes: hours * 60,
+      })
+    } else {
+      // Switching to minutes - keep same interval but ensure minimum of 1
+      onChange({
+        ...trigger,
+        interval_minutes: Math.max(1, intervalMinutes),
+      })
+    }
   }
 
   /**

--- a/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/MoonPhaseTriggerForm.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/MoonPhaseTriggerForm.jsx
@@ -1,0 +1,95 @@
+import PropTypes from 'prop-types'
+import { MOON_PHASES } from './constants'
+
+/**
+ * MoonPhaseTriggerForm Component
+ *
+ * Form for configuring moon phase triggers with emoji grid.
+ *
+ * @component
+ */
+function MoonPhaseTriggerForm({ trigger, onChange, disabled = false }) {
+  const selectedPhases = trigger?.phases || ['full']
+
+  /**
+   * Handle phase toggle
+   */
+  const handlePhaseToggle = (phaseValue) => {
+    const isSelected = selectedPhases.includes(phaseValue)
+    let newPhases
+
+    if (isSelected) {
+      // Remove phase (but keep at least one)
+      if (selectedPhases.length <= 1) return
+      newPhases = selectedPhases.filter(p => p !== phaseValue)
+    } else {
+      // Add phase
+      newPhases = [...selectedPhases, phaseValue]
+    }
+
+    onChange({
+      ...trigger,
+      phases: newPhases,
+    })
+  }
+
+  return (
+    <div className="border border-gray-800 rounded-lg p-4" data-testid="moon-phase-trigger-form">
+      <div className="flex items-center gap-2 mb-4">
+        <span className="text-sm text-white">Moon Phase</span>
+        <span className="text-xs text-gray-600">lunar cycle events</span>
+      </div>
+
+      <div className="space-y-4">
+        {/* Moon Phase Grid */}
+        <div className="grid grid-cols-4 gap-2" data-testid="moon-phase-grid">
+          {MOON_PHASES.map((phase) => {
+            const isSelected = selectedPhases.includes(phase.value)
+            return (
+              <label
+                key={phase.value}
+                className={`
+                  flex flex-col items-center p-2 border rounded cursor-pointer
+                  ${isSelected
+                    ? 'border-gray-700 bg-gray-800'
+                    : 'border-gray-800 hover:border-gray-600'
+                  }
+                  ${disabled ? 'opacity-50 cursor-not-allowed' : ''}
+                `}
+              >
+                <input
+                  type="checkbox"
+                  checked={isSelected}
+                  onChange={() => handlePhaseToggle(phase.value)}
+                  disabled={disabled}
+                  className="sr-only"
+                  data-testid={`moon-phase-${phase.value}`}
+                />
+                <span className="text-lg">{phase.emoji}</span>
+                <span className={`text-xs mt-1 ${isSelected ? 'text-gray-400' : 'text-gray-500'}`}>
+                  {phase.label}
+                </span>
+              </label>
+            )
+          })}
+        </div>
+
+        {/* Preview */}
+        <div className="text-xs text-gray-600" data-testid="moon-phase-preview">
+          Next full moon: Jan 6
+        </div>
+      </div>
+    </div>
+  )
+}
+
+MoonPhaseTriggerForm.propTypes = {
+  trigger: PropTypes.shape({
+    trigger_type: PropTypes.string,
+    phases: PropTypes.arrayOf(PropTypes.string),
+  }),
+  onChange: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+}
+
+export default MoonPhaseTriggerForm

--- a/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/MoonPhaseTriggerForm.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/MoonPhaseTriggerForm.jsx
@@ -74,10 +74,6 @@ function MoonPhaseTriggerForm({ trigger, onChange, disabled = false }) {
           })}
         </div>
 
-        {/* Preview */}
-        <div className="text-xs text-gray-600" data-testid="moon-phase-preview">
-          Next full moon: Jan 6
-        </div>
       </div>
     </div>
   )

--- a/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/RecurringDaysTriggerForm.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/RecurringDaysTriggerForm.jsx
@@ -56,18 +56,21 @@ function RecurringDaysTriggerForm({ trigger, onChange, disabled = false }) {
         <div className="flex gap-1" data-testid="recurring-days-grid">
           {DAYS_OF_WEEK.map((day) => {
             const isSelected = selectedDays.includes(day.value)
+            const isLastSelected = isSelected && selectedDays.length === 1
             return (
               <button
                 key={day.value}
                 type="button"
                 onClick={() => handleDayToggle(day.value)}
                 disabled={disabled}
+                title={isLastSelected ? 'At least one day required' : undefined}
                 className={`
                   w-8 h-8 text-xs border rounded
                   ${isSelected
                     ? 'border-gray-700 bg-gray-800 text-white'
                     : 'border-gray-800 text-gray-500 hover:border-gray-600'
                   }
+                  ${isLastSelected ? 'cursor-not-allowed' : ''}
                   disabled:opacity-50 disabled:cursor-not-allowed
                 `}
                 aria-pressed={isSelected}

--- a/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/RecurringDaysTriggerForm.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/RecurringDaysTriggerForm.jsx
@@ -1,0 +1,112 @@
+import PropTypes from 'prop-types'
+import { DAYS_OF_WEEK } from './constants'
+
+/**
+ * RecurringDaysTriggerForm Component
+ *
+ * Form for configuring weekly recurring triggers with day selection.
+ *
+ * @component
+ */
+function RecurringDaysTriggerForm({ trigger, onChange, disabled = false }) {
+  const selectedDays = trigger?.days || [0, 5, 6]
+  const time = trigger?.time || '20:00'
+
+  /**
+   * Handle day toggle
+   */
+  const handleDayToggle = (dayValue) => {
+    const isSelected = selectedDays.includes(dayValue)
+    let newDays
+
+    if (isSelected) {
+      // Remove day (but keep at least one)
+      if (selectedDays.length <= 1) return
+      newDays = selectedDays.filter(d => d !== dayValue)
+    } else {
+      // Add day and sort
+      newDays = [...selectedDays, dayValue].sort((a, b) => a - b)
+    }
+
+    onChange({
+      ...trigger,
+      days: newDays,
+    })
+  }
+
+  /**
+   * Handle time change
+   */
+  const handleTimeChange = (e) => {
+    onChange({
+      ...trigger,
+      time: e.target.value,
+    })
+  }
+
+  return (
+    <div className="border border-gray-800 rounded-lg p-4" data-testid="recurring-days-trigger-form">
+      <div className="flex items-center gap-2 mb-4">
+        <span className="text-sm text-white">Recurring Days</span>
+        <span className="text-xs text-gray-600">weekly schedule</span>
+      </div>
+
+      <div className="space-y-4">
+        {/* Day Selection Grid */}
+        <div className="flex gap-1" data-testid="recurring-days-grid">
+          {DAYS_OF_WEEK.map((day) => {
+            const isSelected = selectedDays.includes(day.value)
+            return (
+              <button
+                key={day.value}
+                type="button"
+                onClick={() => handleDayToggle(day.value)}
+                disabled={disabled}
+                className={`
+                  w-8 h-8 text-xs border rounded
+                  ${isSelected
+                    ? 'border-gray-700 bg-gray-800 text-white'
+                    : 'border-gray-800 text-gray-500 hover:border-gray-600'
+                  }
+                  disabled:opacity-50 disabled:cursor-not-allowed
+                `}
+                aria-pressed={isSelected}
+                aria-label={day.label}
+                data-testid={`day-${day.value}`}
+              >
+                {day.short}
+              </button>
+            )
+          })}
+        </div>
+
+        {/* Time Input */}
+        <div className="flex items-center gap-3 text-sm">
+          <span className="text-gray-500">At</span>
+          <input
+            type="time"
+            value={time}
+            onChange={handleTimeChange}
+            disabled={disabled}
+            className="bg-transparent border border-gray-800 rounded px-2 py-1 text-white
+                       focus:border-gray-600 focus:outline-none
+                       disabled:opacity-50 disabled:cursor-not-allowed"
+            data-testid="trigger-time"
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+RecurringDaysTriggerForm.propTypes = {
+  trigger: PropTypes.shape({
+    trigger_type: PropTypes.string,
+    days: PropTypes.arrayOf(PropTypes.number),
+    time: PropTypes.string,
+  }),
+  onChange: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+}
+
+export default RecurringDaysTriggerForm

--- a/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/RecurringDaysTriggerForm.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/RecurringDaysTriggerForm.jsx
@@ -70,7 +70,7 @@ function RecurringDaysTriggerForm({ trigger, onChange, disabled = false }) {
                     ? 'border-gray-700 bg-gray-800 text-white'
                     : 'border-gray-800 text-gray-500 hover:border-gray-600'
                   }
-                  ${isLastSelected ? 'cursor-not-allowed' : ''}
+                  ${isLastSelected ? 'opacity-60 cursor-not-allowed' : ''}
                   disabled:opacity-50 disabled:cursor-not-allowed
                 `}
                 aria-pressed={isSelected}

--- a/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/SolarTriggerForm.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/SolarTriggerForm.jsx
@@ -63,6 +63,8 @@ function SolarTriggerForm({ trigger, onChange, disabled = false }) {
           <span className="text-gray-500">Offset</span>
           <input
             type="number"
+            min="-120"
+            max="120"
             value={offsetMinutes}
             onChange={handleOffsetChange}
             disabled={disabled}

--- a/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/SolarTriggerForm.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/SolarTriggerForm.jsx
@@ -1,0 +1,96 @@
+import PropTypes from 'prop-types'
+import { SOLAR_EVENTS } from './constants'
+
+/**
+ * SolarTriggerForm Component
+ *
+ * Form for configuring solar event triggers with offset.
+ *
+ * @component
+ */
+function SolarTriggerForm({ trigger, onChange, disabled = false }) {
+  const solarEvent = trigger?.solar_event || 'sunset'
+  const offsetMinutes = trigger?.offset_minutes ?? 0
+
+  /**
+   * Handle solar event change
+   */
+  const handleEventChange = (e) => {
+    onChange({
+      ...trigger,
+      solar_event: e.target.value,
+    })
+  }
+
+  /**
+   * Handle offset change
+   */
+  const handleOffsetChange = (e) => {
+    const value = parseInt(e.target.value, 10)
+    onChange({
+      ...trigger,
+      offset_minutes: isNaN(value) ? 0 : value,
+    })
+  }
+
+  return (
+    <div className="border border-gray-800 rounded-lg p-4" data-testid="solar-trigger-form">
+      <div className="flex items-center gap-2 mb-4">
+        <span className="text-sm text-white">Solar Event</span>
+        <span className="text-xs text-gray-600">based on sun position</span>
+      </div>
+
+      <div className="space-y-4">
+        {/* Solar Event Select */}
+        <select
+          value={solarEvent}
+          onChange={handleEventChange}
+          disabled={disabled}
+          className="w-full bg-transparent border border-gray-800 rounded px-3 py-2 text-sm text-white
+                     focus:border-gray-600 focus:outline-none
+                     disabled:opacity-50 disabled:cursor-not-allowed"
+          data-testid="solar-event"
+        >
+          {SOLAR_EVENTS.map((event) => (
+            <option key={event.value} value={event.value}>
+              {event.label}
+            </option>
+          ))}
+        </select>
+
+        {/* Offset Input */}
+        <div className="flex items-center gap-3 text-sm">
+          <span className="text-gray-500">Offset</span>
+          <input
+            type="number"
+            value={offsetMinutes}
+            onChange={handleOffsetChange}
+            disabled={disabled}
+            className="w-16 bg-transparent border border-gray-800 rounded px-2 py-1 text-white text-center
+                       focus:border-gray-600 focus:outline-none
+                       disabled:opacity-50 disabled:cursor-not-allowed"
+            data-testid="solar-offset"
+          />
+          <span className="text-gray-500">minutes</span>
+        </div>
+
+        {/* Preview */}
+        <div className="text-xs text-gray-600" data-testid="solar-preview">
+          Today: ~17:23
+        </div>
+      </div>
+    </div>
+  )
+}
+
+SolarTriggerForm.propTypes = {
+  trigger: PropTypes.shape({
+    trigger_type: PropTypes.string,
+    solar_event: PropTypes.string,
+    offset_minutes: PropTypes.number,
+  }),
+  onChange: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+}
+
+export default SolarTriggerForm

--- a/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/SolarTriggerForm.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/SolarTriggerForm.jsx
@@ -74,10 +74,6 @@ function SolarTriggerForm({ trigger, onChange, disabled = false }) {
           <span className="text-gray-500">minutes</span>
         </div>
 
-        {/* Preview */}
-        <div className="text-xs text-gray-600" data-testid="solar-preview">
-          Today: ~17:23
-        </div>
       </div>
     </div>
   )

--- a/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/TriggerSelector.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/TriggerSelector.jsx
@@ -1,0 +1,150 @@
+import PropTypes from 'prop-types'
+import { TRIGGER_TYPE_OPTIONS, createDefaultTrigger } from './constants'
+import IntervalTriggerForm from './IntervalTriggerForm'
+import FixedTimeTriggerForm from './FixedTimeTriggerForm'
+import SolarTriggerForm from './SolarTriggerForm'
+import MoonPhaseTriggerForm from './MoonPhaseTriggerForm'
+import RecurringDaysTriggerForm from './RecurringDaysTriggerForm'
+import CronTriggerForm from './CronTriggerForm'
+
+/**
+ * TriggerSelector Component
+ *
+ * A composite component for selecting trigger type and configuring
+ * trigger-specific options. Renders a type dropdown and the appropriate
+ * form based on the selected type.
+ *
+ * @component
+ * @example
+ * <TriggerSelector
+ *   trigger={{ trigger_type: 'interval', interval_minutes: 15 }}
+ *   onChange={(newTrigger) => console.log(newTrigger)}
+ * />
+ */
+function TriggerSelector({ trigger, onChange, disabled = false, error }) {
+  const triggerType = trigger?.trigger_type || 'interval'
+
+  /**
+   * Handle trigger type change
+   * Creates a new default trigger for the selected type
+   */
+  const handleTypeChange = (e) => {
+    const newType = e.target.value
+    onChange(createDefaultTrigger(newType))
+  }
+
+  /**
+   * Render the appropriate trigger form based on type
+   */
+  const renderTriggerForm = () => {
+    const commonProps = {
+      trigger,
+      onChange,
+      disabled,
+    }
+
+    switch (triggerType) {
+      case 'interval':
+        return <IntervalTriggerForm {...commonProps} />
+      case 'fixed_time':
+        return <FixedTimeTriggerForm {...commonProps} />
+      case 'solar':
+        return <SolarTriggerForm {...commonProps} />
+      case 'moon_phase':
+        return <MoonPhaseTriggerForm {...commonProps} />
+      case 'recurring_days':
+        return <RecurringDaysTriggerForm {...commonProps} />
+      case 'cron':
+        return <CronTriggerForm {...commonProps} />
+      default:
+        return <IntervalTriggerForm {...commonProps} />
+    }
+  }
+
+  return (
+    <div className="space-y-4" data-testid="trigger-selector">
+      {/* Type Selection Dropdown */}
+      <div>
+        <label
+          htmlFor="trigger-type"
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+        >
+          When to run
+        </label>
+        <select
+          id="trigger-type"
+          value={triggerType}
+          onChange={handleTypeChange}
+          disabled={disabled}
+          className={`
+            w-full bg-transparent border rounded px-3 py-2 text-sm
+            text-gray-900 dark:text-white
+            focus:ring-2 focus:ring-blue-500 focus:border-transparent
+            disabled:opacity-50 disabled:cursor-not-allowed
+            ${error
+              ? 'border-red-500 dark:border-red-400'
+              : 'border-gray-300 dark:border-gray-800'
+            }
+          `}
+          data-testid="trigger-type"
+          aria-invalid={!!error}
+          aria-describedby={error ? 'trigger-error' : undefined}
+        >
+          {TRIGGER_TYPE_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+        {error && (
+          <p id="trigger-error" className="mt-1 text-sm text-red-600 dark:text-red-400">
+            {error}
+          </p>
+        )}
+      </div>
+
+      {/* Trigger-Specific Form */}
+      {renderTriggerForm()}
+    </div>
+  )
+}
+
+TriggerSelector.propTypes = {
+  /** Current trigger configuration */
+  trigger: PropTypes.shape({
+    trigger_type: PropTypes.oneOf([
+      'interval',
+      'fixed_time',
+      'solar',
+      'moon_phase',
+      'recurring_days',
+      'cron',
+    ]),
+    // Interval fields
+    interval_minutes: PropTypes.number,
+    time_window: PropTypes.shape({
+      start_time: PropTypes.string,
+      end_time: PropTypes.string,
+    }),
+    // Fixed time fields
+    times: PropTypes.arrayOf(PropTypes.string),
+    // Solar fields
+    solar_event: PropTypes.string,
+    offset_minutes: PropTypes.number,
+    // Moon phase fields
+    phases: PropTypes.arrayOf(PropTypes.string),
+    // Recurring days fields
+    days: PropTypes.arrayOf(PropTypes.number),
+    time: PropTypes.string,
+    // Cron fields
+    cron_expression: PropTypes.string,
+  }),
+  /** Callback when trigger changes */
+  onChange: PropTypes.func.isRequired,
+  /** Whether the form is disabled */
+  disabled: PropTypes.bool,
+  /** Error message to display */
+  error: PropTypes.string,
+}
+
+export default TriggerSelector

--- a/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/__tests__/CronTriggerForm.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/__tests__/CronTriggerForm.test.jsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import CronTriggerForm from '../CronTriggerForm'
+
+describe('CronTriggerForm', () => {
+  const mockOnChange = vi.fn()
+  const defaultTrigger = {
+    trigger_type: 'cron',
+    cron_expression: '*/15 18-6 * * *',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('Rendering', () => {
+    it('renders cron expression input', () => {
+      render(<CronTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('cron-trigger-form')).toBeInTheDocument()
+      expect(screen.getByTestId('cron-expression')).toHaveValue('*/15 18-6 * * *')
+    })
+
+    it('shows advanced badge', () => {
+      render(<CronTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      expect(screen.getByText('advanced')).toBeInTheDocument()
+    })
+
+    it('shows cron description', () => {
+      render(<CronTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('cron-description')).toBeInTheDocument()
+    })
+
+    it('has monospace font on input', () => {
+      render(<CronTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      const input = screen.getByTestId('cron-expression')
+      expect(input).toHaveClass('font-mono')
+    })
+  })
+
+  describe('Expression Changes', () => {
+    it('updates cron_expression when value changes', async () => {
+      const user = userEvent.setup()
+      render(<CronTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      const input = screen.getByTestId('cron-expression')
+      await user.clear(input)
+      await user.type(input, '0 21 * * *')
+
+      // Verify onChange was called with cron_expression property
+      expect(mockOnChange).toHaveBeenCalled()
+      const lastCall = mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1][0]
+      expect(lastCall).toHaveProperty('cron_expression')
+      expect(typeof lastCall.cron_expression).toBe('string')
+    })
+  })
+
+  describe('Description Parsing', () => {
+    it('describes interval pattern', () => {
+      render(
+        <CronTriggerForm
+          trigger={{ ...defaultTrigger, cron_expression: '*/15 * * * *' }}
+          onChange={mockOnChange}
+        />
+      )
+
+      expect(screen.getByTestId('cron-description')).toHaveTextContent(/every 15 minutes/i)
+    })
+
+    it('describes interval with time range', () => {
+      render(
+        <CronTriggerForm
+          trigger={{ ...defaultTrigger, cron_expression: '*/15 18-6 * * *' }}
+          onChange={mockOnChange}
+        />
+      )
+
+      expect(screen.getByTestId('cron-description')).toHaveTextContent(/every 15 minutes.*18.*6/i)
+    })
+
+    it('describes daily pattern', () => {
+      render(
+        <CronTriggerForm
+          trigger={{ ...defaultTrigger, cron_expression: '0 21 * * *' }}
+          onChange={mockOnChange}
+        />
+      )
+
+      expect(screen.getByTestId('cron-description')).toHaveTextContent(/daily.*9pm/i)
+    })
+
+    it('shows custom schedule for complex patterns', () => {
+      render(
+        <CronTriggerForm
+          trigger={{ ...defaultTrigger, cron_expression: '30 4 1,15 * *' }}
+          onChange={mockOnChange}
+        />
+      )
+
+      expect(screen.getByTestId('cron-description')).toHaveTextContent(/custom schedule/i)
+    })
+  })
+
+  describe('Disabled State', () => {
+    it('disables input when disabled prop is true', () => {
+      render(<CronTriggerForm trigger={defaultTrigger} onChange={mockOnChange} disabled />)
+
+      expect(screen.getByTestId('cron-expression')).toBeDisabled()
+    })
+  })
+
+  describe('data-testid attributes', () => {
+    it('has cron-trigger-form on container', () => {
+      render(<CronTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('cron-trigger-form')).toBeInTheDocument()
+    })
+
+    it('has cron-expression on input', () => {
+      render(<CronTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('cron-expression')).toBeInTheDocument()
+    })
+
+    it('has cron-description on description text', () => {
+      render(<CronTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('cron-description')).toBeInTheDocument()
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/__tests__/CronTriggerForm.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/__tests__/CronTriggerForm.test.jsx
@@ -7,7 +7,7 @@ describe('CronTriggerForm', () => {
   const mockOnChange = vi.fn()
   const defaultTrigger = {
     trigger_type: 'cron',
-    cron_expression: '*/15 18-6 * * *',
+    cron_expression: '*/15 * * * *',
   }
 
   beforeEach(() => {
@@ -19,7 +19,7 @@ describe('CronTriggerForm', () => {
       render(<CronTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
 
       expect(screen.getByTestId('cron-trigger-form')).toBeInTheDocument()
-      expect(screen.getByTestId('cron-expression')).toHaveValue('*/15 18-6 * * *')
+      expect(screen.getByTestId('cron-expression')).toHaveValue('*/15 * * * *')
     })
 
     it('shows advanced badge', () => {

--- a/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/__tests__/FixedTimeTriggerForm.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/__tests__/FixedTimeTriggerForm.test.jsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import FixedTimeTriggerForm from '../FixedTimeTriggerForm'
+
+describe('FixedTimeTriggerForm', () => {
+  const mockOnChange = vi.fn()
+  const defaultTrigger = {
+    trigger_type: 'fixed_time',
+    times: ['08:00'],
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('Rendering', () => {
+    it('renders with initial time', () => {
+      render(<FixedTimeTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('fixed-time-trigger-form')).toBeInTheDocument()
+      expect(screen.getByTestId('fixed-time-input-0')).toHaveValue('08:00')
+    })
+
+    it('renders multiple times', () => {
+      render(
+        <FixedTimeTriggerForm
+          trigger={{ ...defaultTrigger, times: ['08:00', '12:00', '18:00'] }}
+          onChange={mockOnChange}
+        />
+      )
+
+      expect(screen.getByTestId('fixed-time-input-0')).toHaveValue('08:00')
+      expect(screen.getByTestId('fixed-time-input-1')).toHaveValue('12:00')
+      expect(screen.getByTestId('fixed-time-input-2')).toHaveValue('18:00')
+    })
+
+    it('shows remove buttons for multiple times', () => {
+      render(
+        <FixedTimeTriggerForm
+          trigger={{ ...defaultTrigger, times: ['08:00', '12:00'] }}
+          onChange={mockOnChange}
+        />
+      )
+
+      expect(screen.getByTestId('fixed-time-remove-0')).toBeInTheDocument()
+      expect(screen.getByTestId('fixed-time-remove-1')).toBeInTheDocument()
+    })
+
+    it('hides remove button when only one time', () => {
+      render(<FixedTimeTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      expect(screen.queryByTestId('fixed-time-remove-0')).not.toBeInTheDocument()
+    })
+
+    it('shows add time button', () => {
+      render(<FixedTimeTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('fixed-time-add')).toBeInTheDocument()
+    })
+  })
+
+  describe('Time Changes', () => {
+    it('updates time at specific index', async () => {
+      const user = userEvent.setup()
+      render(<FixedTimeTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      const input = screen.getByTestId('fixed-time-input-0')
+      // For time inputs, we test that onChange is called when input changes
+      await user.clear(input)
+      await user.type(input, '09:30')
+
+      // Verify onChange was called with times array
+      expect(mockOnChange).toHaveBeenCalled()
+      const lastCall = mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1][0]
+      expect(lastCall).toHaveProperty('times')
+      expect(Array.isArray(lastCall.times)).toBe(true)
+    })
+  })
+
+  describe('Add Time', () => {
+    it('adds new time when add button clicked', async () => {
+      const user = userEvent.setup()
+      render(<FixedTimeTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      await user.click(screen.getByTestId('fixed-time-add'))
+
+      expect(mockOnChange).toHaveBeenCalledWith({
+        ...defaultTrigger,
+        times: ['08:00', '12:00'],
+      })
+    })
+  })
+
+  describe('Remove Time', () => {
+    it('removes time when remove button clicked', async () => {
+      const user = userEvent.setup()
+      render(
+        <FixedTimeTriggerForm
+          trigger={{ ...defaultTrigger, times: ['08:00', '12:00', '18:00'] }}
+          onChange={mockOnChange}
+        />
+      )
+
+      await user.click(screen.getByTestId('fixed-time-remove-1'))
+
+      expect(mockOnChange).toHaveBeenCalledWith({
+        ...defaultTrigger,
+        times: ['08:00', '18:00'],
+      })
+    })
+
+    it('prevents removing last time', () => {
+      render(<FixedTimeTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      // Remove button should not be present with only one time
+      expect(screen.queryByTestId('fixed-time-remove-0')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Disabled State', () => {
+    it('disables all inputs when disabled prop is true', () => {
+      render(
+        <FixedTimeTriggerForm
+          trigger={{ ...defaultTrigger, times: ['08:00', '12:00'] }}
+          onChange={mockOnChange}
+          disabled
+        />
+      )
+
+      expect(screen.getByTestId('fixed-time-input-0')).toBeDisabled()
+      expect(screen.getByTestId('fixed-time-input-1')).toBeDisabled()
+      expect(screen.getByTestId('fixed-time-remove-0')).toBeDisabled()
+      expect(screen.getByTestId('fixed-time-remove-1')).toBeDisabled()
+      expect(screen.getByTestId('fixed-time-add')).toBeDisabled()
+    })
+  })
+
+  describe('data-testid attributes', () => {
+    it('has fixed-time-trigger-form on container', () => {
+      render(<FixedTimeTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('fixed-time-trigger-form')).toBeInTheDocument()
+    })
+
+    it('has fixed-time-list on list container', () => {
+      render(<FixedTimeTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('fixed-time-list')).toBeInTheDocument()
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/__tests__/IntervalTriggerForm.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/__tests__/IntervalTriggerForm.test.jsx
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import IntervalTriggerForm from '../IntervalTriggerForm'
+
+describe('IntervalTriggerForm', () => {
+  const mockOnChange = vi.fn()
+  const defaultTrigger = {
+    trigger_type: 'interval',
+    interval_minutes: 15,
+    time_window: null,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('Rendering', () => {
+    it('renders interval form with value and unit', () => {
+      render(<IntervalTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('interval-trigger-form')).toBeInTheDocument()
+      expect(screen.getByTestId('interval-value')).toHaveValue(15)
+      expect(screen.getByTestId('interval-unit')).toHaveValue('minutes')
+    })
+
+    it('displays hours when interval is divisible by 60', () => {
+      render(
+        <IntervalTriggerForm
+          trigger={{ ...defaultTrigger, interval_minutes: 120 }}
+          onChange={mockOnChange}
+        />
+      )
+
+      expect(screen.getByTestId('interval-value')).toHaveValue(2)
+      expect(screen.getByTestId('interval-unit')).toHaveValue('hours')
+    })
+
+    it('renders time window inputs when enabled', () => {
+      render(
+        <IntervalTriggerForm
+          trigger={{
+            ...defaultTrigger,
+            time_window: { start_time: '18:00', end_time: '06:00' },
+          }}
+          onChange={mockOnChange}
+        />
+      )
+
+      expect(screen.getByTestId('time-window-toggle')).toBeChecked()
+      expect(screen.getByTestId('time-window-start')).toHaveValue('18:00')
+      expect(screen.getByTestId('time-window-end')).toHaveValue('06:00')
+    })
+
+    it('hides time window inputs when disabled', () => {
+      render(<IntervalTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('time-window-toggle')).not.toBeChecked()
+      expect(screen.queryByTestId('time-window-start')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('time-window-end')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Value Changes', () => {
+    it('updates interval_minutes when value changes', async () => {
+      const user = userEvent.setup()
+      render(<IntervalTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      const input = screen.getByTestId('interval-value')
+      await user.clear(input)
+      await user.type(input, '30')
+
+      // Verify onChange was called with correct structure
+      expect(mockOnChange).toHaveBeenCalled()
+      const lastCall = mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1][0]
+      expect(lastCall).toHaveProperty('interval_minutes')
+      expect(typeof lastCall.interval_minutes).toBe('number')
+    })
+
+    it('updates interval_minutes when unit changes to hours', async () => {
+      const user = userEvent.setup()
+      render(<IntervalTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      await user.selectOptions(screen.getByTestId('interval-unit'), 'hours')
+
+      // 15 minutes * 60 = 900 minutes (15 hours)
+      expect(mockOnChange).toHaveBeenLastCalledWith({
+        ...defaultTrigger,
+        interval_minutes: 900,
+      })
+    })
+  })
+
+  describe('Time Window', () => {
+    it('enables time window with default values when checkbox checked', async () => {
+      const user = userEvent.setup()
+      render(<IntervalTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      await user.click(screen.getByTestId('time-window-toggle'))
+
+      expect(mockOnChange).toHaveBeenCalledWith({
+        ...defaultTrigger,
+        time_window: {
+          start_time: '18:00',
+          end_time: '06:00',
+        },
+      })
+    })
+
+    it('disables time window when checkbox unchecked', async () => {
+      const user = userEvent.setup()
+      render(
+        <IntervalTriggerForm
+          trigger={{
+            ...defaultTrigger,
+            time_window: { start_time: '18:00', end_time: '06:00' },
+          }}
+          onChange={mockOnChange}
+        />
+      )
+
+      await user.click(screen.getByTestId('time-window-toggle'))
+
+      expect(mockOnChange).toHaveBeenCalledWith({
+        ...defaultTrigger,
+        time_window: null,
+      })
+    })
+
+    it('updates start time', async () => {
+      const user = userEvent.setup()
+      const trigger = {
+        ...defaultTrigger,
+        time_window: { start_time: '18:00', end_time: '06:00' },
+      }
+      render(<IntervalTriggerForm trigger={trigger} onChange={mockOnChange} />)
+
+      const startInput = screen.getByTestId('time-window-start')
+      // For time inputs, we test that onChange is called when input changes
+      await user.clear(startInput)
+      await user.type(startInput, '20:00')
+
+      // Verify onChange was called (time inputs trigger onChange on each change)
+      expect(mockOnChange).toHaveBeenCalled()
+      // Check that time_window structure is preserved
+      const lastCall = mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1][0]
+      expect(lastCall).toHaveProperty('time_window')
+      expect(lastCall.time_window).toHaveProperty('start_time')
+    })
+
+    it('updates end time', async () => {
+      const user = userEvent.setup()
+      const trigger = {
+        ...defaultTrigger,
+        time_window: { start_time: '18:00', end_time: '06:00' },
+      }
+      render(<IntervalTriggerForm trigger={trigger} onChange={mockOnChange} />)
+
+      const endInput = screen.getByTestId('time-window-end')
+      // For time inputs, we test that onChange is called when input changes
+      await user.clear(endInput)
+      await user.type(endInput, '05:00')
+
+      // Verify onChange was called (time inputs trigger onChange on each change)
+      expect(mockOnChange).toHaveBeenCalled()
+      // Check that time_window structure is preserved
+      const lastCall = mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1][0]
+      expect(lastCall).toHaveProperty('time_window')
+      expect(lastCall.time_window).toHaveProperty('end_time')
+    })
+  })
+
+  describe('Disabled State', () => {
+    it('disables all inputs when disabled prop is true', () => {
+      render(
+        <IntervalTriggerForm
+          trigger={{
+            ...defaultTrigger,
+            time_window: { start_time: '18:00', end_time: '06:00' },
+          }}
+          onChange={mockOnChange}
+          disabled
+        />
+      )
+
+      expect(screen.getByTestId('interval-value')).toBeDisabled()
+      expect(screen.getByTestId('interval-unit')).toBeDisabled()
+      expect(screen.getByTestId('time-window-toggle')).toBeDisabled()
+      expect(screen.getByTestId('time-window-start')).toBeDisabled()
+      expect(screen.getByTestId('time-window-end')).toBeDisabled()
+    })
+  })
+
+  describe('data-testid attributes', () => {
+    it('has interval-trigger-form on container', () => {
+      render(<IntervalTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('interval-trigger-form')).toBeInTheDocument()
+    })
+
+    it('has all required testids', () => {
+      render(
+        <IntervalTriggerForm
+          trigger={{
+            ...defaultTrigger,
+            time_window: { start_time: '18:00', end_time: '06:00' },
+          }}
+          onChange={mockOnChange}
+        />
+      )
+
+      expect(screen.getByTestId('interval-value')).toBeInTheDocument()
+      expect(screen.getByTestId('interval-unit')).toBeInTheDocument()
+      expect(screen.getByTestId('time-window-toggle')).toBeInTheDocument()
+      expect(screen.getByTestId('time-window-start')).toBeInTheDocument()
+      expect(screen.getByTestId('time-window-end')).toBeInTheDocument()
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/__tests__/IntervalTriggerForm.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/__tests__/IntervalTriggerForm.test.jsx
@@ -83,10 +83,10 @@ describe('IntervalTriggerForm', () => {
 
       await user.selectOptions(screen.getByTestId('interval-unit'), 'hours')
 
-      // 15 minutes * 60 = 900 minutes (15 hours)
+      // 15 minutes rounds up to 1 hour = 60 minutes
       expect(mockOnChange).toHaveBeenLastCalledWith({
         ...defaultTrigger,
-        interval_minutes: 900,
+        interval_minutes: 60,
       })
     })
   })

--- a/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/__tests__/MoonPhaseTriggerForm.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/__tests__/MoonPhaseTriggerForm.test.jsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import MoonPhaseTriggerForm from '../MoonPhaseTriggerForm'
+import { MOON_PHASES } from '../constants'
+
+describe('MoonPhaseTriggerForm', () => {
+  const mockOnChange = vi.fn()
+  const defaultTrigger = {
+    trigger_type: 'moon_phase',
+    phases: ['full'],
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('Rendering', () => {
+    it('renders moon phase grid with 4 options', () => {
+      render(<MoonPhaseTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('moon-phase-trigger-form')).toBeInTheDocument()
+      expect(screen.getByTestId('moon-phase-grid')).toBeInTheDocument()
+
+      MOON_PHASES.forEach((phase) => {
+        expect(screen.getByTestId(`moon-phase-${phase.value}`)).toBeInTheDocument()
+      })
+    })
+
+    it('shows correct phase as selected', () => {
+      render(<MoonPhaseTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('moon-phase-full')).toBeChecked()
+      expect(screen.getByTestId('moon-phase-new')).not.toBeChecked()
+    })
+
+    it('renders emojis for each phase', () => {
+      render(<MoonPhaseTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      expect(screen.getByText('🌑')).toBeInTheDocument()
+      expect(screen.getByText('🌓')).toBeInTheDocument()
+      expect(screen.getByText('🌕')).toBeInTheDocument()
+      expect(screen.getByText('🌗')).toBeInTheDocument()
+    })
+
+    it('shows preview text', () => {
+      render(<MoonPhaseTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('moon-phase-preview')).toBeInTheDocument()
+    })
+  })
+
+  describe('Phase Selection', () => {
+    it('adds phase when unselected phase clicked', async () => {
+      const user = userEvent.setup()
+      render(<MoonPhaseTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      await user.click(screen.getByTestId('moon-phase-new'))
+
+      expect(mockOnChange).toHaveBeenCalledWith({
+        ...defaultTrigger,
+        phases: ['full', 'new'],
+      })
+    })
+
+    it('removes phase when selected phase clicked (multiple phases)', async () => {
+      const user = userEvent.setup()
+      render(
+        <MoonPhaseTriggerForm
+          trigger={{ ...defaultTrigger, phases: ['full', 'new'] }}
+          onChange={mockOnChange}
+        />
+      )
+
+      await user.click(screen.getByTestId('moon-phase-full'))
+
+      expect(mockOnChange).toHaveBeenCalledWith({
+        ...defaultTrigger,
+        phases: ['new'],
+      })
+    })
+
+    it('prevents removing last phase', async () => {
+      const user = userEvent.setup()
+      render(<MoonPhaseTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      await user.click(screen.getByTestId('moon-phase-full'))
+
+      // Should not call onChange - can't remove last phase
+      expect(mockOnChange).not.toHaveBeenCalled()
+    })
+
+    it('allows selecting multiple phases', async () => {
+      const user = userEvent.setup()
+      render(<MoonPhaseTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      await user.click(screen.getByTestId('moon-phase-new'))
+
+      expect(mockOnChange).toHaveBeenCalledWith({
+        ...defaultTrigger,
+        phases: ['full', 'new'],
+      })
+    })
+  })
+
+  describe('Disabled State', () => {
+    it('disables all checkboxes when disabled prop is true', () => {
+      render(<MoonPhaseTriggerForm trigger={defaultTrigger} onChange={mockOnChange} disabled />)
+
+      MOON_PHASES.forEach((phase) => {
+        expect(screen.getByTestId(`moon-phase-${phase.value}`)).toBeDisabled()
+      })
+    })
+  })
+
+  describe('data-testid attributes', () => {
+    it('has moon-phase-trigger-form on container', () => {
+      render(<MoonPhaseTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('moon-phase-trigger-form')).toBeInTheDocument()
+    })
+
+    it('has moon-phase-grid on grid container', () => {
+      render(<MoonPhaseTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('moon-phase-grid')).toBeInTheDocument()
+    })
+
+    it('has moon-phase-{value} on each checkbox', () => {
+      render(<MoonPhaseTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('moon-phase-new')).toBeInTheDocument()
+      expect(screen.getByTestId('moon-phase-first_quarter')).toBeInTheDocument()
+      expect(screen.getByTestId('moon-phase-full')).toBeInTheDocument()
+      expect(screen.getByTestId('moon-phase-last_quarter')).toBeInTheDocument()
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/__tests__/MoonPhaseTriggerForm.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/__tests__/MoonPhaseTriggerForm.test.jsx
@@ -43,11 +43,6 @@ describe('MoonPhaseTriggerForm', () => {
       expect(screen.getByText('🌗')).toBeInTheDocument()
     })
 
-    it('shows preview text', () => {
-      render(<MoonPhaseTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
-
-      expect(screen.getByTestId('moon-phase-preview')).toBeInTheDocument()
-    })
   })
 
   describe('Phase Selection', () => {

--- a/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/__tests__/RecurringDaysTriggerForm.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/__tests__/RecurringDaysTriggerForm.test.jsx
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import RecurringDaysTriggerForm from '../RecurringDaysTriggerForm'
+import { DAYS_OF_WEEK } from '../constants'
+
+describe('RecurringDaysTriggerForm', () => {
+  const mockOnChange = vi.fn()
+  const defaultTrigger = {
+    trigger_type: 'recurring_days',
+    days: [0, 5, 6],
+    time: '20:00',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('Rendering', () => {
+    it('renders day selection grid with 7 buttons', () => {
+      render(<RecurringDaysTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('recurring-days-trigger-form')).toBeInTheDocument()
+      expect(screen.getByTestId('recurring-days-grid')).toBeInTheDocument()
+
+      DAYS_OF_WEEK.forEach((day) => {
+        expect(screen.getByTestId(`day-${day.value}`)).toBeInTheDocument()
+      })
+    })
+
+    it('shows correct days as selected', () => {
+      render(<RecurringDaysTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      // Sunday (0), Friday (5), Saturday (6) are selected
+      expect(screen.getByTestId('day-0')).toHaveAttribute('aria-pressed', 'true')
+      expect(screen.getByTestId('day-5')).toHaveAttribute('aria-pressed', 'true')
+      expect(screen.getByTestId('day-6')).toHaveAttribute('aria-pressed', 'true')
+
+      // Monday-Thursday are not selected
+      expect(screen.getByTestId('day-1')).toHaveAttribute('aria-pressed', 'false')
+      expect(screen.getByTestId('day-2')).toHaveAttribute('aria-pressed', 'false')
+      expect(screen.getByTestId('day-3')).toHaveAttribute('aria-pressed', 'false')
+      expect(screen.getByTestId('day-4')).toHaveAttribute('aria-pressed', 'false')
+    })
+
+    it('renders time input with value', () => {
+      render(<RecurringDaysTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('trigger-time')).toHaveValue('20:00')
+    })
+
+    it('displays day labels', () => {
+      render(<RecurringDaysTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      // S, M, T, W, T, F, S
+      expect(screen.getAllByText('S')).toHaveLength(2) // Sunday and Saturday
+      expect(screen.getByText('M')).toBeInTheDocument()
+      expect(screen.getAllByText('T')).toHaveLength(2) // Tuesday and Thursday
+      expect(screen.getByText('W')).toBeInTheDocument()
+      expect(screen.getByText('F')).toBeInTheDocument()
+    })
+  })
+
+  describe('Day Selection', () => {
+    it('adds day when unselected day clicked', async () => {
+      const user = userEvent.setup()
+      render(<RecurringDaysTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      await user.click(screen.getByTestId('day-1')) // Monday
+
+      expect(mockOnChange).toHaveBeenCalledWith({
+        ...defaultTrigger,
+        days: [0, 1, 5, 6], // Sorted order
+      })
+    })
+
+    it('removes day when selected day clicked (multiple days)', async () => {
+      const user = userEvent.setup()
+      render(<RecurringDaysTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      await user.click(screen.getByTestId('day-5')) // Friday
+
+      expect(mockOnChange).toHaveBeenCalledWith({
+        ...defaultTrigger,
+        days: [0, 6],
+      })
+    })
+
+    it('prevents removing last day', async () => {
+      const user = userEvent.setup()
+      render(
+        <RecurringDaysTriggerForm
+          trigger={{ ...defaultTrigger, days: [0] }}
+          onChange={mockOnChange}
+        />
+      )
+
+      await user.click(screen.getByTestId('day-0'))
+
+      // Should not call onChange - can't remove last day
+      expect(mockOnChange).not.toHaveBeenCalled()
+    })
+
+    it('maintains sorted order when adding days', async () => {
+      const user = userEvent.setup()
+      render(
+        <RecurringDaysTriggerForm
+          trigger={{ ...defaultTrigger, days: [6] }}
+          onChange={mockOnChange}
+        />
+      )
+
+      await user.click(screen.getByTestId('day-1'))
+
+      expect(mockOnChange).toHaveBeenCalledWith({
+        ...defaultTrigger,
+        days: [1, 6],
+      })
+    })
+  })
+
+  describe('Time Changes', () => {
+    it('updates time when changed', async () => {
+      const user = userEvent.setup()
+      render(<RecurringDaysTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      const input = screen.getByTestId('trigger-time')
+      // For time inputs, we test that onChange is called when input changes
+      await user.clear(input)
+      await user.type(input, '21:30')
+
+      // Verify onChange was called with time property
+      expect(mockOnChange).toHaveBeenCalled()
+      const lastCall = mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1][0]
+      expect(lastCall).toHaveProperty('time')
+      expect(typeof lastCall.time).toBe('string')
+    })
+  })
+
+  describe('Disabled State', () => {
+    it('disables all inputs when disabled prop is true', () => {
+      render(<RecurringDaysTriggerForm trigger={defaultTrigger} onChange={mockOnChange} disabled />)
+
+      DAYS_OF_WEEK.forEach((day) => {
+        expect(screen.getByTestId(`day-${day.value}`)).toBeDisabled()
+      })
+      expect(screen.getByTestId('trigger-time')).toBeDisabled()
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('has aria-pressed attribute on day buttons', () => {
+      render(<RecurringDaysTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      DAYS_OF_WEEK.forEach((day) => {
+        const button = screen.getByTestId(`day-${day.value}`)
+        expect(button).toHaveAttribute('aria-pressed')
+      })
+    })
+
+    it('has aria-label with full day name', () => {
+      render(<RecurringDaysTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      DAYS_OF_WEEK.forEach((day) => {
+        const button = screen.getByTestId(`day-${day.value}`)
+        expect(button).toHaveAttribute('aria-label', day.label)
+      })
+    })
+  })
+
+  describe('data-testid attributes', () => {
+    it('has recurring-days-trigger-form on container', () => {
+      render(<RecurringDaysTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('recurring-days-trigger-form')).toBeInTheDocument()
+    })
+
+    it('has recurring-days-grid on grid container', () => {
+      render(<RecurringDaysTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('recurring-days-grid')).toBeInTheDocument()
+    })
+
+    it('has trigger-time on time input', () => {
+      render(<RecurringDaysTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('trigger-time')).toBeInTheDocument()
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/__tests__/SolarTriggerForm.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/__tests__/SolarTriggerForm.test.jsx
@@ -37,11 +37,6 @@ describe('SolarTriggerForm', () => {
       })
     })
 
-    it('shows preview text', () => {
-      render(<SolarTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
-
-      expect(screen.getByTestId('solar-preview')).toBeInTheDocument()
-    })
   })
 
   describe('Event Changes', () => {
@@ -136,12 +131,6 @@ describe('SolarTriggerForm', () => {
       render(<SolarTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
 
       expect(screen.getByTestId('solar-offset')).toBeInTheDocument()
-    })
-
-    it('has solar-preview on preview text', () => {
-      render(<SolarTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
-
-      expect(screen.getByTestId('solar-preview')).toBeInTheDocument()
     })
   })
 })

--- a/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/__tests__/SolarTriggerForm.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/__tests__/SolarTriggerForm.test.jsx
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import SolarTriggerForm from '../SolarTriggerForm'
+import { SOLAR_EVENTS } from '../constants'
+
+describe('SolarTriggerForm', () => {
+  const mockOnChange = vi.fn()
+  const defaultTrigger = {
+    trigger_type: 'solar',
+    solar_event: 'sunset',
+    offset_minutes: 0,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('Rendering', () => {
+    it('renders solar event select and offset input', () => {
+      render(<SolarTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('solar-trigger-form')).toBeInTheDocument()
+      expect(screen.getByTestId('solar-event')).toHaveValue('sunset')
+      expect(screen.getByTestId('solar-offset')).toHaveValue(0)
+    })
+
+    it('renders all 8 solar event options', () => {
+      render(<SolarTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      const select = screen.getByTestId('solar-event')
+      const options = within(select).getAllByRole('option')
+
+      expect(options).toHaveLength(SOLAR_EVENTS.length)
+      SOLAR_EVENTS.forEach((event, index) => {
+        expect(options[index]).toHaveValue(event.value)
+      })
+    })
+
+    it('shows preview text', () => {
+      render(<SolarTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('solar-preview')).toBeInTheDocument()
+    })
+  })
+
+  describe('Event Changes', () => {
+    it('updates solar_event when selection changes', async () => {
+      const user = userEvent.setup()
+      render(<SolarTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      await user.selectOptions(screen.getByTestId('solar-event'), 'sunrise')
+
+      expect(mockOnChange).toHaveBeenCalledWith({
+        ...defaultTrigger,
+        solar_event: 'sunrise',
+      })
+    })
+  })
+
+  describe('Offset Changes', () => {
+    it('updates offset_minutes when value changes', async () => {
+      const user = userEvent.setup()
+      render(<SolarTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      const input = screen.getByTestId('solar-offset')
+      await user.clear(input)
+      await user.type(input, '30')
+
+      // Verify onChange was called with correct structure
+      expect(mockOnChange).toHaveBeenCalled()
+      const lastCall = mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1][0]
+      expect(lastCall).toHaveProperty('offset_minutes')
+      expect(typeof lastCall.offset_minutes).toBe('number')
+    })
+
+    it('handles negative offset', async () => {
+      const user = userEvent.setup()
+      render(<SolarTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      const input = screen.getByTestId('solar-offset')
+      await user.clear(input)
+      await user.type(input, '-15')
+
+      // Verify onChange was called with correct structure
+      expect(mockOnChange).toHaveBeenCalled()
+      const lastCall = mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1][0]
+      expect(lastCall).toHaveProperty('offset_minutes')
+      expect(typeof lastCall.offset_minutes).toBe('number')
+    })
+
+    it('handles empty offset as 0', async () => {
+      const user = userEvent.setup()
+      render(
+        <SolarTriggerForm
+          trigger={{ ...defaultTrigger, offset_minutes: 30 }}
+          onChange={mockOnChange}
+        />
+      )
+
+      const input = screen.getByTestId('solar-offset')
+      await user.clear(input)
+
+      // When cleared, offset should be 0
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          offset_minutes: 0,
+        })
+      )
+    })
+  })
+
+  describe('Disabled State', () => {
+    it('disables all inputs when disabled prop is true', () => {
+      render(<SolarTriggerForm trigger={defaultTrigger} onChange={mockOnChange} disabled />)
+
+      expect(screen.getByTestId('solar-event')).toBeDisabled()
+      expect(screen.getByTestId('solar-offset')).toBeDisabled()
+    })
+  })
+
+  describe('data-testid attributes', () => {
+    it('has solar-trigger-form on container', () => {
+      render(<SolarTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('solar-trigger-form')).toBeInTheDocument()
+    })
+
+    it('has solar-event on select', () => {
+      render(<SolarTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('solar-event')).toBeInTheDocument()
+    })
+
+    it('has solar-offset on input', () => {
+      render(<SolarTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('solar-offset')).toBeInTheDocument()
+    })
+
+    it('has solar-preview on preview text', () => {
+      render(<SolarTriggerForm trigger={defaultTrigger} onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('solar-preview')).toBeInTheDocument()
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/__tests__/TriggerSelector.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/__tests__/TriggerSelector.test.jsx
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import TriggerSelector from '../TriggerSelector'
+import { createDefaultTrigger } from '../constants'
+
+// Mock child components to isolate TriggerSelector testing
+vi.mock('../IntervalTriggerForm', () => ({
+  default: ({ trigger }) => (
+    <div data-testid="interval-trigger-form">
+      Interval Form: {trigger?.interval_minutes} min
+    </div>
+  ),
+}))
+
+vi.mock('../FixedTimeTriggerForm', () => ({
+  default: ({ trigger }) => (
+    <div data-testid="fixed-time-trigger-form">
+      Fixed Time Form: {trigger?.times?.join(', ')}
+    </div>
+  ),
+}))
+
+vi.mock('../SolarTriggerForm', () => ({
+  default: ({ trigger }) => (
+    <div data-testid="solar-trigger-form">
+      Solar Form: {trigger?.solar_event}
+    </div>
+  ),
+}))
+
+vi.mock('../MoonPhaseTriggerForm', () => ({
+  default: ({ trigger }) => (
+    <div data-testid="moon-phase-trigger-form">
+      Moon Phase Form: {trigger?.phases?.join(', ')}
+    </div>
+  ),
+}))
+
+vi.mock('../RecurringDaysTriggerForm', () => ({
+  default: ({ trigger }) => (
+    <div data-testid="recurring-days-trigger-form">
+      Recurring Days Form: {trigger?.days?.join(', ')}
+    </div>
+  ),
+}))
+
+vi.mock('../CronTriggerForm', () => ({
+  default: ({ trigger }) => (
+    <div data-testid="cron-trigger-form">
+      Cron Form: {trigger?.cron_expression}
+    </div>
+  ),
+}))
+
+describe('TriggerSelector', () => {
+  const mockOnChange = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('Rendering', () => {
+    it('renders with default trigger type (interval)', () => {
+      render(<TriggerSelector onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('trigger-selector')).toBeInTheDocument()
+      expect(screen.getByTestId('trigger-type')).toHaveValue('interval')
+      expect(screen.getByTestId('interval-trigger-form')).toBeInTheDocument()
+    })
+
+    it('renders type dropdown with all 6 options', () => {
+      render(<TriggerSelector onChange={mockOnChange} />)
+
+      const select = screen.getByTestId('trigger-type')
+      const options = within(select).getAllByRole('option')
+
+      expect(options).toHaveLength(6)
+      expect(options[0]).toHaveValue('interval')
+      expect(options[1]).toHaveValue('fixed_time')
+      expect(options[2]).toHaveValue('solar')
+      expect(options[3]).toHaveValue('moon_phase')
+      expect(options[4]).toHaveValue('recurring_days')
+      expect(options[5]).toHaveValue('cron')
+    })
+
+    it('renders correct form for each trigger type', () => {
+      const { rerender } = render(
+        <TriggerSelector
+          trigger={{ trigger_type: 'interval', interval_minutes: 30 }}
+          onChange={mockOnChange}
+        />
+      )
+      expect(screen.getByTestId('interval-trigger-form')).toBeInTheDocument()
+
+      rerender(
+        <TriggerSelector
+          trigger={{ trigger_type: 'fixed_time', times: ['09:00'] }}
+          onChange={mockOnChange}
+        />
+      )
+      expect(screen.getByTestId('fixed-time-trigger-form')).toBeInTheDocument()
+
+      rerender(
+        <TriggerSelector
+          trigger={{ trigger_type: 'solar', solar_event: 'sunset' }}
+          onChange={mockOnChange}
+        />
+      )
+      expect(screen.getByTestId('solar-trigger-form')).toBeInTheDocument()
+
+      rerender(
+        <TriggerSelector
+          trigger={{ trigger_type: 'moon_phase', phases: ['full'] }}
+          onChange={mockOnChange}
+        />
+      )
+      expect(screen.getByTestId('moon-phase-trigger-form')).toBeInTheDocument()
+
+      rerender(
+        <TriggerSelector
+          trigger={{ trigger_type: 'recurring_days', days: [0, 6] }}
+          onChange={mockOnChange}
+        />
+      )
+      expect(screen.getByTestId('recurring-days-trigger-form')).toBeInTheDocument()
+
+      rerender(
+        <TriggerSelector
+          trigger={{ trigger_type: 'cron', cron_expression: '0 * * * *' }}
+          onChange={mockOnChange}
+        />
+      )
+      expect(screen.getByTestId('cron-trigger-form')).toBeInTheDocument()
+    })
+  })
+
+  describe('Type Selection', () => {
+    it('calls onChange with new default trigger when type changes', async () => {
+      const user = userEvent.setup()
+      render(
+        <TriggerSelector
+          trigger={{ trigger_type: 'interval', interval_minutes: 15 }}
+          onChange={mockOnChange}
+        />
+      )
+
+      await user.selectOptions(screen.getByTestId('trigger-type'), 'solar')
+
+      expect(mockOnChange).toHaveBeenCalledWith(createDefaultTrigger('solar'))
+    })
+
+    it('switching to each type creates correct defaults', async () => {
+      const user = userEvent.setup()
+      render(<TriggerSelector onChange={mockOnChange} />)
+
+      const select = screen.getByTestId('trigger-type')
+
+      // Test each type
+      const types = ['fixed_time', 'solar', 'moon_phase', 'recurring_days', 'cron']
+      for (const type of types) {
+        mockOnChange.mockClear()
+        await user.selectOptions(select, type)
+        expect(mockOnChange).toHaveBeenCalledWith(createDefaultTrigger(type))
+      }
+    })
+  })
+
+  describe('Error Display', () => {
+    it('shows error message when error prop provided', () => {
+      render(
+        <TriggerSelector
+          onChange={mockOnChange}
+          error="Invalid trigger configuration"
+        />
+      )
+
+      expect(screen.getByText('Invalid trigger configuration')).toBeInTheDocument()
+    })
+
+    it('applies error styling to dropdown', () => {
+      render(
+        <TriggerSelector
+          onChange={mockOnChange}
+          error="Error"
+        />
+      )
+
+      const select = screen.getByTestId('trigger-type')
+      expect(select).toHaveAttribute('aria-invalid', 'true')
+    })
+
+    it('does not show error when error prop is absent', () => {
+      render(<TriggerSelector onChange={mockOnChange} />)
+
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+      expect(screen.getByTestId('trigger-type')).toHaveAttribute('aria-invalid', 'false')
+    })
+  })
+
+  describe('Disabled State', () => {
+    it('disables dropdown when disabled prop is true', () => {
+      render(<TriggerSelector onChange={mockOnChange} disabled />)
+
+      expect(screen.getByTestId('trigger-type')).toBeDisabled()
+    })
+
+    it('passes disabled state to child form', () => {
+      // This is tested by verifying the child receives the prop
+      // The mock components don't implement disabled, but we verify the prop is passed
+      render(
+        <TriggerSelector
+          trigger={{ trigger_type: 'interval', interval_minutes: 15 }}
+          onChange={mockOnChange}
+          disabled
+        />
+      )
+
+      expect(screen.getByTestId('trigger-type')).toBeDisabled()
+    })
+  })
+
+  describe('data-testid attributes', () => {
+    it('has trigger-selector on container', () => {
+      render(<TriggerSelector onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('trigger-selector')).toBeInTheDocument()
+    })
+
+    it('has trigger-type on dropdown', () => {
+      render(<TriggerSelector onChange={mockOnChange} />)
+
+      expect(screen.getByTestId('trigger-type')).toBeInTheDocument()
+    })
+  })
+
+  describe('Label', () => {
+    it('has "When to run" label for dropdown', () => {
+      render(<TriggerSelector onChange={mockOnChange} />)
+
+      expect(screen.getByLabelText(/when to run/i)).toBeInTheDocument()
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/constants.js
+++ b/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/constants.js
@@ -1,0 +1,116 @@
+/**
+ * Constants for TriggerSelector components
+ * @module TriggerSelector/constants
+ */
+
+/**
+ * Trigger type options for the dropdown selector
+ * @constant {Array<Object>}
+ */
+export const TRIGGER_TYPE_OPTIONS = [
+  { value: 'interval', label: 'Interval', description: 'repeat at fixed intervals' },
+  { value: 'fixed_time', label: 'Fixed Time', description: 'run at specific times' },
+  { value: 'solar', label: 'Solar Event', description: 'based on sun position' },
+  { value: 'moon_phase', label: 'Moon Phase', description: 'lunar cycle events' },
+  { value: 'recurring_days', label: 'Recurring Days', description: 'weekly schedule' },
+  { value: 'cron', label: 'Cron Expression', description: 'advanced', badge: 'advanced' },
+]
+
+/**
+ * Solar events matching backend schema
+ * @constant {Array<Object>}
+ */
+export const SOLAR_EVENTS = [
+  { value: 'sunset', label: 'Sunset' },
+  { value: 'civil_dusk', label: 'Civil Dusk' },
+  { value: 'nautical_dusk', label: 'Nautical Dusk' },
+  { value: 'astronomical_dusk', label: 'Astronomical Dusk' },
+  { value: 'sunrise', label: 'Sunrise' },
+  { value: 'civil_dawn', label: 'Civil Dawn' },
+  { value: 'nautical_dawn', label: 'Nautical Dawn' },
+  { value: 'astronomical_dawn', label: 'Astronomical Dawn' },
+]
+
+/**
+ * Moon phases with emoji representations
+ * @constant {Array<Object>}
+ */
+export const MOON_PHASES = [
+  { value: 'new', label: 'New', emoji: '🌑' },
+  { value: 'first_quarter', label: 'First', emoji: '🌓' },
+  { value: 'full', label: 'Full', emoji: '🌕' },
+  { value: 'last_quarter', label: 'Last', emoji: '🌗' },
+]
+
+/**
+ * Days of week (0=Sunday per mockup convention)
+ * @constant {Array<Object>}
+ */
+export const DAYS_OF_WEEK = [
+  { value: 0, label: 'Sunday', short: 'S' },
+  { value: 1, label: 'Monday', short: 'M' },
+  { value: 2, label: 'Tuesday', short: 'T' },
+  { value: 3, label: 'Wednesday', short: 'W' },
+  { value: 4, label: 'Thursday', short: 'T' },
+  { value: 5, label: 'Friday', short: 'F' },
+  { value: 6, label: 'Saturday', short: 'S' },
+]
+
+/**
+ * Interval unit options
+ * @constant {Array<Object>}
+ */
+export const INTERVAL_UNITS = [
+  { value: 'minutes', label: 'minutes', multiplier: 1 },
+  { value: 'hours', label: 'hours', multiplier: 60 },
+]
+
+/**
+ * Create default trigger configuration for a given type
+ *
+ * @param {string} type - The trigger type
+ * @returns {Object} Default trigger configuration
+ */
+export function createDefaultTrigger(type) {
+  switch (type) {
+    case 'interval':
+      return {
+        trigger_type: 'interval',
+        interval_minutes: 15,
+        time_window: null,
+      }
+    case 'fixed_time':
+      return {
+        trigger_type: 'fixed_time',
+        times: ['08:00'],
+      }
+    case 'solar':
+      return {
+        trigger_type: 'solar',
+        solar_event: 'sunset',
+        offset_minutes: 0,
+      }
+    case 'moon_phase':
+      return {
+        trigger_type: 'moon_phase',
+        phases: ['full'],
+      }
+    case 'recurring_days':
+      return {
+        trigger_type: 'recurring_days',
+        days: [0, 5, 6],
+        time: '20:00',
+      }
+    case 'cron':
+      return {
+        trigger_type: 'cron',
+        cron_expression: '*/15 18-6 * * *',
+      }
+    default:
+      return {
+        trigger_type: 'interval',
+        interval_minutes: 15,
+        time_window: null,
+      }
+  }
+}

--- a/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/index.js
+++ b/Firmware/webui/frontend/src/components/scheduler/TriggerSelector/index.js
@@ -1,0 +1,26 @@
+/**
+ * TriggerSelector Components
+ *
+ * Composite component for selecting trigger type and configuring
+ * trigger-specific options.
+ *
+ * @module TriggerSelector
+ * @see Issue #323
+ */
+
+export { default as TriggerSelector } from './TriggerSelector'
+export { default as IntervalTriggerForm } from './IntervalTriggerForm'
+export { default as FixedTimeTriggerForm } from './FixedTimeTriggerForm'
+export { default as SolarTriggerForm } from './SolarTriggerForm'
+export { default as MoonPhaseTriggerForm } from './MoonPhaseTriggerForm'
+export { default as RecurringDaysTriggerForm } from './RecurringDaysTriggerForm'
+export { default as CronTriggerForm } from './CronTriggerForm'
+
+export {
+  TRIGGER_TYPE_OPTIONS,
+  SOLAR_EVENTS,
+  MOON_PHASES,
+  DAYS_OF_WEEK,
+  INTERVAL_UNITS,
+  createDefaultTrigger,
+} from './constants'


### PR DESCRIPTION
## Summary
- Add TriggerSelector composite component for selecting and configuring trigger types
- Implement 6 trigger type forms: Interval, Fixed Time, Solar, Moon Phase, Recurring Days, Cron
- Include comprehensive test coverage (90 tests)
- Follow mockup designs with dark mode Tailwind styling

## Components Created
| Component | Description |
|-----------|-------------|
| `TriggerSelector.jsx` | Main container with type dropdown |
| `IntervalTriggerForm.jsx` | Every N min/hr + optional time window |
| `FixedTimeTriggerForm.jsx` | Multiple fixed times with add/remove |
| `SolarTriggerForm.jsx` | Solar event dropdown + offset minutes |
| `MoonPhaseTriggerForm.jsx` | 4-phase emoji grid (multi-select) |
| `RecurringDaysTriggerForm.jsx` | 7-day toggle grid + time input |
| `CronTriggerForm.jsx` | Expert cron input with description |

## Test plan
- [x] All 90 unit tests passing
- [x] ESLint clean (0 errors)
- [ ] Visual review of components matches mockup
- [ ] Integration with parent scheduler forms

Closes #323