### PR TITLE
feat(scheduler): Add DayTimeline component with conflict highlighting (#326)

### DIFF
--- a/Firmware/webui/frontend/src/components/scheduler/CalendarView/CalendarGrid.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/CalendarView/CalendarGrid.jsx
@@ -3,6 +3,7 @@
  *
  * Renders calendar grid with date cells for month/week/day views.
  * Manages execution grouping and moon phase data distribution.
+ * Day view uses DayTimeline component for hourly display with conflict highlighting (Issue #326).
  *
  * @module components/scheduler/CalendarView/CalendarGrid
  */
@@ -10,13 +11,12 @@
 import { useMemo } from 'react'
 import PropTypes from 'prop-types'
 import CalendarCell from './CalendarCell'
+import DayTimeline from '../DayTimeline'
 import {
   getMonthGridDates,
   getWeekDates,
   groupExecutionsByDate,
   isToday,
-  formatTime,
-  getPatternColor,
   getDateKey,
 } from './calendarUtils'
 
@@ -29,6 +29,7 @@ const DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
  * @param {string} props.viewMode - 'month', 'week', or 'day' (required)
  * @param {Date} props.currentDate - The current date being displayed (required)
  * @param {Array} props.executions - Raw executions array from API
+ * @param {Array} [props.conflicts] - Conflict objects from preview API (for day view)
  * @param {Object} props.moonPhases - Moon phases by date { 'YYYY-MM-DD': { phase, phase_name, illumination } }
  * @param {Function} props.onCellClick - Cell click handler (receives date)
  * @param {Function} props.onExecutionClick - Execution click handler (receives execution)
@@ -48,6 +49,7 @@ function CalendarGrid({
   viewMode,
   currentDate,
   executions = [],
+  conflicts = [],
   moonPhases = {},
   onCellClick,
   onExecutionClick,
@@ -163,90 +165,18 @@ function CalendarGrid({
     )
   }
 
-  // Day View: Single day with all executions listed
+  // Day View: Uses DayTimeline for hourly display with conflict highlighting (Issue #326)
   if (viewMode === 'day') {
     const currentDateKey = getDateKey(currentDate)
     const dayExecutions = executionsByDate[currentDateKey] || []
 
-    // Format full date for header
-    const monthNames = [
-      'January',
-      'February',
-      'March',
-      'April',
-      'May',
-      'June',
-      'July',
-      'August',
-      'September',
-      'October',
-      'November',
-      'December',
-    ]
-    const dayNames = [
-      'Sunday',
-      'Monday',
-      'Tuesday',
-      'Wednesday',
-      'Thursday',
-      'Friday',
-      'Saturday',
-    ]
-
-    const fullDate = `${dayNames[currentDate.getDay()]}, ${
-      monthNames[currentDate.getMonth()]
-    } ${currentDate.getDate()}, ${currentDate.getFullYear()}`
-
     return (
-      <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
-        {/* Day header */}
-        <div className="p-4 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800">
-          <div className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-            {fullDate}
-          </div>
-        </div>
-
-        {/* Day content - show all executions for the day */}
-        <div className="p-4 max-h-96 overflow-y-auto">
-          {dayExecutions.length > 0 ? (
-            <div className="space-y-2">
-              {dayExecutions.map((exec) => (
-                <div
-                  key={exec.start_time}
-                  className="p-3 rounded-lg bg-gray-50 dark:bg-gray-700 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors duration-150"
-                  onClick={() => onExecutionClick(exec)}
-                  role="button"
-                  tabIndex={0}
-                  aria-label={`${exec.pattern_name} at ${formatTime(exec.start_time)}`}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault()
-                      onExecutionClick(exec)
-                    }
-                  }}
-                >
-                  <div className="flex items-center gap-2">
-                    <div
-                      className={`w-3 h-3 rounded-full ${getPatternColor(exec.pattern_id)}`}
-                    />
-                    <span className="font-medium text-gray-900 dark:text-gray-100">
-                      {exec.pattern_name}
-                    </span>
-                    <span className="text-gray-500 dark:text-gray-400 ml-auto">
-                      {formatTime(exec.start_time)}
-                    </span>
-                  </div>
-                </div>
-              ))}
-            </div>
-          ) : (
-            /* Empty state */
-            <p className="text-gray-500 dark:text-gray-400 text-center py-8">
-              No executions scheduled
-            </p>
-          )}
-        </div>
-      </div>
+      <DayTimeline
+        date={currentDateKey}
+        executions={dayExecutions}
+        conflicts={conflicts}
+        onExecutionClick={onExecutionClick}
+      />
     )
   }
 
@@ -262,6 +192,16 @@ CalendarGrid.propTypes = {
       pattern_id: PropTypes.string.isRequired,
       pattern_name: PropTypes.string.isRequired,
       start_time: PropTypes.string.isRequired,
+    })
+  ),
+  /** Conflict objects from preview API (for day view, Issue #326) */
+  conflicts: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string,
+      conflict_type: PropTypes.string,
+      severity: PropTypes.oneOf(['error', 'warning']),
+      message: PropTypes.string,
+      start_time: PropTypes.string,
     })
   ),
   moonPhases: PropTypes.objectOf(

--- a/Firmware/webui/frontend/src/components/scheduler/CalendarView/CalendarView.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/CalendarView/CalendarView.jsx
@@ -237,6 +237,7 @@ export function CalendarView() {
           viewMode={viewMode}
           currentDate={currentDate}
           executions={previewData?.executions || []}
+          conflicts={previewData?.conflicts || []}
           moonPhases={previewData?.moon_phases || {}}
           onCellClick={handleCellClick}
           onExecutionClick={handleExecutionClick}

--- a/Firmware/webui/frontend/src/components/scheduler/CalendarView/__tests__/CalendarGrid.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/CalendarView/__tests__/CalendarGrid.test.jsx
@@ -403,8 +403,10 @@ describe('CalendarGrid', () => {
     })
   })
 
-  describe('Day View', () => {
-    it('shows full formatted date in header', () => {
+  describe('Day View (DayTimeline)', () => {
+    // Day view now uses DayTimeline component (Issue #326)
+
+    it('renders DayTimeline with day-timeline testid', () => {
       render(
         <CalendarGrid
           viewMode="day"
@@ -416,10 +418,10 @@ describe('CalendarGrid', () => {
         />
       )
 
-      expect(screen.getByText('Wednesday, January 15, 2025')).toBeInTheDocument()
+      expect(screen.getByTestId('day-timeline')).toBeInTheDocument()
     })
 
-    it('shows all executions for selected date', () => {
+    it('shows executions for selected date in hour rows', () => {
       render(
         <CalendarGrid
           viewMode="day"
@@ -431,12 +433,14 @@ describe('CalendarGrid', () => {
         />
       )
 
-      // Should show 2 executions for Jan 15
-      expect(screen.getByText('Morning Capture')).toBeInTheDocument()
-      expect(screen.getByText('Evening Capture')).toBeInTheDocument()
+      // Should show executions for Jan 15
+      // Evening Capture at 18:00 should be in hour-row-18
+      expect(screen.getByTestId('hour-row-18')).toBeInTheDocument()
+      expect(screen.getByTestId('execution-pattern2-1800')).toBeInTheDocument()
 
-      // Should NOT show execution from Jan 20
-      expect(screen.queryByText('Afternoon Capture')).not.toBeInTheDocument()
+      // Verify we have 24 hour rows
+      expect(screen.getByTestId('hour-row-0')).toBeInTheDocument()
+      expect(screen.getByTestId('hour-row-23')).toBeInTheDocument()
     })
 
     it('shows empty state when no executions for day', () => {
@@ -451,10 +455,11 @@ describe('CalendarGrid', () => {
         />
       )
 
-      expect(screen.getByText('No executions scheduled')).toBeInTheDocument()
+      expect(screen.getByTestId('day-timeline-empty')).toBeInTheDocument()
+      expect(screen.getByText('No scheduled events')).toBeInTheDocument()
     })
 
-    it('calls onExecutionClick when execution is clicked in day view', async () => {
+    it('calls onExecutionClick when execution chip is clicked', async () => {
       const user = userEvent.setup()
 
       render(
@@ -468,18 +473,19 @@ describe('CalendarGrid', () => {
         />
       )
 
-      const executionDiv = screen.getByText('Morning Capture').closest('div')
-      await user.click(executionDiv)
+      // Click the Evening Capture chip
+      const executionChip = screen.getByTestId('execution-pattern2-1800')
+      await user.click(executionChip)
 
       expect(mockOnExecutionClick).toHaveBeenCalledTimes(1)
       expect(mockOnExecutionClick).toHaveBeenCalledWith(
         expect.objectContaining({
-          pattern_name: 'Morning Capture',
+          pattern_name: 'Evening Capture',
         })
       )
     })
 
-    it('shows execution times in day view', () => {
+    it('renders 24 hour rows', () => {
       render(
         <CalendarGrid
           viewMode="day"
@@ -491,62 +497,37 @@ describe('CalendarGrid', () => {
         />
       )
 
-      // formatTime displays times in user's local timezone
-      // Find time elements by their format (H:MM or HH:MM pattern)
-      const timeElements = screen.getAllByText(/^\d{1,2}:\d{2}$/)
-      expect(timeElements).toHaveLength(2) // Two executions should have time displayed
+      // Should have 24 hour rows (0-23)
+      for (let hour = 0; hour < 24; hour++) {
+        expect(screen.getByTestId(`hour-row-${hour}`)).toBeInTheDocument()
+      }
     })
 
-    it('shows pattern color indicators in day view', () => {
-      const { container } = render(
+    it('passes conflicts to DayTimeline', () => {
+      const conflicts = [
+        {
+          id: 'c1',
+          severity: 'error',
+          message: 'camera busy',
+          start_time: '2025-01-15T08:30:00Z',
+        },
+      ]
+
+      render(
         <CalendarGrid
           viewMode="day"
           currentDate={new Date(2025, 0, 15)}
           executions={mockExecutions}
+          conflicts={conflicts}
           moonPhases={{}}
           onCellClick={mockOnCellClick}
           onExecutionClick={mockOnExecutionClick}
         />
       )
 
-      // Find colored dots (w-3 h-3 rounded-full)
-      const colorDots = container.querySelectorAll('.w-3.h-3.rounded-full')
-      expect(colorDots.length).toBe(2) // Two executions on this day
-    })
-
-    it('has scrollable container with max height in day view', () => {
-      const { container } = render(
-        <CalendarGrid
-          viewMode="day"
-          currentDate={new Date(2025, 0, 15)}
-          executions={mockExecutions}
-          moonPhases={{}}
-          onCellClick={mockOnCellClick}
-          onExecutionClick={mockOnExecutionClick}
-        />
-      )
-
-      // Find the scrollable container
-      const scrollableContainer = container.querySelector('.max-h-96.overflow-y-auto')
-      expect(scrollableContainer).toBeInTheDocument()
-    })
-
-    it('has scrollable container in empty state', () => {
-      const { container } = render(
-        <CalendarGrid
-          viewMode="day"
-          currentDate={new Date(2025, 0, 10)} // Day with no executions
-          executions={mockExecutions}
-          moonPhases={{}}
-          onCellClick={mockOnCellClick}
-          onExecutionClick={mockOnExecutionClick}
-        />
-      )
-
-      // Scrollable container should exist even in empty state
-      const scrollableContainer = container.querySelector('.max-h-96.overflow-y-auto')
-      expect(scrollableContainer).toBeInTheDocument()
-      expect(screen.getByText('No executions scheduled')).toBeInTheDocument()
+      // Conflict summary should be visible
+      expect(screen.getByTestId('conflict-summary')).toBeInTheDocument()
+      expect(screen.getByText('1 conflict')).toBeInTheDocument()
     })
   })
 
@@ -673,9 +654,9 @@ describe('CalendarGrid', () => {
         />
       )
 
-      // Check for dark mode background classes
-      const elements = container.querySelectorAll('.dark\\:bg-gray-700')
-      expect(elements.length).toBeGreaterThan(0)
+      // DayTimeline uses dark mode classes for text
+      const darkElements = container.querySelectorAll('[class*="dark:"]')
+      expect(darkElements.length).toBeGreaterThan(0)
     })
   })
 
@@ -710,7 +691,7 @@ describe('CalendarGrid', () => {
   })
 
   describe('Accessibility', () => {
-    it('provides keyboard support for day view executions', async () => {
+    it('provides keyboard support for day view execution chips', async () => {
       const user = userEvent.setup()
 
       render(
@@ -724,8 +705,9 @@ describe('CalendarGrid', () => {
         />
       )
 
-      const executionDiv = screen.getByText('Morning Capture').closest('div')
-      executionDiv.focus()
+      // ExecutionChip uses button element, so we can tab to it and press Enter
+      const executionChip = screen.getByTestId('execution-pattern2-1800')
+      executionChip.focus()
       await user.keyboard('{Enter}')
 
       expect(mockOnExecutionClick).toHaveBeenCalledTimes(1)

--- a/Firmware/webui/frontend/src/components/scheduler/DayTimeline/ConflictSummary.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/DayTimeline/ConflictSummary.jsx
@@ -1,0 +1,72 @@
+/**
+ * ConflictSummary - Conflict count banner for DayTimeline (Issue #326)
+ *
+ * Displays a summary of conflicts in the timeline with counts
+ * broken down by severity (collisions vs warnings).
+ *
+ * @module components/scheduler/DayTimeline/ConflictSummary
+ */
+
+import { memo } from 'react'
+import PropTypes from 'prop-types'
+import { countConflictsBySeverity } from './dayTimelineUtils'
+
+/**
+ * ConflictSummary component
+ *
+ * @param {Object} props - Component props
+ * @param {Array} props.conflicts - Array of conflict objects
+ * @returns {JSX.Element|null} Conflict summary banner or null if no conflicts
+ *
+ * @example
+ * <ConflictSummary conflicts={[
+ *   { severity: 'error', message: '...' },
+ *   { severity: 'warning', message: '...' }
+ * ]} />
+ */
+function ConflictSummary({ conflicts }) {
+  const counts = countConflictsBySeverity(conflicts)
+
+  // Don't render if no conflicts
+  if (counts.total === 0) {
+    return null
+  }
+
+  // Build breakdown text
+  const breakdownParts = []
+  if (counts.errors > 0) {
+    breakdownParts.push(`${counts.errors} collision${counts.errors > 1 ? 's' : ''}`)
+  }
+  if (counts.warnings > 0) {
+    breakdownParts.push(`${counts.warnings} warning${counts.warnings > 1 ? 's' : ''}`)
+  }
+  const breakdownText = breakdownParts.join(', ')
+
+  const ariaLabel = `${counts.total} conflicts: ${breakdownText}`
+
+  return (
+    <div
+      data-testid="conflict-summary"
+      className="mb-6 p-3 border border-red-900/50 rounded text-sm flex items-center gap-3"
+      role="status"
+      aria-label={ariaLabel}
+    >
+      <span className="text-red-400">
+        {counts.total} conflict{counts.total > 1 ? 's' : ''}
+      </span>
+      <span className="text-gray-600">|</span>
+      <span className="text-gray-500">{breakdownText}</span>
+    </div>
+  )
+}
+
+ConflictSummary.propTypes = {
+  /** Array of conflict objects with severity field */
+  conflicts: PropTypes.arrayOf(
+    PropTypes.shape({
+      severity: PropTypes.oneOf(['error', 'warning']).isRequired,
+    })
+  ).isRequired,
+}
+
+export default memo(ConflictSummary)

--- a/Firmware/webui/frontend/src/components/scheduler/DayTimeline/DayTimeline.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/DayTimeline/DayTimeline.jsx
@@ -1,0 +1,194 @@
+/**
+ * DayTimeline - Hourly timeline for day view with conflict highlighting (Issue #326)
+ *
+ * Main container component that displays a 24-hour timeline for a single day.
+ * Shows scheduled executions as chips within hourly rows, with visual indicators
+ * for time collisions (blocking errors) and GPIO state warnings (non-blocking).
+ *
+ * Features:
+ * - 24 hourly rows (0-23)
+ * - Execution chips color-coded by action type
+ * - Red highlighting for time collisions
+ * - Yellow highlighting for GPIO warnings
+ * - Conflict summary banner
+ *
+ * @module components/scheduler/DayTimeline
+ */
+
+import { memo, useMemo } from 'react'
+import PropTypes from 'prop-types'
+import HourRow from './HourRow'
+import ConflictSummary from './ConflictSummary'
+import { LEGEND_ITEMS } from './dayTimelineConstants'
+import {
+  groupExecutionsByHour,
+  getConflictForHour,
+  getConflictForExecution,
+} from './dayTimelineUtils'
+
+/**
+ * Legend component for the timeline
+ */
+function TimelineLegend() {
+  return (
+    <div className="flex items-center gap-6 text-xs text-gray-500 mb-6">
+      {LEGEND_ITEMS.map((item) => (
+        <div key={item.label} className="flex items-center gap-2">
+          <span
+            className={`w-2 h-2 rounded-full ${item.isRing ? item.color : item.color}`}
+          />
+          {item.label}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+/**
+ * DayTimeline component
+ *
+ * @param {Object} props - Component props
+ * @param {string} props.date - ISO date string (YYYY-MM-DD) for the day to display
+ * @param {Array} [props.executions] - Array of execution objects from preview API
+ * @param {Array} [props.conflicts] - Array of conflict objects from preview API
+ * @param {Function} [props.onExecutionClick] - Callback when an execution chip is clicked
+ * @returns {JSX.Element} Day timeline component
+ *
+ * @example
+ * <DayTimeline
+ *   date="2025-12-17"
+ *   executions={previewData.executions}
+ *   conflicts={previewData.conflicts}
+ *   onExecutionClick={handleExecutionClick}
+ * />
+ */
+function DayTimeline({
+  date,
+  executions = [],
+  conflicts = [],
+  onExecutionClick,
+}) {
+  // Generate array of hours [0, 1, 2, ..., 23]
+  const hours = useMemo(() => Array.from({ length: 24 }, (_, i) => i), [])
+
+  // Group executions by hour
+  const executionsByHour = useMemo(
+    () => groupExecutionsByHour(executions, date),
+    [executions, date]
+  )
+
+  // Build map of execution pattern_id to conflict for chip highlighting
+  const executionConflictsMap = useMemo(() => {
+    const map = {}
+    executions.forEach((execution) => {
+      const conflict = getConflictForExecution(execution, conflicts)
+      if (conflict) {
+        map[execution.pattern_id] = conflict
+      }
+    })
+    return map
+  }, [executions, conflicts])
+
+  // Check if there are any executions
+  const hasExecutions = executions.length > 0
+
+  // Empty state
+  if (!hasExecutions) {
+    return (
+      <div
+        data-testid="day-timeline"
+        className="p-4"
+        aria-label={`Day timeline for ${date}`}
+      >
+        <div
+          data-testid="day-timeline-empty"
+          className="text-center text-gray-500 dark:text-gray-400 py-8"
+        >
+          No scheduled events
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      data-testid="day-timeline"
+      className="p-4"
+      aria-label={`Day timeline for ${date}`}
+    >
+      {/* Legend */}
+      <TimelineLegend />
+
+      {/* Conflict Summary */}
+      {conflicts.length > 0 && <ConflictSummary conflicts={conflicts} />}
+
+      {/* Timeline Grid */}
+      <div className="border border-gray-800 rounded-lg divide-y divide-gray-800">
+        {hours.map((hour) => {
+          const hourExecutions = executionsByHour[hour] || []
+          const hourConflict = getConflictForHour(conflicts, hour, date)
+
+          return (
+            <HourRow
+              key={hour}
+              hour={hour}
+              executions={hourExecutions}
+              conflict={hourConflict}
+              onExecutionClick={onExecutionClick}
+              executionConflicts={executionConflictsMap}
+            />
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+DayTimeline.propTypes = {
+  /** ISO date string (YYYY-MM-DD) for the day to display */
+  date: PropTypes.string.isRequired,
+  /** Array of execution objects from preview API */
+  executions: PropTypes.arrayOf(
+    PropTypes.shape({
+      pattern_id: PropTypes.string.isRequired,
+      pattern_name: PropTypes.string.isRequired,
+      start_time: PropTypes.string.isRequired,
+      actions: PropTypes.arrayOf(
+        PropTypes.shape({
+          time: PropTypes.string,
+          action_name: PropTypes.string,
+          action_type: PropTypes.oneOf([
+            'camera',
+            'gpio',
+            'gps_sync',
+            'service',
+          ]),
+          offset_minutes: PropTypes.number,
+        })
+      ),
+    })
+  ),
+  /** Array of conflict objects from preview API */
+  conflicts: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string,
+      conflict_type: PropTypes.oneOf([
+        'time_overlap',
+        'resource_contention',
+        'gpio_state_conflict',
+      ]),
+      severity: PropTypes.oneOf(['error', 'warning']).isRequired,
+      event1_id: PropTypes.string,
+      event1_name: PropTypes.string,
+      event2_id: PropTypes.string,
+      event2_name: PropTypes.string,
+      start_time: PropTypes.string,
+      end_time: PropTypes.string,
+      message: PropTypes.string,
+    })
+  ),
+  /** Callback when an execution chip is clicked */
+  onExecutionClick: PropTypes.func,
+}
+
+export default memo(DayTimeline)

--- a/Firmware/webui/frontend/src/components/scheduler/DayTimeline/DayTimeline.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/DayTimeline/DayTimeline.jsx
@@ -28,21 +28,20 @@ import {
 
 /**
  * Legend component for the timeline
+ * Memoized since LEGEND_ITEMS is static and never changes
  */
-function TimelineLegend() {
+const TimelineLegend = memo(function TimelineLegend() {
   return (
     <div className="flex items-center gap-6 text-xs text-gray-500 mb-6">
       {LEGEND_ITEMS.map((item) => (
         <div key={item.label} className="flex items-center gap-2">
-          <span
-            className={`w-2 h-2 rounded-full ${item.isRing ? item.color : item.color}`}
-          />
+          <span className={`w-2 h-2 rounded-full ${item.color}`} />
           {item.label}
         </div>
       ))}
     </div>
   )
-}
+})
 
 /**
  * DayTimeline component

--- a/Firmware/webui/frontend/src/components/scheduler/DayTimeline/ExecutionChip.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/DayTimeline/ExecutionChip.jsx
@@ -1,0 +1,135 @@
+/**
+ * ExecutionChip - Execution marker within DayTimeline (Issue #326)
+ *
+ * Displays individual scheduled execution as a small chip/pill.
+ * Shows time and action name with color-coding by action type.
+ * Supports conflict highlighting with ring indicators.
+ *
+ * @module components/scheduler/DayTimeline/ExecutionChip
+ */
+
+import { memo } from 'react'
+import PropTypes from 'prop-types'
+import { CHIP_CONFLICT_RINGS } from './dayTimelineConstants'
+import {
+  formatTimeShort,
+  getActionTypeDisplay,
+  getExecutionTestId,
+} from './dayTimelineUtils'
+
+/**
+ * ExecutionChip component
+ *
+ * @param {Object} props - Component props
+ * @param {Object} props.execution - Execution object
+ * @param {string} props.execution.pattern_id - Pattern/routine identifier
+ * @param {string} props.execution.pattern_name - Pattern display name
+ * @param {string} props.execution.start_time - ISO datetime string
+ * @param {Array} [props.execution.actions] - Array of action objects
+ * @param {Function} [props.onClick] - Click handler
+ * @param {string|null} [props.conflictSeverity] - Conflict severity ('error'|'warning'|null)
+ * @returns {JSX.Element} Execution chip component
+ *
+ * @example
+ * <ExecutionChip
+ *   execution={{ pattern_id: 'p1', pattern_name: 'Photo', start_time: '...' }}
+ *   onClick={() => handleClick(execution)}
+ * />
+ *
+ * @example
+ * // With conflict highlighting
+ * <ExecutionChip
+ *   execution={execution}
+ *   conflictSeverity="error"
+ * />
+ */
+function ExecutionChip({ execution, onClick, conflictSeverity = null }) {
+  const { pattern_name, start_time, actions } = execution
+
+  // Format the time display
+  const timeStr = formatTimeShort(start_time)
+
+  // Determine action type from first action, or default to camera
+  const actionType = actions?.[0]?.action_type || 'camera'
+  const actionName = actions?.[0]?.action_name || pattern_name
+
+  // Get color classes for this action type
+  const colorClasses = getActionTypeDisplay(actionType, actionName)
+
+  // Get conflict ring class if applicable
+  const conflictRing = conflictSeverity ? CHIP_CONFLICT_RINGS[conflictSeverity] : ''
+
+  // Build chip display text
+  const displayText = actionName ? `${timeStr} ${actionName}` : timeStr
+
+  // Build class string
+  const chipClasses = [
+    'text-xs px-2 py-0.5 rounded',
+    colorClasses.bg,
+    colorClasses.text,
+    conflictRing,
+    onClick ? 'cursor-pointer hover:brightness-110 transition-all' : '',
+    'focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-blue-400',
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  // Build aria-label
+  const ariaLabel = conflictSeverity
+    ? `${pattern_name} at ${timeStr} - ${conflictSeverity} conflict`
+    : `${pattern_name} at ${timeStr}`
+
+  const handleClick = (e) => {
+    e.stopPropagation()
+    if (onClick) {
+      onClick()
+    }
+  }
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      e.stopPropagation()
+      if (onClick) {
+        onClick()
+      }
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      data-testid={getExecutionTestId(execution)}
+      className={chipClasses}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      title={`${pattern_name} at ${timeStr}`}
+      aria-label={ariaLabel}
+    >
+      {displayText}
+    </button>
+  )
+}
+
+ExecutionChip.propTypes = {
+  /** Execution object containing pattern and timing details */
+  execution: PropTypes.shape({
+    pattern_id: PropTypes.string.isRequired,
+    pattern_name: PropTypes.string.isRequired,
+    start_time: PropTypes.string.isRequired,
+    actions: PropTypes.arrayOf(
+      PropTypes.shape({
+        time: PropTypes.string,
+        action_name: PropTypes.string,
+        action_type: PropTypes.string,
+        offset_minutes: PropTypes.number,
+      })
+    ),
+  }).isRequired,
+  /** Click handler for when chip is selected */
+  onClick: PropTypes.func,
+  /** Conflict severity for highlighting ('error'|'warning'|null) */
+  conflictSeverity: PropTypes.oneOf(['error', 'warning', null]),
+}
+
+export default memo(ExecutionChip)

--- a/Firmware/webui/frontend/src/components/scheduler/DayTimeline/HourRow.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/DayTimeline/HourRow.jsx
@@ -1,0 +1,131 @@
+/**
+ * HourRow - Individual hour row in DayTimeline (Issue #326)
+ *
+ * Displays a single hour row with time label and execution chips.
+ * Supports conflict highlighting with background colors and labels.
+ *
+ * @module components/scheduler/DayTimeline/HourRow
+ */
+
+import { memo } from 'react'
+import PropTypes from 'prop-types'
+import ExecutionChip from './ExecutionChip'
+import { ROW_CONFLICT_STYLES } from './dayTimelineConstants'
+import { formatHourLabel, getExecutionKey } from './dayTimelineUtils'
+
+/**
+ * HourRow component
+ *
+ * @param {Object} props - Component props
+ * @param {number} props.hour - Hour number (0-23)
+ * @param {Array} [props.executions] - Array of executions for this hour
+ * @param {Object} [props.conflict] - Conflict affecting this hour (if any)
+ * @param {Function} [props.onExecutionClick] - Click handler for execution chips
+ * @param {Object} [props.executionConflicts] - Map of execution pattern_id to conflict
+ * @returns {JSX.Element} Hour row component
+ *
+ * @example
+ * <HourRow hour={18} executions={hourExecutions} />
+ *
+ * @example
+ * // With conflict
+ * <HourRow
+ *   hour={19}
+ *   executions={hourExecutions}
+ *   conflict={{ severity: 'error', message: 'Camera busy' }}
+ * />
+ */
+function HourRow({
+  hour,
+  executions = [],
+  conflict = null,
+  onExecutionClick,
+  executionConflicts = {},
+}) {
+  // Get styling for this row based on conflict state
+  const conflictState = conflict?.severity || 'none'
+  const rowStyles = ROW_CONFLICT_STYLES[conflictState] || ROW_CONFLICT_STYLES.none
+
+  // Format hour label
+  const hourLabel = formatHourLabel(hour)
+
+  // Build row classes
+  const rowClasses = ['flex p-3', rowStyles.bg].filter(Boolean).join(' ')
+
+  // Build hour label classes
+  const labelClasses = ['w-12 text-xs', rowStyles.label].join(' ')
+
+  const hasExecutions = executions.length > 0
+
+  return (
+    <div className={rowClasses} data-testid={`hour-row-${hour}`}>
+      <span className={labelClasses}>{hourLabel}</span>
+
+      {hasExecutions ? (
+        <div className="flex gap-2 flex-wrap items-center">
+          {executions.map((execution) => {
+            // Check if this specific execution has a conflict
+            const execConflict = executionConflicts[execution.pattern_id]
+            const conflictSeverity = execConflict?.severity || null
+
+            return (
+              <ExecutionChip
+                key={getExecutionKey(execution)}
+                execution={execution}
+                onClick={
+                  onExecutionClick ? () => onExecutionClick(execution) : undefined
+                }
+                conflictSeverity={conflictSeverity}
+              />
+            )
+          })}
+
+          {/* Inline conflict message */}
+          {conflict && (
+            <span
+              className={`text-xs ml-1 ${conflictState === 'error' ? 'text-red-400' : 'text-yellow-400'}`}
+              data-testid={`conflict-${conflict.id || hour}`}
+            >
+              {conflict.message}
+            </span>
+          )}
+        </div>
+      ) : (
+        <span className="text-xs text-gray-700 dark:text-gray-700">
+          no executions
+        </span>
+      )}
+    </div>
+  )
+}
+
+HourRow.propTypes = {
+  /** Hour number (0-23) */
+  hour: PropTypes.number.isRequired,
+  /** Array of executions for this hour */
+  executions: PropTypes.arrayOf(
+    PropTypes.shape({
+      pattern_id: PropTypes.string.isRequired,
+      pattern_name: PropTypes.string.isRequired,
+      start_time: PropTypes.string.isRequired,
+      actions: PropTypes.array,
+    })
+  ),
+  /** Conflict affecting this hour (if any) */
+  conflict: PropTypes.shape({
+    id: PropTypes.string,
+    severity: PropTypes.oneOf(['error', 'warning']).isRequired,
+    message: PropTypes.string.isRequired,
+    conflict_type: PropTypes.string,
+  }),
+  /** Click handler for execution chips */
+  onExecutionClick: PropTypes.func,
+  /** Map of execution pattern_id to conflict */
+  executionConflicts: PropTypes.objectOf(
+    PropTypes.shape({
+      severity: PropTypes.oneOf(['error', 'warning']).isRequired,
+    })
+  ),
+}
+
+export default memo(HourRow)

--- a/Firmware/webui/frontend/src/components/scheduler/DayTimeline/HourRow.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/DayTimeline/HourRow.jsx
@@ -108,7 +108,14 @@ HourRow.propTypes = {
       pattern_id: PropTypes.string.isRequired,
       pattern_name: PropTypes.string.isRequired,
       start_time: PropTypes.string.isRequired,
-      actions: PropTypes.array,
+      actions: PropTypes.arrayOf(
+        PropTypes.shape({
+          time: PropTypes.string,
+          action_name: PropTypes.string,
+          action_type: PropTypes.oneOf(['camera', 'gpio', 'gps_sync', 'service']),
+          offset_minutes: PropTypes.number,
+        })
+      ),
     })
   ),
   /** Conflict affecting this hour (if any) */

--- a/Firmware/webui/frontend/src/components/scheduler/DayTimeline/HourRow.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/DayTimeline/HourRow.jsx
@@ -63,14 +63,14 @@ function HourRow({
 
       {hasExecutions ? (
         <div className="flex gap-2 flex-wrap items-center">
-          {executions.map((execution) => {
+          {executions.map((execution, index) => {
             // Check if this specific execution has a conflict
             const execConflict = executionConflicts[execution.pattern_id]
             const conflictSeverity = execConflict?.severity || null
 
             return (
               <ExecutionChip
-                key={getExecutionKey(execution)}
+                key={getExecutionKey(execution, index)}
                 execution={execution}
                 onClick={
                   onExecutionClick ? () => onExecutionClick(execution) : undefined

--- a/Firmware/webui/frontend/src/components/scheduler/DayTimeline/__tests__/ConflictSummary.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/DayTimeline/__tests__/ConflictSummary.test.jsx
@@ -1,0 +1,120 @@
+/**
+ * Tests for ConflictSummary component (Issue #326)
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import ConflictSummary from '../ConflictSummary'
+
+describe('ConflictSummary', () => {
+  describe('Rendering', () => {
+    it('renders with correct data-testid', () => {
+      const conflicts = [{ severity: 'error' }]
+      render(<ConflictSummary conflicts={conflicts} />)
+      expect(screen.getByTestId('conflict-summary')).toBeInTheDocument()
+    })
+
+    it('does not render when conflicts array is empty', () => {
+      render(<ConflictSummary conflicts={[]} />)
+      expect(screen.queryByTestId('conflict-summary')).not.toBeInTheDocument()
+    })
+
+    it('displays total conflict count', () => {
+      const conflicts = [
+        { severity: 'error' },
+        { severity: 'warning' },
+        { severity: 'error' },
+      ]
+      render(<ConflictSummary conflicts={conflicts} />)
+      expect(screen.getByText('3 conflicts')).toBeInTheDocument()
+    })
+
+    it('uses singular form for single conflict', () => {
+      const conflicts = [{ severity: 'error' }]
+      render(<ConflictSummary conflicts={conflicts} />)
+      expect(screen.getByText('1 conflict')).toBeInTheDocument()
+    })
+  })
+
+  describe('Breakdown Display', () => {
+    it('shows collision count', () => {
+      const conflicts = [{ severity: 'error' }, { severity: 'error' }]
+      render(<ConflictSummary conflicts={conflicts} />)
+      expect(screen.getByText('2 collisions')).toBeInTheDocument()
+    })
+
+    it('shows warning count', () => {
+      const conflicts = [{ severity: 'warning' }, { severity: 'warning' }]
+      render(<ConflictSummary conflicts={conflicts} />)
+      expect(screen.getByText('2 warnings')).toBeInTheDocument()
+    })
+
+    it('shows both collision and warning counts', () => {
+      const conflicts = [
+        { severity: 'error' },
+        { severity: 'warning' },
+        { severity: 'warning' },
+      ]
+      render(<ConflictSummary conflicts={conflicts} />)
+      expect(screen.getByText(/1 collision/)).toBeInTheDocument()
+      expect(screen.getByText(/2 warnings/)).toBeInTheDocument()
+    })
+
+    it('uses singular form for single collision', () => {
+      const conflicts = [{ severity: 'error' }]
+      render(<ConflictSummary conflicts={conflicts} />)
+      expect(screen.getByText('1 collision')).toBeInTheDocument()
+    })
+
+    it('uses singular form for single warning', () => {
+      const conflicts = [{ severity: 'warning' }]
+      render(<ConflictSummary conflicts={conflicts} />)
+      expect(screen.getByText('1 warning')).toBeInTheDocument()
+    })
+  })
+
+  describe('Styling', () => {
+    it('has red border styling', () => {
+      const conflicts = [{ severity: 'error' }]
+      render(<ConflictSummary conflicts={conflicts} />)
+      const banner = screen.getByTestId('conflict-summary')
+      expect(banner).toHaveClass('border')
+      expect(banner).toHaveClass('border-red-900/50')
+    })
+
+    it('has red text for total count', () => {
+      const conflicts = [{ severity: 'error' }]
+      render(<ConflictSummary conflicts={conflicts} />)
+      const totalText = screen.getByText('1 conflict')
+      expect(totalText).toHaveClass('text-red-400')
+    })
+
+    it('has gray text for breakdown', () => {
+      const conflicts = [{ severity: 'error' }]
+      render(<ConflictSummary conflicts={conflicts} />)
+      const breakdownText = screen.getByText('1 collision')
+      expect(breakdownText).toHaveClass('text-gray-500')
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('has role="status"', () => {
+      const conflicts = [{ severity: 'error' }]
+      render(<ConflictSummary conflicts={conflicts} />)
+      expect(screen.getByRole('status')).toBeInTheDocument()
+    })
+
+    it('has descriptive aria-label', () => {
+      const conflicts = [
+        { severity: 'error' },
+        { severity: 'warning' },
+      ]
+      render(<ConflictSummary conflicts={conflicts} />)
+      const banner = screen.getByRole('status')
+      expect(banner).toHaveAttribute(
+        'aria-label',
+        '2 conflicts: 1 collision, 1 warning'
+      )
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/components/scheduler/DayTimeline/__tests__/DayTimeline.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/DayTimeline/__tests__/DayTimeline.test.jsx
@@ -4,52 +4,17 @@
 
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import DayTimeline from '../DayTimeline'
+import {
+  mockDate,
+  mockExecutions,
+  mockConflicts,
+  mockErrorConflict,
+  mockWarningConflict,
+} from './testFixtures'
 
 describe('DayTimeline', () => {
-  const mockDate = '2025-12-17'
-
-  const mockExecutions = [
-    {
-      pattern_id: 'routine-1',
-      pattern_name: 'Photo Capture',
-      start_time: '2025-12-17T18:00:00Z',
-      actions: [{ action_name: 'Take Photo', action_type: 'camera' }],
-    },
-    {
-      pattern_id: 'routine-2',
-      pattern_name: 'Attract On',
-      start_time: '2025-12-17T18:15:00Z',
-      actions: [{ action_name: 'Attract On', action_type: 'gpio' }],
-    },
-    {
-      pattern_id: 'routine-3',
-      pattern_name: 'Evening Photo',
-      start_time: '2025-12-17T19:00:00Z',
-      actions: [{ action_name: 'Take Photo', action_type: 'camera' }],
-    },
-    {
-      pattern_id: 'routine-4',
-      pattern_name: 'HDR Shot',
-      start_time: '2025-12-17T19:00:00Z',
-      actions: [{ action_name: 'HDR Bracket', action_type: 'camera' }],
-    },
-  ]
-
-  const mockConflicts = [
-    {
-      id: 'c1',
-      conflict_type: 'time_overlap',
-      severity: 'error',
-      event1_id: 'routine-3',
-      event1_name: 'Evening Photo',
-      event2_id: 'routine-4',
-      event2_name: 'HDR Shot',
-      start_time: '2025-12-17T19:00:00Z',
-      end_time: '2025-12-17T19:15:00Z',
-      message: 'camera busy',
-    },
-  ]
 
   describe('Rendering', () => {
     it('renders with correct data-testid', () => {
@@ -201,21 +166,11 @@ describe('DayTimeline', () => {
     })
 
     it('applies yellow highlighting for warning conflicts', () => {
-      const warningConflict = [
-        {
-          id: 'c2',
-          conflict_type: 'gpio_state_conflict',
-          severity: 'warning',
-          event1_id: 'routine-2',
-          start_time: '2025-12-17T18:15:00Z',
-          message: 'unexpected',
-        },
-      ]
       render(
         <DayTimeline
           date={mockDate}
           executions={mockExecutions}
-          conflicts={warningConflict}
+          conflicts={[mockWarningConflict]}
         />
       )
       const row18 = screen.getByTestId('hour-row-18')
@@ -284,6 +239,142 @@ describe('DayTimeline', () => {
       const grid = row0.parentElement
       expect(grid).toHaveClass('divide-y')
       expect(grid).toHaveClass('divide-gray-800')
+    })
+  })
+
+  describe('Complete Conflict Flow (Integration)', () => {
+    it('displays complete conflict visualization flow', () => {
+      render(
+        <DayTimeline
+          date={mockDate}
+          executions={mockExecutions}
+          conflicts={mockConflicts}
+        />
+      )
+
+      // 1. Conflict summary displayed
+      expect(screen.getByTestId('conflict-summary')).toBeInTheDocument()
+
+      // 2. Hour row highlighted with red background
+      const hourRow = screen.getByTestId('hour-row-19')
+      expect(hourRow).toHaveClass('bg-red-950/20')
+
+      // 3. Execution chip has red ring
+      const chip = screen.getByTestId('execution-routine-3-1900')
+      expect(chip).toHaveClass('ring-1')
+      expect(chip).toHaveClass('ring-red-400')
+
+      // 4. Conflict message displayed
+      expect(screen.getByText('camera busy')).toBeInTheDocument()
+    })
+
+    it('displays complete warning conflict visualization flow', () => {
+      render(
+        <DayTimeline
+          date={mockDate}
+          executions={mockExecutions}
+          conflicts={[mockWarningConflict]}
+        />
+      )
+
+      // 1. Conflict summary displayed
+      expect(screen.getByTestId('conflict-summary')).toBeInTheDocument()
+
+      // 2. Hour row highlighted with yellow background
+      const hourRow = screen.getByTestId('hour-row-18')
+      expect(hourRow).toHaveClass('bg-yellow-950/20')
+
+      // 3. Execution chip has yellow ring
+      const chip = screen.getByTestId('execution-routine-2-1815')
+      expect(chip).toHaveClass('ring-1')
+      expect(chip).toHaveClass('ring-yellow-400')
+
+      // 4. Conflict message displayed
+      expect(screen.getByText('unexpected GPIO state')).toBeInTheDocument()
+    })
+
+    it('handles mixed error and warning conflicts', () => {
+      render(
+        <DayTimeline
+          date={mockDate}
+          executions={mockExecutions}
+          conflicts={[mockErrorConflict, mockWarningConflict]}
+        />
+      )
+
+      // Both conflict types should be visible
+      expect(screen.getByTestId('hour-row-19')).toHaveClass('bg-red-950/20')
+      expect(screen.getByTestId('hour-row-18')).toHaveClass('bg-yellow-950/20')
+
+      // Conflict summary should show 2 conflicts
+      expect(screen.getByText('2 conflicts')).toBeInTheDocument()
+    })
+  })
+
+  describe('Keyboard Navigation', () => {
+    it('allows focus on execution chips', () => {
+      render(<DayTimeline date={mockDate} executions={mockExecutions} />)
+
+      const chip1 = screen.getByTestId('execution-routine-1-1800')
+      chip1.focus()
+      expect(chip1).toHaveFocus()
+    })
+
+    it('supports Enter key to activate chip', () => {
+      const handleClick = vi.fn()
+      render(
+        <DayTimeline
+          date={mockDate}
+          executions={mockExecutions}
+          onExecutionClick={handleClick}
+        />
+      )
+
+      const chip = screen.getByTestId('execution-routine-1-1800')
+      chip.focus()
+      fireEvent.keyDown(chip, { key: 'Enter' })
+
+      expect(handleClick).toHaveBeenCalledWith(mockExecutions[0])
+    })
+
+    it('supports Space key to activate chip', () => {
+      const handleClick = vi.fn()
+      render(
+        <DayTimeline
+          date={mockDate}
+          executions={mockExecutions}
+          onExecutionClick={handleClick}
+        />
+      )
+
+      const chip = screen.getByTestId('execution-routine-1-1800')
+      chip.focus()
+      fireEvent.keyDown(chip, { key: ' ' })
+
+      expect(handleClick).toHaveBeenCalledWith(mockExecutions[0])
+    })
+
+    it('allows tab navigation between execution chips', async () => {
+      const user = userEvent.setup()
+      render(<DayTimeline date={mockDate} executions={mockExecutions} />)
+
+      const chip1 = screen.getByTestId('execution-routine-1-1800')
+      const chip2 = screen.getByTestId('execution-routine-2-1815')
+
+      // Focus first chip and tab to next
+      chip1.focus()
+      expect(chip1).toHaveFocus()
+
+      await user.tab()
+      expect(chip2).toHaveFocus()
+    })
+
+    it('execution chips are focusable buttons', () => {
+      render(<DayTimeline date={mockDate} executions={mockExecutions} />)
+
+      const chip = screen.getByTestId('execution-routine-1-1800')
+      expect(chip.tagName).toBe('BUTTON')
+      expect(chip).toHaveAttribute('type', 'button')
     })
   })
 })

--- a/Firmware/webui/frontend/src/components/scheduler/DayTimeline/__tests__/DayTimeline.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/DayTimeline/__tests__/DayTimeline.test.jsx
@@ -1,0 +1,289 @@
+/**
+ * Tests for DayTimeline component (Issue #326)
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import DayTimeline from '../DayTimeline'
+
+describe('DayTimeline', () => {
+  const mockDate = '2025-12-17'
+
+  const mockExecutions = [
+    {
+      pattern_id: 'routine-1',
+      pattern_name: 'Photo Capture',
+      start_time: '2025-12-17T18:00:00Z',
+      actions: [{ action_name: 'Take Photo', action_type: 'camera' }],
+    },
+    {
+      pattern_id: 'routine-2',
+      pattern_name: 'Attract On',
+      start_time: '2025-12-17T18:15:00Z',
+      actions: [{ action_name: 'Attract On', action_type: 'gpio' }],
+    },
+    {
+      pattern_id: 'routine-3',
+      pattern_name: 'Evening Photo',
+      start_time: '2025-12-17T19:00:00Z',
+      actions: [{ action_name: 'Take Photo', action_type: 'camera' }],
+    },
+    {
+      pattern_id: 'routine-4',
+      pattern_name: 'HDR Shot',
+      start_time: '2025-12-17T19:00:00Z',
+      actions: [{ action_name: 'HDR Bracket', action_type: 'camera' }],
+    },
+  ]
+
+  const mockConflicts = [
+    {
+      id: 'c1',
+      conflict_type: 'time_overlap',
+      severity: 'error',
+      event1_id: 'routine-3',
+      event1_name: 'Evening Photo',
+      event2_id: 'routine-4',
+      event2_name: 'HDR Shot',
+      start_time: '2025-12-17T19:00:00Z',
+      end_time: '2025-12-17T19:15:00Z',
+      message: 'camera busy',
+    },
+  ]
+
+  describe('Rendering', () => {
+    it('renders with correct data-testid', () => {
+      render(<DayTimeline date={mockDate} executions={mockExecutions} />)
+      expect(screen.getByTestId('day-timeline')).toBeInTheDocument()
+    })
+
+    it('renders 24 hour rows', () => {
+      render(<DayTimeline date={mockDate} executions={mockExecutions} />)
+      for (let hour = 0; hour < 24; hour++) {
+        expect(screen.getByTestId(`hour-row-${hour}`)).toBeInTheDocument()
+      }
+    })
+
+    it('renders executions in correct hour rows', () => {
+      render(<DayTimeline date={mockDate} executions={mockExecutions} />)
+
+      // Hour 18 should have 2 executions
+      const row18 = screen.getByTestId('hour-row-18')
+      expect(within(row18).getByTestId('execution-routine-1-1800')).toBeInTheDocument()
+      expect(within(row18).getByTestId('execution-routine-2-1815')).toBeInTheDocument()
+
+      // Hour 19 should have 2 executions
+      const row19 = screen.getByTestId('hour-row-19')
+      expect(within(row19).getByTestId('execution-routine-3-1900')).toBeInTheDocument()
+      expect(within(row19).getByTestId('execution-routine-4-1900')).toBeInTheDocument()
+    })
+
+    it('shows empty state when no executions', () => {
+      render(<DayTimeline date={mockDate} executions={[]} />)
+      expect(screen.getByTestId('day-timeline-empty')).toBeInTheDocument()
+      expect(screen.getByText('No scheduled events')).toBeInTheDocument()
+    })
+
+    it('shows empty state when executions is undefined', () => {
+      render(<DayTimeline date={mockDate} />)
+      expect(screen.getByTestId('day-timeline-empty')).toBeInTheDocument()
+    })
+
+    it('has correct aria-label', () => {
+      render(<DayTimeline date={mockDate} executions={mockExecutions} />)
+      expect(screen.getByTestId('day-timeline')).toHaveAttribute(
+        'aria-label',
+        'Day timeline for 2025-12-17'
+      )
+    })
+  })
+
+  describe('Legend', () => {
+    it('renders legend with Camera label', () => {
+      render(<DayTimeline date={mockDate} executions={mockExecutions} />)
+      expect(screen.getByText('Camera')).toBeInTheDocument()
+    })
+
+    it('renders legend with GPIO label', () => {
+      render(<DayTimeline date={mockDate} executions={mockExecutions} />)
+      expect(screen.getByText('GPIO')).toBeInTheDocument()
+    })
+
+    it('renders legend with Collision label', () => {
+      render(<DayTimeline date={mockDate} executions={mockExecutions} />)
+      expect(screen.getByText('Collision')).toBeInTheDocument()
+    })
+
+    it('renders legend with Warning label', () => {
+      render(<DayTimeline date={mockDate} executions={mockExecutions} />)
+      expect(screen.getByText('Warning')).toBeInTheDocument()
+    })
+  })
+
+  describe('Conflict Summary', () => {
+    it('shows conflict summary when conflicts exist', () => {
+      render(
+        <DayTimeline
+          date={mockDate}
+          executions={mockExecutions}
+          conflicts={mockConflicts}
+        />
+      )
+      expect(screen.getByTestId('conflict-summary')).toBeInTheDocument()
+    })
+
+    it('does not show conflict summary when no conflicts', () => {
+      render(
+        <DayTimeline date={mockDate} executions={mockExecutions} conflicts={[]} />
+      )
+      expect(screen.queryByTestId('conflict-summary')).not.toBeInTheDocument()
+    })
+
+    it('shows correct conflict count', () => {
+      render(
+        <DayTimeline
+          date={mockDate}
+          executions={mockExecutions}
+          conflicts={mockConflicts}
+        />
+      )
+      expect(screen.getByText('1 conflict')).toBeInTheDocument()
+    })
+  })
+
+  describe('Conflict Highlighting', () => {
+    it('applies red background to hour with error conflict', () => {
+      render(
+        <DayTimeline
+          date={mockDate}
+          executions={mockExecutions}
+          conflicts={mockConflicts}
+        />
+      )
+      const row19 = screen.getByTestId('hour-row-19')
+      expect(row19).toHaveClass('bg-red-950/20')
+    })
+
+    it('shows conflict message in affected hour row', () => {
+      render(
+        <DayTimeline
+          date={mockDate}
+          executions={mockExecutions}
+          conflicts={mockConflicts}
+        />
+      )
+      expect(screen.getByText('camera busy')).toBeInTheDocument()
+    })
+
+    it('applies red ring to conflicting execution chips', () => {
+      render(
+        <DayTimeline
+          date={mockDate}
+          executions={mockExecutions}
+          conflicts={mockConflicts}
+        />
+      )
+      const chip = screen.getByTestId('execution-routine-3-1900')
+      expect(chip).toHaveClass('ring-1')
+      expect(chip).toHaveClass('ring-red-400')
+    })
+
+    it('does not highlight non-conflicting executions', () => {
+      render(
+        <DayTimeline
+          date={mockDate}
+          executions={mockExecutions}
+          conflicts={mockConflicts}
+        />
+      )
+      const chip = screen.getByTestId('execution-routine-1-1800')
+      expect(chip).not.toHaveClass('ring-1')
+    })
+
+    it('applies yellow highlighting for warning conflicts', () => {
+      const warningConflict = [
+        {
+          id: 'c2',
+          conflict_type: 'gpio_state_conflict',
+          severity: 'warning',
+          event1_id: 'routine-2',
+          start_time: '2025-12-17T18:15:00Z',
+          message: 'unexpected',
+        },
+      ]
+      render(
+        <DayTimeline
+          date={mockDate}
+          executions={mockExecutions}
+          conflicts={warningConflict}
+        />
+      )
+      const row18 = screen.getByTestId('hour-row-18')
+      expect(row18).toHaveClass('bg-yellow-950/20')
+    })
+  })
+
+  describe('Interaction', () => {
+    it('calls onExecutionClick when chip is clicked', () => {
+      const handleClick = vi.fn()
+      render(
+        <DayTimeline
+          date={mockDate}
+          executions={mockExecutions}
+          onExecutionClick={handleClick}
+        />
+      )
+      fireEvent.click(screen.getByTestId('execution-routine-1-1800'))
+      expect(handleClick).toHaveBeenCalledTimes(1)
+      expect(handleClick).toHaveBeenCalledWith(mockExecutions[0])
+    })
+
+    it('does not throw when onExecutionClick is not provided', () => {
+      render(<DayTimeline date={mockDate} executions={mockExecutions} />)
+      expect(() => {
+        fireEvent.click(screen.getByTestId('execution-routine-1-1800'))
+      }).not.toThrow()
+    })
+  })
+
+  describe('Date Filtering', () => {
+    it('only shows executions for the specified date', () => {
+      const mixedDateExecutions = [
+        ...mockExecutions,
+        {
+          pattern_id: 'routine-5',
+          pattern_name: 'Tomorrow Photo',
+          start_time: '2025-12-18T18:00:00Z',
+          actions: [{ action_name: 'Take Photo', action_type: 'camera' }],
+        },
+      ]
+      render(<DayTimeline date={mockDate} executions={mixedDateExecutions} />)
+
+      // Should have executions from 2025-12-17
+      expect(screen.getByTestId('execution-routine-1-1800')).toBeInTheDocument()
+
+      // Should not have execution from 2025-12-18
+      expect(screen.queryByTestId('execution-routine-5-1800')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Timeline Grid Styling', () => {
+    it('has border around timeline grid', () => {
+      render(<DayTimeline date={mockDate} executions={mockExecutions} />)
+      // Find the grid container (parent of hour rows)
+      const row0 = screen.getByTestId('hour-row-0')
+      const grid = row0.parentElement
+      expect(grid).toHaveClass('border')
+      expect(grid).toHaveClass('border-gray-800')
+      expect(grid).toHaveClass('rounded-lg')
+    })
+
+    it('has dividers between hours', () => {
+      render(<DayTimeline date={mockDate} executions={mockExecutions} />)
+      const row0 = screen.getByTestId('hour-row-0')
+      const grid = row0.parentElement
+      expect(grid).toHaveClass('divide-y')
+      expect(grid).toHaveClass('divide-gray-800')
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/components/scheduler/DayTimeline/__tests__/ExecutionChip.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/DayTimeline/__tests__/ExecutionChip.test.jsx
@@ -1,0 +1,186 @@
+/**
+ * Tests for ExecutionChip component (Issue #326)
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import ExecutionChip from '../ExecutionChip'
+
+describe('ExecutionChip', () => {
+  const mockExecution = {
+    pattern_id: 'routine-1',
+    pattern_name: 'Photo Capture',
+    start_time: '2025-12-17T18:30:00Z',
+    actions: [
+      {
+        time: '2025-12-17T18:30:00Z',
+        action_name: 'Take Photo',
+        action_type: 'camera',
+        offset_minutes: 0,
+      },
+    ],
+  }
+
+  describe('Rendering', () => {
+    it('renders with correct data-testid', () => {
+      render(<ExecutionChip execution={mockExecution} />)
+      expect(screen.getByTestId('execution-routine-1-1830')).toBeInTheDocument()
+    })
+
+    it('displays time and action name', () => {
+      render(<ExecutionChip execution={mockExecution} />)
+      const chip = screen.getByRole('button')
+      expect(chip).toHaveTextContent('18:30')
+      expect(chip).toHaveTextContent('Take Photo')
+    })
+
+    it('displays pattern name when no actions', () => {
+      const execution = {
+        pattern_id: 'routine-1',
+        pattern_name: 'Photo Capture',
+        start_time: '2025-12-17T18:30:00Z',
+      }
+      render(<ExecutionChip execution={execution} />)
+      const chip = screen.getByRole('button')
+      expect(chip).toHaveTextContent('18:30')
+      expect(chip).toHaveTextContent('Photo Capture')
+    })
+
+    it('has correct aria-label', () => {
+      render(<ExecutionChip execution={mockExecution} />)
+      const chip = screen.getByRole('button')
+      expect(chip).toHaveAttribute('aria-label', 'Photo Capture at 18:30')
+    })
+
+    it('has correct title attribute', () => {
+      render(<ExecutionChip execution={mockExecution} />)
+      const chip = screen.getByRole('button')
+      expect(chip).toHaveAttribute('title', 'Photo Capture at 18:30')
+    })
+  })
+
+  describe('Action Type Colors', () => {
+    it('applies camera colors for camera type', () => {
+      render(<ExecutionChip execution={mockExecution} />)
+      const chip = screen.getByRole('button')
+      expect(chip).toHaveClass('bg-blue-500/20')
+      expect(chip).toHaveClass('text-blue-400')
+    })
+
+    it('applies gpio colors for gpio type', () => {
+      const gpioExecution = {
+        ...mockExecution,
+        actions: [
+          {
+            action_name: 'Attract On',
+            action_type: 'gpio',
+          },
+        ],
+      }
+      render(<ExecutionChip execution={gpioExecution} />)
+      const chip = screen.getByRole('button')
+      expect(chip).toHaveClass('bg-orange-500/20')
+      expect(chip).toHaveClass('text-orange-400')
+    })
+
+    it('applies hdr colors for HDR action names', () => {
+      const hdrExecution = {
+        ...mockExecution,
+        actions: [
+          {
+            action_name: 'HDR Bracket',
+            action_type: 'camera',
+          },
+        ],
+      }
+      render(<ExecutionChip execution={hdrExecution} />)
+      const chip = screen.getByRole('button')
+      expect(chip).toHaveClass('bg-purple-500/20')
+      expect(chip).toHaveClass('text-purple-400')
+    })
+  })
+
+  describe('Conflict Highlighting', () => {
+    it('applies red ring for error conflict', () => {
+      render(<ExecutionChip execution={mockExecution} conflictSeverity="error" />)
+      const chip = screen.getByRole('button')
+      expect(chip).toHaveClass('ring-1')
+      expect(chip).toHaveClass('ring-red-400')
+    })
+
+    it('applies yellow ring for warning conflict', () => {
+      render(<ExecutionChip execution={mockExecution} conflictSeverity="warning" />)
+      const chip = screen.getByRole('button')
+      expect(chip).toHaveClass('ring-1')
+      expect(chip).toHaveClass('ring-yellow-400')
+    })
+
+    it('has no ring when no conflict', () => {
+      render(<ExecutionChip execution={mockExecution} />)
+      const chip = screen.getByRole('button')
+      expect(chip).not.toHaveClass('ring-1')
+    })
+
+    it('includes conflict in aria-label', () => {
+      render(<ExecutionChip execution={mockExecution} conflictSeverity="error" />)
+      const chip = screen.getByRole('button')
+      expect(chip).toHaveAttribute(
+        'aria-label',
+        'Photo Capture at 18:30 - error conflict'
+      )
+    })
+  })
+
+  describe('Interaction', () => {
+    it('calls onClick when clicked', () => {
+      const handleClick = vi.fn()
+      render(<ExecutionChip execution={mockExecution} onClick={handleClick} />)
+      fireEvent.click(screen.getByRole('button'))
+      expect(handleClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('calls onClick on Enter key', () => {
+      const handleClick = vi.fn()
+      render(<ExecutionChip execution={mockExecution} onClick={handleClick} />)
+      fireEvent.keyDown(screen.getByRole('button'), { key: 'Enter' })
+      expect(handleClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('calls onClick on Space key', () => {
+      const handleClick = vi.fn()
+      render(<ExecutionChip execution={mockExecution} onClick={handleClick} />)
+      fireEvent.keyDown(screen.getByRole('button'), { key: ' ' })
+      expect(handleClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not throw when onClick is not provided', () => {
+      render(<ExecutionChip execution={mockExecution} />)
+      expect(() => {
+        fireEvent.click(screen.getByRole('button'))
+      }).not.toThrow()
+    })
+
+    it('has cursor-pointer when onClick is provided', () => {
+      const handleClick = vi.fn()
+      render(<ExecutionChip execution={mockExecution} onClick={handleClick} />)
+      const chip = screen.getByRole('button')
+      expect(chip).toHaveClass('cursor-pointer')
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('is focusable', () => {
+      render(<ExecutionChip execution={mockExecution} />)
+      const chip = screen.getByRole('button')
+      chip.focus()
+      expect(chip).toHaveFocus()
+    })
+
+    it('has focus ring styles', () => {
+      render(<ExecutionChip execution={mockExecution} />)
+      const chip = screen.getByRole('button')
+      expect(chip).toHaveClass('focus:outline-none')
+      expect(chip).toHaveClass('focus:ring-2')
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/components/scheduler/DayTimeline/__tests__/ExecutionChip.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/DayTimeline/__tests__/ExecutionChip.test.jsx
@@ -5,41 +5,48 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import ExecutionChip from '../ExecutionChip'
+import {
+  mockHdrExecution,
+  mockGpioExecution,
+  createExecution,
+} from './testFixtures'
 
 describe('ExecutionChip', () => {
-  const mockExecution = {
+  // Create a specific execution for chip tests (18:30 time for testid consistency)
+  const chipExecution = createExecution({
     pattern_id: 'routine-1',
     pattern_name: 'Photo Capture',
-    start_time: '2025-12-17T18:30:00Z',
+    start_time: '2025-12-17T18:30:00',
     actions: [
       {
-        time: '2025-12-17T18:30:00Z',
+        time: '2025-12-17T18:30:00',
         action_name: 'Take Photo',
         action_type: 'camera',
         offset_minutes: 0,
       },
     ],
-  }
+  })
 
   describe('Rendering', () => {
     it('renders with correct data-testid', () => {
-      render(<ExecutionChip execution={mockExecution} />)
+      render(<ExecutionChip execution={chipExecution} />)
       expect(screen.getByTestId('execution-routine-1-1830')).toBeInTheDocument()
     })
 
     it('displays time and action name', () => {
-      render(<ExecutionChip execution={mockExecution} />)
+      render(<ExecutionChip execution={chipExecution} />)
       const chip = screen.getByRole('button')
       expect(chip).toHaveTextContent('18:30')
       expect(chip).toHaveTextContent('Take Photo')
     })
 
     it('displays pattern name when no actions', () => {
-      const execution = {
+      const execution = createExecution({
         pattern_id: 'routine-1',
         pattern_name: 'Photo Capture',
-        start_time: '2025-12-17T18:30:00Z',
-      }
+        start_time: '2025-12-17T18:30:00',
+        actions: undefined,
+      })
       render(<ExecutionChip execution={execution} />)
       const chip = screen.getByRole('button')
       expect(chip).toHaveTextContent('18:30')
@@ -47,13 +54,13 @@ describe('ExecutionChip', () => {
     })
 
     it('has correct aria-label', () => {
-      render(<ExecutionChip execution={mockExecution} />)
+      render(<ExecutionChip execution={chipExecution} />)
       const chip = screen.getByRole('button')
       expect(chip).toHaveAttribute('aria-label', 'Photo Capture at 18:30')
     })
 
     it('has correct title attribute', () => {
-      render(<ExecutionChip execution={mockExecution} />)
+      render(<ExecutionChip execution={chipExecution} />)
       const chip = screen.getByRole('button')
       expect(chip).toHaveAttribute('title', 'Photo Capture at 18:30')
     })
@@ -61,39 +68,21 @@ describe('ExecutionChip', () => {
 
   describe('Action Type Colors', () => {
     it('applies camera colors for camera type', () => {
-      render(<ExecutionChip execution={mockExecution} />)
+      render(<ExecutionChip execution={chipExecution} />)
       const chip = screen.getByRole('button')
       expect(chip).toHaveClass('bg-blue-500/20')
       expect(chip).toHaveClass('text-blue-400')
     })
 
     it('applies gpio colors for gpio type', () => {
-      const gpioExecution = {
-        ...mockExecution,
-        actions: [
-          {
-            action_name: 'Attract On',
-            action_type: 'gpio',
-          },
-        ],
-      }
-      render(<ExecutionChip execution={gpioExecution} />)
+      render(<ExecutionChip execution={mockGpioExecution} />)
       const chip = screen.getByRole('button')
       expect(chip).toHaveClass('bg-orange-500/20')
       expect(chip).toHaveClass('text-orange-400')
     })
 
     it('applies hdr colors for HDR action names', () => {
-      const hdrExecution = {
-        ...mockExecution,
-        actions: [
-          {
-            action_name: 'HDR Bracket',
-            action_type: 'camera',
-          },
-        ],
-      }
-      render(<ExecutionChip execution={hdrExecution} />)
+      render(<ExecutionChip execution={mockHdrExecution} />)
       const chip = screen.getByRole('button')
       expect(chip).toHaveClass('bg-purple-500/20')
       expect(chip).toHaveClass('text-purple-400')
@@ -102,27 +91,27 @@ describe('ExecutionChip', () => {
 
   describe('Conflict Highlighting', () => {
     it('applies red ring for error conflict', () => {
-      render(<ExecutionChip execution={mockExecution} conflictSeverity="error" />)
+      render(<ExecutionChip execution={chipExecution} conflictSeverity="error" />)
       const chip = screen.getByRole('button')
       expect(chip).toHaveClass('ring-1')
       expect(chip).toHaveClass('ring-red-400')
     })
 
     it('applies yellow ring for warning conflict', () => {
-      render(<ExecutionChip execution={mockExecution} conflictSeverity="warning" />)
+      render(<ExecutionChip execution={chipExecution} conflictSeverity="warning" />)
       const chip = screen.getByRole('button')
       expect(chip).toHaveClass('ring-1')
       expect(chip).toHaveClass('ring-yellow-400')
     })
 
     it('has no ring when no conflict', () => {
-      render(<ExecutionChip execution={mockExecution} />)
+      render(<ExecutionChip execution={chipExecution} />)
       const chip = screen.getByRole('button')
       expect(chip).not.toHaveClass('ring-1')
     })
 
     it('includes conflict in aria-label', () => {
-      render(<ExecutionChip execution={mockExecution} conflictSeverity="error" />)
+      render(<ExecutionChip execution={chipExecution} conflictSeverity="error" />)
       const chip = screen.getByRole('button')
       expect(chip).toHaveAttribute(
         'aria-label',
@@ -134,27 +123,27 @@ describe('ExecutionChip', () => {
   describe('Interaction', () => {
     it('calls onClick when clicked', () => {
       const handleClick = vi.fn()
-      render(<ExecutionChip execution={mockExecution} onClick={handleClick} />)
+      render(<ExecutionChip execution={chipExecution} onClick={handleClick} />)
       fireEvent.click(screen.getByRole('button'))
       expect(handleClick).toHaveBeenCalledTimes(1)
     })
 
     it('calls onClick on Enter key', () => {
       const handleClick = vi.fn()
-      render(<ExecutionChip execution={mockExecution} onClick={handleClick} />)
+      render(<ExecutionChip execution={chipExecution} onClick={handleClick} />)
       fireEvent.keyDown(screen.getByRole('button'), { key: 'Enter' })
       expect(handleClick).toHaveBeenCalledTimes(1)
     })
 
     it('calls onClick on Space key', () => {
       const handleClick = vi.fn()
-      render(<ExecutionChip execution={mockExecution} onClick={handleClick} />)
+      render(<ExecutionChip execution={chipExecution} onClick={handleClick} />)
       fireEvent.keyDown(screen.getByRole('button'), { key: ' ' })
       expect(handleClick).toHaveBeenCalledTimes(1)
     })
 
     it('does not throw when onClick is not provided', () => {
-      render(<ExecutionChip execution={mockExecution} />)
+      render(<ExecutionChip execution={chipExecution} />)
       expect(() => {
         fireEvent.click(screen.getByRole('button'))
       }).not.toThrow()
@@ -162,7 +151,7 @@ describe('ExecutionChip', () => {
 
     it('has cursor-pointer when onClick is provided', () => {
       const handleClick = vi.fn()
-      render(<ExecutionChip execution={mockExecution} onClick={handleClick} />)
+      render(<ExecutionChip execution={chipExecution} onClick={handleClick} />)
       const chip = screen.getByRole('button')
       expect(chip).toHaveClass('cursor-pointer')
     })
@@ -170,14 +159,14 @@ describe('ExecutionChip', () => {
 
   describe('Accessibility', () => {
     it('is focusable', () => {
-      render(<ExecutionChip execution={mockExecution} />)
+      render(<ExecutionChip execution={chipExecution} />)
       const chip = screen.getByRole('button')
       chip.focus()
       expect(chip).toHaveFocus()
     })
 
     it('has focus ring styles', () => {
-      render(<ExecutionChip execution={mockExecution} />)
+      render(<ExecutionChip execution={chipExecution} />)
       const chip = screen.getByRole('button')
       expect(chip).toHaveClass('focus:outline-none')
       expect(chip).toHaveClass('focus:ring-2')

--- a/Firmware/webui/frontend/src/components/scheduler/DayTimeline/__tests__/HourRow.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/DayTimeline/__tests__/HourRow.test.jsx
@@ -5,22 +5,15 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import HourRow from '../HourRow'
+import {
+  mockExecutions,
+  mockErrorConflict,
+  mockWarningConflict,
+} from './testFixtures'
 
 describe('HourRow', () => {
-  const mockExecutions = [
-    {
-      pattern_id: 'routine-1',
-      pattern_name: 'Photo Capture',
-      start_time: '2025-12-17T18:00:00Z',
-      actions: [{ action_name: 'Take Photo', action_type: 'camera' }],
-    },
-    {
-      pattern_id: 'routine-2',
-      pattern_name: 'Attract On',
-      start_time: '2025-12-17T18:15:00Z',
-      actions: [{ action_name: 'Attract On', action_type: 'gpio' }],
-    },
-  ]
+  // Use first two executions from fixtures for hour row tests
+  const hourExecutions = mockExecutions.slice(0, 2)
 
   describe('Rendering', () => {
     it('renders with correct data-testid', () => {
@@ -44,7 +37,7 @@ describe('HourRow', () => {
     })
 
     it('renders ExecutionChip for each execution', () => {
-      render(<HourRow hour={18} executions={mockExecutions} />)
+      render(<HourRow hour={18} executions={hourExecutions} />)
       expect(screen.getByTestId('execution-routine-1-1800')).toBeInTheDocument()
       expect(screen.getByTestId('execution-routine-2-1815')).toBeInTheDocument()
     })
@@ -61,57 +54,43 @@ describe('HourRow', () => {
   })
 
   describe('Conflict Highlighting', () => {
-    const errorConflict = {
-      id: 'c1',
-      severity: 'error',
-      message: 'camera busy',
-      conflict_type: 'time_overlap',
-    }
-
-    const warningConflict = {
-      id: 'c2',
-      severity: 'warning',
-      message: 'unexpected',
-      conflict_type: 'gpio_state_conflict',
-    }
-
     it('applies red background for error conflict', () => {
-      render(<HourRow hour={19} executions={mockExecutions} conflict={errorConflict} />)
+      render(<HourRow hour={19} executions={hourExecutions} conflict={mockErrorConflict} />)
       const row = screen.getByTestId('hour-row-19')
       expect(row).toHaveClass('bg-red-950/20')
     })
 
     it('applies yellow background for warning conflict', () => {
-      render(<HourRow hour={21} executions={mockExecutions} conflict={warningConflict} />)
+      render(<HourRow hour={21} executions={hourExecutions} conflict={mockWarningConflict} />)
       const row = screen.getByTestId('hour-row-21')
       expect(row).toHaveClass('bg-yellow-950/20')
     })
 
     it('changes hour label color for error conflict', () => {
-      render(<HourRow hour={19} executions={mockExecutions} conflict={errorConflict} />)
+      render(<HourRow hour={19} executions={hourExecutions} conflict={mockErrorConflict} />)
       const label = screen.getByText('19:00')
       expect(label).toHaveClass('text-red-400')
     })
 
     it('changes hour label color for warning conflict', () => {
-      render(<HourRow hour={21} executions={mockExecutions} conflict={warningConflict} />)
+      render(<HourRow hour={21} executions={hourExecutions} conflict={mockWarningConflict} />)
       const label = screen.getByText('21:00')
       expect(label).toHaveClass('text-yellow-400')
     })
 
     it('displays inline conflict message', () => {
-      render(<HourRow hour={19} executions={mockExecutions} conflict={errorConflict} />)
+      render(<HourRow hour={19} executions={hourExecutions} conflict={mockErrorConflict} />)
       expect(screen.getByText('camera busy')).toBeInTheDocument()
     })
 
     it('has conflict data-testid', () => {
-      render(<HourRow hour={19} executions={mockExecutions} conflict={errorConflict} />)
+      render(<HourRow hour={19} executions={hourExecutions} conflict={mockErrorConflict} />)
       expect(screen.getByTestId('conflict-c1')).toBeInTheDocument()
     })
 
     it('uses hour as fallback for conflict testid', () => {
       const conflictNoId = { severity: 'error', message: 'test' }
-      render(<HourRow hour={19} executions={mockExecutions} conflict={conflictNoId} />)
+      render(<HourRow hour={19} executions={hourExecutions} conflict={conflictNoId} />)
       expect(screen.getByTestId('conflict-19')).toBeInTheDocument()
     })
   })
@@ -124,7 +103,7 @@ describe('HourRow', () => {
       render(
         <HourRow
           hour={18}
-          executions={mockExecutions}
+          executions={hourExecutions}
           executionConflicts={executionConflicts}
         />
       )
@@ -141,7 +120,7 @@ describe('HourRow', () => {
       render(
         <HourRow
           hour={18}
-          executions={mockExecutions}
+          executions={hourExecutions}
           executionConflicts={executionConflicts}
         />
       )
@@ -156,17 +135,17 @@ describe('HourRow', () => {
       render(
         <HourRow
           hour={18}
-          executions={mockExecutions}
+          executions={hourExecutions}
           onExecutionClick={handleClick}
         />
       )
       fireEvent.click(screen.getByTestId('execution-routine-1-1800'))
       expect(handleClick).toHaveBeenCalledTimes(1)
-      expect(handleClick).toHaveBeenCalledWith(mockExecutions[0])
+      expect(handleClick).toHaveBeenCalledWith(hourExecutions[0])
     })
 
     it('does not throw when onExecutionClick is not provided', () => {
-      render(<HourRow hour={18} executions={mockExecutions} />)
+      render(<HourRow hour={18} executions={hourExecutions} />)
       expect(() => {
         fireEvent.click(screen.getByTestId('execution-routine-1-1800'))
       }).not.toThrow()

--- a/Firmware/webui/frontend/src/components/scheduler/DayTimeline/__tests__/HourRow.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/DayTimeline/__tests__/HourRow.test.jsx
@@ -1,0 +1,196 @@
+/**
+ * Tests for HourRow component (Issue #326)
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import HourRow from '../HourRow'
+
+describe('HourRow', () => {
+  const mockExecutions = [
+    {
+      pattern_id: 'routine-1',
+      pattern_name: 'Photo Capture',
+      start_time: '2025-12-17T18:00:00Z',
+      actions: [{ action_name: 'Take Photo', action_type: 'camera' }],
+    },
+    {
+      pattern_id: 'routine-2',
+      pattern_name: 'Attract On',
+      start_time: '2025-12-17T18:15:00Z',
+      actions: [{ action_name: 'Attract On', action_type: 'gpio' }],
+    },
+  ]
+
+  describe('Rendering', () => {
+    it('renders with correct data-testid', () => {
+      render(<HourRow hour={18} />)
+      expect(screen.getByTestId('hour-row-18')).toBeInTheDocument()
+    })
+
+    it('displays hour label in HH:00 format', () => {
+      render(<HourRow hour={18} />)
+      expect(screen.getByText('18:00')).toBeInTheDocument()
+    })
+
+    it('displays hour 0 as 0:00', () => {
+      render(<HourRow hour={0} />)
+      expect(screen.getByText('0:00')).toBeInTheDocument()
+    })
+
+    it('displays hour 23 as 23:00', () => {
+      render(<HourRow hour={23} />)
+      expect(screen.getByText('23:00')).toBeInTheDocument()
+    })
+
+    it('renders ExecutionChip for each execution', () => {
+      render(<HourRow hour={18} executions={mockExecutions} />)
+      expect(screen.getByTestId('execution-routine-1-1800')).toBeInTheDocument()
+      expect(screen.getByTestId('execution-routine-2-1815')).toBeInTheDocument()
+    })
+
+    it('shows "no executions" for empty hours', () => {
+      render(<HourRow hour={18} executions={[]} />)
+      expect(screen.getByText('no executions')).toBeInTheDocument()
+    })
+
+    it('shows "no executions" when executions prop is undefined', () => {
+      render(<HourRow hour={18} />)
+      expect(screen.getByText('no executions')).toBeInTheDocument()
+    })
+  })
+
+  describe('Conflict Highlighting', () => {
+    const errorConflict = {
+      id: 'c1',
+      severity: 'error',
+      message: 'camera busy',
+      conflict_type: 'time_overlap',
+    }
+
+    const warningConflict = {
+      id: 'c2',
+      severity: 'warning',
+      message: 'unexpected',
+      conflict_type: 'gpio_state_conflict',
+    }
+
+    it('applies red background for error conflict', () => {
+      render(<HourRow hour={19} executions={mockExecutions} conflict={errorConflict} />)
+      const row = screen.getByTestId('hour-row-19')
+      expect(row).toHaveClass('bg-red-950/20')
+    })
+
+    it('applies yellow background for warning conflict', () => {
+      render(<HourRow hour={21} executions={mockExecutions} conflict={warningConflict} />)
+      const row = screen.getByTestId('hour-row-21')
+      expect(row).toHaveClass('bg-yellow-950/20')
+    })
+
+    it('changes hour label color for error conflict', () => {
+      render(<HourRow hour={19} executions={mockExecutions} conflict={errorConflict} />)
+      const label = screen.getByText('19:00')
+      expect(label).toHaveClass('text-red-400')
+    })
+
+    it('changes hour label color for warning conflict', () => {
+      render(<HourRow hour={21} executions={mockExecutions} conflict={warningConflict} />)
+      const label = screen.getByText('21:00')
+      expect(label).toHaveClass('text-yellow-400')
+    })
+
+    it('displays inline conflict message', () => {
+      render(<HourRow hour={19} executions={mockExecutions} conflict={errorConflict} />)
+      expect(screen.getByText('camera busy')).toBeInTheDocument()
+    })
+
+    it('has conflict data-testid', () => {
+      render(<HourRow hour={19} executions={mockExecutions} conflict={errorConflict} />)
+      expect(screen.getByTestId('conflict-c1')).toBeInTheDocument()
+    })
+
+    it('uses hour as fallback for conflict testid', () => {
+      const conflictNoId = { severity: 'error', message: 'test' }
+      render(<HourRow hour={19} executions={mockExecutions} conflict={conflictNoId} />)
+      expect(screen.getByTestId('conflict-19')).toBeInTheDocument()
+    })
+  })
+
+  describe('Execution Conflict Highlighting', () => {
+    it('passes conflict severity to ExecutionChip', () => {
+      const executionConflicts = {
+        'routine-1': { severity: 'error' },
+      }
+      render(
+        <HourRow
+          hour={18}
+          executions={mockExecutions}
+          executionConflicts={executionConflicts}
+        />
+      )
+      // The chip should have the ring class from conflict
+      const chip = screen.getByTestId('execution-routine-1-1800')
+      expect(chip).toHaveClass('ring-1')
+      expect(chip).toHaveClass('ring-red-400')
+    })
+
+    it('does not add conflict styling to unaffected chips', () => {
+      const executionConflicts = {
+        'routine-1': { severity: 'error' },
+      }
+      render(
+        <HourRow
+          hour={18}
+          executions={mockExecutions}
+          executionConflicts={executionConflicts}
+        />
+      )
+      const chip = screen.getByTestId('execution-routine-2-1815')
+      expect(chip).not.toHaveClass('ring-1')
+    })
+  })
+
+  describe('Interaction', () => {
+    it('calls onExecutionClick with execution when chip is clicked', () => {
+      const handleClick = vi.fn()
+      render(
+        <HourRow
+          hour={18}
+          executions={mockExecutions}
+          onExecutionClick={handleClick}
+        />
+      )
+      fireEvent.click(screen.getByTestId('execution-routine-1-1800'))
+      expect(handleClick).toHaveBeenCalledTimes(1)
+      expect(handleClick).toHaveBeenCalledWith(mockExecutions[0])
+    })
+
+    it('does not throw when onExecutionClick is not provided', () => {
+      render(<HourRow hour={18} executions={mockExecutions} />)
+      expect(() => {
+        fireEvent.click(screen.getByTestId('execution-routine-1-1800'))
+      }).not.toThrow()
+    })
+  })
+
+  describe('Styling', () => {
+    it('has correct base row styling', () => {
+      render(<HourRow hour={18} />)
+      const row = screen.getByTestId('hour-row-18')
+      expect(row).toHaveClass('flex')
+      expect(row).toHaveClass('p-3')
+    })
+
+    it('has fixed width for hour label', () => {
+      render(<HourRow hour={18} />)
+      const label = screen.getByText('18:00')
+      expect(label).toHaveClass('w-12')
+    })
+
+    it('has default gray color for normal hour label', () => {
+      render(<HourRow hour={18} />)
+      const label = screen.getByText('18:00')
+      expect(label).toHaveClass('text-gray-600')
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/components/scheduler/DayTimeline/__tests__/dayTimelineUtils.test.js
+++ b/Firmware/webui/frontend/src/components/scheduler/DayTimeline/__tests__/dayTimelineUtils.test.js
@@ -32,6 +32,25 @@ describe('dayTimelineUtils', () => {
       expect(getHourFromIsoTime('invalid')).toBeNull()
       expect(getHourFromIsoTime(123)).toBeNull()
     })
+
+    describe('timezone handling', () => {
+      it('handles UTC timestamps with Z suffix', () => {
+        expect(getHourFromIsoTime('2025-12-17T23:00:00Z')).toBe(23)
+        expect(getHourFromIsoTime('2025-12-17T00:00:00Z')).toBe(0)
+      })
+
+      it('handles timestamps without timezone indicator', () => {
+        expect(getHourFromIsoTime('2025-12-17T14:30:00')).toBe(14)
+        expect(getHourFromIsoTime('2025-12-17T08:15:00')).toBe(8)
+      })
+
+      it('extracts hour directly from ISO format (avoids local timezone)', () => {
+        // This test verifies that the regex extraction is used, not Date.getHours()
+        // which would be affected by the local timezone
+        expect(getHourFromIsoTime('2025-12-17T23:00:00')).toBe(23)
+        expect(getHourFromIsoTime('2025-12-17T05:00:00')).toBe(5)
+      })
+    })
   })
 
   describe('getMinuteFromIsoTime', () => {
@@ -45,6 +64,18 @@ describe('dayTimelineUtils', () => {
       expect(getMinuteFromIsoTime(null)).toBeNull()
       expect(getMinuteFromIsoTime('')).toBeNull()
       expect(getMinuteFromIsoTime('invalid')).toBeNull()
+    })
+
+    describe('timezone handling', () => {
+      it('handles timestamps without timezone indicator', () => {
+        expect(getMinuteFromIsoTime('2025-12-17T14:45:00')).toBe(45)
+        expect(getMinuteFromIsoTime('2025-12-17T08:05:00')).toBe(5)
+      })
+
+      it('extracts minute directly from ISO format (avoids local timezone)', () => {
+        expect(getMinuteFromIsoTime('2025-12-17T23:59:00')).toBe(59)
+        expect(getMinuteFromIsoTime('2025-12-17T00:01:00')).toBe(1)
+      })
     })
   })
 

--- a/Firmware/webui/frontend/src/components/scheduler/DayTimeline/__tests__/dayTimelineUtils.test.js
+++ b/Firmware/webui/frontend/src/components/scheduler/DayTimeline/__tests__/dayTimelineUtils.test.js
@@ -33,6 +33,22 @@ describe('dayTimelineUtils', () => {
       expect(getHourFromIsoTime(123)).toBeNull()
     })
 
+    describe('ISO format validation', () => {
+      it('rejects malformed date formats without T separator', () => {
+        expect(getHourFromIsoTime('2025-12-17 18:30:00')).toBeNull()
+        expect(getHourFromIsoTime('18:30:00')).toBeNull()
+      })
+
+      it('accepts valid ISO format with milliseconds', () => {
+        expect(getHourFromIsoTime('2025-12-17T18:30:00.123Z')).toBe(18)
+      })
+
+      it('handles ISO strings with various valid suffixes', () => {
+        expect(getHourFromIsoTime('2025-12-17T18:30:00Z')).toBe(18)
+        expect(getHourFromIsoTime('2025-12-17T18:30:00')).toBe(18)
+      })
+    })
+
     describe('timezone handling', () => {
       it('handles UTC timestamps with Z suffix', () => {
         expect(getHourFromIsoTime('2025-12-17T23:00:00Z')).toBe(23)
@@ -64,6 +80,17 @@ describe('dayTimelineUtils', () => {
       expect(getMinuteFromIsoTime(null)).toBeNull()
       expect(getMinuteFromIsoTime('')).toBeNull()
       expect(getMinuteFromIsoTime('invalid')).toBeNull()
+    })
+
+    describe('ISO format validation', () => {
+      it('rejects malformed date formats without T separator', () => {
+        expect(getMinuteFromIsoTime('2025-12-17 18:30:00')).toBeNull()
+        expect(getMinuteFromIsoTime('18:30:00')).toBeNull()
+      })
+
+      it('accepts valid ISO format with milliseconds', () => {
+        expect(getMinuteFromIsoTime('2025-12-17T18:30:00.123Z')).toBe(30)
+      })
     })
 
     describe('timezone handling', () => {
@@ -106,6 +133,17 @@ describe('dayTimelineUtils', () => {
       expect(formatTimeShort(null)).toBe('')
       expect(formatTimeShort('')).toBe('')
       expect(formatTimeShort('invalid')).toBe('')
+    })
+
+    describe('ISO format validation', () => {
+      it('rejects malformed date formats without T separator', () => {
+        expect(formatTimeShort('2025-12-17 18:30:00')).toBe('')
+        expect(formatTimeShort('18:30:00')).toBe('')
+      })
+
+      it('formats valid ISO with milliseconds', () => {
+        expect(formatTimeShort('2025-12-17T18:30:00.123Z')).toBe('18:30')
+      })
     })
   })
 
@@ -305,16 +343,45 @@ describe('dayTimelineUtils', () => {
   })
 
   describe('getExecutionKey', () => {
-    it('generates unique key from pattern_id and time', () => {
+    it('generates unique key from pattern_id, time, and id', () => {
+      const execution = {
+        id: 'exec-123',
+        pattern_id: 'routine-1',
+        start_time: '2025-12-17T18:30:00Z',
+      }
+      expect(getExecutionKey(execution)).toBe(
+        'routine-1-2025-12-17T18:30:00Z-exec-123'
+      )
+    })
+
+    it('uses index as fallback when id is missing', () => {
       const execution = {
         pattern_id: 'routine-1',
         start_time: '2025-12-17T18:30:00Z',
       }
-      expect(getExecutionKey(execution)).toBe('routine-1-2025-12-17T18:30:00Z')
+      expect(getExecutionKey(execution, 5)).toBe(
+        'routine-1-2025-12-17T18:30:00Z-5'
+      )
+    })
+
+    it('uses 0 as default index', () => {
+      const execution = {
+        pattern_id: 'routine-1',
+        start_time: '2025-12-17T18:30:00Z',
+      }
+      expect(getExecutionKey(execution)).toBe(
+        'routine-1-2025-12-17T18:30:00Z-0'
+      )
     })
 
     it('handles missing fields', () => {
-      expect(getExecutionKey({})).toBe('unknown-')
+      expect(getExecutionKey({})).toBe('unknown--0')
+    })
+
+    it('prevents key collision for same pattern_id and time', () => {
+      const exec1 = { pattern_id: 'r1', start_time: '2025-12-17T18:00:00Z' }
+      const exec2 = { pattern_id: 'r1', start_time: '2025-12-17T18:00:00Z' }
+      expect(getExecutionKey(exec1, 0)).not.toBe(getExecutionKey(exec2, 1))
     })
   })
 

--- a/Firmware/webui/frontend/src/components/scheduler/DayTimeline/__tests__/dayTimelineUtils.test.js
+++ b/Firmware/webui/frontend/src/components/scheduler/DayTimeline/__tests__/dayTimelineUtils.test.js
@@ -1,0 +1,303 @@
+/**
+ * Tests for DayTimeline utility functions (Issue #326)
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  getHourFromIsoTime,
+  getMinuteFromIsoTime,
+  formatHourLabel,
+  formatTimeShort,
+  groupExecutionsByHour,
+  getConflictForHour,
+  getActionTypeDisplay,
+  countConflictsBySeverity,
+  getConflictForExecution,
+  getExecutionKey,
+  getExecutionTestId,
+} from '../dayTimelineUtils'
+
+describe('dayTimelineUtils', () => {
+  describe('getHourFromIsoTime', () => {
+    it('extracts hour from valid ISO string', () => {
+      expect(getHourFromIsoTime('2025-12-17T18:30:00Z')).toBe(18)
+      expect(getHourFromIsoTime('2025-12-17T00:00:00Z')).toBe(0)
+      expect(getHourFromIsoTime('2025-12-17T23:59:59Z')).toBe(23)
+    })
+
+    it('returns null for invalid input', () => {
+      expect(getHourFromIsoTime(null)).toBeNull()
+      expect(getHourFromIsoTime(undefined)).toBeNull()
+      expect(getHourFromIsoTime('')).toBeNull()
+      expect(getHourFromIsoTime('invalid')).toBeNull()
+      expect(getHourFromIsoTime(123)).toBeNull()
+    })
+  })
+
+  describe('getMinuteFromIsoTime', () => {
+    it('extracts minute from valid ISO string', () => {
+      expect(getMinuteFromIsoTime('2025-12-17T18:30:00Z')).toBe(30)
+      expect(getMinuteFromIsoTime('2025-12-17T18:00:00Z')).toBe(0)
+      expect(getMinuteFromIsoTime('2025-12-17T18:59:00Z')).toBe(59)
+    })
+
+    it('returns null for invalid input', () => {
+      expect(getMinuteFromIsoTime(null)).toBeNull()
+      expect(getMinuteFromIsoTime('')).toBeNull()
+      expect(getMinuteFromIsoTime('invalid')).toBeNull()
+    })
+  })
+
+  describe('formatHourLabel', () => {
+    it('formats hour to HH:00 string', () => {
+      expect(formatHourLabel(0)).toBe('0:00')
+      expect(formatHourLabel(9)).toBe('9:00')
+      expect(formatHourLabel(18)).toBe('18:00')
+      expect(formatHourLabel(23)).toBe('23:00')
+    })
+
+    it('returns empty string for invalid input', () => {
+      expect(formatHourLabel(-1)).toBe('')
+      expect(formatHourLabel(24)).toBe('')
+      expect(formatHourLabel(null)).toBe('')
+      expect(formatHourLabel('18')).toBe('')
+    })
+  })
+
+  describe('formatTimeShort', () => {
+    it('formats ISO string to HH:MM', () => {
+      expect(formatTimeShort('2025-12-17T18:30:00Z')).toBe('18:30')
+      expect(formatTimeShort('2025-12-17T09:05:00Z')).toBe('9:05')
+      expect(formatTimeShort('2025-12-17T00:00:00Z')).toBe('0:00')
+    })
+
+    it('returns empty string for invalid input', () => {
+      expect(formatTimeShort(null)).toBe('')
+      expect(formatTimeShort('')).toBe('')
+      expect(formatTimeShort('invalid')).toBe('')
+    })
+  })
+
+  describe('groupExecutionsByHour', () => {
+    const mockExecutions = [
+      { pattern_id: 'p1', pattern_name: 'Test 1', start_time: '2025-12-17T18:00:00Z' },
+      { pattern_id: 'p2', pattern_name: 'Test 2', start_time: '2025-12-17T18:15:00Z' },
+      { pattern_id: 'p3', pattern_name: 'Test 3', start_time: '2025-12-17T19:00:00Z' },
+      { pattern_id: 'p4', pattern_name: 'Test 4', start_time: '2025-12-18T18:00:00Z' }, // Different date
+    ]
+
+    it('groups executions by hour', () => {
+      const grouped = groupExecutionsByHour(mockExecutions, '2025-12-17')
+      expect(grouped[18]).toHaveLength(2)
+      expect(grouped[19]).toHaveLength(1)
+      expect(grouped[20]).toBeUndefined()
+    })
+
+    it('filters by date when provided', () => {
+      const grouped = groupExecutionsByHour(mockExecutions, '2025-12-17')
+      // Should not include the execution from 2025-12-18
+      expect(grouped[18]).toHaveLength(2)
+    })
+
+    it('includes all dates when date is not provided', () => {
+      const grouped = groupExecutionsByHour(mockExecutions, null)
+      expect(grouped[18]).toHaveLength(3) // 2 from 12-17 + 1 from 12-18
+    })
+
+    it('returns empty object for invalid input', () => {
+      expect(groupExecutionsByHour(null, '2025-12-17')).toEqual({})
+      expect(groupExecutionsByHour([], '2025-12-17')).toEqual({})
+      expect(groupExecutionsByHour('invalid', '2025-12-17')).toEqual({})
+    })
+
+    it('skips executions without start_time', () => {
+      const executions = [
+        { pattern_id: 'p1', pattern_name: 'Test 1' }, // No start_time
+        { pattern_id: 'p2', pattern_name: 'Test 2', start_time: '2025-12-17T18:00:00Z' },
+      ]
+      const grouped = groupExecutionsByHour(executions, '2025-12-17')
+      expect(grouped[18]).toHaveLength(1)
+    })
+  })
+
+  describe('getConflictForHour', () => {
+    const mockConflicts = [
+      {
+        id: 'c1',
+        severity: 'error',
+        start_time: '2025-12-17T19:00:00Z',
+        message: 'Camera busy',
+      },
+      {
+        id: 'c2',
+        severity: 'warning',
+        start_time: '2025-12-17T21:00:00Z',
+        message: 'Unexpected GPIO state',
+      },
+      {
+        id: 'c3',
+        severity: 'warning',
+        start_time: '2025-12-17T19:00:00Z',
+        message: 'Another warning',
+      },
+    ]
+
+    it('finds conflict for matching hour', () => {
+      const conflict = getConflictForHour(mockConflicts, 19, '2025-12-17')
+      expect(conflict).not.toBeNull()
+      expect(conflict.id).toBe('c1') // Error is more severe
+    })
+
+    it('returns most severe conflict when multiple exist', () => {
+      const conflict = getConflictForHour(mockConflicts, 19, '2025-12-17')
+      expect(conflict.severity).toBe('error')
+    })
+
+    it('returns null when no conflict for hour', () => {
+      const conflict = getConflictForHour(mockConflicts, 18, '2025-12-17')
+      expect(conflict).toBeNull()
+    })
+
+    it('filters by date', () => {
+      const conflict = getConflictForHour(mockConflicts, 19, '2025-12-18')
+      expect(conflict).toBeNull()
+    })
+
+    it('returns null for invalid input', () => {
+      expect(getConflictForHour(null, 19, '2025-12-17')).toBeNull()
+      expect(getConflictForHour([], 19, '2025-12-17')).toBeNull()
+      expect(getConflictForHour(mockConflicts, -1, '2025-12-17')).toBeNull()
+      expect(getConflictForHour(mockConflicts, 25, '2025-12-17')).toBeNull()
+    })
+  })
+
+  describe('getActionTypeDisplay', () => {
+    it('returns camera colors for camera type', () => {
+      const display = getActionTypeDisplay('camera', 'takephoto')
+      expect(display.bg).toBe('bg-blue-500/20')
+      expect(display.text).toBe('text-blue-400')
+    })
+
+    it('returns gpio colors for gpio type', () => {
+      const display = getActionTypeDisplay('gpio', 'attract_on')
+      expect(display.bg).toBe('bg-orange-500/20')
+      expect(display.text).toBe('text-orange-400')
+    })
+
+    it('returns hdr colors for HDR action names', () => {
+      const display1 = getActionTypeDisplay('camera', 'HDR Bracket')
+      const display2 = getActionTypeDisplay('camera', 'hdr_capture')
+      expect(display1.bg).toBe('bg-purple-500/20')
+      expect(display2.bg).toBe('bg-purple-500/20')
+    })
+
+    it('returns default colors for unknown types', () => {
+      const display = getActionTypeDisplay('unknown', 'test')
+      expect(display.bg).toBe('bg-blue-500/20')
+    })
+
+    it('returns gps_sync colors', () => {
+      const display = getActionTypeDisplay('gps_sync', 'sync')
+      expect(display.bg).toBe('bg-green-500/20')
+    })
+
+    it('returns service colors', () => {
+      const display = getActionTypeDisplay('service', 'restart')
+      expect(display.bg).toBe('bg-gray-500/20')
+    })
+  })
+
+  describe('countConflictsBySeverity', () => {
+    it('counts conflicts correctly', () => {
+      const conflicts = [
+        { severity: 'error' },
+        { severity: 'error' },
+        { severity: 'warning' },
+      ]
+      const result = countConflictsBySeverity(conflicts)
+      expect(result.total).toBe(3)
+      expect(result.errors).toBe(2)
+      expect(result.warnings).toBe(1)
+    })
+
+    it('returns zeros for empty array', () => {
+      const result = countConflictsBySeverity([])
+      expect(result.total).toBe(0)
+      expect(result.errors).toBe(0)
+      expect(result.warnings).toBe(0)
+    })
+
+    it('returns zeros for invalid input', () => {
+      const result = countConflictsBySeverity(null)
+      expect(result.total).toBe(0)
+    })
+  })
+
+  describe('getConflictForExecution', () => {
+    const execution = {
+      pattern_id: 'routine-1',
+      start_time: '2025-12-17T19:00:00Z',
+    }
+
+    const conflicts = [
+      {
+        id: 'c1',
+        event1_id: 'routine-1',
+        event2_id: 'routine-2',
+        severity: 'error',
+        start_time: '2025-12-17T19:00:00Z',
+      },
+    ]
+
+    it('finds conflict by pattern_id match', () => {
+      const conflict = getConflictForExecution(execution, conflicts)
+      expect(conflict).not.toBeNull()
+      expect(conflict.id).toBe('c1')
+    })
+
+    it('finds conflict by time match', () => {
+      const exec = { pattern_id: 'other', start_time: '2025-12-17T19:00:00Z' }
+      const conflict = getConflictForExecution(exec, conflicts)
+      expect(conflict).not.toBeNull()
+    })
+
+    it('returns null when no match', () => {
+      const exec = { pattern_id: 'other', start_time: '2025-12-17T20:00:00Z' }
+      const conflict = getConflictForExecution(exec, conflicts)
+      expect(conflict).toBeNull()
+    })
+
+    it('returns null for invalid input', () => {
+      expect(getConflictForExecution(null, conflicts)).toBeNull()
+      expect(getConflictForExecution(execution, null)).toBeNull()
+    })
+  })
+
+  describe('getExecutionKey', () => {
+    it('generates unique key from pattern_id and time', () => {
+      const execution = {
+        pattern_id: 'routine-1',
+        start_time: '2025-12-17T18:30:00Z',
+      }
+      expect(getExecutionKey(execution)).toBe('routine-1-2025-12-17T18:30:00Z')
+    })
+
+    it('handles missing fields', () => {
+      expect(getExecutionKey({})).toBe('unknown-')
+    })
+  })
+
+  describe('getExecutionTestId', () => {
+    it('generates data-testid format', () => {
+      const execution = {
+        pattern_id: 'routine-1',
+        start_time: '2025-12-17T18:30:00Z',
+      }
+      expect(getExecutionTestId(execution)).toBe('execution-routine-1-1830')
+    })
+
+    it('handles missing fields', () => {
+      expect(getExecutionTestId({})).toBe('execution-unknown-')
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/components/scheduler/DayTimeline/__tests__/testFixtures.js
+++ b/Firmware/webui/frontend/src/components/scheduler/DayTimeline/__tests__/testFixtures.js
@@ -1,0 +1,226 @@
+/**
+ * Shared test fixtures for DayTimeline components (Issue #326)
+ *
+ * Consolidates mock data used across test files to reduce duplication
+ * and ensure consistency in test scenarios.
+ *
+ * @module components/scheduler/DayTimeline/__tests__/testFixtures
+ */
+
+/**
+ * Standard date used across tests (YYYY-MM-DD format)
+ */
+export const mockDate = '2025-12-17'
+
+/**
+ * Standard execution objects for testing
+ */
+export const mockExecutions = [
+  {
+    pattern_id: 'routine-1',
+    pattern_name: 'Photo Capture',
+    start_time: '2025-12-17T18:00:00',
+    actions: [
+      {
+        time: '2025-12-17T18:00:00',
+        action_name: 'Take Photo',
+        action_type: 'camera',
+        offset_minutes: 0,
+      },
+    ],
+  },
+  {
+    pattern_id: 'routine-2',
+    pattern_name: 'Attract On',
+    start_time: '2025-12-17T18:15:00',
+    actions: [
+      {
+        time: '2025-12-17T18:15:00',
+        action_name: 'Attract On',
+        action_type: 'gpio',
+        offset_minutes: 0,
+      },
+    ],
+  },
+  {
+    pattern_id: 'routine-3',
+    pattern_name: 'Evening Photo',
+    start_time: '2025-12-17T19:00:00',
+    actions: [
+      {
+        time: '2025-12-17T19:00:00',
+        action_name: 'Take Photo',
+        action_type: 'camera',
+        offset_minutes: 0,
+      },
+    ],
+  },
+  {
+    pattern_id: 'routine-4',
+    pattern_name: 'HDR Shot',
+    start_time: '2025-12-17T19:00:00',
+    actions: [
+      {
+        time: '2025-12-17T19:00:00',
+        action_name: 'HDR Bracket',
+        action_type: 'camera',
+        offset_minutes: 0,
+      },
+    ],
+  },
+]
+
+/**
+ * Single execution for simple component tests
+ */
+export const mockExecution = mockExecutions[0]
+
+/**
+ * Error conflict (blocking - time collision)
+ */
+export const mockErrorConflict = {
+  id: 'c1',
+  conflict_type: 'time_overlap',
+  severity: 'error',
+  event1_id: 'routine-3',
+  event1_name: 'Evening Photo',
+  event2_id: 'routine-4',
+  event2_name: 'HDR Shot',
+  start_time: '2025-12-17T19:00:00',
+  end_time: '2025-12-17T19:15:00',
+  message: 'camera busy',
+}
+
+/**
+ * Warning conflict (non-blocking - GPIO state)
+ */
+export const mockWarningConflict = {
+  id: 'c2',
+  conflict_type: 'gpio_state_conflict',
+  severity: 'warning',
+  event1_id: 'routine-2',
+  event1_name: 'Attract On',
+  start_time: '2025-12-17T18:15:00',
+  message: 'unexpected GPIO state',
+}
+
+/**
+ * Array containing the error conflict for standard tests
+ */
+export const mockConflicts = [mockErrorConflict]
+
+/**
+ * Array containing both error and warning conflicts
+ */
+export const mockMixedConflicts = [mockErrorConflict, mockWarningConflict]
+
+/**
+ * Execution with HDR action for testing HDR color styling
+ */
+export const mockHdrExecution = {
+  pattern_id: 'routine-hdr',
+  pattern_name: 'HDR Capture',
+  start_time: '2025-12-17T20:00:00',
+  actions: [
+    {
+      time: '2025-12-17T20:00:00',
+      action_name: 'HDR Bracket',
+      action_type: 'camera',
+      offset_minutes: 0,
+    },
+  ],
+}
+
+/**
+ * Execution with GPIO action for testing GPIO color styling
+ */
+export const mockGpioExecution = {
+  pattern_id: 'routine-gpio',
+  pattern_name: 'Flash On',
+  start_time: '2025-12-17T21:00:00',
+  actions: [
+    {
+      time: '2025-12-17T21:00:00',
+      action_name: 'Flash On',
+      action_type: 'gpio',
+      offset_minutes: 0,
+    },
+  ],
+}
+
+/**
+ * Execution with GPS sync action
+ */
+export const mockGpsSyncExecution = {
+  pattern_id: 'routine-gps',
+  pattern_name: 'GPS Sync',
+  start_time: '2025-12-17T12:00:00',
+  actions: [
+    {
+      time: '2025-12-17T12:00:00',
+      action_name: 'Sync GPS',
+      action_type: 'gps_sync',
+      offset_minutes: 0,
+    },
+  ],
+}
+
+/**
+ * Execution with service action
+ */
+export const mockServiceExecution = {
+  pattern_id: 'routine-service',
+  pattern_name: 'Restart Service',
+  start_time: '2025-12-17T00:00:00',
+  actions: [
+    {
+      time: '2025-12-17T00:00:00',
+      action_name: 'Restart Camera',
+      action_type: 'service',
+      offset_minutes: 0,
+    },
+  ],
+}
+
+/**
+ * Factory function to create custom execution objects
+ * @param {Object} overrides - Properties to override
+ * @returns {Object} Execution object
+ */
+export function createExecution(overrides = {}) {
+  return {
+    pattern_id: 'routine-custom',
+    pattern_name: 'Custom Execution',
+    start_time: '2025-12-17T18:00:00',
+    actions: [
+      {
+        time: '2025-12-17T18:00:00',
+        action_name: 'Custom Action',
+        action_type: 'camera',
+        offset_minutes: 0,
+      },
+    ],
+    ...overrides,
+  }
+}
+
+/**
+ * Factory function to create custom conflict objects
+ * @param {Object} overrides - Properties to override
+ * @returns {Object} Conflict object
+ */
+export function createConflict(overrides = {}) {
+  return {
+    id: 'custom-conflict',
+    conflict_type: 'time_overlap',
+    severity: 'error',
+    event1_id: 'routine-1',
+    event1_name: 'Routine 1',
+    event2_id: 'routine-2',
+    event2_name: 'Routine 2',
+    start_time: '2025-12-17T18:00:00',
+    end_time: '2025-12-17T18:15:00',
+    message: 'Test conflict message',
+    ...overrides,
+  }
+}

--- a/Firmware/webui/frontend/src/components/scheduler/DayTimeline/dayTimelineConstants.js
+++ b/Firmware/webui/frontend/src/components/scheduler/DayTimeline/dayTimelineConstants.js
@@ -16,32 +16,22 @@ export const ACTION_TYPE_COLORS = {
   camera: {
     bg: 'bg-blue-500/20',
     text: 'text-blue-400',
-    darkBg: 'dark:bg-blue-500/20',
-    darkText: 'dark:text-blue-400',
   },
   gpio: {
     bg: 'bg-orange-500/20',
     text: 'text-orange-400',
-    darkBg: 'dark:bg-orange-500/20',
-    darkText: 'dark:text-orange-400',
   },
   hdr: {
     bg: 'bg-purple-500/20',
     text: 'text-purple-400',
-    darkBg: 'dark:bg-purple-500/20',
-    darkText: 'dark:text-purple-400',
   },
   gps_sync: {
     bg: 'bg-green-500/20',
     text: 'text-green-400',
-    darkBg: 'dark:bg-green-500/20',
-    darkText: 'dark:text-green-400',
   },
   service: {
     bg: 'bg-gray-500/20',
     text: 'text-gray-400',
-    darkBg: 'dark:bg-gray-500/20',
-    darkText: 'dark:text-gray-400',
   },
 }
 
@@ -51,8 +41,6 @@ export const ACTION_TYPE_COLORS = {
 export const DEFAULT_ACTION_COLORS = {
   bg: 'bg-blue-500/20',
   text: 'text-blue-400',
-  darkBg: 'dark:bg-blue-500/20',
-  darkText: 'dark:text-blue-400',
 }
 
 /**

--- a/Firmware/webui/frontend/src/components/scheduler/DayTimeline/dayTimelineConstants.js
+++ b/Firmware/webui/frontend/src/components/scheduler/DayTimeline/dayTimelineConstants.js
@@ -1,0 +1,108 @@
+/**
+ * DayTimeline styling constants (Issue #326)
+ *
+ * Provides static Tailwind class mappings for JIT compatibility.
+ * Dynamic class construction doesn't work with Tailwind's JIT compiler,
+ * so we define all possible class combinations here.
+ *
+ * @module components/scheduler/DayTimeline/dayTimelineConstants
+ */
+
+/**
+ * Action type color mapping for execution chips.
+ * Maps action types to their Tailwind background/text classes.
+ */
+export const ACTION_TYPE_COLORS = {
+  camera: {
+    bg: 'bg-blue-500/20',
+    text: 'text-blue-400',
+    darkBg: 'dark:bg-blue-500/20',
+    darkText: 'dark:text-blue-400',
+  },
+  gpio: {
+    bg: 'bg-orange-500/20',
+    text: 'text-orange-400',
+    darkBg: 'dark:bg-orange-500/20',
+    darkText: 'dark:text-orange-400',
+  },
+  hdr: {
+    bg: 'bg-purple-500/20',
+    text: 'text-purple-400',
+    darkBg: 'dark:bg-purple-500/20',
+    darkText: 'dark:text-purple-400',
+  },
+  gps_sync: {
+    bg: 'bg-green-500/20',
+    text: 'text-green-400',
+    darkBg: 'dark:bg-green-500/20',
+    darkText: 'dark:text-green-400',
+  },
+  service: {
+    bg: 'bg-gray-500/20',
+    text: 'text-gray-400',
+    darkBg: 'dark:bg-gray-500/20',
+    darkText: 'dark:text-gray-400',
+  },
+}
+
+/**
+ * Default colors for unknown action types.
+ */
+export const DEFAULT_ACTION_COLORS = {
+  bg: 'bg-blue-500/20',
+  text: 'text-blue-400',
+  darkBg: 'dark:bg-blue-500/20',
+  darkText: 'dark:text-blue-400',
+}
+
+/**
+ * Row background and label colors for conflict states.
+ */
+export const ROW_CONFLICT_STYLES = {
+  error: {
+    bg: 'bg-red-950/20',
+    label: 'text-red-400',
+  },
+  warning: {
+    bg: 'bg-yellow-950/20',
+    label: 'text-yellow-400',
+  },
+  none: {
+    bg: '',
+    label: 'text-gray-600 dark:text-gray-600',
+  },
+}
+
+/**
+ * Conflict ring styles for execution chips.
+ */
+export const CHIP_CONFLICT_RINGS = {
+  error: 'ring-1 ring-red-400',
+  warning: 'ring-1 ring-yellow-400',
+}
+
+/**
+ * Legend items for the timeline.
+ */
+export const LEGEND_ITEMS = [
+  { color: 'bg-blue-400', label: 'Camera' },
+  { color: 'bg-orange-400', label: 'GPIO' },
+  { color: 'ring-1 ring-red-400', label: 'Collision', isRing: true },
+  { color: 'ring-1 ring-yellow-400', label: 'Warning', isRing: true },
+]
+
+/**
+ * Action names that indicate HDR mode.
+ */
+export const HDR_ACTION_NAMES = ['hdr', 'hdr_bracket', 'bracket']
+
+/**
+ * Checks if an action name indicates HDR mode.
+ * @param {string} actionName - The action name to check
+ * @returns {boolean} True if this is an HDR action
+ */
+export function isHdrAction(actionName) {
+  if (!actionName) return false
+  const lower = actionName.toLowerCase()
+  return HDR_ACTION_NAMES.some((name) => lower.includes(name))
+}

--- a/Firmware/webui/frontend/src/components/scheduler/DayTimeline/dayTimelineUtils.js
+++ b/Firmware/webui/frontend/src/components/scheduler/DayTimeline/dayTimelineUtils.js
@@ -1,0 +1,281 @@
+/**
+ * DayTimeline utility functions (Issue #326)
+ *
+ * Provides pure utility functions for the DayTimeline component:
+ * - Grouping executions by hour
+ * - Formatting time strings
+ * - Finding conflicts for specific hours
+ * - Getting action type display information
+ *
+ * @module components/scheduler/DayTimeline/dayTimelineUtils
+ */
+
+import {
+  ACTION_TYPE_COLORS,
+  DEFAULT_ACTION_COLORS,
+  isHdrAction,
+} from './dayTimelineConstants'
+
+/**
+ * Extracts the hour (0-23) from an ISO datetime string.
+ * Uses local timezone to match user's display expectations.
+ *
+ * @param {string} isoString - ISO datetime string (e.g., "2025-12-17T18:30:00")
+ * @returns {number|null} Hour number (0-23), or null if invalid
+ */
+export function getHourFromIsoTime(isoString) {
+  if (!isoString || typeof isoString !== 'string') {
+    return null
+  }
+
+  // Extract time directly from ISO string format (HH:MM:SS)
+  // This avoids timezone conversion issues
+  const timeMatch = isoString.match(/T(\d{2}):(\d{2})/)
+  if (timeMatch) {
+    return parseInt(timeMatch[1], 10)
+  }
+
+  // Fallback to Date parsing for non-standard formats
+  const date = new Date(isoString)
+  if (isNaN(date.getTime())) {
+    return null
+  }
+
+  return date.getHours()
+}
+
+/**
+ * Extracts the minute (0-59) from an ISO datetime string.
+ *
+ * @param {string} isoString - ISO datetime string
+ * @returns {number|null} Minute number (0-59), or null if invalid
+ */
+export function getMinuteFromIsoTime(isoString) {
+  if (!isoString || typeof isoString !== 'string') {
+    return null
+  }
+
+  // Extract time directly from ISO string format (HH:MM:SS)
+  const timeMatch = isoString.match(/T(\d{2}):(\d{2})/)
+  if (timeMatch) {
+    return parseInt(timeMatch[2], 10)
+  }
+
+  // Fallback to Date parsing for non-standard formats
+  const date = new Date(isoString)
+  if (isNaN(date.getTime())) {
+    return null
+  }
+
+  return date.getMinutes()
+}
+
+/**
+ * Formats an hour number to a display string (e.g., 18 -> "18:00").
+ *
+ * @param {number} hour - Hour number (0-23)
+ * @returns {string} Formatted time string
+ */
+export function formatHourLabel(hour) {
+  if (typeof hour !== 'number' || hour < 0 || hour > 23) {
+    return ''
+  }
+  return `${hour}:00`
+}
+
+/**
+ * Formats an ISO datetime string to a short time string (e.g., "18:30").
+ *
+ * @param {string} isoString - ISO datetime string
+ * @returns {string} Formatted time string (HH:MM)
+ */
+export function formatTimeShort(isoString) {
+  if (!isoString || typeof isoString !== 'string') {
+    return ''
+  }
+
+  // Extract time directly from ISO string format to avoid timezone issues
+  const timeMatch = isoString.match(/T(\d{2}):(\d{2})/)
+  if (timeMatch) {
+    const hours = parseInt(timeMatch[1], 10)
+    const minutes = timeMatch[2]
+    return `${hours}:${minutes}`
+  }
+
+  // Fallback to Date parsing for non-standard formats
+  const date = new Date(isoString)
+  if (isNaN(date.getTime())) {
+    return ''
+  }
+
+  const hours = date.getHours()
+  const minutes = date.getMinutes()
+  return `${hours}:${minutes.toString().padStart(2, '0')}`
+}
+
+/**
+ * Groups executions by hour (0-23) for a given date.
+ *
+ * @param {Array} executions - Array of execution objects with start_time
+ * @param {string} date - ISO date string (YYYY-MM-DD) to filter by
+ * @returns {Object} Map of hour (0-23) -> array of executions
+ */
+export function groupExecutionsByHour(executions, date) {
+  if (!executions || !Array.isArray(executions)) {
+    return {}
+  }
+
+  const grouped = {}
+
+  executions.forEach((execution) => {
+    if (!execution.start_time) return
+
+    // Check if execution is on the target date
+    const executionDate = execution.start_time.split('T')[0]
+    if (date && executionDate !== date) return
+
+    const hour = getHourFromIsoTime(execution.start_time)
+    if (hour === null) return
+
+    if (!grouped[hour]) {
+      grouped[hour] = []
+    }
+
+    grouped[hour].push(execution)
+  })
+
+  return grouped
+}
+
+/**
+ * Finds the most severe conflict affecting a specific hour.
+ *
+ * @param {Array} conflicts - Array of conflict objects with start_time/end_time
+ * @param {number} hour - Hour to check (0-23)
+ * @param {string} date - ISO date string (YYYY-MM-DD)
+ * @returns {Object|null} Most severe conflict for this hour, or null
+ */
+export function getConflictForHour(conflicts, hour, date) {
+  if (!conflicts || !Array.isArray(conflicts) || conflicts.length === 0) {
+    return null
+  }
+
+  if (typeof hour !== 'number' || hour < 0 || hour > 23) {
+    return null
+  }
+
+  // Find all conflicts that affect this hour
+  const matchingConflicts = conflicts.filter((conflict) => {
+    if (!conflict.start_time) return false
+
+    // Check if conflict is on the target date
+    const conflictDate = conflict.start_time.split('T')[0]
+    if (date && conflictDate !== date) return false
+
+    const conflictHour = getHourFromIsoTime(conflict.start_time)
+    return conflictHour === hour
+  })
+
+  if (matchingConflicts.length === 0) {
+    return null
+  }
+
+  // Return the most severe conflict (error > warning)
+  const errorConflict = matchingConflicts.find((c) => c.severity === 'error')
+  return errorConflict || matchingConflicts[0]
+}
+
+/**
+ * Gets display information for an action type.
+ *
+ * @param {string} actionType - Action type ('camera', 'gpio', 'gps_sync', 'service')
+ * @param {string} actionName - Action name (used to detect HDR)
+ * @returns {Object} { bg, text, darkBg, darkText } Tailwind classes
+ */
+export function getActionTypeDisplay(actionType, actionName) {
+  // Check for HDR first (special purple color)
+  if (isHdrAction(actionName)) {
+    return ACTION_TYPE_COLORS.hdr
+  }
+
+  // Return colors for known action types, or default
+  return ACTION_TYPE_COLORS[actionType] || DEFAULT_ACTION_COLORS
+}
+
+/**
+ * Counts conflicts by severity.
+ *
+ * @param {Array} conflicts - Array of conflict objects
+ * @returns {Object} { total, errors, warnings }
+ */
+export function countConflictsBySeverity(conflicts) {
+  if (!conflicts || !Array.isArray(conflicts)) {
+    return { total: 0, errors: 0, warnings: 0 }
+  }
+
+  const errors = conflicts.filter((c) => c.severity === 'error').length
+  const warnings = conflicts.filter((c) => c.severity === 'warning').length
+
+  return {
+    total: conflicts.length,
+    errors,
+    warnings,
+  }
+}
+
+/**
+ * Checks if an execution is involved in a conflict.
+ *
+ * @param {Object} execution - Execution object with pattern_id
+ * @param {Array} conflicts - Array of conflict objects
+ * @returns {Object|null} Conflict affecting this execution, or null
+ */
+export function getConflictForExecution(execution, conflicts) {
+  if (!execution || !conflicts || !Array.isArray(conflicts)) {
+    return null
+  }
+
+  // Find conflict by matching pattern_id or execution time
+  const match = conflicts.find((conflict) => {
+    // Check by event IDs
+    if (conflict.event1_id === execution.pattern_id) return true
+    if (conflict.event2_id === execution.pattern_id) return true
+
+    // Check by time overlap
+    if (conflict.start_time && execution.start_time) {
+      const conflictTime = conflict.start_time
+      const execTime = execution.start_time
+      // Exact time match indicates this execution is part of the conflict
+      if (conflictTime === execTime) return true
+    }
+
+    return false
+  })
+
+  return match || null
+}
+
+/**
+ * Generates a unique key for an execution chip.
+ *
+ * @param {Object} execution - Execution object
+ * @returns {string} Unique key for React rendering
+ */
+export function getExecutionKey(execution) {
+  const patternId = execution.pattern_id || 'unknown'
+  const time = execution.start_time || ''
+  return `${patternId}-${time}`
+}
+
+/**
+ * Formats execution for data-testid attribute.
+ * Format: execution-{routine_id}-{time}
+ *
+ * @param {Object} execution - Execution object
+ * @returns {string} data-testid value
+ */
+export function getExecutionTestId(execution) {
+  const routineId = execution.pattern_id || 'unknown'
+  const time = formatTimeShort(execution.start_time).replace(':', '')
+  return `execution-${routineId}-${time}`
+}

--- a/Firmware/webui/frontend/src/components/scheduler/DayTimeline/dayTimelineUtils.js
+++ b/Firmware/webui/frontend/src/components/scheduler/DayTimeline/dayTimelineUtils.js
@@ -18,7 +18,8 @@ import {
 
 /**
  * Extracts the hour (0-23) from an ISO datetime string.
- * Uses local timezone to match user's display expectations.
+ * Uses regex extraction from ISO format for consistency.
+ * Note: All times are treated as UTC to avoid timezone inconsistencies.
  *
  * @param {string} isoString - ISO datetime string (e.g., "2025-12-17T18:30:00")
  * @returns {number|null} Hour number (0-23), or null if invalid
@@ -36,16 +37,18 @@ export function getHourFromIsoTime(isoString) {
   }
 
   // Fallback to Date parsing for non-standard formats
+  // Use UTC to match the behavior of regex extraction
   const date = new Date(isoString)
   if (isNaN(date.getTime())) {
     return null
   }
 
-  return date.getHours()
+  return date.getUTCHours()
 }
 
 /**
  * Extracts the minute (0-59) from an ISO datetime string.
+ * Note: All times are treated as UTC to avoid timezone inconsistencies.
  *
  * @param {string} isoString - ISO datetime string
  * @returns {number|null} Minute number (0-59), or null if invalid
@@ -62,12 +65,13 @@ export function getMinuteFromIsoTime(isoString) {
   }
 
   // Fallback to Date parsing for non-standard formats
+  // Use UTC to match the behavior of regex extraction
   const date = new Date(isoString)
   if (isNaN(date.getTime())) {
     return null
   }
 
-  return date.getMinutes()
+  return date.getUTCMinutes()
 }
 
 /**
@@ -103,13 +107,14 @@ export function formatTimeShort(isoString) {
   }
 
   // Fallback to Date parsing for non-standard formats
+  // Use UTC to match the behavior of regex extraction
   const date = new Date(isoString)
   if (isNaN(date.getTime())) {
     return ''
   }
 
-  const hours = date.getHours()
-  const minutes = date.getMinutes()
+  const hours = date.getUTCHours()
+  const minutes = date.getUTCMinutes()
   return `${hours}:${minutes.toString().padStart(2, '0')}`
 }
 

--- a/Firmware/webui/frontend/src/components/scheduler/DayTimeline/dayTimelineUtils.js
+++ b/Firmware/webui/frontend/src/components/scheduler/DayTimeline/dayTimelineUtils.js
@@ -8,6 +8,12 @@
  * - Getting action type display information
  *
  * @module components/scheduler/DayTimeline/dayTimelineUtils
+ *
+ * @note TIMEZONE HANDLING: All times in this module are treated as UTC to avoid
+ * timezone inconsistencies. The backend API returns times in ISO 8601 format
+ * (e.g., "2025-12-17T18:30:00Z") and this module extracts hours/minutes directly
+ * from the string format to avoid browser timezone conversion. Ensure your
+ * backend returns UTC times for consistent display across timezones.
  */
 
 import {
@@ -15,6 +21,23 @@ import {
   DEFAULT_ACTION_COLORS,
   isHdrAction,
 } from './dayTimelineConstants'
+
+/**
+ * Regex for validating ISO 8601 datetime format.
+ * Matches: YYYY-MM-DDTHH:MM:SS with optional milliseconds and Z suffix.
+ */
+const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?Z?$/
+
+/**
+ * Logs a warning in development mode for invalid time strings.
+ * @param {string} isoString - The invalid ISO string
+ * @param {string} context - Function name for context
+ */
+function warnInvalidTime(isoString, context) {
+  if (import.meta.env.DEV) {
+    console.warn(`[${context}] Invalid ISO time string:`, isoString)
+  }
+}
 
 /**
  * Extracts the hour (0-23) from an ISO datetime string.
@@ -36,10 +59,17 @@ export function getHourFromIsoTime(isoString) {
     return parseInt(timeMatch[1], 10)
   }
 
+  // Validate format before attempting Date parsing
+  if (!ISO_DATE_REGEX.test(isoString)) {
+    warnInvalidTime(isoString, 'getHourFromIsoTime')
+    return null
+  }
+
   // Fallback to Date parsing for non-standard formats
   // Use UTC to match the behavior of regex extraction
   const date = new Date(isoString)
   if (isNaN(date.getTime())) {
+    warnInvalidTime(isoString, 'getHourFromIsoTime')
     return null
   }
 
@@ -64,10 +94,17 @@ export function getMinuteFromIsoTime(isoString) {
     return parseInt(timeMatch[2], 10)
   }
 
+  // Validate format before attempting Date parsing
+  if (!ISO_DATE_REGEX.test(isoString)) {
+    warnInvalidTime(isoString, 'getMinuteFromIsoTime')
+    return null
+  }
+
   // Fallback to Date parsing for non-standard formats
   // Use UTC to match the behavior of regex extraction
   const date = new Date(isoString)
   if (isNaN(date.getTime())) {
+    warnInvalidTime(isoString, 'getMinuteFromIsoTime')
     return null
   }
 
@@ -106,10 +143,17 @@ export function formatTimeShort(isoString) {
     return `${hours}:${minutes}`
   }
 
+  // Validate format before attempting Date parsing
+  if (!ISO_DATE_REGEX.test(isoString)) {
+    warnInvalidTime(isoString, 'formatTimeShort')
+    return ''
+  }
+
   // Fallback to Date parsing for non-standard formats
   // Use UTC to match the behavior of regex extraction
   const date = new Date(isoString)
   if (isNaN(date.getTime())) {
+    warnInvalidTime(isoString, 'formatTimeShort')
     return ''
   }
 
@@ -263,13 +307,19 @@ export function getConflictForExecution(execution, conflicts) {
 /**
  * Generates a unique key for an execution chip.
  *
+ * Uses execution.id if available, otherwise falls back to pattern_id + time + index.
+ * The index parameter prevents key collisions when multiple executions share
+ * the same pattern_id and start_time.
+ *
  * @param {Object} execution - Execution object
+ * @param {number} [index=0] - Array index for uniqueness fallback
  * @returns {string} Unique key for React rendering
  */
-export function getExecutionKey(execution) {
+export function getExecutionKey(execution, index = 0) {
   const patternId = execution.pattern_id || 'unknown'
   const time = execution.start_time || ''
-  return `${patternId}-${time}`
+  const uniqueId = execution.id || index
+  return `${patternId}-${time}-${uniqueId}`
 }
 
 /**

--- a/Firmware/webui/frontend/src/components/scheduler/DayTimeline/index.js
+++ b/Firmware/webui/frontend/src/components/scheduler/DayTimeline/index.js
@@ -1,0 +1,13 @@
+/**
+ * DayTimeline component exports (Issue #326)
+ *
+ * @module components/scheduler/DayTimeline
+ */
+
+export { default } from './DayTimeline'
+export { default as DayTimeline } from './DayTimeline'
+export { default as HourRow } from './HourRow'
+export { default as ExecutionChip } from './ExecutionChip'
+export { default as ConflictSummary } from './ConflictSummary'
+export * from './dayTimelineUtils'
+export * from './dayTimelineConstants'


### PR DESCRIPTION
## Summary
- Create DayTimeline component for hourly day view with conflict highlighting
- Red highlighting for time collisions (blocking conflicts)
- Yellow highlighting for GPIO warnings (non-blocking conflicts)
- Execution chips showing routine actions with action-type colors

## Changes
### New Files (8)
- `DayTimeline/dayTimelineConstants.js` - Static Tailwind class mappings for JIT
- `DayTimeline/dayTimelineUtils.js` - Utility functions (time parsing, grouping, conflict matching)
- `DayTimeline/ExecutionChip.jsx` - Execution marker chip with color-coded action types
- `DayTimeline/ConflictSummary.jsx` - Conflict count banner
- `DayTimeline/HourRow.jsx` - Individual hour row with executions
- `DayTimeline/DayTimeline.jsx` - Main container with 24 hour rows
- `DayTimeline/index.js` - Component exports
- Test files for all components (112 new tests)

### Modified Files
- `CalendarGrid.jsx` - Use DayTimeline for day view, add conflicts prop
- `CalendarView.jsx` - Pass conflicts to CalendarGrid

## Test plan
- [x] All 112 DayTimeline tests passing
- [x] All 1792 scheduler tests passing
- [x] ESLint passing
- [x] Ruff checks passing
- [ ] Manual testing of day view with schedule preview
- [ ] Verify conflict highlighting with overlapping routines

Closes #326