### PR TITLE
feat(scheduler): Add ActivationProgress component (#327)

### DIFF
--- a/Firmware/webui/frontend/src/components/scheduler/ActivationProgress/ActivationProgress.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ActivationProgress/ActivationProgress.jsx
@@ -57,7 +57,11 @@ export default function ActivationProgress({
   const onErrorRef = useRef(onError)
 
   // Update refs on every render to avoid stale closures in WebSocket handler.
-  // This is intentional - refs capture the latest callback without triggering effect re-runs.
+  // Pattern explanation: This effect has no dependency array intentionally.
+  // - Refs capture the latest callback on every render
+  // - No dependencies means this runs after every render (not just on prop changes)
+  // - This prevents stale closures in async WebSocket handlers without triggering socket reconnects
+  // See: https://react.dev/reference/react/useRef#referencing-a-value-with-a-ref
   useEffect(() => {
     onCompleteRef.current = onComplete
     onErrorRef.current = onError
@@ -67,10 +71,25 @@ export default function ActivationProgress({
     // Setup WebSocket connection using window.location.origin for robust URL handling
     const wsUrl = window.location.origin
 
+    /**
+     * Helper to handle connection errors uniformly.
+     * Called for both sync errors (io() throws) and async errors (connect_error event).
+     */
+    const handleConnectionError = (error) => {
+      console.error('WebSocket connection failed:', error)
+      setState('error')
+      setErrorMessage('Connection failed')
+      onErrorRef.current?.('Connection failed')
+    }
+
     try {
       socketRef.current = io(wsUrl, {
         transports: ['websocket', 'polling'],
       })
+
+      // Handle async connection errors (network issues, server unavailable, etc.)
+      socketRef.current.on('connect_error', handleConnectionError)
+      socketRef.current.on('error', handleConnectionError)
 
       socketRef.current.on('schedule:activation_progress', (data) => {
         // Filter events for this specific schedule
@@ -90,16 +109,15 @@ export default function ActivationProgress({
         }
       })
     } catch (error) {
-      // Handle WebSocket connection failure gracefully
-      console.error('WebSocket connection failed:', error)
-      setState('error')
-      setErrorMessage('Connection failed')
-      onErrorRef.current?.('Connection failed')
+      // Handle sync errors (e.g., io() throws immediately)
+      handleConnectionError(error)
     }
 
     return () => {
       if (socketRef.current) {
         socketRef.current.off('schedule:activation_progress')
+        socketRef.current.off('connect_error')
+        socketRef.current.off('error')
         socketRef.current.disconnect()
       }
     }
@@ -109,6 +127,8 @@ export default function ActivationProgress({
     // Disconnect old socket to prevent stale messages from previous attempt
     if (socketRef.current) {
       socketRef.current.off('schedule:activation_progress')
+      socketRef.current.off('connect_error')
+      socketRef.current.off('error')
       socketRef.current.disconnect()
       socketRef.current = null
     }

--- a/Firmware/webui/frontend/src/components/scheduler/ActivationProgress/ActivationProgress.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ActivationProgress/ActivationProgress.jsx
@@ -1,0 +1,177 @@
+/**
+ * ActivationProgress - Real-time schedule activation status (Issue #327)
+ *
+ * Displays activation progress via WebSocket events:
+ * - Spinner and progress bar during activation
+ * - Phase labels for current operation
+ * - Error state with retry option
+ *
+ * The component manages its own Socket.io connection and listens for
+ * `schedule:activation_progress` events filtered by scheduleId.
+ *
+ * @module components/scheduler/ActivationProgress/ActivationProgress
+ */
+
+import { useState, useEffect, useRef, useCallback } from 'react'
+import PropTypes from 'prop-types'
+import { io } from 'socket.io-client'
+import { PHASE_LABELS } from './constants'
+
+/**
+ * ActivationProgress component
+ *
+ * @param {Object} props - Component props
+ * @param {string} props.scheduleId - ID of the schedule being activated
+ * @param {Function} [props.onComplete] - Callback when activation succeeds
+ * @param {Function} [props.onError] - Callback when activation fails (receives error message)
+ * @param {Function} [props.onRetry] - Callback when user clicks Retry button
+ * @returns {JSX.Element} Activation progress display
+ *
+ * @example
+ * <ActivationProgress
+ *   scheduleId="sched-123"
+ *   onComplete={() => toast.success('Activated!')}
+ *   onError={(msg) => toast.error(msg)}
+ *   onRetry={() => activateMutation.mutate()}
+ * />
+ */
+export default function ActivationProgress({
+  scheduleId,
+  onComplete,
+  onError,
+  onRetry,
+}) {
+  const [state, setState] = useState('activating')
+  const [progress, setProgress] = useState(0)
+  const [phase, setPhase] = useState('checking_conflicts')
+  const [errorMessage, setErrorMessage] = useState('')
+  const socketRef = useRef(null)
+
+  // Memoize callbacks to avoid effect re-runs
+  const handleComplete = useCallback(() => {
+    onComplete?.()
+  }, [onComplete])
+
+  const handleError = useCallback(
+    (msg) => {
+      onError?.(msg)
+    },
+    [onError]
+  )
+
+  useEffect(() => {
+    // Setup WebSocket connection (following Camera.jsx pattern)
+    const host = window.location.hostname
+    const port = window.location.port || (window.location.protocol === 'https:' ? '443' : '80')
+    const wsUrl = `${window.location.protocol}//${host}:${port}`
+
+    socketRef.current = io(wsUrl, {
+      transports: ['websocket', 'polling'],
+    })
+
+    socketRef.current.on('schedule:activation_progress', (data) => {
+      // Filter events for this specific schedule
+      if (data.schedule_id !== scheduleId) return
+
+      setProgress(data.progress)
+      setPhase(data.phase)
+
+      if (data.phase === 'complete') {
+        setState('complete')
+        handleComplete()
+      } else if (data.phase === 'failed') {
+        setState('error')
+        const msg = data.error || 'Activation failed'
+        setErrorMessage(msg)
+        handleError(msg)
+      }
+    })
+
+    return () => {
+      if (socketRef.current) {
+        socketRef.current.disconnect()
+      }
+    }
+  }, [scheduleId, handleComplete, handleError])
+
+  const handleRetryClick = () => {
+    // Reset state for retry
+    setState('activating')
+    setProgress(0)
+    setPhase('checking_conflicts')
+    setErrorMessage('')
+    onRetry?.()
+  }
+
+  // Error state
+  if (state === 'error') {
+    return (
+      <div
+        data-testid="activation-progress"
+        className="border border-red-900/50 rounded-lg p-4 space-y-3"
+      >
+        <div data-testid="activation-error" className="flex items-center justify-between">
+          <span className="text-xs text-red-400">Failed</span>
+          <button
+            type="button"
+            onClick={handleRetryClick}
+            className="text-sm text-gray-400 hover:text-white"
+          >
+            Retry
+          </button>
+        </div>
+        <div className="text-xs text-gray-500">{errorMessage}</div>
+      </div>
+    )
+  }
+
+  // Complete state - minimal display, parent handles full active UI
+  if (state === 'complete') {
+    return (
+      <div data-testid="activation-progress" className="space-y-2">
+        <div className="flex items-center gap-2">
+          <div className="w-2 h-2 bg-green-500 rounded-full" />
+          <span className="text-xs text-green-400">Activated</span>
+        </div>
+      </div>
+    )
+  }
+
+  // Activating state - progress bar with phase label
+  return (
+    <div data-testid="activation-progress" className="space-y-2">
+      <div className="flex items-center gap-2">
+        <div
+          className="w-3 h-3 border-2 border-blue-400 border-t-transparent rounded-full animate-spin"
+          aria-hidden="true"
+        />
+        <span className="text-xs text-blue-400">Activating</span>
+      </div>
+      <div className="h-1 bg-gray-800 rounded-full overflow-hidden">
+        <div
+          data-testid="activation-progress-bar"
+          className="h-full bg-blue-500 transition-all duration-300"
+          style={{ width: `${progress}%` }}
+          role="progressbar"
+          aria-valuenow={progress}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label="Activation progress"
+        />
+      </div>
+      <div className="flex justify-between text-xs">
+        <span data-testid="activation-phase" className="text-gray-500">
+          {PHASE_LABELS[phase] || phase}
+        </span>
+        <span className="text-gray-600">{progress}%</span>
+      </div>
+    </div>
+  )
+}
+
+ActivationProgress.propTypes = {
+  scheduleId: PropTypes.string.isRequired,
+  onComplete: PropTypes.func,
+  onError: PropTypes.func,
+  onRetry: PropTypes.func,
+}

--- a/Firmware/webui/frontend/src/components/scheduler/ActivationProgress/ActivationProgress.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ActivationProgress/ActivationProgress.jsx
@@ -9,6 +9,10 @@
  * The component manages its own Socket.io connection and listens for
  * `schedule:activation_progress` events filtered by scheduleId.
  *
+ * @important Only one ActivationProgress should be rendered at a time.
+ * Multiple instances will create separate WebSocket connections.
+ * The scheduler UI enforces single-schedule activation.
+ *
  * @module components/scheduler/ActivationProgress/ActivationProgress
  */
 
@@ -45,45 +49,53 @@ export default function ActivationProgress({
   const [progress, setProgress] = useState(0)
   const [phase, setPhase] = useState('checking_conflicts')
   const [errorMessage, setErrorMessage] = useState('')
+  const [reconnectTrigger, setReconnectTrigger] = useState(0)
   const socketRef = useRef(null)
 
   // Store latest callbacks in refs to avoid effect re-runs when parent re-renders
   const onCompleteRef = useRef(onComplete)
   const onErrorRef = useRef(onError)
 
-  // Keep refs in sync with props
+  // Update refs on every render to avoid stale closures in WebSocket handler.
+  // This is intentional - refs capture the latest callback without triggering effect re-runs.
   useEffect(() => {
     onCompleteRef.current = onComplete
     onErrorRef.current = onError
   })
 
   useEffect(() => {
-    // Setup WebSocket connection (following Camera.jsx pattern)
-    const host = window.location.hostname
-    const port = window.location.port || (window.location.protocol === 'https:' ? '443' : '80')
-    const wsUrl = `${window.location.protocol}//${host}:${port}`
+    // Setup WebSocket connection using window.location.origin for robust URL handling
+    const wsUrl = window.location.origin
 
-    socketRef.current = io(wsUrl, {
-      transports: ['websocket', 'polling'],
-    })
+    try {
+      socketRef.current = io(wsUrl, {
+        transports: ['websocket', 'polling'],
+      })
 
-    socketRef.current.on('schedule:activation_progress', (data) => {
-      // Filter events for this specific schedule
-      if (data.schedule_id !== scheduleId) return
+      socketRef.current.on('schedule:activation_progress', (data) => {
+        // Filter events for this specific schedule
+        if (data.schedule_id !== scheduleId) return
 
-      setProgress(data.progress)
-      setPhase(data.phase)
+        setProgress(data.progress)
+        setPhase(data.phase)
 
-      if (data.phase === 'complete') {
-        setState('complete')
-        onCompleteRef.current?.()
-      } else if (data.phase === 'failed') {
-        setState('error')
-        const msg = data.error || 'Activation failed'
-        setErrorMessage(msg)
-        onErrorRef.current?.(msg)
-      }
-    })
+        if (data.phase === 'complete') {
+          setState('complete')
+          onCompleteRef.current?.()
+        } else if (data.phase === 'failed') {
+          setState('error')
+          const msg = data.error || 'Activation failed'
+          setErrorMessage(msg)
+          onErrorRef.current?.(msg)
+        }
+      })
+    } catch (error) {
+      // Handle WebSocket connection failure gracefully
+      console.error('WebSocket connection failed:', error)
+      setState('error')
+      setErrorMessage('Connection failed')
+      onErrorRef.current?.('Connection failed')
+    }
 
     return () => {
       if (socketRef.current) {
@@ -91,14 +103,25 @@ export default function ActivationProgress({
         socketRef.current.disconnect()
       }
     }
-  }, [scheduleId])
+  }, [scheduleId, reconnectTrigger])
 
   const handleRetryClick = () => {
+    // Disconnect old socket to prevent stale messages from previous attempt
+    if (socketRef.current) {
+      socketRef.current.off('schedule:activation_progress')
+      socketRef.current.disconnect()
+      socketRef.current = null
+    }
+
     // Reset state for retry
     setState('activating')
     setProgress(0)
     setPhase('checking_conflicts')
     setErrorMessage('')
+
+    // Force effect re-run to reconnect socket
+    setReconnectTrigger((prev) => prev + 1)
+
     onRetry?.()
   }
 
@@ -139,6 +162,10 @@ export default function ActivationProgress({
   // Activating state - progress bar with phase label
   return (
     <div data-testid="activation-progress" className="space-y-2">
+      {/* ARIA live region for screen reader announcements */}
+      <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+        {PHASE_LABELS[phase] || phase} - {progress}%
+      </div>
       <div className="flex items-center gap-2">
         <div
           className="w-3 h-3 border-2 border-blue-500 dark:border-blue-400 border-t-transparent rounded-full animate-spin"

--- a/Firmware/webui/frontend/src/components/scheduler/ActivationProgress/ActivationProgress.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ActivationProgress/ActivationProgress.jsx
@@ -12,7 +12,7 @@
  * @module components/scheduler/ActivationProgress/ActivationProgress
  */
 
-import { useState, useEffect, useRef, useCallback } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 import { io } from 'socket.io-client'
 import { PHASE_LABELS } from './constants'
@@ -47,17 +47,15 @@ export default function ActivationProgress({
   const [errorMessage, setErrorMessage] = useState('')
   const socketRef = useRef(null)
 
-  // Memoize callbacks to avoid effect re-runs
-  const handleComplete = useCallback(() => {
-    onComplete?.()
-  }, [onComplete])
+  // Store latest callbacks in refs to avoid effect re-runs when parent re-renders
+  const onCompleteRef = useRef(onComplete)
+  const onErrorRef = useRef(onError)
 
-  const handleError = useCallback(
-    (msg) => {
-      onError?.(msg)
-    },
-    [onError]
-  )
+  // Keep refs in sync with props
+  useEffect(() => {
+    onCompleteRef.current = onComplete
+    onErrorRef.current = onError
+  })
 
   useEffect(() => {
     // Setup WebSocket connection (following Camera.jsx pattern)
@@ -78,21 +76,22 @@ export default function ActivationProgress({
 
       if (data.phase === 'complete') {
         setState('complete')
-        handleComplete()
+        onCompleteRef.current?.()
       } else if (data.phase === 'failed') {
         setState('error')
         const msg = data.error || 'Activation failed'
         setErrorMessage(msg)
-        handleError(msg)
+        onErrorRef.current?.(msg)
       }
     })
 
     return () => {
       if (socketRef.current) {
+        socketRef.current.off('schedule:activation_progress')
         socketRef.current.disconnect()
       }
     }
-  }, [scheduleId, handleComplete, handleError])
+  }, [scheduleId])
 
   const handleRetryClick = () => {
     // Reset state for retry
@@ -108,19 +107,19 @@ export default function ActivationProgress({
     return (
       <div
         data-testid="activation-progress"
-        className="border border-red-900/50 rounded-lg p-4 space-y-3"
+        className="border border-red-300 dark:border-red-900/50 rounded-lg p-4 space-y-3 bg-red-50 dark:bg-transparent"
       >
         <div data-testid="activation-error" className="flex items-center justify-between">
-          <span className="text-xs text-red-400">Failed</span>
+          <span className="text-xs text-red-600 dark:text-red-400">Failed</span>
           <button
             type="button"
             onClick={handleRetryClick}
-            className="text-sm text-gray-400 hover:text-white"
+            className="text-sm text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
           >
             Retry
           </button>
         </div>
-        <div className="text-xs text-gray-500">{errorMessage}</div>
+        <div className="text-xs text-gray-600 dark:text-gray-500">{errorMessage}</div>
       </div>
     )
   }
@@ -131,7 +130,7 @@ export default function ActivationProgress({
       <div data-testid="activation-progress" className="space-y-2">
         <div className="flex items-center gap-2">
           <div className="w-2 h-2 bg-green-500 rounded-full" />
-          <span className="text-xs text-green-400">Activated</span>
+          <span className="text-xs text-green-600 dark:text-green-400">Activated</span>
         </div>
       </div>
     )
@@ -142,12 +141,12 @@ export default function ActivationProgress({
     <div data-testid="activation-progress" className="space-y-2">
       <div className="flex items-center gap-2">
         <div
-          className="w-3 h-3 border-2 border-blue-400 border-t-transparent rounded-full animate-spin"
+          className="w-3 h-3 border-2 border-blue-500 dark:border-blue-400 border-t-transparent rounded-full animate-spin"
           aria-hidden="true"
         />
-        <span className="text-xs text-blue-400">Activating</span>
+        <span className="text-xs text-blue-600 dark:text-blue-400">Activating</span>
       </div>
-      <div className="h-1 bg-gray-800 rounded-full overflow-hidden">
+      <div className="h-1 bg-gray-200 dark:bg-gray-800 rounded-full overflow-hidden">
         <div
           data-testid="activation-progress-bar"
           className="h-full bg-blue-500 transition-all duration-300"
@@ -160,10 +159,10 @@ export default function ActivationProgress({
         />
       </div>
       <div className="flex justify-between text-xs">
-        <span data-testid="activation-phase" className="text-gray-500">
+        <span data-testid="activation-phase" className="text-gray-600 dark:text-gray-500">
           {PHASE_LABELS[phase] || phase}
         </span>
-        <span className="text-gray-600">{progress}%</span>
+        <span className="text-gray-500 dark:text-gray-600">{progress}%</span>
       </div>
     </div>
   )

--- a/Firmware/webui/frontend/src/components/scheduler/ActivationProgress/__tests__/ActivationProgress.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ActivationProgress/__tests__/ActivationProgress.test.jsx
@@ -403,6 +403,14 @@ describe('ActivationProgress', () => {
   // ==========================================================================
 
   describe('Socket Cleanup', () => {
+    it('removes event listener on unmount', () => {
+      const { unmount } = render(<ActivationProgress scheduleId="sched-1" />)
+
+      unmount()
+
+      expect(mockSocket.off).toHaveBeenCalledWith('schedule:activation_progress')
+    })
+
     it('disconnects socket on unmount', () => {
       const { unmount } = render(<ActivationProgress scheduleId="sched-1" />)
 
@@ -468,13 +476,14 @@ describe('ActivationProgress', () => {
   // ==========================================================================
 
   describe('Dark Mode', () => {
-    it('has dark mode classes on progress bar container', () => {
+    it('has light and dark mode classes on progress bar container', () => {
       render(<ActivationProgress scheduleId="sched-1" />)
       const container = screen.getByTestId('activation-progress-bar').parentElement
-      expect(container).toHaveClass('bg-gray-800')
+      expect(container).toHaveClass('bg-gray-200')
+      expect(container).toHaveClass('dark:bg-gray-800')
     })
 
-    it('has dark mode classes on error state', async () => {
+    it('has light and dark mode classes on error state', async () => {
       render(<ActivationProgress scheduleId="sched-1" />)
 
       simulateProgressEvent({
@@ -485,7 +494,8 @@ describe('ActivationProgress', () => {
 
       await waitFor(() => {
         const wrapper = screen.getByTestId('activation-progress')
-        expect(wrapper).toHaveClass('border-red-900/50')
+        expect(wrapper).toHaveClass('border-red-300')
+        expect(wrapper).toHaveClass('dark:border-red-900/50')
       })
     })
   })

--- a/Firmware/webui/frontend/src/components/scheduler/ActivationProgress/__tests__/ActivationProgress.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ActivationProgress/__tests__/ActivationProgress.test.jsx
@@ -556,5 +556,100 @@ describe('ActivationProgress', () => {
         expect(screen.getByText('Activating')).toBeInTheDocument()
       })
     })
+
+    it('handles WebSocket connection failure gracefully', async () => {
+      // Mock io to throw an error on next call
+      const { io: ioMock } = await import('socket.io-client')
+      vi.mocked(ioMock).mockImplementationOnce(() => {
+        throw new Error('Connection failed')
+      })
+
+      // Component should handle error without crashing
+      expect(() => render(<ActivationProgress scheduleId="sched-1" />)).not.toThrow()
+    })
+  })
+
+  // ==========================================================================
+  // Retry Socket Reconnection
+  // ==========================================================================
+
+  describe('Retry Socket Reconnection', () => {
+    it('disconnects socket when retry is clicked', async () => {
+      const user = userEvent.setup()
+      render(<ActivationProgress scheduleId="sched-1" />)
+
+      simulateProgressEvent({
+        schedule_id: 'sched-1',
+        phase: 'failed',
+        progress: 0,
+      })
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+      })
+
+      // Clear mock calls before retry
+      mockSocket.off.mockClear()
+      mockSocket.disconnect.mockClear()
+
+      await user.click(screen.getByRole('button', { name: /retry/i }))
+
+      // Should have disconnected old socket
+      expect(mockSocket.off).toHaveBeenCalledWith('schedule:activation_progress')
+      expect(mockSocket.disconnect).toHaveBeenCalled()
+    })
+
+    it('creates new socket connection on retry', async () => {
+      const user = userEvent.setup()
+      const { io: ioMock } = await import('socket.io-client')
+      render(<ActivationProgress scheduleId="sched-1" />)
+
+      const initialCallCount = vi.mocked(ioMock).mock.calls.length
+
+      simulateProgressEvent({
+        schedule_id: 'sched-1',
+        phase: 'failed',
+        progress: 0,
+      })
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: /retry/i }))
+
+      // Should have created a new socket connection
+      await waitFor(() => {
+        expect(vi.mocked(ioMock).mock.calls.length).toBeGreaterThan(initialCallCount)
+      })
+    })
+  })
+
+  // ==========================================================================
+  // ARIA Live Region
+  // ==========================================================================
+
+  describe('ARIA Live Region', () => {
+    it('has aria-live region for screen reader announcements', () => {
+      render(<ActivationProgress scheduleId="sched-1" />)
+      const liveRegion = screen.getByRole('status')
+      expect(liveRegion).toHaveAttribute('aria-live', 'polite')
+      expect(liveRegion).toHaveAttribute('aria-atomic', 'true')
+    })
+
+    it('announces progress updates to screen readers', async () => {
+      render(<ActivationProgress scheduleId="sched-1" />)
+
+      simulateProgressEvent({
+        schedule_id: 'sched-1',
+        phase: 'generating_cron',
+        progress: 30,
+      })
+
+      await waitFor(() => {
+        const liveRegion = screen.getByRole('status')
+        expect(liveRegion).toHaveTextContent('Generating schedule... - 30%')
+      })
+    })
   })
 })

--- a/Firmware/webui/frontend/src/components/scheduler/ActivationProgress/__tests__/ActivationProgress.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ActivationProgress/__tests__/ActivationProgress.test.jsx
@@ -1,0 +1,550 @@
+/**
+ * Tests for ActivationProgress component (Issue #327)
+ *
+ * ActivationProgress displays real-time schedule activation status
+ * via WebSocket events, including progress bar, phase labels, and error handling.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ActivationProgress from '../ActivationProgress'
+import { PHASE_LABELS } from '../constants'
+
+// Mock socket.io-client
+const mockSocket = {
+  on: vi.fn(),
+  off: vi.fn(),
+  disconnect: vi.fn(),
+}
+
+vi.mock('socket.io-client', () => ({
+  io: vi.fn(() => mockSocket),
+}))
+
+/**
+ * Helper to simulate WebSocket progress events
+ * Wraps state updates in act() to avoid React warnings
+ * @param {Object} data - Event data with schedule_id, phase, progress, and optional error
+ */
+const simulateProgressEvent = (data) => {
+  const handler = mockSocket.on.mock.calls.find(
+    (call) => call[0] === 'schedule:activation_progress'
+  )?.[1]
+  act(() => {
+    handler?.(data)
+  })
+}
+
+describe('ActivationProgress', () => {
+  beforeEach(() => {
+    mockSocket.on.mockClear()
+    mockSocket.off.mockClear()
+    mockSocket.disconnect.mockClear()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // ==========================================================================
+  // Rendering Tests
+  // ==========================================================================
+
+  describe('Rendering', () => {
+    it('renders with data-testid="activation-progress"', () => {
+      render(<ActivationProgress scheduleId="sched-1" />)
+      expect(screen.getByTestId('activation-progress')).toBeInTheDocument()
+    })
+
+    it('shows activating state initially', () => {
+      render(<ActivationProgress scheduleId="sched-1" />)
+      expect(screen.getByText('Activating')).toBeInTheDocument()
+    })
+
+    it('renders progress bar', () => {
+      render(<ActivationProgress scheduleId="sched-1" />)
+      expect(screen.getByTestId('activation-progress-bar')).toBeInTheDocument()
+    })
+
+    it('renders phase label', () => {
+      render(<ActivationProgress scheduleId="sched-1" />)
+      expect(screen.getByTestId('activation-phase')).toBeInTheDocument()
+    })
+
+    it('shows initial phase label', () => {
+      render(<ActivationProgress scheduleId="sched-1" />)
+      expect(screen.getByTestId('activation-phase')).toHaveTextContent(
+        PHASE_LABELS.checking_conflicts
+      )
+    })
+
+    it('shows initial progress of 0%', () => {
+      render(<ActivationProgress scheduleId="sched-1" />)
+      expect(screen.getByText('0%')).toBeInTheDocument()
+    })
+  })
+
+  // ==========================================================================
+  // Progress Updates
+  // ==========================================================================
+
+  describe('Progress Updates', () => {
+    it('updates progress bar when receiving progress events', async () => {
+      render(<ActivationProgress scheduleId="sched-1" />)
+
+      simulateProgressEvent({
+        schedule_id: 'sched-1',
+        phase: 'generating_cron',
+        progress: 30,
+      })
+
+      await waitFor(() => {
+        const progressBar = screen.getByTestId('activation-progress-bar')
+        expect(progressBar).toHaveStyle({ width: '30%' })
+      })
+    })
+
+    it('updates progress percentage text', async () => {
+      render(<ActivationProgress scheduleId="sched-1" />)
+
+      simulateProgressEvent({
+        schedule_id: 'sched-1',
+        phase: 'applying_cron',
+        progress: 60,
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText('60%')).toBeInTheDocument()
+      })
+    })
+
+    it('updates phase label for each phase', async () => {
+      render(<ActivationProgress scheduleId="sched-1" />)
+
+      simulateProgressEvent({
+        schedule_id: 'sched-1',
+        phase: 'generating_cron',
+        progress: 30,
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('activation-phase')).toHaveTextContent(
+          PHASE_LABELS.generating_cron
+        )
+      })
+    })
+
+    it('displays applying_cron phase correctly', async () => {
+      render(<ActivationProgress scheduleId="sched-1" />)
+
+      simulateProgressEvent({
+        schedule_id: 'sched-1',
+        phase: 'applying_cron',
+        progress: 60,
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('activation-phase')).toHaveTextContent('Writing crontab...')
+      })
+    })
+
+    it('displays updating_state phase correctly', async () => {
+      render(<ActivationProgress scheduleId="sched-1" />)
+
+      simulateProgressEvent({
+        schedule_id: 'sched-1',
+        phase: 'updating_state',
+        progress: 90,
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('activation-phase')).toHaveTextContent('Updating state...')
+      })
+    })
+
+    it('falls back to raw phase name if label not found', async () => {
+      render(<ActivationProgress scheduleId="sched-1" />)
+
+      simulateProgressEvent({
+        schedule_id: 'sched-1',
+        phase: 'unknown_phase',
+        progress: 50,
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('activation-phase')).toHaveTextContent('unknown_phase')
+      })
+    })
+  })
+
+  // ==========================================================================
+  // Complete State
+  // ==========================================================================
+
+  describe('Complete State', () => {
+    it('shows complete state when phase is complete', async () => {
+      render(<ActivationProgress scheduleId="sched-1" />)
+
+      simulateProgressEvent({
+        schedule_id: 'sched-1',
+        phase: 'complete',
+        progress: 100,
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText('Activated')).toBeInTheDocument()
+      })
+    })
+
+    it('calls onComplete callback when phase is complete', async () => {
+      const onComplete = vi.fn()
+      render(<ActivationProgress scheduleId="sched-1" onComplete={onComplete} />)
+
+      simulateProgressEvent({
+        schedule_id: 'sched-1',
+        phase: 'complete',
+        progress: 100,
+      })
+
+      await waitFor(() => {
+        expect(onComplete).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+
+  // ==========================================================================
+  // Error State
+  // ==========================================================================
+
+  describe('Error State', () => {
+    it('shows error state when phase is failed', async () => {
+      render(<ActivationProgress scheduleId="sched-1" />)
+
+      simulateProgressEvent({
+        schedule_id: 'sched-1',
+        phase: 'failed',
+        progress: 0,
+        error: 'Could not write to crontab',
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('activation-error')).toBeInTheDocument()
+      })
+    })
+
+    it('displays error message', async () => {
+      render(<ActivationProgress scheduleId="sched-1" />)
+
+      simulateProgressEvent({
+        schedule_id: 'sched-1',
+        phase: 'failed',
+        progress: 0,
+        error: 'Could not write to crontab',
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText('Could not write to crontab')).toBeInTheDocument()
+      })
+    })
+
+    it('shows "Failed" label in error state', async () => {
+      render(<ActivationProgress scheduleId="sched-1" />)
+
+      simulateProgressEvent({
+        schedule_id: 'sched-1',
+        phase: 'failed',
+        progress: 0,
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText('Failed')).toBeInTheDocument()
+      })
+    })
+
+    it('shows Retry button in error state', async () => {
+      render(<ActivationProgress scheduleId="sched-1" />)
+
+      simulateProgressEvent({
+        schedule_id: 'sched-1',
+        phase: 'failed',
+        progress: 0,
+      })
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+      })
+    })
+
+    it('calls onError callback when phase is failed', async () => {
+      const onError = vi.fn()
+      render(<ActivationProgress scheduleId="sched-1" onError={onError} />)
+
+      simulateProgressEvent({
+        schedule_id: 'sched-1',
+        phase: 'failed',
+        progress: 0,
+        error: 'Could not write to crontab',
+      })
+
+      await waitFor(() => {
+        expect(onError).toHaveBeenCalledTimes(1)
+        expect(onError).toHaveBeenCalledWith('Could not write to crontab')
+      })
+    })
+
+    it('uses default error message when none provided', async () => {
+      const onError = vi.fn()
+      render(<ActivationProgress scheduleId="sched-1" onError={onError} />)
+
+      simulateProgressEvent({
+        schedule_id: 'sched-1',
+        phase: 'failed',
+        progress: 0,
+      })
+
+      await waitFor(() => {
+        expect(onError).toHaveBeenCalledWith('Activation failed')
+        expect(screen.getByText('Activation failed')).toBeInTheDocument()
+      })
+    })
+  })
+
+  // ==========================================================================
+  // Retry Functionality
+  // ==========================================================================
+
+  describe('Retry Functionality', () => {
+    it('calls onRetry when Retry button is clicked', async () => {
+      const user = userEvent.setup()
+      const onRetry = vi.fn()
+      render(<ActivationProgress scheduleId="sched-1" onRetry={onRetry} />)
+
+      simulateProgressEvent({
+        schedule_id: 'sched-1',
+        phase: 'failed',
+        progress: 0,
+      })
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: /retry/i }))
+
+      expect(onRetry).toHaveBeenCalledTimes(1)
+    })
+
+    it('resets to activating state when Retry is clicked', async () => {
+      const user = userEvent.setup()
+      render(<ActivationProgress scheduleId="sched-1" />)
+
+      simulateProgressEvent({
+        schedule_id: 'sched-1',
+        phase: 'failed',
+        progress: 0,
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('activation-error')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: /retry/i }))
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('activation-error')).not.toBeInTheDocument()
+        expect(screen.getByText('Activating')).toBeInTheDocument()
+      })
+    })
+  })
+
+  // ==========================================================================
+  // Schedule ID Filtering
+  // ==========================================================================
+
+  describe('Schedule ID Filtering', () => {
+    it('ignores progress events for other schedules', async () => {
+      const onComplete = vi.fn()
+      render(<ActivationProgress scheduleId="sched-1" onComplete={onComplete} />)
+
+      // Send event for different schedule
+      simulateProgressEvent({
+        schedule_id: 'sched-2',
+        phase: 'complete',
+        progress: 100,
+      })
+
+      // Wait a bit to ensure no state change
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // Should still be in activating state
+      expect(screen.getByText('Activating')).toBeInTheDocument()
+      expect(onComplete).not.toHaveBeenCalled()
+    })
+
+    it('processes events for matching schedule', async () => {
+      const onComplete = vi.fn()
+      render(<ActivationProgress scheduleId="sched-1" onComplete={onComplete} />)
+
+      simulateProgressEvent({
+        schedule_id: 'sched-1',
+        phase: 'complete',
+        progress: 100,
+      })
+
+      await waitFor(() => {
+        expect(onComplete).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+
+  // ==========================================================================
+  // Socket Cleanup
+  // ==========================================================================
+
+  describe('Socket Cleanup', () => {
+    it('disconnects socket on unmount', () => {
+      const { unmount } = render(<ActivationProgress scheduleId="sched-1" />)
+
+      unmount()
+
+      expect(mockSocket.disconnect).toHaveBeenCalledTimes(1)
+    })
+
+    it('registers event listener on mount', () => {
+      render(<ActivationProgress scheduleId="sched-1" />)
+
+      expect(mockSocket.on).toHaveBeenCalledWith(
+        'schedule:activation_progress',
+        expect.any(Function)
+      )
+    })
+  })
+
+  // ==========================================================================
+  // Accessibility
+  // ==========================================================================
+
+  describe('Accessibility', () => {
+    it('progress bar has role="progressbar"', () => {
+      render(<ActivationProgress scheduleId="sched-1" />)
+      expect(screen.getByRole('progressbar')).toBeInTheDocument()
+    })
+
+    it('progress bar has aria-valuenow', () => {
+      render(<ActivationProgress scheduleId="sched-1" />)
+      expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '0')
+    })
+
+    it('progress bar has aria-valuemin and aria-valuemax', () => {
+      render(<ActivationProgress scheduleId="sched-1" />)
+      const progressBar = screen.getByRole('progressbar')
+      expect(progressBar).toHaveAttribute('aria-valuemin', '0')
+      expect(progressBar).toHaveAttribute('aria-valuemax', '100')
+    })
+
+    it('progress bar has aria-label', () => {
+      render(<ActivationProgress scheduleId="sched-1" />)
+      expect(screen.getByRole('progressbar')).toHaveAttribute('aria-label', 'Activation progress')
+    })
+
+    it('updates aria-valuenow with progress', async () => {
+      render(<ActivationProgress scheduleId="sched-1" />)
+
+      simulateProgressEvent({
+        schedule_id: 'sched-1',
+        phase: 'generating_cron',
+        progress: 30,
+      })
+
+      await waitFor(() => {
+        expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '30')
+      })
+    })
+  })
+
+  // ==========================================================================
+  // Dark Mode
+  // ==========================================================================
+
+  describe('Dark Mode', () => {
+    it('has dark mode classes on progress bar container', () => {
+      render(<ActivationProgress scheduleId="sched-1" />)
+      const container = screen.getByTestId('activation-progress-bar').parentElement
+      expect(container).toHaveClass('bg-gray-800')
+    })
+
+    it('has dark mode classes on error state', async () => {
+      render(<ActivationProgress scheduleId="sched-1" />)
+
+      simulateProgressEvent({
+        schedule_id: 'sched-1',
+        phase: 'failed',
+        progress: 0,
+      })
+
+      await waitFor(() => {
+        const wrapper = screen.getByTestId('activation-progress')
+        expect(wrapper).toHaveClass('border-red-900/50')
+      })
+    })
+  })
+
+  // ==========================================================================
+  // Edge Cases
+  // ==========================================================================
+
+  describe('Edge Cases', () => {
+    it('handles missing onComplete callback gracefully', async () => {
+      render(<ActivationProgress scheduleId="sched-1" />)
+
+      // Should not throw
+      simulateProgressEvent({
+        schedule_id: 'sched-1',
+        phase: 'complete',
+        progress: 100,
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText('Activated')).toBeInTheDocument()
+      })
+    })
+
+    it('handles missing onError callback gracefully', async () => {
+      render(<ActivationProgress scheduleId="sched-1" />)
+
+      // Should not throw
+      simulateProgressEvent({
+        schedule_id: 'sched-1',
+        phase: 'failed',
+        progress: 0,
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('activation-error')).toBeInTheDocument()
+      })
+    })
+
+    it('handles missing onRetry callback gracefully', async () => {
+      const user = userEvent.setup()
+      render(<ActivationProgress scheduleId="sched-1" />)
+
+      simulateProgressEvent({
+        schedule_id: 'sched-1',
+        phase: 'failed',
+        progress: 0,
+      })
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+      })
+
+      // Should not throw
+      await user.click(screen.getByRole('button', { name: /retry/i }))
+
+      await waitFor(() => {
+        expect(screen.getByText('Activating')).toBeInTheDocument()
+      })
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/components/scheduler/ActivationProgress/__tests__/ActivationProgress.test.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ActivationProgress/__tests__/ActivationProgress.test.jsx
@@ -567,6 +567,33 @@ describe('ActivationProgress', () => {
       // Component should handle error without crashing
       expect(() => render(<ActivationProgress scheduleId="sched-1" />)).not.toThrow()
     })
+
+    it('handles async connect_error events', async () => {
+      const onError = vi.fn()
+      render(<ActivationProgress scheduleId="sched-1" onError={onError} />)
+
+      // Simulate async connection error via connect_error event
+      const connectErrorHandler = mockSocket.on.mock.calls.find(
+        (call) => call[0] === 'connect_error'
+      )?.[1]
+
+      act(() => {
+        connectErrorHandler?.(new Error('Network unavailable'))
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('activation-error')).toBeInTheDocument()
+        expect(screen.getByText('Connection failed')).toBeInTheDocument()
+        expect(onError).toHaveBeenCalledWith('Connection failed')
+      })
+    })
+
+    it('registers connect_error and error event listeners', () => {
+      render(<ActivationProgress scheduleId="sched-1" />)
+
+      expect(mockSocket.on).toHaveBeenCalledWith('connect_error', expect.any(Function))
+      expect(mockSocket.on).toHaveBeenCalledWith('error', expect.any(Function))
+    })
   })
 
   // ==========================================================================

--- a/Firmware/webui/frontend/src/components/scheduler/ActivationProgress/constants.js
+++ b/Firmware/webui/frontend/src/components/scheduler/ActivationProgress/constants.js
@@ -1,0 +1,34 @@
+/**
+ * Constants for ActivationProgress component (Issue #327)
+ *
+ * Maps backend activation phases to user-friendly labels and progress values.
+ * Backend phase constants are defined in scheduler_service.py:84-97.
+ *
+ * @module components/scheduler/ActivationProgress/constants
+ */
+
+/**
+ * Human-readable labels for each activation phase.
+ * Keys match backend phase constants from scheduler_service.py.
+ */
+export const PHASE_LABELS = {
+  checking_conflicts: 'Checking for conflicts...',
+  generating_cron: 'Generating schedule...',
+  applying_cron: 'Writing crontab...',
+  updating_state: 'Updating state...',
+  complete: 'Complete',
+  failed: 'Failed',
+}
+
+/**
+ * Progress percentages for each activation phase.
+ * Values match backend ACTIVATION_PROGRESS_* constants from scheduler_service.py:92-97.
+ */
+export const PHASE_PROGRESS = {
+  checking_conflicts: 10,
+  generating_cron: 30,
+  applying_cron: 60,
+  updating_state: 90,
+  complete: 100,
+  failed: 0,
+}

--- a/Firmware/webui/frontend/src/components/scheduler/ActivationProgress/constants.js
+++ b/Firmware/webui/frontend/src/components/scheduler/ActivationProgress/constants.js
@@ -1,7 +1,7 @@
 /**
  * Constants for ActivationProgress component (Issue #327)
  *
- * Maps backend activation phases to user-friendly labels and progress values.
+ * Maps backend activation phases to user-friendly labels.
  * Backend phase constants are defined in scheduler_service.py:84-97.
  *
  * @module components/scheduler/ActivationProgress/constants
@@ -18,17 +18,4 @@ export const PHASE_LABELS = {
   updating_state: 'Updating state...',
   complete: 'Complete',
   failed: 'Failed',
-}
-
-/**
- * Progress percentages for each activation phase.
- * Values match backend ACTIVATION_PROGRESS_* constants from scheduler_service.py:92-97.
- */
-export const PHASE_PROGRESS = {
-  checking_conflicts: 10,
-  generating_cron: 30,
-  applying_cron: 60,
-  updating_state: 90,
-  complete: 100,
-  failed: 0,
 }

--- a/Firmware/webui/frontend/src/components/scheduler/ActivationProgress/index.js
+++ b/Firmware/webui/frontend/src/components/scheduler/ActivationProgress/index.js
@@ -1,0 +1,8 @@
+/**
+ * ActivationProgress module exports (Issue #327)
+ *
+ * @module components/scheduler/ActivationProgress
+ */
+
+export { default as ActivationProgress } from './ActivationProgress'
+export { PHASE_LABELS, PHASE_PROGRESS } from './constants'

--- a/Firmware/webui/frontend/src/components/scheduler/ActivationProgress/index.js
+++ b/Firmware/webui/frontend/src/components/scheduler/ActivationProgress/index.js
@@ -5,4 +5,4 @@
  */
 
 export { default as ActivationProgress } from './ActivationProgress'
-export { PHASE_LABELS, PHASE_PROGRESS } from './constants'
+export { PHASE_LABELS } from './constants'


### PR DESCRIPTION
## Summary

- Create ActivationProgress component for displaying real-time schedule activation status via WebSocket events
- WebSocket integration with `schedule:activation_progress` events filtered by scheduleId
- Progress bar with percentage and phase labels (Checking for conflicts, Generating schedule, Writing crontab, etc.)
- Error state with retry button that calls `onRetry` callback for parent handling

## Test plan

- [x] 36 unit tests passing
- [x] Progress bar updates correctly on WebSocket events
- [x] Phase labels display for each activation phase
- [x] Error state renders with retry button
- [x] Socket cleanup on unmount
- [x] ESLint passes

Closes #327