### PR TITLE
feat(scheduler): GPIO state reconciliation on activation and boot (#398)

### DIFF
--- a/Firmware/Tests/unit/test_cron_bridge.py
+++ b/Firmware/Tests/unit/test_cron_bridge.py
@@ -996,8 +996,8 @@ class TestApplyToSystem:
                 result = apply_to_system(entries, schedule_id="test-123")
 
             assert result is True
-            # Should only create one job (the enabled one)
-            assert mock_cron.new.call_count == 1
+            # Should create one schedule job (the enabled one) + 2 meta entries
+            assert mock_cron.new.call_count == 3
 
     def test_apply_skips_rtc_when_disabled(self):
         """apply_to_system skips RTC wakealarm when set_rtc=False."""
@@ -1024,6 +1024,26 @@ class TestApplyToSystem:
             result = apply_to_system(entries, schedule_id="test-123")
 
             assert result is False
+
+    def test_apply_adds_meta_cron_entries(self):
+        """apply_to_system adds @reboot and weekly meta-cron entries (Issue #398)."""
+        from unittest.mock import MagicMock, call, patch
+
+        entries = [CronEntry(expression="0 21 * * *", command="cmd1", comment="Mothbox: test")]
+        with patch("webui.backend.lib.cron_bridge.CronTab") as mock_crontab_class:
+            mock_cron = MagicMock()
+            mock_crontab_class.return_value = mock_cron
+            mock_cron.__iter__ = MagicMock(return_value=iter([]))
+
+            result = apply_to_system(entries, schedule_id="test-123")
+
+            assert result is True
+            # 1 schedule entry + 2 meta entries = 3 new() calls
+            assert mock_cron.new.call_count == 3
+            # Verify meta-cron comments in the new() calls
+            comments = [c.kwargs.get("comment", "") for c in mock_cron.new.call_args_list]
+            assert any("boot GPIO reconciliation" in c for c in comments)
+            assert any("weekly cron refresh" in c for c in comments)
 
 
 class TestRemoveFromSystem:
@@ -1117,6 +1137,27 @@ class TestRemoveFromSystem:
 
             # Should be called with user parameter
             mock_crontab_class.assert_called_once_with(user="testuser")
+
+    def test_remove_removes_meta_cron_entries(self):
+        """remove_from_system removes meta-cron entries since they contain 'Mothbox' (Issue #398)."""
+        from unittest.mock import MagicMock, patch
+
+        with patch("webui.backend.lib.cron_bridge.CronTab") as mock_crontab_class:
+            mock_cron = MagicMock()
+            mock_crontab_class.return_value = mock_cron
+
+            # Simulate meta-cron jobs (contain "Mothbox" in comment/command)
+            reboot_job = MagicMock()
+            reboot_job.command = "systemd-cat -t mothbox /usr/bin/python3 /opt/mothbox/webui/cli/reconcile_on_boot.py"
+            refresh_job = MagicMock()
+            refresh_job.command = "systemd-cat -t mothbox /usr/bin/python3 /opt/mothbox/webui/cli/refresh_schedule.py"
+
+            mock_cron.__iter__ = MagicMock(return_value=iter([reboot_job, refresh_job]))
+
+            result = remove_from_system()
+
+            assert result is True
+            assert mock_cron.remove.call_count == 2
 
 
 class TestPreviewSchedule:

--- a/Firmware/Tests/unit/test_meta_cron_entries.py
+++ b/Firmware/Tests/unit/test_meta_cron_entries.py
@@ -1,0 +1,38 @@
+"""Unit tests for meta-cron entries (Issue #398)."""
+
+from webui.backend.lib.cron_bridge import _get_meta_cron_entries
+
+
+class TestGetMetaCronEntries:
+    """Tests for _get_meta_cron_entries() helper."""
+
+    def test_returns_two_entries(self):
+        """Should return @reboot and weekly refresh entries."""
+        entries = _get_meta_cron_entries()
+        assert len(entries) == 2
+
+    def test_reboot_entry(self):
+        """First entry is @reboot for boot reconciliation."""
+        entries = _get_meta_cron_entries()
+        reboot = [e for e in entries if e.expression == "@reboot"]
+        assert len(reboot) == 1
+        assert "reconcile_on_boot" in reboot[0].command
+        assert "Mothbox" in reboot[0].comment
+
+    def test_weekly_refresh_entry(self):
+        """Second entry is weekly cron refresh (Sunday 2am)."""
+        entries = _get_meta_cron_entries()
+        weekly = [e for e in entries if e.expression == "0 2 * * 0"]
+        assert len(weekly) == 1
+        assert "refresh_schedule" in weekly[0].command
+        assert "Mothbox" in weekly[0].comment
+
+    def test_entries_identifiable_as_mothbox(self):
+        """Meta entries are identifiable by is_mothbox_command() for cleanup."""
+        from webui.backend.lib.cron_security import is_mothbox_command
+
+        entries = _get_meta_cron_entries()
+        for entry in entries:
+            assert is_mothbox_command(entry.command), (
+                f"Meta entry not identifiable as Mothbox: {entry.command}"
+            )

--- a/Firmware/Tests/unit/test_meta_cron_entries.py
+++ b/Firmware/Tests/unit/test_meta_cron_entries.py
@@ -1,5 +1,7 @@
 """Unit tests for meta-cron entries (Issue #398)."""
 
+from unittest.mock import patch
+
 from webui.backend.lib.cron_bridge import _get_meta_cron_entries
 
 
@@ -8,12 +10,13 @@ class TestGetMetaCronEntries:
 
     def test_returns_two_entries(self):
         """Should return @reboot and weekly refresh entries."""
-        entries = _get_meta_cron_entries()
+        entries, warnings = _get_meta_cron_entries()
         assert len(entries) == 2
+        assert warnings == []
 
     def test_reboot_entry(self):
         """First entry is @reboot for boot reconciliation."""
-        entries = _get_meta_cron_entries()
+        entries, _warnings = _get_meta_cron_entries()
         reboot = [e for e in entries if e.expression == "@reboot"]
         assert len(reboot) == 1
         assert "reconcile_on_boot" in reboot[0].command
@@ -21,7 +24,7 @@ class TestGetMetaCronEntries:
 
     def test_weekly_refresh_entry(self):
         """Second entry is weekly cron refresh (Sunday 2am)."""
-        entries = _get_meta_cron_entries()
+        entries, _warnings = _get_meta_cron_entries()
         weekly = [e for e in entries if e.expression == "0 2 * * 0"]
         assert len(weekly) == 1
         assert "refresh_schedule" in weekly[0].command
@@ -31,8 +34,21 @@ class TestGetMetaCronEntries:
         """Meta entries are identifiable by is_mothbox_command() for cleanup."""
         from webui.backend.lib.cron_security import is_mothbox_command
 
-        entries = _get_meta_cron_entries()
+        entries, _warnings = _get_meta_cron_entries()
         for entry in entries:
             assert is_mothbox_command(entry.command), (
                 f"Meta entry not identifiable as Mothbox: {entry.command}"
             )
+
+    def test_validation_failure_returns_warning(self):
+        """If a script key fails validation, a warning is returned."""
+        with patch(
+            "webui.backend.lib.cron_bridge.get_validated_command",
+            side_effect=ValueError("script not found"),
+        ):
+            entries, warnings = _get_meta_cron_entries()
+
+        assert entries == []
+        assert len(warnings) == 2
+        assert "boot reconciliation" in warnings[0]
+        assert "weekly refresh" in warnings[1]

--- a/Firmware/Tests/unit/test_reconcile_on_boot.py
+++ b/Firmware/Tests/unit/test_reconcile_on_boot.py
@@ -3,9 +3,17 @@
 import json
 from unittest.mock import MagicMock, patch
 
+from lib.gpio_protocol import SOCKET_PATH
+
 
 class TestReconcileOnBoot:
     """Tests for the boot reconciliation CLI."""
+
+    def test_gpio_socket_uses_protocol_constant(self):
+        """GPIO_SOCKET path matches the shared gpio_protocol.SOCKET_PATH."""
+        from webui.cli.reconcile_on_boot import GPIO_SOCKET
+
+        assert str(GPIO_SOCKET) == SOCKET_PATH
 
     def test_no_active_state_exits_cleanly(self, tmp_path, monkeypatch):
         """No active_state.json -> exits 0."""
@@ -69,6 +77,42 @@ class TestReconcileOnBoot:
         assert result == 0
         mock_reconcile.assert_called_once_with(mock_schedule, 9.0, -79.0, "America/Panama")
         mock_execute.assert_called_once()
+
+    @patch("webui.cli.reconcile_on_boot.wait_for_gpio_daemon", return_value=False)
+    def test_failed_actions_return_exit_code_2(self, mock_daemon, tmp_path, monkeypatch):
+        """Failed reconciliation actions -> returns 2 (partial success)."""
+        monkeypatch.setattr("mothbox_paths.CONFIG_DIR", tmp_path)
+
+        state = {
+            "schedule_id": "test-123",
+            "latitude": 9.0,
+            "longitude": -79.0,
+            "timezone_name": "America/Panama",
+        }
+        (tmp_path / "active_state.json").write_text(json.dumps(state))
+
+        mock_schedule = MagicMock()
+        mock_actions = [{"action_type": "gpio", "action_name": "attract_on", "source_time": None}]
+
+        with (
+            patch(
+                "webui.backend.lib.schedule_storage.read_schedule",
+                return_value=mock_schedule,
+            ),
+            patch(
+                "webui.backend.lib.schedule_reconciler.reconcile_schedule",
+                return_value=mock_actions,
+            ),
+            patch(
+                "webui.backend.lib.schedule_reconciler.execute_reconciliation",
+                return_value=[{"action_name": "attract_on", "success": False, "error": "daemon unavailable"}],
+            ),
+        ):
+            from webui.cli.reconcile_on_boot import main
+
+            result = main()
+
+        assert result == 2
 
     def test_daemon_socket_timeout(self, tmp_path, monkeypatch):
         """Socket never appears -> proceeds with warning, still returns 0 if no state."""

--- a/Firmware/Tests/unit/test_reconcile_on_boot.py
+++ b/Firmware/Tests/unit/test_reconcile_on_boot.py
@@ -6,6 +6,22 @@ from unittest.mock import MagicMock, patch
 from lib.gpio_protocol import SOCKET_PATH
 
 
+class TestCronSecurityWhitelist:
+    """Verify CLI scripts remain in the cron security whitelist."""
+
+    def test_reconcile_on_boot_in_allowed_scripts(self):
+        """reconcile_on_boot must be in ALLOWED_SCRIPTS to run via cron."""
+        from webui.backend.lib.cron_security import ALLOWED_SCRIPTS
+
+        assert "reconcile_on_boot" in ALLOWED_SCRIPTS
+
+    def test_refresh_schedule_in_allowed_scripts(self):
+        """refresh_schedule must be in ALLOWED_SCRIPTS to run via cron."""
+        from webui.backend.lib.cron_security import ALLOWED_SCRIPTS
+
+        assert "refresh_schedule" in ALLOWED_SCRIPTS
+
+
 class TestReconcileOnBoot:
     """Tests for the boot reconciliation CLI."""
 
@@ -105,7 +121,9 @@ class TestReconcileOnBoot:
             ),
             patch(
                 "webui.backend.lib.schedule_reconciler.execute_reconciliation",
-                return_value=[{"action_name": "attract_on", "success": False, "error": "daemon unavailable"}],
+                return_value=[
+                    {"action_name": "attract_on", "success": False, "error": "daemon unavailable"}
+                ],
             ),
         ):
             from webui.cli.reconcile_on_boot import main

--- a/Firmware/Tests/unit/test_reconcile_on_boot.py
+++ b/Firmware/Tests/unit/test_reconcile_on_boot.py
@@ -146,6 +146,41 @@ class TestReconcileOnBoot:
         assert result == 0
 
     @patch("webui.cli.reconcile_on_boot.wait_for_gpio_daemon", return_value=True)
+    def test_missing_coordinates_uses_timezone_fallback(self, mock_daemon, tmp_path, monkeypatch):
+        """Missing lat/lon in state -> falls back to timezone-derived coordinates."""
+        monkeypatch.setattr("mothbox_paths.CONFIG_DIR", tmp_path)
+
+        state = {
+            "schedule_id": "test-123",
+            "timezone_name": "America/Panama",
+        }
+        (tmp_path / "active_state.json").write_text(json.dumps(state))
+
+        mock_schedule = MagicMock()
+        mock_actions = []
+
+        with (
+            patch(
+                "webui.backend.lib.schedule_storage.read_schedule",
+                return_value=mock_schedule,
+            ),
+            patch(
+                "webui.backend.lib.schedule_reconciler.reconcile_schedule",
+                return_value=mock_actions,
+            ) as mock_reconcile,
+            patch(
+                "webui.backend.lib.timezone_coordinates.get_fallback_coordinates",
+                return_value=(8.98, -79.52, "America/Panama"),
+            ),
+        ):
+            from webui.cli.reconcile_on_boot import main
+
+            result = main()
+
+        assert result == 0
+        mock_reconcile.assert_called_once_with(mock_schedule, 8.98, -79.52, "America/Panama")
+
+    @patch("webui.cli.reconcile_on_boot.wait_for_gpio_daemon", return_value=True)
     def test_schedule_not_found_returns_1(self, mock_daemon, tmp_path, monkeypatch):
         """Schedule ID in state but not in storage -> returns 1."""
         monkeypatch.setattr("mothbox_paths.CONFIG_DIR", tmp_path)

--- a/Firmware/Tests/unit/test_reconcile_on_boot.py
+++ b/Firmware/Tests/unit/test_reconcile_on_boot.py
@@ -1,0 +1,102 @@
+"""Unit tests for reconcile_on_boot CLI script."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+
+class TestReconcileOnBoot:
+    """Tests for the boot reconciliation CLI."""
+
+    def test_no_active_state_exits_cleanly(self, tmp_path, monkeypatch):
+        """No active_state.json -> exits 0."""
+        monkeypatch.setattr("mothbox_paths.CONFIG_DIR", tmp_path)
+
+        from webui.cli.reconcile_on_boot import main
+
+        with patch("webui.cli.reconcile_on_boot.wait_for_gpio_daemon", return_value=True):
+            result = main()
+
+        assert result == 0
+
+    def test_empty_schedule_id_exits_cleanly(self, tmp_path, monkeypatch):
+        """active_state.json with no schedule_id -> exits 0."""
+        monkeypatch.setattr("mothbox_paths.CONFIG_DIR", tmp_path)
+        state_file = tmp_path / "active_state.json"
+        state_file.write_text(json.dumps({"schedule_id": None}))
+
+        from webui.cli.reconcile_on_boot import main
+
+        with patch("webui.cli.reconcile_on_boot.wait_for_gpio_daemon", return_value=True):
+            result = main()
+
+        assert result == 0
+
+    @patch("webui.cli.reconcile_on_boot.wait_for_gpio_daemon", return_value=True)
+    def test_loads_schedule_and_reconciles(self, mock_daemon, tmp_path, monkeypatch):
+        """Mock file + reconciler, verify flow."""
+        monkeypatch.setattr("mothbox_paths.CONFIG_DIR", tmp_path)
+
+        state = {
+            "schedule_id": "test-123",
+            "latitude": 9.0,
+            "longitude": -79.0,
+            "timezone_name": "America/Panama",
+        }
+        state_file = tmp_path / "active_state.json"
+        state_file.write_text(json.dumps(state))
+
+        mock_schedule = MagicMock()
+        mock_actions = [{"action_type": "gpio", "action_name": "attract_on", "source_time": None}]
+
+        with (
+            patch(
+                "webui.backend.lib.schedule_storage.read_schedule",
+                return_value=mock_schedule,
+            ),
+            patch(
+                "webui.backend.lib.schedule_reconciler.reconcile_schedule",
+                return_value=mock_actions,
+            ) as mock_reconcile,
+            patch(
+                "webui.backend.lib.schedule_reconciler.execute_reconciliation",
+                return_value=[{"action_name": "attract_on", "success": True, "error": None}],
+            ) as mock_execute,
+        ):
+            from webui.cli.reconcile_on_boot import main
+
+            result = main()
+
+        assert result == 0
+        mock_reconcile.assert_called_once_with(mock_schedule, 9.0, -79.0, "America/Panama")
+        mock_execute.assert_called_once()
+
+    def test_daemon_socket_timeout(self, tmp_path, monkeypatch):
+        """Socket never appears -> proceeds with warning, still returns 0 if no state."""
+        monkeypatch.setattr("mothbox_paths.CONFIG_DIR", tmp_path)
+
+        from webui.cli.reconcile_on_boot import main
+
+        # Patch wait_for_gpio_daemon to return False (timeout)
+        with patch("webui.cli.reconcile_on_boot.wait_for_gpio_daemon", return_value=False):
+            result = main()
+
+        # No active state, so exits 0 despite daemon timeout
+        assert result == 0
+
+    @patch("webui.cli.reconcile_on_boot.wait_for_gpio_daemon", return_value=True)
+    def test_schedule_not_found_returns_1(self, mock_daemon, tmp_path, monkeypatch):
+        """Schedule ID in state but not in storage -> returns 1."""
+        monkeypatch.setattr("mothbox_paths.CONFIG_DIR", tmp_path)
+
+        state = {"schedule_id": "nonexistent"}
+        (tmp_path / "active_state.json").write_text(json.dumps(state))
+
+        with patch(
+            "webui.backend.lib.schedule_storage.read_schedule",
+            return_value=None,
+        ):
+            from webui.cli.reconcile_on_boot import main
+
+            result = main()
+
+        assert result == 1

--- a/Firmware/Tests/unit/test_refresh_schedule.py
+++ b/Firmware/Tests/unit/test_refresh_schedule.py
@@ -112,6 +112,12 @@ class TestRefreshSchedule:
         assert "entries" in updated_state
         assert len(updated_state["entries"]) == 1
 
+        # Verify pre-existing keys are preserved (not clobbered by the save)
+        assert updated_state["schedule_id"] == "test-123"
+        assert updated_state["latitude"] == 9.0
+        assert updated_state["longitude"] == -79.0
+        assert updated_state["timezone_name"] == "America/Panama"
+
     def test_schedule_not_found_returns_1(self, tmp_path, monkeypatch):
         """Schedule not found in storage -> returns 1."""
         monkeypatch.setattr("mothbox_paths.CONFIG_DIR", tmp_path)

--- a/Firmware/Tests/unit/test_refresh_schedule.py
+++ b/Firmware/Tests/unit/test_refresh_schedule.py
@@ -1,0 +1,158 @@
+"""Unit tests for refresh_schedule CLI script."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from webui.backend.lib.cron_bridge import CronBridgeResult, CronEntry
+
+
+class TestRefreshSchedule:
+    """Tests for the weekly cron refresh CLI."""
+
+    def test_no_active_state_exits_cleanly(self, tmp_path, monkeypatch):
+        """No active_state.json -> exits 0."""
+        monkeypatch.setattr("mothbox_paths.CONFIG_DIR", tmp_path)
+
+        from webui.cli.refresh_schedule import main
+
+        result = main()
+        assert result == 0
+
+    def test_refreshes_cron_entries(self, tmp_path, monkeypatch):
+        """Mock cron_bridge functions, verify schedule_to_cron + apply_to_system called."""
+        monkeypatch.setattr("mothbox_paths.CONFIG_DIR", tmp_path)
+
+        state = {
+            "schedule_id": "test-123",
+            "latitude": 9.0,
+            "longitude": -79.0,
+            "timezone_name": "America/Panama",
+        }
+        (tmp_path / "active_state.json").write_text(json.dumps(state))
+
+        mock_schedule = MagicMock()
+        mock_entries = [
+            CronEntry(expression="0 21 * * *", command="test-cmd", comment="Mothbox: test")
+        ]
+        mock_result = CronBridgeResult(
+            entries=mock_entries, rtc_waketime=None, schedule_id="test-123", errors=[]
+        )
+
+        with (
+            patch(
+                "webui.backend.lib.schedule_storage.read_schedule",
+                return_value=mock_schedule,
+            ),
+            patch(
+                "webui.backend.lib.cron_bridge.schedule_to_cron",
+                return_value=mock_result,
+            ) as mock_s2c,
+            patch(
+                "webui.backend.lib.cron_bridge.apply_to_system",
+                return_value=True,
+            ) as mock_apply,
+            patch(
+                "webui.backend.lib.cron_bridge.expand_pattern_entries",
+                return_value=mock_entries,
+            ),
+        ):
+            from webui.cli.refresh_schedule import main
+
+            result = main()
+
+        assert result == 0
+        mock_s2c.assert_called_once()
+        mock_apply.assert_called_once()
+
+    def test_updates_active_state(self, tmp_path, monkeypatch):
+        """Verify expanded entries written back to active_state.json."""
+        monkeypatch.setattr("mothbox_paths.CONFIG_DIR", tmp_path)
+
+        state = {
+            "schedule_id": "test-123",
+            "latitude": 9.0,
+            "longitude": -79.0,
+            "timezone_name": "America/Panama",
+        }
+        state_file = tmp_path / "active_state.json"
+        state_file.write_text(json.dumps(state))
+
+        mock_schedule = MagicMock()
+        mock_entry = CronEntry(expression="0 21 * * *", command="test-cmd", comment="Mothbox: test")
+        mock_result = CronBridgeResult(
+            entries=[mock_entry], rtc_waketime=None, schedule_id="test-123", errors=[]
+        )
+
+        with (
+            patch(
+                "webui.backend.lib.schedule_storage.read_schedule",
+                return_value=mock_schedule,
+            ),
+            patch(
+                "webui.backend.lib.cron_bridge.schedule_to_cron",
+                return_value=mock_result,
+            ),
+            patch(
+                "webui.backend.lib.cron_bridge.apply_to_system",
+                return_value=True,
+            ),
+            patch(
+                "webui.backend.lib.cron_bridge.expand_pattern_entries",
+                return_value=[mock_entry],
+            ),
+        ):
+            from webui.cli.refresh_schedule import main
+
+            result = main()
+
+        assert result == 0
+
+        # Verify active_state.json was updated with entries
+        updated_state = json.loads(state_file.read_text())
+        assert "entries" in updated_state
+        assert len(updated_state["entries"]) == 1
+
+    def test_schedule_not_found_returns_1(self, tmp_path, monkeypatch):
+        """Schedule not found in storage -> returns 1."""
+        monkeypatch.setattr("mothbox_paths.CONFIG_DIR", tmp_path)
+
+        state = {"schedule_id": "nonexistent"}
+        (tmp_path / "active_state.json").write_text(json.dumps(state))
+
+        with patch(
+            "webui.backend.lib.schedule_storage.read_schedule",
+            return_value=None,
+        ):
+            from webui.cli.refresh_schedule import main
+
+            result = main()
+
+        assert result == 1
+
+    def test_cron_conversion_errors_returns_1(self, tmp_path, monkeypatch):
+        """Cron conversion errors -> returns 1."""
+        monkeypatch.setattr("mothbox_paths.CONFIG_DIR", tmp_path)
+
+        state = {"schedule_id": "test-123"}
+        (tmp_path / "active_state.json").write_text(json.dumps(state))
+
+        mock_schedule = MagicMock()
+        mock_result = CronBridgeResult(
+            entries=[], rtc_waketime=None, schedule_id="test-123", errors=["Solar calc failed"]
+        )
+
+        with (
+            patch(
+                "webui.backend.lib.schedule_storage.read_schedule",
+                return_value=mock_schedule,
+            ),
+            patch(
+                "webui.backend.lib.cron_bridge.schedule_to_cron",
+                return_value=mock_result,
+            ),
+        ):
+            from webui.cli.refresh_schedule import main
+
+            result = main()
+
+        assert result == 1

--- a/Firmware/Tests/unit/test_refresh_schedule.py
+++ b/Firmware/Tests/unit/test_refresh_schedule.py
@@ -118,6 +118,55 @@ class TestRefreshSchedule:
         assert updated_state["longitude"] == -79.0
         assert updated_state["timezone_name"] == "America/Panama"
 
+    def test_missing_coordinates_uses_timezone_fallback(self, tmp_path, monkeypatch):
+        """Missing lat/lon in state -> falls back to timezone-derived coordinates."""
+        monkeypatch.setattr("mothbox_paths.CONFIG_DIR", tmp_path)
+
+        state = {
+            "schedule_id": "test-123",
+            "timezone_name": "America/Panama",
+        }
+        (tmp_path / "active_state.json").write_text(json.dumps(state))
+
+        mock_schedule = MagicMock()
+        mock_entries = [
+            CronEntry(expression="0 21 * * *", command="test-cmd", comment="Mothbox: test")
+        ]
+        mock_result = CronBridgeResult(
+            entries=mock_entries, rtc_waketime=None, schedule_id="test-123", errors=[]
+        )
+
+        with (
+            patch(
+                "webui.backend.lib.schedule_storage.read_schedule",
+                return_value=mock_schedule,
+            ),
+            patch(
+                "webui.backend.lib.cron_bridge.schedule_to_cron",
+                return_value=mock_result,
+            ) as mock_s2c,
+            patch(
+                "webui.backend.lib.cron_bridge.apply_to_system",
+                return_value=True,
+            ),
+            patch(
+                "webui.backend.lib.cron_bridge.expand_pattern_entries",
+                return_value=mock_entries,
+            ),
+            patch(
+                "webui.backend.lib.timezone_coordinates.get_fallback_coordinates",
+                return_value=(8.98, -79.52, "America/Panama"),
+            ),
+        ):
+            from webui.cli.refresh_schedule import main
+
+            result = main()
+
+        assert result == 0
+        call_kwargs = mock_s2c.call_args[1]
+        assert call_kwargs["latitude"] == 8.98
+        assert call_kwargs["longitude"] == -79.52
+
     def test_schedule_not_found_returns_1(self, tmp_path, monkeypatch):
         """Schedule not found in storage -> returns 1."""
         monkeypatch.setattr("mothbox_paths.CONFIG_DIR", tmp_path)

--- a/Firmware/Tests/unit/test_refresh_schedule.py
+++ b/Firmware/Tests/unit/test_refresh_schedule.py
@@ -135,6 +135,55 @@ class TestRefreshSchedule:
 
         assert result == 1
 
+    def test_save_aborts_if_schedule_changed(self, tmp_path, monkeypatch):
+        """save_active_state returns False if schedule_id changed since load."""
+        monkeypatch.setattr("mothbox_paths.CONFIG_DIR", tmp_path)
+
+        state = {
+            "schedule_id": "original-schedule",
+            "latitude": 9.0,
+            "longitude": -79.0,
+            "timezone_name": "UTC",
+        }
+        state_file = tmp_path / "active_state.json"
+        state_file.write_text(json.dumps(state))
+
+        from webui.cli.refresh_schedule import save_active_state
+
+        result = save_active_state(
+            [{"expression": "0 0 * * *"}],
+            expected_schedule_id="different-schedule",
+        )
+        assert result is False
+
+        # Verify file is unmodified
+        unchanged = json.loads(state_file.read_text())
+        assert "entries" not in unchanged
+        assert unchanged["schedule_id"] == "original-schedule"
+
+    def test_save_succeeds_with_matching_schedule_id(self, tmp_path, monkeypatch):
+        """save_active_state succeeds when expected_schedule_id matches."""
+        monkeypatch.setattr("mothbox_paths.CONFIG_DIR", tmp_path)
+
+        state = {
+            "schedule_id": "test-123",
+            "latitude": 9.0,
+        }
+        state_file = tmp_path / "active_state.json"
+        state_file.write_text(json.dumps(state))
+
+        from webui.cli.refresh_schedule import save_active_state
+
+        result = save_active_state(
+            [{"expression": "0 0 * * *"}],
+            expected_schedule_id="test-123",
+        )
+        assert result is True
+
+        updated = json.loads(state_file.read_text())
+        assert updated["entries"] == [{"expression": "0 0 * * *"}]
+        assert updated["schedule_id"] == "test-123"
+
     def test_cron_conversion_errors_returns_1(self, tmp_path, monkeypatch):
         """Cron conversion errors -> returns 1."""
         monkeypatch.setattr("mothbox_paths.CONFIG_DIR", tmp_path)

--- a/Firmware/Tests/unit/test_schedule_reconciler.py
+++ b/Firmware/Tests/unit/test_schedule_reconciler.py
@@ -257,6 +257,16 @@ class TestReconcileSchedule:
         assert result[0]["action_name"] == "attract_off"
         assert result[0]["source_time"] == day2_trigger + timedelta(minutes=120)
 
+    def test_naive_datetime_raises_valueerror(self):
+        """Passing a naive datetime for now raises ValueError."""
+        import pytest
+
+        schedule = _make_schedule(routines=[])
+        naive_now = datetime(2025, 6, 15, 22, 0, 0)  # no tzinfo
+
+        with pytest.raises(ValueError, match="timezone-aware"):
+            reconcile_schedule(schedule, 9.0, -79.0, "America/Panama", now=naive_now)
+
 
 class TestExecuteReconciliation:
     """Tests for execute_reconciliation()."""

--- a/Firmware/Tests/unit/test_schedule_reconciler.py
+++ b/Firmware/Tests/unit/test_schedule_reconciler.py
@@ -267,6 +267,15 @@ class TestReconcileSchedule:
         with pytest.raises(ValueError, match="timezone-aware"):
             reconcile_schedule(schedule, 9.0, -79.0, "America/Panama", now=naive_now)
 
+    def test_invalid_timezone_raises_valueerror(self):
+        """Passing an invalid timezone_name raises ValueError."""
+        import pytest
+
+        schedule = _make_schedule(routines=[])
+
+        with pytest.raises(ValueError, match="Unknown timezone"):
+            reconcile_schedule(schedule, 9.0, -79.0, "Not/A_Timezone")
+
 
 class TestExecuteReconciliation:
     """Tests for execute_reconciliation()."""

--- a/Firmware/Tests/unit/test_schedule_reconciler.py
+++ b/Firmware/Tests/unit/test_schedule_reconciler.py
@@ -276,6 +276,19 @@ class TestReconcileSchedule:
         with pytest.raises(ValueError, match="Unknown timezone"):
             reconcile_schedule(schedule, 9.0, -79.0, "Not/A_Timezone")
 
+    def test_invalid_coordinates_raise_valueerror(self):
+        """Out-of-range coordinates raise ValueError."""
+        import pytest
+
+        schedule = _make_schedule(routines=[])
+        now = _aware(datetime(2025, 6, 15, 22, 0, 0))
+
+        with pytest.raises(ValueError, match="Invalid coordinates"):
+            reconcile_schedule(schedule, 91.0, -79.0, "America/Panama", now=now)
+
+        with pytest.raises(ValueError, match="Invalid coordinates"):
+            reconcile_schedule(schedule, 9.0, 181.0, "America/Panama", now=now)
+
 
 class TestExecuteReconciliation:
     """Tests for execute_reconciliation()."""

--- a/Firmware/Tests/unit/test_schedule_reconciler.py
+++ b/Firmware/Tests/unit/test_schedule_reconciler.py
@@ -354,7 +354,7 @@ class TestExecuteReconciliation:
         results = execute_reconciliation(actions)
         assert len(results) == 1
         assert results[0]["success"] is False
-        assert results[0]["error"] == "timeout"
+        assert "timed out" in results[0]["error"]
 
     @patch("webui.backend.lib.schedule_reconciler.subprocess.run")
     @patch("webui.backend.lib.schedule_reconciler.get_validated_command")

--- a/Firmware/Tests/unit/test_schedule_reconciler.py
+++ b/Firmware/Tests/unit/test_schedule_reconciler.py
@@ -1,0 +1,372 @@
+"""Unit tests for schedule_reconciler module."""
+
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytz
+
+from webui.backend.lib.schedule_reconciler import (
+    execute_reconciliation,
+    reconcile_schedule,
+)
+from webui.backend.lib.schedule_schema import (
+    Action,
+    FixedTimeTrigger,
+    Routine,
+    Schedule,
+    SensorTrigger,
+    SolarTrigger,
+)
+
+TZ = pytz.timezone("America/Panama")
+
+
+def _make_schedule(routines=None):
+    """Helper to create a Schedule with given routines."""
+    return Schedule(
+        schedule_id="test-sched-1",
+        name="Test Schedule",
+        routines=routines or [],
+        enabled=True,
+    )
+
+
+def _make_routine(trigger, actions, routine_id="routine-1"):
+    """Helper to create a Routine."""
+    return Routine(
+        routine_id=routine_id,
+        name="Test Routine",
+        trigger=trigger,
+        actions=actions,
+    )
+
+
+def _aware(dt):
+    """Make a naive datetime timezone-aware in America/Panama."""
+    return TZ.localize(dt)
+
+
+class TestReconcileSchedule:
+    """Tests for reconcile_schedule()."""
+
+    def test_no_routines_returns_empty(self):
+        schedule = _make_schedule(routines=[])
+        now = _aware(datetime(2025, 6, 15, 22, 0, 0))
+        result = reconcile_schedule(schedule, 0.0, 0.0, "America/Panama", now=now)
+        assert result == []
+
+    @patch("webui.backend.lib.schedule_reconciler.calculate_execution_times")
+    def test_attract_on_in_past_returns_attract_on(self, mock_calc):
+        """Sunset attract_on 2h ago -> reconcile returns attract_on."""
+        now = _aware(datetime(2025, 6, 15, 22, 0, 0))
+        trigger_time = _aware(datetime(2025, 6, 15, 20, 0, 0))
+        mock_calc.return_value = [trigger_time]
+
+        trigger = SolarTrigger(solar_event="sunset")
+        actions = [Action(action_type="gpio", action_name="attract_on", offset_minutes=0)]
+        routine = _make_routine(trigger, actions)
+        schedule = _make_schedule(routines=[routine])
+
+        result = reconcile_schedule(schedule, 9.0, -79.0, "America/Panama", now=now)
+
+        assert len(result) == 1
+        assert result[0]["action_name"] == "attract_on"
+        assert result[0]["action_type"] == "gpio"
+        assert result[0]["source_time"] == trigger_time
+
+    @patch("webui.backend.lib.schedule_reconciler.calculate_execution_times")
+    def test_attract_on_then_off_returns_off(self, mock_calc):
+        """attract_on 3h ago, attract_off 1h ago -> returns attract_off."""
+        now = _aware(datetime(2025, 6, 15, 22, 0, 0))
+        trigger_time = _aware(datetime(2025, 6, 15, 19, 0, 0))
+        mock_calc.return_value = [trigger_time]
+
+        trigger = SolarTrigger(solar_event="sunset")
+        actions = [
+            Action(action_type="gpio", action_name="attract_on", offset_minutes=0),
+            Action(action_type="gpio", action_name="attract_off", offset_minutes=120),
+        ]
+        routine = _make_routine(trigger, actions)
+        schedule = _make_schedule(routines=[routine])
+
+        result = reconcile_schedule(schedule, 9.0, -79.0, "America/Panama", now=now)
+
+        assert len(result) == 1
+        assert result[0]["action_name"] == "attract_off"
+        # attract_off should be trigger_time + 120min = 1h ago
+        assert result[0]["source_time"] == trigger_time + timedelta(minutes=120)
+
+    @patch("webui.backend.lib.schedule_reconciler.calculate_execution_times")
+    def test_future_actions_ignored(self, mock_calc):
+        """Action 2h in the future -> not returned."""
+        now = _aware(datetime(2025, 6, 15, 18, 0, 0))
+        trigger_time = _aware(datetime(2025, 6, 15, 20, 0, 0))
+        mock_calc.return_value = [trigger_time]
+
+        trigger = SolarTrigger(solar_event="sunset")
+        actions = [Action(action_type="gpio", action_name="attract_on", offset_minutes=0)]
+        routine = _make_routine(trigger, actions)
+        schedule = _make_schedule(routines=[routine])
+
+        result = reconcile_schedule(schedule, 9.0, -79.0, "America/Panama", now=now)
+        assert result == []
+
+    @patch("webui.backend.lib.schedule_reconciler.calculate_execution_times")
+    def test_non_reconcilable_skipped(self, mock_calc):
+        """Camera/takephoto actions are filtered out."""
+        now = _aware(datetime(2025, 6, 15, 22, 0, 0))
+        trigger_time = _aware(datetime(2025, 6, 15, 21, 0, 0))
+        mock_calc.return_value = [trigger_time]
+
+        trigger = FixedTimeTrigger(time="21:00")
+        actions = [
+            Action(action_type="camera", action_name="takephoto", offset_minutes=0),
+        ]
+        routine = _make_routine(trigger, actions)
+        schedule = _make_schedule(routines=[routine])
+
+        result = reconcile_schedule(schedule, 9.0, -79.0, "America/Panama", now=now)
+        assert result == []
+
+    @patch("webui.backend.lib.schedule_reconciler.calculate_execution_times")
+    def test_multiple_resources_independent(self, mock_calc):
+        """Attract and flash reconciled independently."""
+        now = _aware(datetime(2025, 6, 15, 22, 0, 0))
+        trigger_time = _aware(datetime(2025, 6, 15, 20, 0, 0))
+        mock_calc.return_value = [trigger_time]
+
+        trigger = SolarTrigger(solar_event="sunset")
+        actions = [
+            Action(action_type="gpio", action_name="attract_on", offset_minutes=0),
+            Action(action_type="gpio", action_name="flash_on", offset_minutes=5),
+        ]
+        routine = _make_routine(trigger, actions)
+        schedule = _make_schedule(routines=[routine])
+
+        result = reconcile_schedule(schedule, 9.0, -79.0, "America/Panama", now=now)
+
+        assert len(result) == 2
+        action_names = {r["action_name"] for r in result}
+        assert action_names == {"attract_on", "flash_on"}
+
+    @patch("webui.backend.lib.schedule_reconciler.calculate_execution_times")
+    def test_lookback_window_respected(self, mock_calc):
+        """Action 72h ago (outside 48h window) -> not returned."""
+        now = _aware(datetime(2025, 6, 15, 22, 0, 0))
+        # Trigger 72h ago — outside the 48h lookback
+        trigger_time = _aware(datetime(2025, 6, 12, 22, 0, 0))
+        mock_calc.return_value = [trigger_time]
+
+        trigger = SolarTrigger(solar_event="sunset")
+        actions = [Action(action_type="gpio", action_name="attract_on", offset_minutes=0)]
+        routine = _make_routine(trigger, actions)
+        schedule = _make_schedule(routines=[routine])
+
+        result = reconcile_schedule(schedule, 9.0, -79.0, "America/Panama", now=now)
+        assert result == []
+
+    @patch("webui.backend.lib.schedule_reconciler.calculate_execution_times")
+    def test_action_offsets_applied(self, mock_calc):
+        """Routine triggers at sunset, action at offset_minutes=5 -> correct action_time."""
+        now = _aware(datetime(2025, 6, 15, 22, 0, 0))
+        trigger_time = _aware(datetime(2025, 6, 15, 21, 0, 0))
+        mock_calc.return_value = [trigger_time]
+
+        trigger = SolarTrigger(solar_event="sunset")
+        actions = [
+            Action(action_type="gpio", action_name="attract_on", offset_minutes=5),
+        ]
+        routine = _make_routine(trigger, actions)
+        schedule = _make_schedule(routines=[routine])
+
+        result = reconcile_schedule(schedule, 9.0, -79.0, "America/Panama", now=now)
+
+        assert len(result) == 1
+        expected_time = trigger_time + timedelta(minutes=5)
+        assert result[0]["source_time"] == expected_time
+
+    @patch("webui.backend.lib.schedule_reconciler.calculate_execution_times")
+    def test_gps_sync_reconciled(self, mock_calc):
+        """gps_sync within window -> returned (action_name is 'sync')."""
+        now = _aware(datetime(2025, 6, 15, 22, 0, 0))
+        trigger_time = _aware(datetime(2025, 6, 15, 21, 0, 0))
+        mock_calc.return_value = [trigger_time]
+
+        trigger = FixedTimeTrigger(time="21:00")
+        actions = [
+            Action(action_type="gps_sync", action_name="sync", offset_minutes=0),
+        ]
+        routine = _make_routine(trigger, actions)
+        schedule = _make_schedule(routines=[routine])
+
+        result = reconcile_schedule(schedule, 9.0, -79.0, "America/Panama", now=now)
+
+        assert len(result) == 1
+        assert result[0]["action_name"] == "sync"
+        assert result[0]["action_type"] == "gps_sync"
+
+    def test_sensor_trigger_skipped(self):
+        """Routines with SensorTrigger are skipped (not schedulable)."""
+        trigger = SensorTrigger(
+            sensor_type="light",
+            comparison="lt",
+            threshold=100,
+        )
+        actions = [Action(action_type="gpio", action_name="attract_on", offset_minutes=0)]
+        routine = _make_routine(trigger, actions)
+        schedule = _make_schedule(routines=[routine])
+
+        now = _aware(datetime(2025, 6, 15, 22, 0, 0))
+        result = reconcile_schedule(schedule, 9.0, -79.0, "America/Panama", now=now)
+        assert result == []
+
+    @patch("webui.backend.lib.schedule_reconciler.calculate_execution_times")
+    def test_calculation_error_skips_routine(self, mock_calc):
+        """If calculate_execution_times raises, that routine is skipped."""
+        mock_calc.side_effect = ValueError("Solar calculation failed")
+
+        trigger = SolarTrigger(solar_event="sunset")
+        actions = [Action(action_type="gpio", action_name="attract_on", offset_minutes=0)]
+        routine = _make_routine(trigger, actions)
+        schedule = _make_schedule(routines=[routine])
+
+        now = _aware(datetime(2025, 6, 15, 22, 0, 0))
+        result = reconcile_schedule(schedule, 9.0, -79.0, "America/Panama", now=now)
+        assert result == []
+
+    @patch("webui.backend.lib.schedule_reconciler.calculate_execution_times")
+    def test_multiple_trigger_times_most_recent_wins(self, mock_calc):
+        """With triggers on day 1 and day 2, the most recent one wins."""
+        now = _aware(datetime(2025, 6, 16, 22, 0, 0))
+        day1_trigger = _aware(datetime(2025, 6, 15, 20, 0, 0))
+        day2_trigger = _aware(datetime(2025, 6, 16, 20, 0, 0))
+        mock_calc.return_value = [day1_trigger, day2_trigger]
+
+        trigger = SolarTrigger(solar_event="sunset")
+        actions = [
+            Action(action_type="gpio", action_name="attract_on", offset_minutes=0),
+            Action(action_type="gpio", action_name="attract_off", offset_minutes=120),
+        ]
+        routine = _make_routine(trigger, actions)
+        schedule = _make_schedule(routines=[routine])
+
+        result = reconcile_schedule(schedule, 9.0, -79.0, "America/Panama", now=now)
+
+        assert len(result) == 1
+        # Day 2 attract_on at 20:00 is most recent (attract_off at 22:00 == now, included)
+        assert result[0]["action_name"] == "attract_off"
+        assert result[0]["source_time"] == day2_trigger + timedelta(minutes=120)
+
+
+class TestExecuteReconciliation:
+    """Tests for execute_reconciliation()."""
+
+    @patch("webui.backend.lib.schedule_reconciler.subprocess.run")
+    @patch("webui.backend.lib.schedule_reconciler.get_validated_command")
+    @patch("webui.backend.lib.schedule_reconciler.get_script_key_for_action")
+    def test_executes_command_success(self, mock_key, mock_cmd, mock_run):
+        mock_key.return_value = "attract_on"
+        mock_cmd.return_value = "systemd-cat -t mothbox /usr/bin/python3 /opt/mothbox/Attract_On.py"
+        mock_run.return_value.returncode = 0
+
+        actions = [
+            {
+                "action_type": "gpio",
+                "action_name": "attract_on",
+                "source_time": datetime(2025, 6, 15, 20, 0, 0),
+            }
+        ]
+
+        results = execute_reconciliation(actions)
+
+        assert len(results) == 1
+        assert results[0]["success"] is True
+        mock_run.assert_called_once()
+
+    @patch("webui.backend.lib.schedule_reconciler.subprocess.run")
+    @patch("webui.backend.lib.schedule_reconciler.get_validated_command")
+    @patch("webui.backend.lib.schedule_reconciler.get_script_key_for_action")
+    def test_nonzero_exit_reports_failure(self, mock_key, mock_cmd, mock_run):
+        """Non-zero exit code from script is reported as failure."""
+        mock_key.return_value = "attract_on"
+        mock_cmd.return_value = "systemd-cat -t mothbox /usr/bin/python3 /opt/mothbox/Attract_On.py"
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stderr = b"GPIO daemon not running"
+
+        actions = [
+            {
+                "action_type": "gpio",
+                "action_name": "attract_on",
+                "source_time": datetime(2025, 6, 15, 20, 0, 0),
+            }
+        ]
+
+        results = execute_reconciliation(actions)
+
+        assert len(results) == 1
+        assert results[0]["success"] is False
+        assert "GPIO daemon not running" in results[0]["error"]
+
+    @patch("webui.backend.lib.schedule_reconciler.get_script_key_for_action")
+    def test_unknown_script_key(self, mock_key):
+        mock_key.return_value = None
+
+        actions = [
+            {
+                "action_type": "unknown",
+                "action_name": "unknown_action",
+                "source_time": datetime(2025, 6, 15, 20, 0, 0),
+            }
+        ]
+
+        results = execute_reconciliation(actions)
+        assert len(results) == 1
+        assert results[0]["success"] is False
+
+    @patch("webui.backend.lib.schedule_reconciler.subprocess.run")
+    @patch("webui.backend.lib.schedule_reconciler.get_validated_command")
+    @patch("webui.backend.lib.schedule_reconciler.get_script_key_for_action")
+    def test_timeout_handled(self, mock_key, mock_cmd, mock_run):
+        import subprocess as sp
+
+        mock_key.return_value = "attract_on"
+        mock_cmd.return_value = "some-command"
+        mock_run.side_effect = sp.TimeoutExpired(cmd="some-command", timeout=30)
+
+        actions = [
+            {
+                "action_type": "gpio",
+                "action_name": "attract_on",
+                "source_time": datetime(2025, 6, 15, 20, 0, 0),
+            }
+        ]
+
+        results = execute_reconciliation(actions)
+        assert len(results) == 1
+        assert results[0]["success"] is False
+        assert results[0]["error"] == "timeout"
+
+    @patch("webui.backend.lib.schedule_reconciler.subprocess.run")
+    @patch("webui.backend.lib.schedule_reconciler.get_validated_command")
+    @patch("webui.backend.lib.schedule_reconciler.get_script_key_for_action")
+    def test_oserror_handled(self, mock_key, mock_cmd, mock_run):
+        mock_key.return_value = "attract_on"
+        mock_cmd.return_value = "some-command"
+        mock_run.side_effect = OSError("No such file")
+
+        actions = [
+            {
+                "action_type": "gpio",
+                "action_name": "attract_on",
+                "source_time": datetime(2025, 6, 15, 20, 0, 0),
+            }
+        ]
+
+        results = execute_reconciliation(actions)
+        assert len(results) == 1
+        assert results[0]["success"] is False
+        assert "No such file" in results[0]["error"]
+
+    def test_empty_actions(self):
+        results = execute_reconciliation([])
+        assert results == []

--- a/Firmware/Tests/unit/test_schedule_reconciler.py
+++ b/Firmware/Tests/unit/test_schedule_reconciler.py
@@ -237,7 +237,7 @@ class TestReconcileSchedule:
     @patch("webui.backend.lib.schedule_reconciler.calculate_execution_times")
     def test_multiple_trigger_times_most_recent_wins(self, mock_calc):
         """With triggers on day 1 and day 2, the most recent one wins."""
-        now = _aware(datetime(2025, 6, 16, 22, 0, 0))
+        now = _aware(datetime(2025, 6, 16, 22, 1, 0))
         day1_trigger = _aware(datetime(2025, 6, 15, 20, 0, 0))
         day2_trigger = _aware(datetime(2025, 6, 16, 20, 0, 0))
         mock_calc.return_value = [day1_trigger, day2_trigger]
@@ -253,7 +253,7 @@ class TestReconcileSchedule:
         result = reconcile_schedule(schedule, 9.0, -79.0, "America/Panama", now=now)
 
         assert len(result) == 1
-        # Day 2 attract_on at 20:00 is most recent (attract_off at 22:00 == now, included)
+        # Day 2 attract_off at 22:00 is most recent (strictly before now at 22:01)
         assert result[0]["action_name"] == "attract_off"
         assert result[0]["source_time"] == day2_trigger + timedelta(minutes=120)
 

--- a/Firmware/Tests/unit/test_scheduler_activation_reconcile.py
+++ b/Firmware/Tests/unit/test_scheduler_activation_reconcile.py
@@ -85,11 +85,10 @@ class TestActivationReconciliation:
         create_schedule(sample_schedule)
         scheduler_service.set_enabled_schedule(schedule_id)
 
-        with patch(
-            "webui.backend.lib.schedule_reconciler.reconcile_schedule"
-        ) as mock_reconcile, patch(
-            "webui.backend.lib.schedule_reconciler.execute_reconciliation"
-        ) as mock_execute:
+        with (
+            patch("webui.backend.lib.schedule_reconciler.reconcile_schedule") as mock_reconcile,
+            patch("webui.backend.lib.schedule_reconciler.execute_reconciliation") as mock_execute,
+        ):
             mock_reconcile.return_value = [
                 {"action_type": "gpio", "action_name": "attract_on", "source_time": None}
             ]

--- a/Firmware/Tests/unit/test_scheduler_activation_reconcile.py
+++ b/Firmware/Tests/unit/test_scheduler_activation_reconcile.py
@@ -1,0 +1,141 @@
+"""Tests for reconciliation integration in scheduler activation (Issue #398)."""
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from webui.backend.lib.schedule_schema import (
+    Action,
+    IntervalTrigger,
+    Routine,
+    Schedule,
+    TimeWindow,
+)
+from webui.backend.services.scheduler_service import SchedulerService
+
+
+def _test_uuid(name):
+    return str(uuid.uuid5(uuid.NAMESPACE_DNS, f"reconcile-test-{name}"))
+
+
+@pytest.fixture
+def temp_schedules_dir(tmp_path, monkeypatch):
+    """Create temp directory and mock SCHEDULES_DIR and ACTIVE_STATE_FILE."""
+    schedules = tmp_path / "schedules"
+    schedules.mkdir()
+    monkeypatch.setattr("mothbox_paths.SCHEDULES_DIR", schedules)
+    monkeypatch.setattr("webui.backend.lib.schedule_storage.SCHEDULES_DIR", schedules)
+    active_state_file = tmp_path / "active_state.json"
+    monkeypatch.setattr(
+        "webui.backend.services.scheduler_service.ACTIVE_STATE_FILE", active_state_file
+    )
+    return schedules
+
+
+@pytest.fixture
+def sample_schedule():
+    """Create a valid Schedule for testing."""
+    actions = [
+        Action(
+            action_type="gpio",
+            action_name="attract_on",
+            offset_minutes=0,
+        ),
+        Action(
+            action_type="gpio",
+            action_name="attract_off",
+            offset_minutes=15,
+        ),
+    ]
+    trigger = IntervalTrigger(
+        interval_minutes=60,
+        time_window=TimeWindow(start_time="21:00", end_time="05:00"),
+    )
+    routine = Routine(
+        routine_id="",
+        name="Test Routine",
+        trigger=trigger,
+        actions=actions,
+    )
+    return Schedule(
+        schedule_id="",
+        name="Test Schedule",
+        routines=[routine],
+        enabled=True,
+    )
+
+
+@pytest.fixture
+def scheduler_service(temp_schedules_dir):
+    return SchedulerService(cache_ttl=300, max_cache_size=100)
+
+
+class TestActivationReconciliation:
+    """Tests for reconciliation during schedule activation."""
+
+    def test_activate_calls_reconciler(
+        self, scheduler_service, temp_schedules_dir, sample_schedule, mock_cron_system
+    ):
+        """Reconciler is called with correct args after activation."""
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        schedule_id = _test_uuid("reconcile-called")
+        sample_schedule.schedule_id = schedule_id
+        create_schedule(sample_schedule)
+        scheduler_service.set_enabled_schedule(schedule_id)
+
+        with patch(
+            "webui.backend.lib.schedule_reconciler.reconcile_schedule"
+        ) as mock_reconcile, patch(
+            "webui.backend.lib.schedule_reconciler.execute_reconciliation"
+        ) as mock_execute:
+            mock_reconcile.return_value = [
+                {"action_type": "gpio", "action_name": "attract_on", "source_time": None}
+            ]
+            mock_execute.return_value = [
+                {"action_name": "attract_on", "success": True, "error": None}
+            ]
+
+            scheduler_service.activate_schedule(
+                schedule_id=schedule_id,
+                check_conflicts=False,
+                latitude=9.0,
+                longitude=-79.0,
+                timezone_name="America/Panama",
+            )
+
+            mock_reconcile.assert_called_once()
+            call_args = mock_reconcile.call_args
+            # Verify schedule, lat, lon, timezone passed
+            assert call_args[0][1] == 9.0  # latitude
+            assert call_args[0][2] == -79.0  # longitude
+            assert call_args[0][3] == "America/Panama"  # timezone
+            mock_execute.assert_called_once()
+
+    def test_reconciler_failure_nonfatal(
+        self, scheduler_service, temp_schedules_dir, sample_schedule, mock_cron_system
+    ):
+        """Reconciler raising an exception does NOT prevent activation."""
+        from webui.backend.lib.schedule_storage import create_schedule
+
+        schedule_id = _test_uuid("reconcile-failure")
+        sample_schedule.schedule_id = schedule_id
+        create_schedule(sample_schedule)
+        scheduler_service.set_enabled_schedule(schedule_id)
+
+        with patch(
+            "webui.backend.lib.schedule_reconciler.reconcile_schedule",
+            side_effect=RuntimeError("Reconciliation exploded"),
+        ):
+            # Should NOT raise — reconciliation failure is non-fatal
+            scheduler_service.activate_schedule(
+                schedule_id=schedule_id,
+                check_conflicts=False,
+                latitude=9.0,
+                longitude=-79.0,
+                timezone_name="America/Panama",
+            )
+
+        # Activation succeeded despite reconciliation failure
+        assert scheduler_service._active_schedule_id == schedule_id

--- a/Firmware/webui/backend/lib/active_state.py
+++ b/Firmware/webui/backend/lib/active_state.py
@@ -1,0 +1,35 @@
+"""Shared helpers for reading active_state.json."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def load_active_state() -> dict | None:
+    """Load active_state.json from CONFIG_DIR with shared file lock.
+
+    Returns the parsed dict, or None if no active state.
+    """
+    from mothbox_paths import CONFIG_DIR
+    from webui.backend.lib.sidecar_metadata import FileLock
+
+    state_file = CONFIG_DIR / "active_state.json"
+    if not state_file.exists():
+        logger.info("No active_state.json found")
+        return None
+
+    try:
+        with FileLock(state_file, exclusive=False, timeout=10.0) as f:
+            state = json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        logger.error(f"Failed to read active_state.json: {e}")
+        return None
+
+    if not state.get("schedule_id"):
+        logger.info("No active schedule in state file")
+        return None
+
+    return state

--- a/Firmware/webui/backend/lib/cron_bridge.py
+++ b/Firmware/webui/backend/lib/cron_bridge.py
@@ -2469,6 +2469,45 @@ def _get_events_recurring_days_routine(
 # =============================================================================
 
 
+def _get_meta_cron_entries() -> list[CronEntry]:
+    """Generate meta-cron entries for boot reconciliation and weekly refresh.
+
+    These entries handle:
+    - @reboot: Reconcile GPIO state after Pi reboot (Issue #398)
+    - Weekly: Refresh date-specific cron entries to prevent 60-day expiration
+
+    Note: These entries are removed by remove_from_system() since their
+    comments contain "Mothbox" which matches is_mothbox_command().
+    """
+    entries = []
+
+    try:
+        reboot_cmd = get_validated_command("reconcile_on_boot")
+        entries.append(
+            CronEntry(
+                expression="@reboot",
+                command=reboot_cmd,
+                comment="Mothbox: boot GPIO reconciliation",
+            )
+        )
+    except ValueError as e:
+        logger.warning(f"Could not create boot reconciliation entry: {e}")
+
+    try:
+        refresh_cmd = get_validated_command("refresh_schedule")
+        entries.append(
+            CronEntry(
+                expression="0 2 * * 0",
+                command=refresh_cmd,
+                comment="Mothbox: weekly cron refresh",
+            )
+        )
+    except ValueError as e:
+        logger.warning(f"Could not create weekly refresh entry: {e}")
+
+    return entries
+
+
 def apply_to_system(
     entries: list[CronEntry],
     schedule_id: str,
@@ -2524,6 +2563,15 @@ def apply_to_system(
                 job = cron.new(command=entry.command, comment=entry.comment)
                 job.setall(entry.expression)
                 added_count += 1
+
+        # Add meta-cron entries for schedule maintenance (Issue #398)
+        for meta in _get_meta_cron_entries():
+            job = cron.new(command=meta.command, comment=meta.comment)
+            if meta.expression == "@reboot":
+                job.every_reboot()
+            else:
+                job.setall(meta.expression)
+            added_count += 1
 
         # Write changes
         cron.write()

--- a/Firmware/webui/backend/lib/cron_bridge.py
+++ b/Firmware/webui/backend/lib/cron_bridge.py
@@ -2481,6 +2481,7 @@ def _get_meta_cron_entries() -> list[CronEntry]:
     """
     entries = []
 
+    # Each entry is independent — if one fails validation, the other still gets created
     try:
         reboot_cmd = get_validated_command("reconcile_on_boot")
         entries.append(

--- a/Firmware/webui/backend/lib/cron_bridge.py
+++ b/Firmware/webui/backend/lib/cron_bridge.py
@@ -2469,7 +2469,7 @@ def _get_events_recurring_days_routine(
 # =============================================================================
 
 
-def _get_meta_cron_entries() -> list[CronEntry]:
+def _get_meta_cron_entries() -> tuple[list[CronEntry], list[str]]:
     """Generate meta-cron entries for boot reconciliation and weekly refresh.
 
     These entries handle:
@@ -2478,8 +2478,13 @@ def _get_meta_cron_entries() -> list[CronEntry]:
 
     Note: These entries are removed by remove_from_system() since their
     comments contain "Mothbox" which matches is_mothbox_command().
+
+    Returns:
+        Tuple of (entries, warnings). Warnings are non-empty when a meta-entry
+        could not be created (e.g. script missing from ALLOWED_SCRIPTS).
     """
-    entries = []
+    entries: list[CronEntry] = []
+    warnings: list[str] = []
 
     # Each entry is independent — if one fails validation, the other still gets created
     try:
@@ -2492,7 +2497,7 @@ def _get_meta_cron_entries() -> list[CronEntry]:
             )
         )
     except ValueError as e:
-        logger.warning(f"Could not create boot reconciliation entry: {e}")
+        warnings.append(f"Could not create boot reconciliation entry: {e}")
 
     try:
         refresh_cmd = get_validated_command("refresh_schedule")
@@ -2504,9 +2509,9 @@ def _get_meta_cron_entries() -> list[CronEntry]:
             )
         )
     except ValueError as e:
-        logger.warning(f"Could not create weekly refresh entry: {e}")
+        warnings.append(f"Could not create weekly refresh entry: {e}")
 
-    return entries
+    return entries, warnings
 
 
 def apply_to_system(
@@ -2566,7 +2571,10 @@ def apply_to_system(
                 added_count += 1
 
         # Add meta-cron entries for schedule maintenance (Issue #398)
-        for meta in _get_meta_cron_entries():
+        meta_entries, meta_warnings = _get_meta_cron_entries()
+        for warning in meta_warnings:
+            logger.error(warning)
+        for meta in meta_entries:
             job = cron.new(command=meta.command, comment=meta.comment)
             if meta.expression == "@reboot":
                 job.every_reboot()

--- a/Firmware/webui/backend/lib/cron_security.py
+++ b/Firmware/webui/backend/lib/cron_security.py
@@ -67,6 +67,9 @@ ALLOWED_SCRIPTS: Final[dict[str, str]] = {
     "debug_mode": "DebugMode.py",
     "stop_cron": "StopCron.py",
     "start_cron": "StartCron.py",
+    # Schedule maintenance (Issue #398)
+    "reconcile_on_boot": "webui/cli/reconcile_on_boot.py",
+    "refresh_schedule": "webui/cli/refresh_schedule.py",
 }
 
 

--- a/Firmware/webui/backend/lib/schedule_reconciler.py
+++ b/Firmware/webui/backend/lib/schedule_reconciler.py
@@ -1,0 +1,240 @@
+"""Schedule state reconciliation for GPIO catch-up.
+
+When a schedule is activated after a solar trigger has already passed (e.g.,
+activating an overnight survey after sunset), cron skips the past entries.
+GPIO actions like turning on attract lamps never fire until the next day.
+
+This module computes what GPIO state *should* be at the current time by
+looking back through the schedule's trigger history, then executes the
+most recent action for each GPIO resource.
+
+Same logic handles Pi reboot recovery: GPIO resets on boot, so we
+reconcile to restore the expected state.
+"""
+
+from __future__ import annotations
+
+import logging
+import shlex
+import subprocess
+from datetime import datetime, timedelta
+from math import ceil
+
+import pytz
+
+from webui.backend.lib.cron_bridge import calculate_execution_times
+from webui.backend.lib.cron_security import get_script_key_for_action, get_validated_command
+from webui.backend.lib.schedule_schema import Schedule, SensorTrigger
+
+logger = logging.getLogger(__name__)
+
+# Actions that are safe to replay (idempotent GPIO toggles and GPS sync)
+RECONCILABLE_ACTIONS: set[str] = {
+    "attract_on",
+    "attract_off",
+    "flash_on",
+    "flash_off",
+    "sync",  # gps_sync action uses action_name="sync"
+}
+
+# GPIO resource grouping: maps action names to their logical resource.
+# gps_sync ("sync") is not included here because it has no on/off pairing —
+# it's handled as a standalone resource in the grouping loop below.
+_ACTION_RESOURCE: dict[str, str] = {
+    "attract_on": "attract",
+    "attract_off": "attract",
+    "flash_on": "flash",
+    "flash_off": "flash",
+}
+
+# How far back to look for missed actions
+LOOKBACK_HOURS: int = 48
+
+
+def reconcile_schedule(
+    schedule: Schedule,
+    latitude: float,
+    longitude: float,
+    timezone_name: str,
+    now: datetime | None = None,
+) -> list[dict]:
+    """Determine which GPIO/idempotent actions should be executed now.
+
+    Looks back LOOKBACK_HOURS from ``now``, computes all trigger times for
+    each routine, applies action offsets, then for each GPIO resource finds
+    the most recent past action and returns it.
+
+    Args:
+        schedule: The active schedule to reconcile.
+        latitude: Observer latitude for solar calculations.
+        longitude: Observer longitude for solar calculations.
+        timezone_name: IANA timezone name (e.g. "America/New_York").
+        now: Current time. Must be timezone-aware. Defaults to now in
+            the schedule's timezone.
+
+    Returns:
+        List of dicts with keys:
+            - action_type (str): e.g. "gpio", "gps_sync"
+            - action_name (str): e.g. "attract_on", "flash_off", "sync"
+            - source_time (datetime): when this action should have fired
+    """
+    if now is None:
+        tz = pytz.timezone(timezone_name)
+        now = datetime.now(tz)
+
+    if not schedule.routines:
+        return []
+
+    lookback_start = now - timedelta(hours=LOOKBACK_HOURS)
+
+    # Collect all (action_time, action_type, action_name) in the lookback window
+    all_actions: list[tuple[datetime, str, str]] = []
+
+    for routine in schedule.routines:
+        # Skip sensor-only triggers (not schedulable)
+        if isinstance(routine.trigger, SensorTrigger):
+            continue
+
+        try:
+            trigger_times = calculate_execution_times(
+                trigger=routine.trigger,
+                latitude=latitude,
+                longitude=longitude,
+                timezone_name=timezone_name,
+                from_date=lookback_start.date(),
+                days_ahead=ceil(LOOKBACK_HOURS / 24) + 1,
+            )
+        except (ValueError, TypeError) as e:
+            logger.warning(
+                f"Skipping routine {routine.routine_id} during reconciliation: {e}"
+            )
+            continue
+
+        for trigger_time in trigger_times:
+            for action in routine.actions:
+                if action.action_name not in RECONCILABLE_ACTIONS:
+                    continue
+
+                action_time = trigger_time + timedelta(minutes=action.offset_minutes)
+
+                # Only past actions within the lookback window
+                if lookback_start <= action_time <= now:
+                    all_actions.append(
+                        (action_time, action.action_type, action.action_name)
+                    )
+
+    if not all_actions:
+        return []
+
+    # Group by resource, keep most recent per resource
+    resource_latest: dict[str, tuple[datetime, str, str]] = {}
+
+    for action_time, action_type, action_name in all_actions:
+        if action_type == "gps_sync":
+            # gps_sync is standalone — no on/off pairing
+            resource_key = "gps_sync"
+        else:
+            resource_key = _ACTION_RESOURCE.get(action_name)
+            if resource_key is None:
+                continue
+
+        existing = resource_latest.get(resource_key)
+        if existing is None or action_time > existing[0]:
+            resource_latest[resource_key] = (action_time, action_type, action_name)
+
+    # Build result list
+    results = []
+    for _resource_key, (action_time, action_type, action_name) in resource_latest.items():
+        results.append(
+            {
+                "action_type": action_type,
+                "action_name": action_name,
+                "source_time": action_time,
+            }
+        )
+
+    return results
+
+
+def execute_reconciliation(
+    actions: list[dict],
+) -> list[dict]:
+    """Execute reconciled actions by running the corresponding scripts.
+
+    Uses get_validated_command() from cron_security to get the safe command
+    for each action. Runs via subprocess. Returns results list.
+
+    Non-fatal: failures are logged but don't raise.
+
+    Args:
+        actions: List of action dicts from reconcile_schedule().
+
+    Returns:
+        List of result dicts with keys:
+            - action_name (str)
+            - success (bool)
+            - error (str | None)
+    """
+    results = []
+
+    for action in actions:
+        action_type = action["action_type"]
+        action_name = action["action_name"]
+
+        script_key = get_script_key_for_action(action_type, action_name)
+        if script_key is None:
+            logger.warning(f"No script key for action {action_type}/{action_name}")
+            results.append(
+                {
+                    "action_name": action_name,
+                    "success": False,
+                    "error": f"Unknown script key for {action_type}/{action_name}",
+                }
+            )
+            continue
+
+        try:
+            command = get_validated_command(script_key)
+        except ValueError as e:
+            logger.warning(f"Invalid command for {script_key}: {e}")
+            results.append(
+                {"action_name": action_name, "success": False, "error": str(e)}
+            )
+            continue
+
+        try:
+            logger.info(
+                f"Reconciling {action_name} (should have fired at {action['source_time']})"
+            )
+            proc = subprocess.run(  # noqa: S603
+                shlex.split(command),
+                timeout=30,
+                check=False,
+                capture_output=True,
+            )
+            if proc.returncode != 0:
+                error_msg = (
+                    proc.stderr.decode("utf-8", errors="replace").strip()
+                    if proc.stderr
+                    else f"exit code {proc.returncode}"
+                )
+                logger.warning(f"Reconciliation script failed: {action_name}: {error_msg}")
+                results.append(
+                    {"action_name": action_name, "success": False, "error": error_msg}
+                )
+            else:
+                results.append(
+                    {"action_name": action_name, "success": True, "error": None}
+                )
+        except subprocess.TimeoutExpired:
+            logger.warning(f"Reconciliation command timed out: {action_name}")
+            results.append(
+                {"action_name": action_name, "success": False, "error": "timeout"}
+            )
+        except OSError as e:
+            logger.warning(f"Reconciliation command failed: {action_name}: {e}")
+            results.append(
+                {"action_name": action_name, "success": False, "error": str(e)}
+            )
+
+    return results

--- a/Firmware/webui/backend/lib/schedule_reconciler.py
+++ b/Firmware/webui/backend/lib/schedule_reconciler.py
@@ -29,7 +29,9 @@ from webui.backend.lib.schedule_schema import Schedule, SensorTrigger
 
 logger = logging.getLogger(__name__)
 
-# Actions that are safe to replay (idempotent GPIO toggles and GPS sync)
+# Actions that are safe to replay (idempotent GPIO toggles and GPS sync).
+# Flash is included because the scheduled scripts (FlashOn.py/FlashOff.py) set
+# sustained relay state, unlike the web UI flash endpoint which pulses momentarily.
 RECONCILABLE_ACTIONS: set[str] = {
     "attract_on",
     "attract_off",

--- a/Firmware/webui/backend/lib/schedule_reconciler.py
+++ b/Firmware/webui/backend/lib/schedule_reconciler.py
@@ -81,6 +81,8 @@ def reconcile_schedule(
     if now is None:
         tz = pytz.timezone(timezone_name)
         now = datetime.now(tz)
+    elif now.tzinfo is None:
+        raise ValueError("now must be timezone-aware; got naive datetime")
 
     if not schedule.routines:
         return []
@@ -198,7 +200,7 @@ def execute_reconciliation(
 
         try:
             logger.info(f"Reconciling {action_name} (should have fired at {action['source_time']})")
-            proc = subprocess.run(  # noqa: S603
+            proc = subprocess.run(  # noqa: S603 - command from validated whitelist
                 shlex.split(command),
                 timeout=30,
                 check=False,

--- a/Firmware/webui/backend/lib/schedule_reconciler.py
+++ b/Firmware/webui/backend/lib/schedule_reconciler.py
@@ -97,7 +97,10 @@ def reconcile_schedule(
             - source_time (datetime): when this action should have fired
     """
     if now is None:
-        tz = pytz.timezone(timezone_name)
+        try:
+            tz = pytz.timezone(timezone_name)
+        except pytz.exceptions.UnknownTimeZoneError as e:
+            raise ValueError(f"Unknown timezone: {timezone_name!r}") from e
         now = datetime.now(tz)
     elif now.tzinfo is None:
         raise ValueError("now must be timezone-aware; got naive datetime")

--- a/Firmware/webui/backend/lib/schedule_reconciler.py
+++ b/Firmware/webui/backend/lib/schedule_reconciler.py
@@ -140,7 +140,10 @@ def reconcile_schedule(
                 days_ahead=ceil(LOOKBACK_HOURS / 24) + 1,
             )
         except (ValueError, TypeError) as e:
-            logger.warning(f"Skipping routine {routine.routine_id} during reconciliation: {e}")
+            trigger_type = type(routine.trigger).__name__
+            logger.warning(
+                f"Skipping routine {routine.routine_id} ({trigger_type}) during reconciliation: {e}"
+            )
             continue
 
         for trigger_time in trigger_times:

--- a/Firmware/webui/backend/lib/schedule_reconciler.py
+++ b/Firmware/webui/backend/lib/schedule_reconciler.py
@@ -105,9 +105,7 @@ def reconcile_schedule(
                 days_ahead=ceil(LOOKBACK_HOURS / 24) + 1,
             )
         except (ValueError, TypeError) as e:
-            logger.warning(
-                f"Skipping routine {routine.routine_id} during reconciliation: {e}"
-            )
+            logger.warning(f"Skipping routine {routine.routine_id} during reconciliation: {e}")
             continue
 
         for trigger_time in trigger_times:
@@ -119,9 +117,7 @@ def reconcile_schedule(
 
                 # Only past actions within the lookback window
                 if lookback_start <= action_time <= now:
-                    all_actions.append(
-                        (action_time, action.action_type, action.action_name)
-                    )
+                    all_actions.append((action_time, action.action_type, action.action_name))
 
     if not all_actions:
         return []
@@ -197,15 +193,11 @@ def execute_reconciliation(
             command = get_validated_command(script_key)
         except ValueError as e:
             logger.warning(f"Invalid command for {script_key}: {e}")
-            results.append(
-                {"action_name": action_name, "success": False, "error": str(e)}
-            )
+            results.append({"action_name": action_name, "success": False, "error": str(e)})
             continue
 
         try:
-            logger.info(
-                f"Reconciling {action_name} (should have fired at {action['source_time']})"
-            )
+            logger.info(f"Reconciling {action_name} (should have fired at {action['source_time']})")
             proc = subprocess.run(  # noqa: S603
                 shlex.split(command),
                 timeout=30,
@@ -219,22 +211,14 @@ def execute_reconciliation(
                     else f"exit code {proc.returncode}"
                 )
                 logger.warning(f"Reconciliation script failed: {action_name}: {error_msg}")
-                results.append(
-                    {"action_name": action_name, "success": False, "error": error_msg}
-                )
+                results.append({"action_name": action_name, "success": False, "error": error_msg})
             else:
-                results.append(
-                    {"action_name": action_name, "success": True, "error": None}
-                )
+                results.append({"action_name": action_name, "success": True, "error": None})
         except subprocess.TimeoutExpired:
             logger.warning(f"Reconciliation command timed out: {action_name}")
-            results.append(
-                {"action_name": action_name, "success": False, "error": "timeout"}
-            )
+            results.append({"action_name": action_name, "success": False, "error": "timeout"})
         except OSError as e:
             logger.warning(f"Reconciliation command failed: {action_name}: {e}")
-            results.append(
-                {"action_name": action_name, "success": False, "error": str(e)}
-            )
+            results.append({"action_name": action_name, "success": False, "error": str(e)})
 
     return results

--- a/Firmware/webui/backend/lib/schedule_reconciler.py
+++ b/Firmware/webui/backend/lib/schedule_reconciler.py
@@ -19,6 +19,7 @@ import shlex
 import subprocess
 from datetime import datetime, timedelta
 from math import ceil
+from typing import TypedDict
 
 import pytz
 
@@ -47,8 +48,25 @@ _ACTION_RESOURCE: dict[str, str] = {
     "flash_off": "flash",
 }
 
-# How far back to look for missed actions
+
+class ReconcileAction(TypedDict):
+    action_type: str
+    action_name: str
+    source_time: datetime
+
+
+class ReconcileResult(TypedDict):
+    action_name: str
+    success: bool
+    error: str | None
+
+
+# 48h covers two full solar cycles, ensuring we catch both "today's" and
+# "yesterday's" triggers regardless of when reconciliation runs
 LOOKBACK_HOURS: int = 48
+
+# Timeout for reconciliation subprocess commands (seconds)
+RECONCILE_TIMEOUT: int = 30
 
 
 def reconcile_schedule(
@@ -57,7 +75,7 @@ def reconcile_schedule(
     longitude: float,
     timezone_name: str,
     now: datetime | None = None,
-) -> list[dict]:
+) -> list[ReconcileAction]:
     """Determine which GPIO/idempotent actions should be executed now.
 
     Looks back LOOKBACK_HOURS from ``now``, computes all trigger times for
@@ -98,6 +116,8 @@ def reconcile_schedule(
             continue
 
         try:
+            # +1 day buffer ensures we capture all triggers in the lookback window
+            # even when trigger times fall near end-of-day boundaries
             trigger_times = calculate_execution_times(
                 trigger=routine.trigger,
                 latitude=latitude,
@@ -155,8 +175,8 @@ def reconcile_schedule(
 
 
 def execute_reconciliation(
-    actions: list[dict],
-) -> list[dict]:
+    actions: list[ReconcileAction],
+) -> list[ReconcileResult]:
     """Execute reconciled actions by running the corresponding scripts.
 
     Uses get_validated_command() from cron_security to get the safe command
@@ -202,7 +222,7 @@ def execute_reconciliation(
             logger.info(f"Reconciling {action_name} (should have fired at {action['source_time']})")
             proc = subprocess.run(  # noqa: S603 - command from validated whitelist
                 shlex.split(command),
-                timeout=30,
+                timeout=RECONCILE_TIMEOUT,
                 check=False,
                 capture_output=True,
             )
@@ -217,8 +237,9 @@ def execute_reconciliation(
             else:
                 results.append({"action_name": action_name, "success": True, "error": None})
         except subprocess.TimeoutExpired:
+            error_msg = f"Command timed out after {RECONCILE_TIMEOUT}s"
             logger.warning(f"Reconciliation command timed out: {action_name}")
-            results.append({"action_name": action_name, "success": False, "error": "timeout"})
+            results.append({"action_name": action_name, "success": False, "error": error_msg})
         except OSError as e:
             logger.warning(f"Reconciliation command failed: {action_name}: {e}")
             results.append({"action_name": action_name, "success": False, "error": str(e)})

--- a/Firmware/webui/backend/lib/schedule_reconciler.py
+++ b/Firmware/webui/backend/lib/schedule_reconciler.py
@@ -140,8 +140,8 @@ def reconcile_schedule(
 
                 action_time = trigger_time + timedelta(minutes=action.offset_minutes)
 
-                # Only past actions within the lookback window
-                if lookback_start <= action_time <= now:
+                # Only past actions within the lookback window (strict upper bound)
+                if lookback_start <= action_time < now:
                     all_actions.append((action_time, action.action_type, action.action_name))
 
     if not all_actions:

--- a/Firmware/webui/backend/lib/schedule_reconciler.py
+++ b/Firmware/webui/backend/lib/schedule_reconciler.py
@@ -37,7 +37,9 @@ RECONCILABLE_ACTIONS: set[str] = {
     "attract_off",
     "flash_on",
     "flash_off",
-    "sync",  # gps_sync action uses action_name="sync"
+    # GPS.py acquires a fresh fix and syncs the system clock — idempotent and
+    # safe to replay at any time, especially useful after reboot to correct drift.
+    "sync",
 }
 
 # GPIO resource grouping: maps action names to their logical resource.
@@ -67,8 +69,9 @@ class ReconcileResult(TypedDict):
 # "yesterday's" triggers regardless of when reconciliation runs
 LOOKBACK_HOURS: int = 48
 
-# Timeout for reconciliation subprocess commands (seconds)
-RECONCILE_TIMEOUT: int = 30
+# Timeout for reconciliation subprocess commands (seconds).
+# Kept short to avoid blocking boot: 3 resources × 15s = 45s worst case.
+RECONCILE_TIMEOUT: int = 15
 
 
 def reconcile_schedule(

--- a/Firmware/webui/backend/lib/schedule_reconciler.py
+++ b/Firmware/webui/backend/lib/schedule_reconciler.py
@@ -25,6 +25,7 @@ import pytz
 
 from webui.backend.lib.cron_bridge import calculate_execution_times
 from webui.backend.lib.cron_security import get_script_key_for_action, get_validated_command
+from webui.backend.lib.haversine import validate_coordinates
 from webui.backend.lib.schedule_schema import Schedule, SensorTrigger
 
 logger = logging.getLogger(__name__)
@@ -109,6 +110,10 @@ def reconcile_schedule(
         now = datetime.now(tz)
     elif now.tzinfo is None:
         raise ValueError("now must be timezone-aware; got naive datetime")
+
+    valid, err = validate_coordinates(latitude, longitude)
+    if not valid:
+        raise ValueError(f"Invalid coordinates: {err}")
 
     if not schedule.routines:
         return []

--- a/Firmware/webui/backend/services/scheduler_service.py
+++ b/Firmware/webui/backend/services/scheduler_service.py
@@ -1224,9 +1224,7 @@ class SchedulerService:
                         schedule, latitude, longitude, timezone_name
                     )
                     if reconcile_actions:
-                        logger.info(
-                            f"Reconciling {len(reconcile_actions)} missed actions"
-                        )
+                        logger.info(f"Reconciling {len(reconcile_actions)} missed actions")
                         results = execute_reconciliation(reconcile_actions)
                         failed = [r for r in results if not r["success"]]
                         if failed:

--- a/Firmware/webui/backend/services/scheduler_service.py
+++ b/Firmware/webui/backend/services/scheduler_service.py
@@ -1212,6 +1212,30 @@ class SchedulerService:
                         f"Failed to persist activation state: {persist_error}"
                     ) from persist_error
 
+                # Reconcile missed GPIO actions (Issue #398)
+                # Non-fatal: reconciliation failure must NOT prevent activation
+                try:
+                    from webui.backend.lib.schedule_reconciler import (
+                        execute_reconciliation,
+                        reconcile_schedule,
+                    )
+
+                    reconcile_actions = reconcile_schedule(
+                        schedule, latitude, longitude, timezone_name
+                    )
+                    if reconcile_actions:
+                        logger.info(
+                            f"Reconciling {len(reconcile_actions)} missed actions"
+                        )
+                        results = execute_reconciliation(reconcile_actions)
+                        failed = [r for r in results if not r["success"]]
+                        if failed:
+                            logger.warning(
+                                f"Reconciliation: {len(failed)} actions failed: {failed}"
+                            )
+                except Exception as e:
+                    logger.warning(f"Reconciliation failed (non-fatal): {e}")
+
             except ScheduleActivationError:
                 # Re-raise our own errors, but rollback cron if already applied
                 if cron_applied:

--- a/Firmware/webui/cli/reconcile_on_boot.py
+++ b/Firmware/webui/cli/reconcile_on_boot.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Reconcile GPIO state after boot.
+
+Called via @reboot cron entry. Waits for GPIO daemon socket,
+loads active schedule from active_state.json, runs reconciler.
+
+Usage: systemd-cat -t mothbox /usr/bin/python3 /path/to/reconcile_on_boot.py
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+import time
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger("reconcile_on_boot")
+
+# GPIO daemon socket path
+GPIO_SOCKET = Path("/run/mothbox/gpio.sock")
+
+# Backoff schedule: 0.5, 1, 2, 4, 8, 16 seconds (~31.5s total)
+BACKOFF_DELAYS = [0.5, 1, 2, 4, 8, 16]
+
+
+def wait_for_gpio_daemon() -> bool:
+    """Poll for GPIO daemon socket with exponential backoff.
+
+    Returns True if socket appeared, False if timeout.
+    """
+    for delay in BACKOFF_DELAYS:
+        if GPIO_SOCKET.exists():
+            logger.info("GPIO daemon socket found")
+            return True
+        logger.debug(f"Waiting {delay}s for GPIO daemon socket...")
+        time.sleep(delay)
+
+    # One final check
+    if GPIO_SOCKET.exists():
+        logger.info("GPIO daemon socket found")
+        return True
+
+    logger.warning("GPIO daemon socket not found after timeout")
+    return False
+
+
+def load_active_state() -> dict | None:
+    """Load active_state.json from CONFIG_DIR.
+
+    Returns the parsed dict, or None if no active state.
+    """
+    from mothbox_paths import CONFIG_DIR
+
+    state_file = CONFIG_DIR / "active_state.json"
+    if not state_file.exists():
+        logger.info("No active_state.json found — nothing to reconcile")
+        return None
+
+    try:
+        with open(state_file) as f:
+            state = json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        logger.error(f"Failed to read active_state.json: {e}")
+        return None
+
+    if not state.get("schedule_id"):
+        logger.info("No active schedule in state file")
+        return None
+
+    return state
+
+
+def main() -> int:
+    """Main entry point for boot reconciliation."""
+    logger.info("Starting boot GPIO reconciliation")
+
+    # Wait for GPIO daemon
+    if not wait_for_gpio_daemon():
+        logger.warning("Proceeding without GPIO daemon — commands may fail")
+
+    # Load active state
+    state = load_active_state()
+    if state is None:
+        return 0
+
+    schedule_id = state["schedule_id"]
+    latitude = state.get("latitude", 0.0)
+    longitude = state.get("longitude", 0.0)
+    timezone_name = state.get("timezone_name", "UTC")
+
+    logger.info(f"Reconciling schedule: {schedule_id}")
+
+    # Load the schedule from storage
+    from webui.backend.lib.schedule_storage import read_schedule
+
+    schedule = read_schedule(schedule_id)
+    if schedule is None:
+        logger.error(f"Schedule not found in storage: {schedule_id}")
+        return 1
+
+    # Run reconciliation
+    from webui.backend.lib.schedule_reconciler import (
+        execute_reconciliation,
+        reconcile_schedule,
+    )
+
+    try:
+        actions = reconcile_schedule(schedule, latitude, longitude, timezone_name)
+    except Exception as e:
+        logger.error(f"Reconciliation computation failed: {e}")
+        return 1
+
+    if not actions:
+        logger.info("No actions to reconcile")
+        return 0
+
+    logger.info(f"Executing {len(actions)} reconciled actions")
+    results = execute_reconciliation(actions)
+
+    failed = [r for r in results if not r["success"]]
+    if failed:
+        logger.warning(f"{len(failed)} actions failed: {failed}")
+    else:
+        logger.info("All reconciled actions executed successfully")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Firmware/webui/cli/reconcile_on_boot.py
+++ b/Firmware/webui/cli/reconcile_on_boot.py
@@ -81,9 +81,18 @@ def main() -> int:
         logger.error("GPIO daemon unavailable — reconciliation actions will likely fail")
 
     schedule_id = state["schedule_id"]
-    latitude = state.get("latitude", 0.0)
-    longitude = state.get("longitude", 0.0)
+    latitude = state.get("latitude")
+    longitude = state.get("longitude")
     timezone_name = state.get("timezone_name", "UTC")
+
+    # Fallback: derive coordinates from timezone (matches scheduler_service activation pattern)
+    if latitude is None or longitude is None:
+        from webui.backend.lib.timezone_coordinates import get_fallback_coordinates
+
+        fb_lat, fb_lon, fb_source = get_fallback_coordinates()
+        latitude = latitude if latitude is not None else fb_lat
+        longitude = longitude if longitude is not None else fb_lon
+        logger.warning(f"Coordinates missing from state — using timezone fallback ({fb_source})")
 
     logger.info(f"Reconciling schedule: {schedule_id}")
 
@@ -103,7 +112,7 @@ def main() -> int:
 
     try:
         actions = reconcile_schedule(schedule, latitude, longitude, timezone_name)
-    except Exception as e:
+    except (ValueError, TypeError) as e:
         logger.error(f"Reconciliation computation failed: {e}")
         return 1
 

--- a/Firmware/webui/cli/reconcile_on_boot.py
+++ b/Firmware/webui/cli/reconcile_on_boot.py
@@ -9,7 +9,6 @@ Usage: systemd-cat -t mothbox /usr/bin/python3 /path/to/reconcile_on_boot.py
 
 from __future__ import annotations
 
-import json
 import logging
 import sys
 import time
@@ -53,26 +52,9 @@ def load_active_state() -> dict | None:
 
     Returns the parsed dict, or None if no active state.
     """
-    from mothbox_paths import CONFIG_DIR
-    from webui.backend.lib.sidecar_metadata import FileLock
+    from webui.backend.lib.active_state import load_active_state as _load
 
-    state_file = CONFIG_DIR / "active_state.json"
-    if not state_file.exists():
-        logger.info("No active_state.json found — nothing to reconcile")
-        return None
-
-    try:
-        with FileLock(state_file, exclusive=False, timeout=10.0) as f:
-            state = json.load(f)
-    except (json.JSONDecodeError, OSError) as e:
-        logger.error(f"Failed to read active_state.json: {e}")
-        return None
-
-    if not state.get("schedule_id"):
-        logger.info("No active schedule in state file")
-        return None
-
-    return state
+    return _load()
 
 
 def main() -> int:

--- a/Firmware/webui/cli/reconcile_on_boot.py
+++ b/Firmware/webui/cli/reconcile_on_boot.py
@@ -95,6 +95,9 @@ def main() -> int:
     if state is None:
         return 0
 
+    if not daemon_ready:
+        logger.error("GPIO daemon unavailable — reconciliation actions will likely fail")
+
     schedule_id = state["schedule_id"]
     latitude = state.get("latitude", 0.0)
     longitude = state.get("longitude", 0.0)

--- a/Firmware/webui/cli/reconcile_on_boot.py
+++ b/Firmware/webui/cli/reconcile_on_boot.py
@@ -15,11 +15,13 @@ import sys
 import time
 from pathlib import Path
 
+from lib.gpio_protocol import SOCKET_PATH
+
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger("reconcile_on_boot")
 
-# GPIO daemon socket path
-GPIO_SOCKET = Path("/run/mothbox/gpio.sock")
+# GPIO daemon socket path (from shared protocol constants)
+GPIO_SOCKET = Path(SOCKET_PATH)
 
 # Backoff schedule: 0.5, 1, 2, 4, 8, 16 seconds (~31.5s total)
 BACKOFF_DELAYS = [0.5, 1, 2, 4, 8, 16]
@@ -74,11 +76,18 @@ def load_active_state() -> dict | None:
 
 
 def main() -> int:
-    """Main entry point for boot reconciliation."""
+    """Main entry point for boot reconciliation.
+
+    Returns:
+        0: Success (or no work to do)
+        1: Fatal error (schedule not found, computation failed)
+        2: Partial success (some actions failed, e.g. daemon unavailable)
+    """
     logger.info("Starting boot GPIO reconciliation")
 
     # Wait for GPIO daemon
-    if not wait_for_gpio_daemon():
+    daemon_ready = wait_for_gpio_daemon()
+    if not daemon_ready:
         logger.warning("Proceeding without GPIO daemon — commands may fail")
 
     # Load active state
@@ -123,6 +132,7 @@ def main() -> int:
     failed = [r for r in results if not r["success"]]
     if failed:
         logger.warning(f"{len(failed)} actions failed: {failed}")
+        return 2
     else:
         logger.info("All reconciled actions executed successfully")
 

--- a/Firmware/webui/cli/reconcile_on_boot.py
+++ b/Firmware/webui/cli/reconcile_on_boot.py
@@ -47,11 +47,12 @@ def wait_for_gpio_daemon() -> bool:
 
 
 def load_active_state() -> dict | None:
-    """Load active_state.json from CONFIG_DIR.
+    """Load active_state.json from CONFIG_DIR with shared file lock.
 
     Returns the parsed dict, or None if no active state.
     """
     from mothbox_paths import CONFIG_DIR
+    from webui.backend.lib.sidecar_metadata import FileLock
 
     state_file = CONFIG_DIR / "active_state.json"
     if not state_file.exists():
@@ -59,7 +60,7 @@ def load_active_state() -> dict | None:
         return None
 
     try:
-        with open(state_file) as f:
+        with FileLock(state_file, exclusive=False, timeout=10.0) as f:
             state = json.load(f)
     except (json.JSONDecodeError, OSError) as e:
         logger.error(f"Failed to read active_state.json: {e}")

--- a/Firmware/webui/cli/reconcile_on_boot.py
+++ b/Firmware/webui/cli/reconcile_on_boot.py
@@ -10,20 +10,28 @@ Usage: systemd-cat -t mothbox /usr/bin/python3 /path/to/reconcile_on_boot.py
 from __future__ import annotations
 
 import logging
+import os
 import sys
 import time
 from pathlib import Path
 
 from lib.gpio_protocol import SOCKET_PATH
 
-logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+log_level = os.environ.get("MOTHBOX_LOG_LEVEL", "INFO").upper()
+logging.basicConfig(
+    level=getattr(logging, log_level, logging.INFO), format="%(levelname)s: %(message)s"
+)
 logger = logging.getLogger("reconcile_on_boot")
 
 # GPIO daemon socket path (from shared protocol constants)
 GPIO_SOCKET = Path(SOCKET_PATH)
 
-# Backoff schedule: 0.5, 1, 2, 4, 8, 16 seconds (~31.5s total)
-BACKOFF_DELAYS = [0.5, 1, 2, 4, 8, 16]
+# Backoff schedule: 0.5, 1, 2, 4, 8, 16, 32 seconds (~63.5s total)
+BACKOFF_DELAYS = [0.5, 1, 2, 4, 8, 16, 32]
+
+EXIT_SUCCESS = 0
+EXIT_FATAL = 1
+EXIT_PARTIAL = 2
 
 
 def wait_for_gpio_daemon() -> bool:
@@ -61,9 +69,9 @@ def main() -> int:
     """Main entry point for boot reconciliation.
 
     Returns:
-        0: Success (or no work to do)
-        1: Fatal error (schedule not found, computation failed)
-        2: Partial success (some actions failed, e.g. daemon unavailable)
+        EXIT_SUCCESS (0): Success (or no work to do)
+        EXIT_FATAL (1): Fatal error (schedule not found, computation failed)
+        EXIT_PARTIAL (2): Partial success (some actions failed, e.g. daemon unavailable)
     """
     logger.info("Starting boot GPIO reconciliation")
 
@@ -75,7 +83,7 @@ def main() -> int:
     # Load active state
     state = load_active_state()
     if state is None:
-        return 0
+        return EXIT_SUCCESS
 
     if not daemon_ready:
         logger.error("GPIO daemon unavailable — reconciliation actions will likely fail")
@@ -102,7 +110,7 @@ def main() -> int:
     schedule = read_schedule(schedule_id)
     if schedule is None:
         logger.error(f"Schedule not found in storage: {schedule_id}")
-        return 1
+        return EXIT_FATAL
 
     # Run reconciliation
     from webui.backend.lib.schedule_reconciler import (
@@ -114,11 +122,11 @@ def main() -> int:
         actions = reconcile_schedule(schedule, latitude, longitude, timezone_name)
     except (ValueError, TypeError) as e:
         logger.error(f"Reconciliation computation failed: {e}")
-        return 1
+        return EXIT_FATAL
 
     if not actions:
         logger.info("No actions to reconcile")
-        return 0
+        return EXIT_SUCCESS
 
     logger.info(f"Executing {len(actions)} reconciled actions")
     results = execute_reconciliation(actions)
@@ -126,11 +134,11 @@ def main() -> int:
     failed = [r for r in results if not r["success"]]
     if failed:
         logger.warning(f"{len(failed)} actions failed: {failed}")
-        return 2
+        return EXIT_PARTIAL
     else:
         logger.info("All reconciled actions executed successfully")
 
-    return 0
+    return EXIT_SUCCESS
 
 
 if __name__ == "__main__":

--- a/Firmware/webui/cli/refresh_schedule.py
+++ b/Firmware/webui/cli/refresh_schedule.py
@@ -44,8 +44,11 @@ def load_active_state() -> dict | None:
     return state
 
 
-def save_active_state(state: dict) -> bool:
-    """Write updated active_state.json back to CONFIG_DIR with exclusive file lock.
+def save_active_state(entries_update: list[dict]) -> bool:
+    """Merge updated entries into active_state.json under exclusive file lock.
+
+    Re-reads the file under the exclusive lock to prevent clobbering
+    concurrent modifications from other processes.
 
     Returns True on success, False on failure.
     """
@@ -56,10 +59,13 @@ def save_active_state(state: dict) -> bool:
     try:
         with FileLock(state_file, exclusive=True, timeout=10.0) as f:
             f.seek(0)
+            current_state = json.load(f)
+            current_state["entries"] = entries_update
+            f.seek(0)
             f.truncate()
-            json.dump(state, f, indent=2)
+            json.dump(current_state, f, indent=2)
         return True
-    except OSError as e:
+    except (OSError, json.JSONDecodeError) as e:
         logger.error(f"Failed to write active_state.json: {e}")
         return False
 
@@ -133,8 +139,7 @@ def main() -> int:
             entries=result.entries,
             timezone_name=timezone_name,
         )
-        state["entries"] = [e.to_dict() for e in expanded]
-        if not save_active_state(state):
+        if not save_active_state([e.to_dict() for e in expanded]):
             logger.warning("Failed to update active_state.json with new entries")
     except Exception as e:
         logger.warning(f"Failed to expand/persist entries (non-fatal): {e}")

--- a/Firmware/webui/cli/refresh_schedule.py
+++ b/Firmware/webui/cli/refresh_schedule.py
@@ -11,11 +11,18 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import sys
 from typing import Any
 
-logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+log_level = os.environ.get("MOTHBOX_LOG_LEVEL", "INFO").upper()
+logging.basicConfig(
+    level=getattr(logging, log_level, logging.INFO), format="%(levelname)s: %(message)s"
+)
 logger = logging.getLogger("refresh_schedule")
+
+EXIT_SUCCESS = 0
+EXIT_FATAL = 1
 
 
 def load_active_state() -> dict | None:
@@ -76,7 +83,7 @@ def main() -> int:
     # Load active state
     state = load_active_state()
     if state is None:
-        return 0
+        return EXIT_SUCCESS
 
     schedule_id = state["schedule_id"]
     latitude = state.get("latitude")
@@ -100,7 +107,7 @@ def main() -> int:
     schedule = read_schedule(schedule_id)
     if schedule is None:
         logger.error(f"Schedule not found in storage: {schedule_id}")
-        return 1
+        return EXIT_FATAL
 
     # Regenerate cron entries
     from webui.backend.lib.cron_bridge import (
@@ -118,11 +125,11 @@ def main() -> int:
         )
     except ValueError as e:
         logger.error(f"Cron generation failed: {e}")
-        return 1
+        return EXIT_FATAL
 
     if result.errors:
         logger.error(f"Cron conversion errors: {'; '.join(result.errors)}")
-        return 1
+        return EXIT_FATAL
 
     # Apply to system cron (replaces existing Mothbox entries)
     try:
@@ -133,11 +140,11 @@ def main() -> int:
         )
     except (ValueError, OSError) as e:
         logger.error(f"Failed to apply cron entries: {e}")
-        return 1
+        return EXIT_FATAL
 
     if not success:
         logger.error("apply_to_system returned False")
-        return 1
+        return EXIT_FATAL
 
     logger.info(f"Applied {len(result.entries)} refreshed cron entries")
 
@@ -153,7 +160,7 @@ def main() -> int:
         logger.warning(f"Failed to expand/persist entries (non-fatal): {e}")
 
     logger.info("Weekly cron refresh complete")
-    return 0
+    return EXIT_SUCCESS
 
 
 if __name__ == "__main__":

--- a/Firmware/webui/cli/refresh_schedule.py
+++ b/Firmware/webui/cli/refresh_schedule.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 import logging
 import sys
+from typing import Any
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger("refresh_schedule")
@@ -44,7 +45,7 @@ def load_active_state() -> dict | None:
     return state
 
 
-def save_active_state(entries_update: list[dict]) -> bool:
+def save_active_state(entries_update: list[dict[str, Any]]) -> bool:
     """Merge updated entries into active_state.json under exclusive file lock.
 
     Re-reads the file under the exclusive lock to prevent clobbering

--- a/Firmware/webui/cli/refresh_schedule.py
+++ b/Firmware/webui/cli/refresh_schedule.py
@@ -49,6 +49,8 @@ def save_active_state(
     state_file = CONFIG_DIR / "active_state.json"
     try:
         with FileLock(state_file, exclusive=True, timeout=10.0) as f:
+            # Exclusive lock guarantees atomic check-and-write: no other process
+            # can read or modify the file between the schedule_id check and the write.
             f.seek(0)
             current_state = json.load(f)
             if (
@@ -77,9 +79,18 @@ def main() -> int:
         return 0
 
     schedule_id = state["schedule_id"]
-    latitude = state.get("latitude", 0.0)
-    longitude = state.get("longitude", 0.0)
+    latitude = state.get("latitude")
+    longitude = state.get("longitude")
     timezone_name = state.get("timezone_name", "UTC")
+
+    # Fallback: derive coordinates from timezone (matches scheduler_service activation pattern)
+    if latitude is None or longitude is None:
+        from webui.backend.lib.timezone_coordinates import get_fallback_coordinates
+
+        fb_lat, fb_lon, fb_source = get_fallback_coordinates()
+        latitude = latitude if latitude is not None else fb_lat
+        longitude = longitude if longitude is not None else fb_lon
+        logger.warning(f"Coordinates missing from state — using timezone fallback ({fb_source})")
 
     logger.info(f"Refreshing cron entries for schedule: {schedule_id}")
 
@@ -105,7 +116,7 @@ def main() -> int:
             longitude=longitude,
             timezone_name=timezone_name,
         )
-    except Exception as e:
+    except ValueError as e:
         logger.error(f"Cron generation failed: {e}")
         return 1
 
@@ -120,7 +131,7 @@ def main() -> int:
             schedule_id=schedule_id,
             set_rtc=True,
         )
-    except Exception as e:
+    except (ValueError, OSError) as e:
         logger.error(f"Failed to apply cron entries: {e}")
         return 1
 
@@ -138,7 +149,7 @@ def main() -> int:
         )
         if not save_active_state([e.to_dict() for e in expanded], expected_schedule_id=schedule_id):
             logger.warning("Failed to update active_state.json with new entries")
-    except Exception as e:
+    except (ValueError, KeyError) as e:
         logger.warning(f"Failed to expand/persist entries (non-fatal): {e}")
 
     logger.info("Weekly cron refresh complete")

--- a/Firmware/webui/cli/refresh_schedule.py
+++ b/Firmware/webui/cli/refresh_schedule.py
@@ -23,33 +23,23 @@ def load_active_state() -> dict | None:
 
     Returns the parsed dict, or None if no active state.
     """
-    from mothbox_paths import CONFIG_DIR
-    from webui.backend.lib.sidecar_metadata import FileLock
+    from webui.backend.lib.active_state import load_active_state as _load
 
-    state_file = CONFIG_DIR / "active_state.json"
-    if not state_file.exists():
-        logger.info("No active_state.json found — nothing to refresh")
-        return None
-
-    try:
-        with FileLock(state_file, exclusive=False, timeout=10.0) as f:
-            state = json.load(f)
-    except (json.JSONDecodeError, OSError) as e:
-        logger.error(f"Failed to read active_state.json: {e}")
-        return None
-
-    if not state.get("schedule_id"):
-        logger.info("No active schedule in state file")
-        return None
-
-    return state
+    return _load()
 
 
-def save_active_state(entries_update: list[dict[str, Any]]) -> bool:
+def save_active_state(
+    entries_update: list[dict[str, Any]], expected_schedule_id: str | None = None
+) -> bool:
     """Merge updated entries into active_state.json under exclusive file lock.
 
     Re-reads the file under the exclusive lock to prevent clobbering
     concurrent modifications from other processes.
+
+    Args:
+        entries_update: New entries to write.
+        expected_schedule_id: If provided, abort if the schedule_id in the
+            state file has changed (another activation happened concurrently).
 
     Returns True on success, False on failure.
     """
@@ -61,6 +51,12 @@ def save_active_state(entries_update: list[dict[str, Any]]) -> bool:
         with FileLock(state_file, exclusive=True, timeout=10.0) as f:
             f.seek(0)
             current_state = json.load(f)
+            if (
+                expected_schedule_id is not None
+                and current_state.get("schedule_id") != expected_schedule_id
+            ):
+                logger.warning("Schedule changed during refresh — aborting entry update")
+                return False
             current_state["entries"] = entries_update
             f.seek(0)
             f.truncate()
@@ -140,7 +136,7 @@ def main() -> int:
             entries=result.entries,
             timezone_name=timezone_name,
         )
-        if not save_active_state([e.to_dict() for e in expanded]):
+        if not save_active_state([e.to_dict() for e in expanded], expected_schedule_id=schedule_id):
             logger.warning("Failed to update active_state.json with new entries")
     except Exception as e:
         logger.warning(f"Failed to expand/persist entries (non-fatal): {e}")

--- a/Firmware/webui/cli/refresh_schedule.py
+++ b/Firmware/webui/cli/refresh_schedule.py
@@ -18,11 +18,12 @@ logger = logging.getLogger("refresh_schedule")
 
 
 def load_active_state() -> dict | None:
-    """Load active_state.json from CONFIG_DIR.
+    """Load active_state.json from CONFIG_DIR with shared file lock.
 
     Returns the parsed dict, or None if no active state.
     """
     from mothbox_paths import CONFIG_DIR
+    from webui.backend.lib.sidecar_metadata import FileLock
 
     state_file = CONFIG_DIR / "active_state.json"
     if not state_file.exists():
@@ -30,7 +31,7 @@ def load_active_state() -> dict | None:
         return None
 
     try:
-        with open(state_file) as f:
+        with FileLock(state_file, exclusive=False, timeout=10.0) as f:
             state = json.load(f)
     except (json.JSONDecodeError, OSError) as e:
         logger.error(f"Failed to read active_state.json: {e}")
@@ -44,15 +45,18 @@ def load_active_state() -> dict | None:
 
 
 def save_active_state(state: dict) -> bool:
-    """Write updated active_state.json back to CONFIG_DIR.
+    """Write updated active_state.json back to CONFIG_DIR with exclusive file lock.
 
     Returns True on success, False on failure.
     """
     from mothbox_paths import CONFIG_DIR
+    from webui.backend.lib.sidecar_metadata import FileLock
 
     state_file = CONFIG_DIR / "active_state.json"
     try:
-        with open(state_file, "w") as f:
+        with FileLock(state_file, exclusive=True, timeout=10.0) as f:
+            f.seek(0)
+            f.truncate()
             json.dump(state, f, indent=2)
         return True
     except OSError as e:

--- a/Firmware/webui/cli/refresh_schedule.py
+++ b/Firmware/webui/cli/refresh_schedule.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Refresh cron entries for active schedule.
+
+Regenerates date-specific cron entries (solar, moon, recurring) to prevent
+60-day expiration. Called weekly via cron (0 2 * * 0).
+
+Usage: systemd-cat -t mothbox /usr/bin/python3 /path/to/refresh_schedule.py
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger("refresh_schedule")
+
+
+def load_active_state() -> dict | None:
+    """Load active_state.json from CONFIG_DIR.
+
+    Returns the parsed dict, or None if no active state.
+    """
+    from mothbox_paths import CONFIG_DIR
+
+    state_file = CONFIG_DIR / "active_state.json"
+    if not state_file.exists():
+        logger.info("No active_state.json found — nothing to refresh")
+        return None
+
+    try:
+        with open(state_file) as f:
+            state = json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        logger.error(f"Failed to read active_state.json: {e}")
+        return None
+
+    if not state.get("schedule_id"):
+        logger.info("No active schedule in state file")
+        return None
+
+    return state
+
+
+def save_active_state(state: dict) -> bool:
+    """Write updated active_state.json back to CONFIG_DIR.
+
+    Returns True on success, False on failure.
+    """
+    from mothbox_paths import CONFIG_DIR
+
+    state_file = CONFIG_DIR / "active_state.json"
+    try:
+        with open(state_file, "w") as f:
+            json.dump(state, f, indent=2)
+        return True
+    except OSError as e:
+        logger.error(f"Failed to write active_state.json: {e}")
+        return False
+
+
+def main() -> int:
+    """Main entry point for cron refresh."""
+    logger.info("Starting weekly cron entry refresh")
+
+    # Load active state
+    state = load_active_state()
+    if state is None:
+        return 0
+
+    schedule_id = state["schedule_id"]
+    latitude = state.get("latitude", 0.0)
+    longitude = state.get("longitude", 0.0)
+    timezone_name = state.get("timezone_name", "UTC")
+
+    logger.info(f"Refreshing cron entries for schedule: {schedule_id}")
+
+    # Load the schedule from storage
+    from webui.backend.lib.schedule_storage import read_schedule
+
+    schedule = read_schedule(schedule_id)
+    if schedule is None:
+        logger.error(f"Schedule not found in storage: {schedule_id}")
+        return 1
+
+    # Regenerate cron entries
+    from webui.backend.lib.cron_bridge import (
+        apply_to_system,
+        expand_pattern_entries,
+        schedule_to_cron,
+    )
+
+    try:
+        result = schedule_to_cron(
+            schedule,
+            latitude=latitude,
+            longitude=longitude,
+            timezone_name=timezone_name,
+        )
+    except Exception as e:
+        logger.error(f"Cron generation failed: {e}")
+        return 1
+
+    if result.errors:
+        logger.error(f"Cron conversion errors: {'; '.join(result.errors)}")
+        return 1
+
+    # Apply to system cron (replaces existing Mothbox entries)
+    try:
+        success = apply_to_system(
+            entries=result.entries,
+            schedule_id=schedule_id,
+            set_rtc=True,
+        )
+    except Exception as e:
+        logger.error(f"Failed to apply cron entries: {e}")
+        return 1
+
+    if not success:
+        logger.error("apply_to_system returned False")
+        return 1
+
+    logger.info(f"Applied {len(result.entries)} refreshed cron entries")
+
+    # Expand entries and update active_state.json
+    try:
+        expanded = expand_pattern_entries(
+            entries=result.entries,
+            timezone_name=timezone_name,
+        )
+        state["entries"] = [e.to_dict() for e in expanded]
+        if not save_active_state(state):
+            logger.warning("Failed to update active_state.json with new entries")
+    except Exception as e:
+        logger.warning(f"Failed to expand/persist entries (non-fatal): {e}")
+
+    logger.info("Weekly cron refresh complete")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Firmware/webui/docs/SCHEDULE_RECONCILIATION.md
+++ b/Firmware/webui/docs/SCHEDULE_RECONCILIATION.md
@@ -18,7 +18,7 @@ Runs automatically via a `@reboot` cron entry installed when a schedule is activ
 
 1. Waits for the GPIO daemon socket (exponential backoff, ~63.5s timeout)
 2. Loads the active schedule from `active_state.json`
-3. Looks back 48 hours through the schedule's trigger history
+3. Looks back 48 hours through the schedule's trigger history (if the Pi was off longer than 48 hours, the state before that window is not recovered)
 4. For each GPIO resource (attract, flash), finds the most recent past action
 5. Executes those actions to restore the expected state
 

--- a/Firmware/webui/docs/SCHEDULE_RECONCILIATION.md
+++ b/Firmware/webui/docs/SCHEDULE_RECONCILIATION.md
@@ -1,0 +1,125 @@
+# Schedule Reconciliation
+
+> Related: [Scheduler User Guide](SCHEDULER_USER_GUIDE.md) | Issue #398
+
+## Overview
+
+When a Mothbox reboots or a schedule is activated after a trigger has already passed, GPIO state (attract lamps, flash) may not match what the schedule expects. For example, activating an overnight moth survey after sunset means the `attract_on` cron entry was missed — lamps stay off until the next evening.
+
+**Schedule reconciliation** solves this by computing what GPIO state *should* be at the current time and executing the necessary catch-up actions.
+
+---
+
+## How It Works
+
+### Boot Reconciliation (`reconcile_on_boot.py`)
+
+Runs automatically via a `@reboot` cron entry installed when a schedule is activated.
+
+1. Waits for the GPIO daemon socket (exponential backoff, ~63.5s timeout)
+2. Loads the active schedule from `active_state.json`
+3. Looks back 48 hours through the schedule's trigger history
+4. For each GPIO resource (attract, flash), finds the most recent past action
+5. Executes those actions to restore the expected state
+
+### Weekly Cron Refresh (`refresh_schedule.py`)
+
+Runs via `0 2 * * 0` (Sunday 2:00 AM) cron entry.
+
+Solar, moon phase, and recurring-day triggers generate date-specific cron entries that expire after 60 days. The weekly refresh regenerates these entries so the schedule continues running indefinitely.
+
+---
+
+## What To Expect
+
+### Normal Boot Sequence
+
+After a reboot with an active schedule, you'll see messages like:
+
+```
+INFO: Starting boot GPIO reconciliation
+INFO: GPIO daemon socket found
+INFO: Reconciling schedule: summer-moth-survey
+INFO: Executing 2 reconciled actions
+INFO: Reconciling attract_on (should have fired at 2025-06-15 18:32:00-05:00)
+INFO: Reconciling flash_on (should have fired at 2025-06-15 18:37:00-05:00)
+INFO: All reconciled actions executed successfully
+```
+
+### No Actions Needed
+
+If no triggers have fired in the past 48 hours (e.g., daytime reboot with a nighttime-only schedule):
+
+```
+INFO: Starting boot GPIO reconciliation
+INFO: GPIO daemon socket found
+INFO: Reconciling schedule: summer-moth-survey
+INFO: No actions to reconcile
+```
+
+---
+
+## Exit Codes
+
+| Code | Meaning | Example |
+|------|---------|---------|
+| 0 | Success or no work to do | No active schedule, or all actions executed |
+| 1 | Fatal error | Schedule not found, computation failed |
+| 2 | Partial success (boot only) | Some GPIO actions failed (e.g., daemon unavailable) |
+
+---
+
+## Troubleshooting
+
+### GPIO Daemon Unavailable
+
+```
+WARNING: GPIO daemon socket not found after timeout
+WARNING: Proceeding without GPIO daemon — commands may fail
+```
+
+The GPIO daemon hasn't started within the ~63.5s timeout. Reconciliation proceeds but actions will likely fail (exit code 2). Check that the GPIO daemon service is enabled:
+
+```bash
+sudo systemctl status mothbox-gpio-daemon
+sudo systemctl enable mothbox-gpio-daemon
+```
+
+### Schedule Not Found
+
+```
+ERROR: Schedule not found in storage: my-schedule-id
+```
+
+The schedule referenced in `active_state.json` no longer exists in storage. Re-activate a schedule from the web UI.
+
+### Computation Failed
+
+```
+ERROR: Reconciliation computation failed: Invalid coordinates: ...
+```
+
+The stored coordinates are invalid. Re-activate the schedule with valid GPS coordinates, or ensure the Mothbox has a GPS fix.
+
+### Viewing Logs
+
+Boot reconciliation logs via systemd journal:
+
+```bash
+# Recent reconciliation logs
+journalctl -t mothbox --since "1 hour ago"
+
+# Follow live during boot
+journalctl -t mothbox -f
+```
+
+### Adjusting Log Verbosity
+
+Set the `MOTHBOX_LOG_LEVEL` environment variable to control log output:
+
+```bash
+# In crontab or systemd service override
+MOTHBOX_LOG_LEVEL=DEBUG systemd-cat -t mothbox /usr/bin/python3 /path/to/reconcile_on_boot.py
+```
+
+Valid levels: `DEBUG`, `INFO` (default), `WARNING`, `ERROR`.


### PR DESCRIPTION
Closes #398

## Summary
- Add schedule reconciler that looks back 48h through trigger history and executes the most recent GPIO action per resource (attract, flash, gps_sync) to catch up missed state
- Integrate reconciler into `activate_schedule()` as a non-fatal post-activation step so GPIO matches expected state immediately
- Add `reconcile_on_boot.py` CLI for @reboot cron to restore GPIO state after Pi reboots
- Add `refresh_schedule.py` CLI for weekly cron to regenerate date-specific entries before 60-day expiration
- Add meta-cron entries (@reboot + weekly) automatically installed/removed with schedule activation

## Test plan
- [x] 35 new unit tests (reconciler, activation integration, boot CLI, refresh CLI, meta-cron entries)
- [x] 403 total tests passing (368 existing + 35 new, zero regressions)
- [x] Ruff check and format clean
- [ ] Deploy to remote Pi, activate a schedule after sunset, verify attract lamps turn on
- [ ] Reboot Pi with active schedule, verify GPIO state restored via `journalctl -t mothbox`
- [ ] Verify `crontab -l` shows @reboot and weekly meta-cron entries