### PR TITLE
Fix GPS EXIF tagger glob bug, add deployment-aware coordinate resolution (#410)

### DIFF
--- a/Firmware/.gitignore
+++ b/Firmware/.gitignore
@@ -1,1 +1,2 @@
 active_state.json
+.worktrees/

--- a/Firmware/Tests/unit/test_gps_coordinate_resolver.py
+++ b/Firmware/Tests/unit/test_gps_coordinate_resolver.py
@@ -1,0 +1,218 @@
+"""Tests for GPS coordinate resolver module.
+
+The coordinate resolver walks a configurable chain of sources
+(deployment, gps, manual) and returns the first valid GPS coordinates.
+"""
+
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from webui.backend.lib.gps_coordinate_resolver import resolve_coordinates
+
+
+class TestDeploymentSource:
+    """Tests for the deployment sidecar source."""
+
+    def test_deployment_source_returns_coords_from_sidecar(self):
+        """Deployment source reads lat/lon from DeploymentService sidecar metadata."""
+        deployment_service = Mock()
+        metadata = Mock()
+        metadata.latitude = 35.9606
+        metadata.longitude = -83.9207
+        metadata.altitude = 350.0
+        metadata.deployment_name = "Forest Survey 2024"
+        deployment_service.find_deployment_for_photo.return_value = metadata
+
+        result = resolve_coordinates(
+            photo_path=Path("/photos/test.jpg"),
+            sources=("deployment",),
+            deployment_service=deployment_service,
+        )
+
+        assert result is not None
+        assert result["source"] == "deployment"
+        assert result["lat"] == 35.9606
+        assert result["lon"] == -83.9207
+        assert result["deployment_name"] == "Forest Survey 2024"
+        deployment_service.find_deployment_for_photo.assert_called_once_with(
+            Path("/photos/test.jpg")
+        )
+
+    def test_deployment_with_null_coords_skipped(self):
+        """Deployment metadata with lat=None is treated as no valid coords."""
+        deployment_service = Mock()
+        metadata = Mock()
+        metadata.latitude = None
+        metadata.longitude = -83.9207
+        metadata.deployment_name = "Incomplete Deployment"
+        deployment_service.find_deployment_for_photo.return_value = metadata
+
+        result = resolve_coordinates(
+            photo_path=Path("/photos/test.jpg"),
+            sources=("deployment",),
+            deployment_service=deployment_service,
+        )
+
+        assert result is None
+
+
+class TestGpsSource:
+    """Tests for the GPS controls.txt source."""
+
+    @patch("webui.backend.lib.gps_coordinate_resolver.get_gps_data_from_controls")
+    def test_gps_source_reads_controls_txt(self, mock_get_gps):
+        """GPS source calls get_gps_data_from_controls and extracts coordinates."""
+        mock_get_gps.return_value = {
+            "has_fix": True,
+            "latitude": 37.7749,
+            "longitude": -122.4194,
+            "altitude": 10.0,
+            "fix_mode": 3,
+            "gpstime": 1700000000,
+            "satellites_used": 8,
+            "hdop": 1.2,
+            "pdop": 2.1,
+        }
+
+        result = resolve_coordinates(
+            photo_path=Path("/photos/test.jpg"),
+            sources=("gps",),
+        )
+
+        assert result is not None
+        assert result["source"] == "gps"
+        assert result["lat"] == 37.7749
+        assert result["lon"] == -122.4194
+        mock_get_gps.assert_called_once()
+
+    @patch("webui.backend.lib.gps_coordinate_resolver.get_gps_data_from_controls")
+    def test_gps_data_includes_full_metadata(self, mock_get_gps):
+        """GPS source result includes the full gps_data dict for embed_gps_exif."""
+        gps_data = {
+            "has_fix": True,
+            "latitude": 37.7749,
+            "longitude": -122.4194,
+            "altitude": 10.0,
+            "fix_mode": 3,
+            "gpstime": 1700000000,
+            "satellites_used": 8,
+            "hdop": 1.2,
+            "pdop": 2.1,
+        }
+        mock_get_gps.return_value = gps_data
+
+        result = resolve_coordinates(
+            photo_path=Path("/photos/test.jpg"),
+            sources=("gps",),
+        )
+
+        assert result is not None
+        assert result["gps_data"]["has_fix"] is True
+        assert result["gps_data"]["latitude"] == 37.7749
+        assert result["gps_data"]["longitude"] == -122.4194
+        assert result["gps_data"]["altitude"] == 10.0
+        assert result["gps_data"]["fix_mode"] == 3
+        assert result["gps_data"]["gpstime"] == 1700000000
+        assert result["gps_data"]["satellites_used"] == 8
+        assert result["gps_data"]["hdop"] == 1.2
+        assert result["gps_data"]["pdop"] == 2.1
+
+
+class TestManualSource:
+    """Tests for the manual coordinate pass-through source."""
+
+    def test_manual_source_passes_through(self):
+        """Manual source uses provided manual_coords dict."""
+        manual = {"lat": 51.5074, "lon": -0.1278}
+
+        result = resolve_coordinates(
+            photo_path=Path("/photos/test.jpg"),
+            sources=("manual",),
+            manual_coords=manual,
+        )
+
+        assert result is not None
+        assert result["source"] == "manual"
+        assert result["lat"] == 51.5074
+        assert result["lon"] == -0.1278
+
+    def test_manual_without_coords_skipped(self):
+        """Manual source with manual_coords=None is skipped."""
+        result = resolve_coordinates(
+            photo_path=Path("/photos/test.jpg"),
+            sources=("manual",),
+            manual_coords=None,
+        )
+
+        assert result is None
+
+
+class TestFallbackChain:
+    """Tests for the source fallback chain logic."""
+
+    @patch("webui.backend.lib.gps_coordinate_resolver.get_gps_data_from_controls")
+    def test_fallback_chain_skips_failed_sources(self, mock_get_gps):
+        """When deployment returns None, resolver falls back to GPS source."""
+        deployment_service = Mock()
+        deployment_service.find_deployment_for_photo.return_value = None
+
+        mock_get_gps.return_value = {
+            "has_fix": True,
+            "latitude": 37.7749,
+            "longitude": -122.4194,
+            "altitude": 10.0,
+            "fix_mode": 3,
+            "gpstime": 1700000000,
+            "satellites_used": 8,
+            "hdop": 1.2,
+            "pdop": 2.1,
+        }
+
+        result = resolve_coordinates(
+            photo_path=Path("/photos/test.jpg"),
+            sources=("deployment", "gps"),
+            deployment_service=deployment_service,
+        )
+
+        assert result is not None
+        assert result["source"] == "gps"
+
+    @patch("webui.backend.lib.gps_coordinate_resolver.get_gps_data_from_controls")
+    def test_returns_none_when_all_sources_fail(self, mock_get_gps):
+        """Returns None when all sources in the chain fail."""
+        deployment_service = Mock()
+        deployment_service.find_deployment_for_photo.return_value = None
+
+        mock_get_gps.return_value = {
+            "has_fix": False,
+            "latitude": None,
+            "longitude": None,
+            "altitude": None,
+            "fix_mode": 0,
+            "gpstime": 0,
+            "satellites_used": 0,
+            "hdop": 99.99,
+            "pdop": 99.99,
+        }
+
+        result = resolve_coordinates(
+            photo_path=Path("/photos/test.jpg"),
+            sources=("deployment", "gps"),
+            deployment_service=deployment_service,
+        )
+
+        assert result is None
+
+
+class TestValidation:
+    """Tests for input validation."""
+
+    def test_invalid_source_name_raises(self):
+        """Unknown source name raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown source"):
+            resolve_coordinates(
+                photo_path=Path("/photos/test.jpg"),
+                sources=("deployment", "weather_station"),
+            )

--- a/Firmware/Tests/unit/test_gps_exif_routes.py
+++ b/Firmware/Tests/unit/test_gps_exif_routes.py
@@ -1,0 +1,363 @@
+"""Tests for GPS EXIF tagger API routes.
+
+Tests the endpoints in webui/backend/routes/gps_exif.py:
+- GET /api/gps-exif/status
+- POST /api/gps-exif/tag-photo
+- POST /api/gps-exif/batch-tag
+- GET /api/gps-exif/config
+- PUT /api/gps-exif/config
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Path setup for imports
+_test_dir = Path(__file__).resolve().parent
+_tests_root = _test_dir.parent
+_firmware_root = _tests_root.parent
+sys.path.insert(0, str(_firmware_root))
+sys.path.insert(0, str(_firmware_root / "webui" / "backend"))
+
+
+@pytest.fixture()
+def gps_exif_app(tmp_path):
+    """Create a Flask test app with gps_exif blueprint registered."""
+    from flask import Flask
+    from routes.gps_exif import gps_exif_bp
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["WTF_CSRF_ENABLED"] = False
+    app.register_blueprint(gps_exif_bp, url_prefix="/api/gps-exif")
+
+    return app
+
+
+@pytest.fixture()
+def client(gps_exif_app):
+    """Flask test client."""
+    return gps_exif_app.test_client()
+
+
+# ============================================================================
+# GET /status
+# ============================================================================
+
+
+class TestGetStatus:
+    """Tests for GET /api/gps-exif/status."""
+
+    def test_get_status_returns_200(self, client):
+        """GET /status returns 200 with expected top-level keys."""
+        with patch("routes.gps_exif.PHOTOS_DIR", Path("/tmp/nonexistent_photos")):
+            response = client.get("/api/gps-exif/status")
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert "coordinate_sources" in data
+        assert "service_running" in data
+        assert "stats" in data
+
+    def test_get_status_coordinate_sources(self, client):
+        """GET /status includes known coordinate source names."""
+        with patch("routes.gps_exif.PHOTOS_DIR", Path("/tmp/nonexistent_photos")):
+            response = client.get("/api/gps-exif/status")
+
+        data = response.get_json()
+        sources = data["coordinate_sources"]
+        assert isinstance(sources, list)
+        assert "deployment" in sources
+        assert "gps" in sources
+
+
+# ============================================================================
+# POST /tag-photo
+# ============================================================================
+
+
+class TestTagPhoto:
+    """Tests for POST /api/gps-exif/tag-photo."""
+
+    def test_tag_photo_rejects_missing_path(self, client):
+        """POST /tag-photo with no photo_path returns 400."""
+        response = client.post(
+            "/api/gps-exif/tag-photo",
+            data=json.dumps({}),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "error" in data
+
+    def test_tag_photo_rejects_empty_path(self, client):
+        """POST /tag-photo with empty photo_path returns 400."""
+        response = client.post(
+            "/api/gps-exif/tag-photo",
+            data=json.dumps({"photo_path": ""}),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+
+    def test_tag_photo_rejects_path_traversal(self, client):
+        """POST /tag-photo with ../etc/passwd returns 400."""
+        response = client.post(
+            "/api/gps-exif/tag-photo",
+            data=json.dumps({"photo_path": "../etc/passwd"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "error" in data
+        # Should mention path traversal or invalid path
+        assert "path" in data["error"].lower() or "traversal" in data["error"].lower()
+
+    def test_tag_photo_rejects_absolute_path(self, client):
+        """POST /tag-photo with absolute path returns 400."""
+        response = client.post(
+            "/api/gps-exif/tag-photo",
+            data=json.dumps({"photo_path": "/etc/passwd"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+
+    def test_tag_photo_returns_404_for_missing_file(self, client, tmp_path):
+        """POST /tag-photo returns 404 when photo file does not exist."""
+        with patch("routes.gps_exif.PHOTOS_DIR", tmp_path):
+            response = client.post(
+                "/api/gps-exif/tag-photo",
+                data=json.dumps({"photo_path": "nonexistent.jpg"}),
+                content_type="application/json",
+            )
+        assert response.status_code == 404
+
+    def test_tag_photo_success(self, client, tmp_path):
+        """POST /tag-photo successfully tags a photo."""
+        # Create a test photo file
+        photo = tmp_path / "test.jpg"
+        photo.touch()
+
+        mock_resolved = {
+            "lat": 9.123,
+            "lon": -83.456,
+            "source": "deployment",
+            "deployment_name": "test",
+            "gps_data": {"has_fix": True, "latitude": 9.123, "longitude": -83.456},
+        }
+        mock_embed_result = {
+            "success": True,
+            "skipped": False,
+            "error": None,
+            "gps_embedded": True,
+            "original_had_gps": False,
+            "backup_path": None,
+        }
+
+        with (
+            patch("routes.gps_exif.PHOTOS_DIR", tmp_path),
+            patch("routes.gps_exif.resolve_coordinates", return_value=mock_resolved),
+            patch("routes.gps_exif.embed_gps_exif", return_value=mock_embed_result),
+        ):
+            response = client.post(
+                "/api/gps-exif/tag-photo",
+                data=json.dumps({"photo_path": "test.jpg"}),
+                content_type="application/json",
+            )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["success"] is True
+        assert data["source_used"] == "deployment"
+        assert data["coordinates"]["lat"] == 9.123
+        assert data["coordinates"]["lon"] == -83.456
+
+
+# ============================================================================
+# POST /batch-tag
+# ============================================================================
+
+
+class TestBatchTag:
+    """Tests for POST /api/gps-exif/batch-tag."""
+
+    def test_batch_tag_returns_stats(self, client, tmp_path):
+        """POST /batch-tag returns stats dict when batch processing succeeds."""
+        mock_stats = {
+            "total": 10,
+            "tagged": 7,
+            "skipped": 2,
+            "errors": 1,
+            "error_list": [],
+            "source_counts": {"deployment": 5, "gps": 2},
+        }
+
+        with (
+            patch("routes.gps_exif.PHOTOS_DIR", tmp_path),
+            patch(
+                "webui.cli.gps_exif_tagger.batch_process_directory",
+                return_value=mock_stats,
+            ),
+        ):
+            response = client.post(
+                "/api/gps-exif/batch-tag",
+                data=json.dumps({"coordinate_sources": ["deployment", "gps"]}),
+                content_type="application/json",
+            )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["total"] == 10
+        assert data["tagged"] == 7
+        assert data["skipped"] == 2
+        assert data["errors"] == 1
+        assert data["source_counts"]["deployment"] == 5
+
+    def test_batch_tag_rejects_path_traversal_directory(self, client, tmp_path):
+        """POST /batch-tag rejects directory with path traversal."""
+        with patch("routes.gps_exif.PHOTOS_DIR", tmp_path):
+            response = client.post(
+                "/api/gps-exif/batch-tag",
+                data=json.dumps({"directory": "../../etc"}),
+                content_type="application/json",
+            )
+        assert response.status_code == 400
+
+    def test_batch_tag_uses_default_photos_dir(self, client, tmp_path):
+        """POST /batch-tag with no directory uses PHOTOS_DIR."""
+        mock_stats = {
+            "total": 0,
+            "tagged": 0,
+            "skipped": 0,
+            "errors": 0,
+            "error_list": [],
+            "source_counts": {},
+        }
+
+        with (
+            patch("routes.gps_exif.PHOTOS_DIR", tmp_path),
+            patch(
+                "webui.cli.gps_exif_tagger.batch_process_directory",
+                return_value=mock_stats,
+            ) as mock_batch,
+        ):
+            response = client.post(
+                "/api/gps-exif/batch-tag",
+                data=json.dumps({}),
+                content_type="application/json",
+            )
+
+        assert response.status_code == 200
+        # Should have been called with PHOTOS_DIR (tmp_path)
+        call_args = mock_batch.call_args
+        assert call_args[0][0] == tmp_path
+
+
+# ============================================================================
+# GET /config
+# ============================================================================
+
+
+class TestGetConfig:
+    """Tests for GET /api/gps-exif/config."""
+
+    def test_get_config_returns_defaults(self, client, tmp_path):
+        """GET /config returns default sources when no config file exists."""
+        config_file = tmp_path / "gps_exif_config.json"
+
+        with patch("routes.gps_exif._get_config_file", return_value=config_file):
+            response = client.get("/api/gps-exif/config")
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert "default_sources" in data
+        assert "pattern" in data
+        # Default sources should include deployment and gps
+        assert "deployment" in data["default_sources"]
+        assert "gps" in data["default_sources"]
+
+    def test_get_config_reads_existing_file(self, client, tmp_path):
+        """GET /config reads from existing config file."""
+        config_file = tmp_path / "gps_exif_config.json"
+        config_data = {"default_sources": ["gps"], "pattern": "*.jpeg"}
+        config_file.write_text(json.dumps(config_data))
+
+        with patch("routes.gps_exif._get_config_file", return_value=config_file):
+            response = client.get("/api/gps-exif/config")
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["default_sources"] == ["gps"]
+        assert data["pattern"] == "*.jpeg"
+
+
+# ============================================================================
+# PUT /config
+# ============================================================================
+
+
+class TestUpdateConfig:
+    """Tests for PUT /api/gps-exif/config."""
+
+    def test_update_config_validates_sources(self, client, tmp_path):
+        """PUT /config with invalid source returns 400."""
+        config_file = tmp_path / "gps_exif_config.json"
+
+        with patch("routes.gps_exif._get_config_file", return_value=config_file):
+            response = client.put(
+                "/api/gps-exif/config",
+                data=json.dumps({"default_sources": ["invalid_source"]}),
+                content_type="application/json",
+            )
+
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "error" in data
+
+    def test_update_config_saves_valid_sources(self, client, tmp_path):
+        """PUT /config saves valid configuration."""
+        config_file = tmp_path / "gps_exif_config.json"
+
+        with patch("routes.gps_exif._get_config_file", return_value=config_file):
+            response = client.put(
+                "/api/gps-exif/config",
+                data=json.dumps({"default_sources": ["gps"], "pattern": "*.jpeg"}),
+                content_type="application/json",
+            )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["success"] is True
+        assert data["config"]["default_sources"] == ["gps"]
+        assert data["config"]["pattern"] == "*.jpeg"
+
+        # Verify it was persisted
+        saved = json.loads(config_file.read_text())
+        assert saved["default_sources"] == ["gps"]
+
+    def test_update_config_rejects_empty_sources(self, client, tmp_path):
+        """PUT /config with empty sources list returns 400."""
+        config_file = tmp_path / "gps_exif_config.json"
+
+        with patch("routes.gps_exif._get_config_file", return_value=config_file):
+            response = client.put(
+                "/api/gps-exif/config",
+                data=json.dumps({"default_sources": []}),
+                content_type="application/json",
+            )
+
+        assert response.status_code == 400
+
+    def test_update_config_rejects_no_body(self, client, tmp_path):
+        """PUT /config with no request body returns 400."""
+        config_file = tmp_path / "gps_exif_config.json"
+
+        with patch("routes.gps_exif._get_config_file", return_value=config_file):
+            response = client.put(
+                "/api/gps-exif/config",
+                content_type="application/json",
+            )
+
+        assert response.status_code == 400

--- a/Firmware/Tests/unit/test_gps_exif_tagger_cli.py
+++ b/Firmware/Tests/unit/test_gps_exif_tagger_cli.py
@@ -16,12 +16,20 @@ class TestCLIArgumentParsing:
 
     def test_default_arguments(self):
         """Test that default arguments are correctly set."""
-        with patch('sys.argv', ['gps_exif_tagger.py']):
-            with patch.object(gps_exif_tagger, 'batch_process_directory', return_value={'errors': 0}) as mock_batch:
-                with patch.object(gps_exif_tagger, 'setup_logging', return_value=Mock()):
-                    with patch.object(gps_exif_tagger, 'get_hardware_config', return_value={'gps_enabled': True}):
-                        with patch.object(gps_exif_tagger, 'get_gps_data_from_controls', return_value={'has_fix': True}):
-                            with patch('pathlib.Path.exists', return_value=True):
+        with patch("sys.argv", ["gps_exif_tagger.py"]):
+            with patch.object(
+                gps_exif_tagger, "batch_process_directory", return_value={"errors": 0}
+            ) as mock_batch:
+                with patch.object(gps_exif_tagger, "setup_logging", return_value=Mock()):
+                    with patch.object(
+                        gps_exif_tagger, "get_hardware_config", return_value={"gps_enabled": True}
+                    ):
+                        with patch.object(
+                            gps_exif_tagger,
+                            "get_gps_data_from_controls",
+                            return_value={"has_fix": True},
+                        ):
+                            with patch("pathlib.Path.exists", return_value=True):
                                 # Should run without raising (no sys.exit when errors=0)
                                 gps_exif_tagger.main()
 
@@ -30,14 +38,20 @@ class TestCLIArgumentParsing:
 
     def test_watch_mode_argument(self):
         """Test --watch flag enables immediate mode."""
-        test_args = ['gps_exif_tagger.py', '--watch', '--directory', '/tmp/test']
+        test_args = ["gps_exif_tagger.py", "--watch", "--directory", "/tmp/test"]
 
-        with patch('sys.argv', test_args):
-            with patch.object(gps_exif_tagger, 'watch_directory') as mock_watch:
-                with patch.object(gps_exif_tagger, 'setup_logging', return_value=Mock()):
-                    with patch.object(gps_exif_tagger, 'get_hardware_config', return_value={'gps_enabled': True}):
-                        with patch.object(gps_exif_tagger, 'get_gps_data_from_controls', return_value={'has_fix': True}):
-                            with patch('pathlib.Path.exists', return_value=True):
+        with patch("sys.argv", test_args):
+            with patch.object(gps_exif_tagger, "watch_directory") as mock_watch:
+                with patch.object(gps_exif_tagger, "setup_logging", return_value=Mock()):
+                    with patch.object(
+                        gps_exif_tagger, "get_hardware_config", return_value={"gps_enabled": True}
+                    ):
+                        with patch.object(
+                            gps_exif_tagger,
+                            "get_gps_data_from_controls",
+                            return_value={"has_fix": True},
+                        ):
+                            with patch("pathlib.Path.exists", return_value=True):
                                 # Mock KeyboardInterrupt to exit watch loop
                                 mock_watch.side_effect = KeyboardInterrupt
 
@@ -46,14 +60,22 @@ class TestCLIArgumentParsing:
 
     def test_batch_mode_argument(self):
         """Test --mode batch runs batch processing."""
-        test_args = ['gps_exif_tagger.py', '--mode', 'batch', '--directory', '/tmp/test']
+        test_args = ["gps_exif_tagger.py", "--mode", "batch", "--directory", "/tmp/test"]
 
-        with patch('sys.argv', test_args):
-            with patch.object(gps_exif_tagger, 'batch_process_directory', return_value={'errors': 0}) as mock_batch:
-                with patch.object(gps_exif_tagger, 'setup_logging', return_value=Mock()):
-                    with patch.object(gps_exif_tagger, 'get_hardware_config', return_value={'gps_enabled': True}):
-                        with patch.object(gps_exif_tagger, 'get_gps_data_from_controls', return_value={'has_fix': True}):
-                            with patch('pathlib.Path.exists', return_value=True):
+        with patch("sys.argv", test_args):
+            with patch.object(
+                gps_exif_tagger, "batch_process_directory", return_value={"errors": 0}
+            ) as mock_batch:
+                with patch.object(gps_exif_tagger, "setup_logging", return_value=Mock()):
+                    with patch.object(
+                        gps_exif_tagger, "get_hardware_config", return_value={"gps_enabled": True}
+                    ):
+                        with patch.object(
+                            gps_exif_tagger,
+                            "get_gps_data_from_controls",
+                            return_value={"has_fix": True},
+                        ):
+                            with patch("pathlib.Path.exists", return_value=True):
                                 gps_exif_tagger.main()
 
                                 # Verify batch was called
@@ -61,14 +83,20 @@ class TestCLIArgumentParsing:
 
     def test_immediate_mode_argument(self):
         """Test --mode immediate runs watch mode."""
-        test_args = ['gps_exif_tagger.py', '--mode', 'immediate', '--directory', '/tmp/test']
+        test_args = ["gps_exif_tagger.py", "--mode", "immediate", "--directory", "/tmp/test"]
 
-        with patch('sys.argv', test_args):
-            with patch.object(gps_exif_tagger, 'watch_directory') as mock_watch:
-                with patch.object(gps_exif_tagger, 'setup_logging', return_value=Mock()):
-                    with patch.object(gps_exif_tagger, 'get_hardware_config', return_value={'gps_enabled': True}):
-                        with patch.object(gps_exif_tagger, 'get_gps_data_from_controls', return_value={'has_fix': True}):
-                            with patch('pathlib.Path.exists', return_value=True):
+        with patch("sys.argv", test_args):
+            with patch.object(gps_exif_tagger, "watch_directory") as mock_watch:
+                with patch.object(gps_exif_tagger, "setup_logging", return_value=Mock()):
+                    with patch.object(
+                        gps_exif_tagger, "get_hardware_config", return_value={"gps_enabled": True}
+                    ):
+                        with patch.object(
+                            gps_exif_tagger,
+                            "get_gps_data_from_controls",
+                            return_value={"has_fix": True},
+                        ):
+                            with patch("pathlib.Path.exists", return_value=True):
                                 mock_watch.side_effect = KeyboardInterrupt
 
                                 with pytest.raises(KeyboardInterrupt):
@@ -78,15 +106,23 @@ class TestCLIArgumentParsing:
 
     def test_directory_argument(self):
         """Test --directory sets custom photo directory."""
-        custom_dir = '/custom/photo/dir'
-        test_args = ['gps_exif_tagger.py', '--directory', custom_dir]
+        custom_dir = "/custom/photo/dir"
+        test_args = ["gps_exif_tagger.py", "--directory", custom_dir]
 
-        with patch('sys.argv', test_args):
-            with patch.object(gps_exif_tagger, 'batch_process_directory', return_value={'errors': 0}) as mock_batch:
-                with patch.object(gps_exif_tagger, 'setup_logging', return_value=Mock()):
-                    with patch.object(gps_exif_tagger, 'get_hardware_config', return_value={'gps_enabled': True}):
-                        with patch.object(gps_exif_tagger, 'get_gps_data_from_controls', return_value={'has_fix': True}):
-                            with patch('pathlib.Path.exists', return_value=True):
+        with patch("sys.argv", test_args):
+            with patch.object(
+                gps_exif_tagger, "batch_process_directory", return_value={"errors": 0}
+            ) as mock_batch:
+                with patch.object(gps_exif_tagger, "setup_logging", return_value=Mock()):
+                    with patch.object(
+                        gps_exif_tagger, "get_hardware_config", return_value={"gps_enabled": True}
+                    ):
+                        with patch.object(
+                            gps_exif_tagger,
+                            "get_gps_data_from_controls",
+                            return_value={"has_fix": True},
+                        ):
+                            with patch("pathlib.Path.exists", return_value=True):
                                 gps_exif_tagger.main()
 
                                 # Check first argument (directory) passed to batch_process_directory
@@ -95,89 +131,137 @@ class TestCLIArgumentParsing:
 
     def test_pattern_argument(self):
         """Test --pattern sets file matching pattern."""
-        test_args = ['gps_exif_tagger.py', '--pattern', '*.jpeg']
+        test_args = ["gps_exif_tagger.py", "--pattern", "*.jpeg"]
 
-        with patch('sys.argv', test_args):
-            with patch.object(gps_exif_tagger, 'batch_process_directory', return_value={'errors': 0}) as mock_batch:
-                with patch.object(gps_exif_tagger, 'setup_logging', return_value=Mock()):
-                    with patch.object(gps_exif_tagger, 'get_hardware_config', return_value={'gps_enabled': True}):
-                        with patch.object(gps_exif_tagger, 'get_gps_data_from_controls', return_value={'has_fix': True}):
-                            with patch('pathlib.Path.exists', return_value=True):
+        with patch("sys.argv", test_args):
+            with patch.object(
+                gps_exif_tagger, "batch_process_directory", return_value={"errors": 0}
+            ) as mock_batch:
+                with patch.object(gps_exif_tagger, "setup_logging", return_value=Mock()):
+                    with patch.object(
+                        gps_exif_tagger, "get_hardware_config", return_value={"gps_enabled": True}
+                    ):
+                        with patch.object(
+                            gps_exif_tagger,
+                            "get_gps_data_from_controls",
+                            return_value={"has_fix": True},
+                        ):
+                            with patch("pathlib.Path.exists", return_value=True):
                                 gps_exif_tagger.main()
 
                                 # Check pattern kwarg
-                                assert mock_batch.call_args[1]['pattern'] == '*.jpeg'
+                                assert mock_batch.call_args[1]["pattern"] == "*.jpeg"
 
     def test_interval_argument(self):
         """Test --interval sets watch mode polling interval."""
-        test_args = ['gps_exif_tagger.py', '--watch', '--interval', '30']
+        test_args = ["gps_exif_tagger.py", "--watch", "--interval", "30"]
 
-        with patch('sys.argv', test_args):
-            with patch.object(gps_exif_tagger, 'watch_directory') as mock_watch:
-                with patch.object(gps_exif_tagger, 'setup_logging', return_value=Mock()):
-                    with patch.object(gps_exif_tagger, 'get_hardware_config', return_value={'gps_enabled': True}):
-                        with patch.object(gps_exif_tagger, 'get_gps_data_from_controls', return_value={'has_fix': True}):
-                            with patch('pathlib.Path.exists', return_value=True):
+        with patch("sys.argv", test_args):
+            with patch.object(gps_exif_tagger, "watch_directory") as mock_watch:
+                with patch.object(gps_exif_tagger, "setup_logging", return_value=Mock()):
+                    with patch.object(
+                        gps_exif_tagger, "get_hardware_config", return_value={"gps_enabled": True}
+                    ):
+                        with patch.object(
+                            gps_exif_tagger,
+                            "get_gps_data_from_controls",
+                            return_value={"has_fix": True},
+                        ):
+                            with patch("pathlib.Path.exists", return_value=True):
                                 mock_watch.side_effect = KeyboardInterrupt
 
                                 with pytest.raises(KeyboardInterrupt):
                                     gps_exif_tagger.main()
 
                                 # Check interval kwarg
-                                assert mock_watch.call_args[1]['interval'] == 30
+                                assert mock_watch.call_args[1]["interval"] == 30
 
     def test_dry_run_argument(self):
         """Test --dry-run flag enables test mode."""
-        test_args = ['gps_exif_tagger.py', '--dry-run']
+        test_args = ["gps_exif_tagger.py", "--dry-run"]
 
-        with patch('sys.argv', test_args):
-            with patch.object(gps_exif_tagger, 'batch_process_directory', return_value={'errors': 0}) as mock_batch:
-                with patch.object(gps_exif_tagger, 'setup_logging', return_value=Mock()):
-                    with patch.object(gps_exif_tagger, 'get_hardware_config', return_value={'gps_enabled': True}):
-                        with patch.object(gps_exif_tagger, 'get_gps_data_from_controls', return_value={'has_fix': True}):
-                            with patch('pathlib.Path.exists', return_value=True):
+        with patch("sys.argv", test_args):
+            with patch.object(
+                gps_exif_tagger, "batch_process_directory", return_value={"errors": 0}
+            ) as mock_batch:
+                with patch.object(gps_exif_tagger, "setup_logging", return_value=Mock()):
+                    with patch.object(
+                        gps_exif_tagger, "get_hardware_config", return_value={"gps_enabled": True}
+                    ):
+                        with patch.object(
+                            gps_exif_tagger,
+                            "get_gps_data_from_controls",
+                            return_value={"has_fix": True},
+                        ):
+                            with patch("pathlib.Path.exists", return_value=True):
                                 gps_exif_tagger.main()
 
-                                assert mock_batch.call_args[1]['dry_run'] is True
+                                assert mock_batch.call_args[1]["dry_run"] is True
 
     def test_backup_argument(self):
         """Test --backup flag enables backup creation."""
-        test_args = ['gps_exif_tagger.py', '--backup']
+        test_args = ["gps_exif_tagger.py", "--backup"]
 
-        with patch('sys.argv', test_args):
-            with patch.object(gps_exif_tagger, 'batch_process_directory', return_value={'errors': 0}) as mock_batch:
-                with patch.object(gps_exif_tagger, 'setup_logging', return_value=Mock()):
-                    with patch.object(gps_exif_tagger, 'get_hardware_config', return_value={'gps_enabled': True}):
-                        with patch.object(gps_exif_tagger, 'get_gps_data_from_controls', return_value={'has_fix': True}):
-                            with patch('pathlib.Path.exists', return_value=True):
+        with patch("sys.argv", test_args):
+            with patch.object(
+                gps_exif_tagger, "batch_process_directory", return_value={"errors": 0}
+            ) as mock_batch:
+                with patch.object(gps_exif_tagger, "setup_logging", return_value=Mock()):
+                    with patch.object(
+                        gps_exif_tagger, "get_hardware_config", return_value={"gps_enabled": True}
+                    ):
+                        with patch.object(
+                            gps_exif_tagger,
+                            "get_gps_data_from_controls",
+                            return_value={"has_fix": True},
+                        ):
+                            with patch("pathlib.Path.exists", return_value=True):
                                 gps_exif_tagger.main()
 
-                                assert mock_batch.call_args[1]['backup'] is True
+                                assert mock_batch.call_args[1]["backup"] is True
 
     def test_force_argument(self):
         """Test --force flag enables re-tagging."""
-        test_args = ['gps_exif_tagger.py', '--force']
+        test_args = ["gps_exif_tagger.py", "--force"]
 
-        with patch('sys.argv', test_args):
-            with patch.object(gps_exif_tagger, 'batch_process_directory', return_value={'errors': 0}) as mock_batch:
-                with patch.object(gps_exif_tagger, 'setup_logging', return_value=Mock()):
-                    with patch.object(gps_exif_tagger, 'get_hardware_config', return_value={'gps_enabled': True}):
-                        with patch.object(gps_exif_tagger, 'get_gps_data_from_controls', return_value={'has_fix': True}):
-                            with patch('pathlib.Path.exists', return_value=True):
+        with patch("sys.argv", test_args):
+            with patch.object(
+                gps_exif_tagger, "batch_process_directory", return_value={"errors": 0}
+            ) as mock_batch:
+                with patch.object(gps_exif_tagger, "setup_logging", return_value=Mock()):
+                    with patch.object(
+                        gps_exif_tagger, "get_hardware_config", return_value={"gps_enabled": True}
+                    ):
+                        with patch.object(
+                            gps_exif_tagger,
+                            "get_gps_data_from_controls",
+                            return_value={"has_fix": True},
+                        ):
+                            with patch("pathlib.Path.exists", return_value=True):
                                 gps_exif_tagger.main()
 
-                                assert mock_batch.call_args[1]['force'] is True
+                                assert mock_batch.call_args[1]["force"] is True
 
     def test_verbose_argument(self):
         """Test --verbose flag enables debug logging."""
-        test_args = ['gps_exif_tagger.py', '--verbose']
+        test_args = ["gps_exif_tagger.py", "--verbose"]
 
-        with patch('sys.argv', test_args):
-            with patch.object(gps_exif_tagger, 'batch_process_directory', return_value={'errors': 0}):
-                with patch.object(gps_exif_tagger, 'setup_logging', return_value=Mock()) as mock_logging:
-                    with patch.object(gps_exif_tagger, 'get_hardware_config', return_value={'gps_enabled': True}):
-                        with patch.object(gps_exif_tagger, 'get_gps_data_from_controls', return_value={'has_fix': True}):
-                            with patch('pathlib.Path.exists', return_value=True):
+        with patch("sys.argv", test_args):
+            with patch.object(
+                gps_exif_tagger, "batch_process_directory", return_value={"errors": 0}
+            ):
+                with patch.object(
+                    gps_exif_tagger, "setup_logging", return_value=Mock()
+                ) as mock_logging:
+                    with patch.object(
+                        gps_exif_tagger, "get_hardware_config", return_value={"gps_enabled": True}
+                    ):
+                        with patch.object(
+                            gps_exif_tagger,
+                            "get_gps_data_from_controls",
+                            return_value={"has_fix": True},
+                        ):
+                            with patch("pathlib.Path.exists", return_value=True):
                                 gps_exif_tagger.main()
 
                                 # Verify setup_logging was called with verbose=True
@@ -186,21 +270,31 @@ class TestCLIArgumentParsing:
     def test_default_pattern_is_recursive(self):
         """Default pattern should match photos in subdirectories."""
         from webui.cli.gps_exif_tagger import PATTERN_DEFAULT
+
         assert "**" in PATTERN_DEFAULT, "Default pattern must be recursive"
 
     def test_coordinate_source_argument_exists(self):
         """CLI parser accepts --coordinate-source flag."""
         test_args = [
-            'gps_exif_tagger.py',
-            '--coordinate-source', 'gps,manual',
+            "gps_exif_tagger.py",
+            "--coordinate-source",
+            "gps,manual",
         ]
 
-        with patch('sys.argv', test_args):
-            with patch.object(gps_exif_tagger, 'batch_process_directory', return_value={'errors': 0}):
-                with patch.object(gps_exif_tagger, 'setup_logging', return_value=Mock()):
-                    with patch.object(gps_exif_tagger, 'get_hardware_config', return_value={'gps_enabled': True}):
-                        with patch.object(gps_exif_tagger, 'get_gps_data_from_controls', return_value={'has_fix': True}):
-                            with patch('pathlib.Path.exists', return_value=True):
+        with patch("sys.argv", test_args):
+            with patch.object(
+                gps_exif_tagger, "batch_process_directory", return_value={"errors": 0}
+            ):
+                with patch.object(gps_exif_tagger, "setup_logging", return_value=Mock()):
+                    with patch.object(
+                        gps_exif_tagger, "get_hardware_config", return_value={"gps_enabled": True}
+                    ):
+                        with patch.object(
+                            gps_exif_tagger,
+                            "get_gps_data_from_controls",
+                            return_value={"has_fix": True},
+                        ):
+                            with patch("pathlib.Path.exists", return_value=True):
                                 # Should not raise - the flag should be accepted
                                 gps_exif_tagger.main()
 
@@ -210,11 +304,11 @@ class TestCLIValidation:
 
     def test_nonexistent_directory_exits_with_error(self):
         """Test that nonexistent directory causes exit with error code 1."""
-        test_args = ['gps_exif_tagger.py', '--directory', '/nonexistent/path']
+        test_args = ["gps_exif_tagger.py", "--directory", "/nonexistent/path"]
 
-        with patch('sys.argv', test_args):
-            with patch.object(gps_exif_tagger, 'setup_logging', return_value=Mock()):
-                with patch('pathlib.Path.exists', return_value=False):
+        with patch("sys.argv", test_args):
+            with patch.object(gps_exif_tagger, "setup_logging", return_value=Mock()):
+                with patch("pathlib.Path.exists", return_value=False):
                     with pytest.raises(SystemExit) as exc_info:
                         gps_exif_tagger.main()
 
@@ -222,50 +316,80 @@ class TestCLIValidation:
 
     def test_gps_disabled_warning(self):
         """Test warning when GPS is disabled in hardware config."""
-        test_args = ['gps_exif_tagger.py']
+        test_args = ["gps_exif_tagger.py"]
 
-        with patch('sys.argv', test_args):
+        with patch("sys.argv", test_args):
             mock_logger = Mock()
-            with patch.object(gps_exif_tagger, 'setup_logging', return_value=mock_logger):
-                with patch.object(gps_exif_tagger, 'get_hardware_config', return_value={'gps_enabled': False}):
-                    with patch.object(gps_exif_tagger, 'get_gps_data_from_controls', return_value={'has_fix': False}):
-                        with patch.object(gps_exif_tagger, 'batch_process_directory', return_value={'errors': 0}):
-                            with patch('pathlib.Path.exists', return_value=True):
+            with patch.object(gps_exif_tagger, "setup_logging", return_value=mock_logger):
+                with patch.object(
+                    gps_exif_tagger, "get_hardware_config", return_value={"gps_enabled": False}
+                ):
+                    with patch.object(
+                        gps_exif_tagger,
+                        "get_gps_data_from_controls",
+                        return_value={"has_fix": False},
+                    ):
+                        with patch.object(
+                            gps_exif_tagger, "batch_process_directory", return_value={"errors": 0}
+                        ):
+                            with patch("pathlib.Path.exists", return_value=True):
                                 gps_exif_tagger.main()
 
                                 # Check warning was logged
-                                warning_calls = [call for call in mock_logger.warning.call_args_list
-                                               if 'GPS is disabled' in str(call)]
+                                warning_calls = [
+                                    call
+                                    for call in mock_logger.warning.call_args_list
+                                    if "GPS is disabled" in str(call)
+                                ]
                                 assert len(warning_calls) > 0
 
     def test_no_gps_fix_warning(self):
         """Test warning when GPS has no fix."""
-        test_args = ['gps_exif_tagger.py']
+        test_args = ["gps_exif_tagger.py"]
 
-        with patch('sys.argv', test_args):
+        with patch("sys.argv", test_args):
             mock_logger = Mock()
-            with patch.object(gps_exif_tagger, 'setup_logging', return_value=mock_logger):
-                with patch.object(gps_exif_tagger, 'get_hardware_config', return_value={'gps_enabled': True}):
-                    with patch.object(gps_exif_tagger, 'get_gps_data_from_controls', return_value={'has_fix': False}):
-                        with patch.object(gps_exif_tagger, 'batch_process_directory', return_value={'errors': 0}):
-                            with patch('pathlib.Path.exists', return_value=True):
+            with patch.object(gps_exif_tagger, "setup_logging", return_value=mock_logger):
+                with patch.object(
+                    gps_exif_tagger, "get_hardware_config", return_value={"gps_enabled": True}
+                ):
+                    with patch.object(
+                        gps_exif_tagger,
+                        "get_gps_data_from_controls",
+                        return_value={"has_fix": False},
+                    ):
+                        with patch.object(
+                            gps_exif_tagger, "batch_process_directory", return_value={"errors": 0}
+                        ):
+                            with patch("pathlib.Path.exists", return_value=True):
                                 gps_exif_tagger.main()
 
                                 # Check warning was logged
-                                warning_calls = [call for call in mock_logger.warning.call_args_list
-                                               if 'No GPS fix' in str(call)]
+                                warning_calls = [
+                                    call
+                                    for call in mock_logger.warning.call_args_list
+                                    if "No GPS fix" in str(call)
+                                ]
                                 assert len(warning_calls) > 0
 
     def test_batch_errors_exit_with_error_code(self):
         """Test that batch processing errors cause exit with code 1."""
-        test_args = ['gps_exif_tagger.py']
+        test_args = ["gps_exif_tagger.py"]
 
-        with patch('sys.argv', test_args):
-            with patch.object(gps_exif_tagger, 'setup_logging', return_value=Mock()):
-                with patch.object(gps_exif_tagger, 'get_hardware_config', return_value={'gps_enabled': True}):
-                    with patch.object(gps_exif_tagger, 'get_gps_data_from_controls', return_value={'has_fix': True}):
-                        with patch.object(gps_exif_tagger, 'batch_process_directory', return_value={'errors': 5}):
-                            with patch('pathlib.Path.exists', return_value=True):
+        with patch("sys.argv", test_args):
+            with patch.object(gps_exif_tagger, "setup_logging", return_value=Mock()):
+                with patch.object(
+                    gps_exif_tagger, "get_hardware_config", return_value={"gps_enabled": True}
+                ):
+                    with patch.object(
+                        gps_exif_tagger,
+                        "get_gps_data_from_controls",
+                        return_value={"has_fix": True},
+                    ):
+                        with patch.object(
+                            gps_exif_tagger, "batch_process_directory", return_value={"errors": 5}
+                        ):
+                            with patch("pathlib.Path.exists", return_value=True):
                                 with pytest.raises(SystemExit) as exc_info:
                                     gps_exif_tagger.main()
 
@@ -273,32 +397,57 @@ class TestCLIValidation:
 
     def test_fatal_exception_exits_with_error_code(self):
         """Test that hardware config errors are logged as warnings."""
-        test_args = ['gps_exif_tagger.py']
+        test_args = ["gps_exif_tagger.py"]
 
-        with patch('sys.argv', test_args):
+        with patch("sys.argv", test_args):
             mock_logger = Mock()
-            with patch.object(gps_exif_tagger, 'setup_logging', return_value=mock_logger):
-                with patch.object(gps_exif_tagger, 'get_hardware_config', side_effect=Exception("Fatal error")):
-                    with patch.object(gps_exif_tagger, 'get_gps_data_from_controls', return_value={'has_fix': False}):
-                        with patch('pathlib.Path.exists', return_value=True):
-                            with patch.object(gps_exif_tagger, 'batch_process_directory', return_value={'errors': 0}):
+            with patch.object(gps_exif_tagger, "setup_logging", return_value=mock_logger):
+                with patch.object(
+                    gps_exif_tagger, "get_hardware_config", side_effect=Exception("Fatal error")
+                ):
+                    with patch.object(
+                        gps_exif_tagger,
+                        "get_gps_data_from_controls",
+                        return_value={"has_fix": False},
+                    ):
+                        with patch("pathlib.Path.exists", return_value=True):
+                            with patch.object(
+                                gps_exif_tagger,
+                                "batch_process_directory",
+                                return_value={"errors": 0},
+                            ):
                                 # Should log warning but not exit
                                 gps_exif_tagger.main()
 
                                 # Verify warning was logged
-                                assert any('hardware config' in str(call).lower() for call in mock_logger.warning.call_args_list)
+                                assert any(
+                                    "hardware config" in str(call).lower()
+                                    for call in mock_logger.warning.call_args_list
+                                )
 
     def test_fatal_exception_with_verbose_shows_traceback(self):
         """Test that --verbose shows full traceback on fatal errors."""
-        test_args = ['gps_exif_tagger.py', '--verbose']
+        test_args = ["gps_exif_tagger.py", "--verbose"]
 
-        with patch('sys.argv', test_args):
+        with patch("sys.argv", test_args):
             mock_logger = Mock()
-            with patch.object(gps_exif_tagger, 'setup_logging', return_value=mock_logger):
-                with patch('pathlib.Path.exists', return_value=True):
-                    with patch.object(gps_exif_tagger, 'batch_process_directory', side_effect=RuntimeError("Test error")):
-                        with patch.object(gps_exif_tagger, 'get_hardware_config', return_value={'gps_enabled': True}):
-                            with patch.object(gps_exif_tagger, 'get_gps_data_from_controls', return_value={'has_fix': True}):
+            with patch.object(gps_exif_tagger, "setup_logging", return_value=mock_logger):
+                with patch("pathlib.Path.exists", return_value=True):
+                    with patch.object(
+                        gps_exif_tagger,
+                        "batch_process_directory",
+                        side_effect=RuntimeError("Test error"),
+                    ):
+                        with patch.object(
+                            gps_exif_tagger,
+                            "get_hardware_config",
+                            return_value={"gps_enabled": True},
+                        ):
+                            with patch.object(
+                                gps_exif_tagger,
+                                "get_gps_data_from_controls",
+                                return_value={"has_fix": True},
+                            ):
                                 with pytest.raises(SystemExit):
                                     gps_exif_tagger.main()
 
@@ -307,71 +456,105 @@ class TestCLIValidation:
 
     def test_hardware_config_read_error_continues(self):
         """Test that hardware config read errors don't stop execution."""
-        test_args = ['gps_exif_tagger.py']
+        test_args = ["gps_exif_tagger.py"]
 
-        with patch('sys.argv', test_args):
+        with patch("sys.argv", test_args):
             mock_logger = Mock()
-            with patch.object(gps_exif_tagger, 'setup_logging', return_value=mock_logger):
-                with patch.object(gps_exif_tagger, 'get_hardware_config', side_effect=Exception("Config error")):
-                    with patch.object(gps_exif_tagger, 'get_gps_data_from_controls', return_value={'has_fix': True}):
-                        with patch.object(gps_exif_tagger, 'batch_process_directory', return_value={'errors': 0}):
-                            with patch('pathlib.Path.exists', return_value=True):
+            with patch.object(gps_exif_tagger, "setup_logging", return_value=mock_logger):
+                with patch.object(
+                    gps_exif_tagger, "get_hardware_config", side_effect=Exception("Config error")
+                ):
+                    with patch.object(
+                        gps_exif_tagger,
+                        "get_gps_data_from_controls",
+                        return_value={"has_fix": True},
+                    ):
+                        with patch.object(
+                            gps_exif_tagger, "batch_process_directory", return_value={"errors": 0}
+                        ):
+                            with patch("pathlib.Path.exists", return_value=True):
                                 gps_exif_tagger.main()
 
                                 # Should log warning but continue
-                                warning_calls = [call for call in mock_logger.warning.call_args_list
-                                               if 'Could not read hardware config' in str(call)]
+                                warning_calls = [
+                                    call
+                                    for call in mock_logger.warning.call_args_list
+                                    if "Could not read hardware config" in str(call)
+                                ]
                                 assert len(warning_calls) > 0
 
     def test_gps_data_read_error_continues(self):
         """Test that GPS data read errors don't stop execution."""
-        test_args = ['gps_exif_tagger.py']
+        test_args = ["gps_exif_tagger.py"]
 
-        with patch('sys.argv', test_args):
+        with patch("sys.argv", test_args):
             mock_logger = Mock()
-            with patch.object(gps_exif_tagger, 'setup_logging', return_value=mock_logger):
-                with patch.object(gps_exif_tagger, 'get_hardware_config', return_value={'gps_enabled': True}):
-                    with patch.object(gps_exif_tagger, 'get_gps_data_from_controls', side_effect=Exception("GPS error")):
-                        with patch.object(gps_exif_tagger, 'batch_process_directory', return_value={'errors': 0}):
-                            with patch('pathlib.Path.exists', return_value=True):
+            with patch.object(gps_exif_tagger, "setup_logging", return_value=mock_logger):
+                with patch.object(
+                    gps_exif_tagger, "get_hardware_config", return_value={"gps_enabled": True}
+                ):
+                    with patch.object(
+                        gps_exif_tagger,
+                        "get_gps_data_from_controls",
+                        side_effect=Exception("GPS error"),
+                    ):
+                        with patch.object(
+                            gps_exif_tagger, "batch_process_directory", return_value={"errors": 0}
+                        ):
+                            with patch("pathlib.Path.exists", return_value=True):
                                 gps_exif_tagger.main()
 
                                 # Should log warning but continue
-                                warning_calls = [call for call in mock_logger.warning.call_args_list
-                                               if 'Could not read GPS data' in str(call)]
+                                warning_calls = [
+                                    call
+                                    for call in mock_logger.warning.call_args_list
+                                    if "Could not read GPS data" in str(call)
+                                ]
                                 assert len(warning_calls) > 0
 
     def test_zero_interval_raises_error(self):
         """Test that --interval 0 raises ValueError (would cause CPU spinning)."""
-        test_args = ['gps_exif_tagger.py', '--watch', '--interval', '0']
+        test_args = ["gps_exif_tagger.py", "--watch", "--interval", "0"]
 
-        with patch('sys.argv', test_args):
-            with patch.object(gps_exif_tagger, 'setup_logging', return_value=Mock()):
-                with patch.object(gps_exif_tagger, 'get_hardware_config', return_value={'gps_enabled': True}):
-                    with patch.object(gps_exif_tagger, 'get_gps_data_from_controls', return_value={'has_fix': True}):
-                        with patch('pathlib.Path.exists', return_value=True):
+        with patch("sys.argv", test_args):
+            with patch.object(gps_exif_tagger, "setup_logging", return_value=Mock()):
+                with patch.object(
+                    gps_exif_tagger, "get_hardware_config", return_value={"gps_enabled": True}
+                ):
+                    with patch.object(
+                        gps_exif_tagger,
+                        "get_gps_data_from_controls",
+                        return_value={"has_fix": True},
+                    ):
+                        with patch("pathlib.Path.exists", return_value=True):
                             with pytest.raises((ValueError, SystemExit)) as exc_info:
                                 gps_exif_tagger.main()
 
                             # Should raise ValueError with message about interval
                             if isinstance(exc_info.value, ValueError):
-                                assert 'interval' in str(exc_info.value).lower()
+                                assert "interval" in str(exc_info.value).lower()
 
     def test_negative_interval_raises_error(self):
         """Test that negative --interval raises ValueError."""
-        test_args = ['gps_exif_tagger.py', '--watch', '--interval', '-5']
+        test_args = ["gps_exif_tagger.py", "--watch", "--interval", "-5"]
 
-        with patch('sys.argv', test_args):
-            with patch.object(gps_exif_tagger, 'setup_logging', return_value=Mock()):
-                with patch.object(gps_exif_tagger, 'get_hardware_config', return_value={'gps_enabled': True}):
-                    with patch.object(gps_exif_tagger, 'get_gps_data_from_controls', return_value={'has_fix': True}):
-                        with patch('pathlib.Path.exists', return_value=True):
+        with patch("sys.argv", test_args):
+            with patch.object(gps_exif_tagger, "setup_logging", return_value=Mock()):
+                with patch.object(
+                    gps_exif_tagger, "get_hardware_config", return_value={"gps_enabled": True}
+                ):
+                    with patch.object(
+                        gps_exif_tagger,
+                        "get_gps_data_from_controls",
+                        return_value={"has_fix": True},
+                    ):
+                        with patch("pathlib.Path.exists", return_value=True):
                             with pytest.raises((ValueError, SystemExit)) as exc_info:
                                 gps_exif_tagger.main()
 
                             # Should raise ValueError with message about interval
                             if isinstance(exc_info.value, ValueError):
-                                assert 'interval' in str(exc_info.value).lower()
+                                assert "interval" in str(exc_info.value).lower()
 
 
 class TestLogging:
@@ -389,19 +572,29 @@ class TestLogging:
 
     def test_startup_messages_logged(self):
         """Test that startup messages are logged."""
-        test_args = ['gps_exif_tagger.py']
+        test_args = ["gps_exif_tagger.py"]
 
-        with patch('sys.argv', test_args):
+        with patch("sys.argv", test_args):
             mock_logger = Mock()
-            with patch.object(gps_exif_tagger, 'setup_logging', return_value=mock_logger):
-                with patch.object(gps_exif_tagger, 'get_hardware_config', return_value={'gps_enabled': True}):
-                    with patch.object(gps_exif_tagger, 'get_gps_data_from_controls', return_value={'has_fix': True}):
-                        with patch.object(gps_exif_tagger, 'batch_process_directory', return_value={'errors': 0}):
-                            with patch('pathlib.Path.exists', return_value=True):
+            with patch.object(gps_exif_tagger, "setup_logging", return_value=mock_logger):
+                with patch.object(
+                    gps_exif_tagger, "get_hardware_config", return_value={"gps_enabled": True}
+                ):
+                    with patch.object(
+                        gps_exif_tagger,
+                        "get_gps_data_from_controls",
+                        return_value={"has_fix": True},
+                    ):
+                        with patch.object(
+                            gps_exif_tagger, "batch_process_directory", return_value={"errors": 0}
+                        ):
+                            with patch("pathlib.Path.exists", return_value=True):
                                 gps_exif_tagger.main()
 
                                 # Check that info messages were logged
                                 info_calls = mock_logger.info.call_args_list
-                                assert any('GPS EXIF Tagger starting' in str(call) for call in info_calls)
-                                assert any('Mode:' in str(call) for call in info_calls)
-                                assert any('Directory:' in str(call) for call in info_calls)
+                                assert any(
+                                    "GPS EXIF Tagger starting" in str(call) for call in info_calls
+                                )
+                                assert any("Mode:" in str(call) for call in info_calls)
+                                assert any("Directory:" in str(call) for call in info_calls)

--- a/Firmware/Tests/unit/test_gps_exif_tagger_cli.py
+++ b/Firmware/Tests/unit/test_gps_exif_tagger_cli.py
@@ -3,12 +3,9 @@ Unit tests for gps_exif_tagger.py CLI functionality
 Tests argument parsing, validation, and main entry point
 """
 
+from unittest.mock import Mock, patch
+
 import pytest
-import sys
-import argparse
-from pathlib import Path
-from unittest.mock import Mock, patch, MagicMock, call
-from io import StringIO
 
 # Import the module under test
 from webui.cli import gps_exif_tagger

--- a/Firmware/Tests/unit/test_gps_exif_tagger_cli.py
+++ b/Firmware/Tests/unit/test_gps_exif_tagger_cli.py
@@ -186,6 +186,27 @@ class TestCLIArgumentParsing:
                                 # Verify setup_logging was called with verbose=True
                                 mock_logging.assert_called_once_with(True)
 
+    def test_default_pattern_is_recursive(self):
+        """Default pattern should match photos in subdirectories."""
+        from webui.cli.gps_exif_tagger import PATTERN_DEFAULT
+        assert "**" in PATTERN_DEFAULT, "Default pattern must be recursive"
+
+    def test_coordinate_source_argument_exists(self):
+        """CLI parser accepts --coordinate-source flag."""
+        test_args = [
+            'gps_exif_tagger.py',
+            '--coordinate-source', 'gps,manual',
+        ]
+
+        with patch('sys.argv', test_args):
+            with patch.object(gps_exif_tagger, 'batch_process_directory', return_value={'errors': 0}):
+                with patch.object(gps_exif_tagger, 'setup_logging', return_value=Mock()):
+                    with patch.object(gps_exif_tagger, 'get_hardware_config', return_value={'gps_enabled': True}):
+                        with patch.object(gps_exif_tagger, 'get_gps_data_from_controls', return_value={'has_fix': True}):
+                            with patch('pathlib.Path.exists', return_value=True):
+                                # Should not raise - the flag should be accepted
+                                gps_exif_tagger.main()
+
 
 class TestCLIValidation:
     """Test CLI input validation and error handling."""

--- a/Firmware/Tests/unit/test_gps_exif_tagger_operations.py
+++ b/Firmware/Tests/unit/test_gps_exif_tagger_operations.py
@@ -253,8 +253,19 @@ class TestBatchProcessing:
                 processed_files.append(photo_path.name)
                 return {"success": True, "skipped": False}
 
+            mock_resolved = {
+                "lat": 35.96, "lon": -83.92, "source": "gps",
+                "deployment_name": None,
+                "gps_data": {"has_fix": True, "latitude": 35.96, "longitude": -83.92,
+                             "altitude": None, "fix_mode": 3, "gpstime": 0,
+                             "satellites_used": 0, "hdop": 99.99, "pdop": 99.99},
+            }
+
             with patch.object(
                 gps_exif_tagger, "process_single_photo", side_effect=track_processing
+            ), patch(
+                "webui.cli.gps_exif_tagger.resolve_coordinates",
+                return_value=mock_resolved,
             ):
                 gps_exif_tagger.batch_process_directory(
                     tmp_path, logger, pattern="*.jpg", force=False, backup=False, dry_run=False
@@ -298,8 +309,19 @@ class TestBatchProcessing:
                 processed_files.append(photo_path.name)
                 return {"success": True, "skipped": False}
 
+            mock_resolved = {
+                "lat": 35.96, "lon": -83.92, "source": "gps",
+                "deployment_name": None,
+                "gps_data": {"has_fix": True, "latitude": 35.96, "longitude": -83.92,
+                             "altitude": None, "fix_mode": 3, "gpstime": 0,
+                             "satellites_used": 0, "hdop": 99.99, "pdop": 99.99},
+            }
+
             with patch.object(
                 gps_exif_tagger, "process_single_photo", side_effect=track_processing
+            ), patch(
+                "webui.cli.gps_exif_tagger.resolve_coordinates",
+                return_value=mock_resolved,
             ):
                 gps_exif_tagger.batch_process_directory(
                     tmp_path, logger, pattern="*.jpg", force=False, backup=False, dry_run=False
@@ -818,3 +840,134 @@ class TestFileStability:
         finally:
             # Restore permissions
             os.chmod(tmp_path, 0o755)
+
+
+class TestResolverIntegration:
+    """Test that tagger uses coordinate resolver per photo."""
+
+    def test_batch_uses_resolver_per_photo(self):
+        """batch_process_directory calls resolve_coordinates for each photo."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            logger = Mock()
+
+            # Create two photos in a subdirectory (tests recursive glob)
+            subdir = tmp_path / "2026-02-10"
+            subdir.mkdir()
+            for name in ["photo_001.jpg", "photo_002.jpg"]:
+                img = Image.new("RGB", (100, 100), color="white")
+                img.save(subdir / name)
+
+            mock_result = {
+                "lat": 35.96,
+                "lon": -83.92,
+                "source": "deployment",
+                "deployment_name": "Test Deploy",
+                "gps_data": {
+                    "has_fix": True,
+                    "latitude": 35.96,
+                    "longitude": -83.92,
+                    "altitude": None,
+                    "fix_mode": 3,
+                    "gpstime": 0,
+                    "satellites_used": 0,
+                    "hdop": 99.99,
+                    "pdop": 99.99,
+                },
+            }
+
+            with patch(
+                "webui.cli.gps_exif_tagger.resolve_coordinates",
+                return_value=mock_result,
+            ) as mock_resolve:
+                stats = gps_exif_tagger.batch_process_directory(
+                    tmp_path,
+                    logger,
+                    pattern="**/*.jpg",
+                    coordinate_sources=("deployment", "gps"),
+                )
+
+            assert mock_resolve.call_count == 2
+            assert stats["total"] == 2
+
+    def test_batch_skips_when_resolver_returns_none(self):
+        """Photos are skipped when resolver returns None."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            logger = Mock()
+
+            img = Image.new("RGB", (100, 100), color="white")
+            img.save(tmp_path / "photo.jpg")
+
+            with patch(
+                "webui.cli.gps_exif_tagger.resolve_coordinates",
+                return_value=None,
+            ):
+                stats = gps_exif_tagger.batch_process_directory(
+                    tmp_path,
+                    logger,
+                    pattern="**/*.jpg",
+                    coordinate_sources=("deployment", "gps"),
+                )
+
+            assert stats["skipped"] == 1
+
+    def test_batch_stats_include_source_counts(self):
+        """Batch stats track how many photos tagged per source."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            logger = Mock()
+
+            for i in range(3):
+                img = Image.new("RGB", (100, 100), color="white")
+                img.save(tmp_path / f"photo_{i}.jpg")
+
+            mock_result = {
+                "lat": 35.96,
+                "lon": -83.92,
+                "source": "deployment",
+                "deployment_name": "Test",
+                "gps_data": {
+                    "has_fix": True, "latitude": 35.96, "longitude": -83.92,
+                    "altitude": None, "fix_mode": 3, "gpstime": 0,
+                    "satellites_used": 0, "hdop": 99.99, "pdop": 99.99,
+                },
+            }
+
+            with patch(
+                "webui.cli.gps_exif_tagger.resolve_coordinates",
+                return_value=mock_result,
+            ):
+                stats = gps_exif_tagger.batch_process_directory(
+                    tmp_path,
+                    logger,
+                    pattern="**/*.jpg",
+                    coordinate_sources=("deployment",),
+                )
+
+            assert "source_counts" in stats
+            assert stats["source_counts"].get("deployment", 0) >= 0
+
+    def test_process_single_photo_accepts_gps_data(self):
+        """process_single_photo can receive pre-resolved gps_data."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            logger = Mock()
+
+            photo_path = tmp_path / "test.jpg"
+            img = Image.new("RGB", (100, 100), color="white")
+            img.save(photo_path)
+
+            gps_data = {
+                "has_fix": True, "latitude": 35.96, "longitude": -83.92,
+                "altitude": None, "fix_mode": 3, "gpstime": 0,
+                "satellites_used": 0, "hdop": 99.99, "pdop": 99.99,
+            }
+
+            result = gps_exif_tagger.process_single_photo(
+                photo_path, logger, gps_data=gps_data,
+            )
+
+            # Should succeed or at least not error on the gps_data param
+            assert isinstance(result, dict)
+            assert "success" in result

--- a/Firmware/Tests/unit/test_gps_exif_tagger_operations.py
+++ b/Firmware/Tests/unit/test_gps_exif_tagger_operations.py
@@ -254,18 +254,29 @@ class TestBatchProcessing:
                 return {"success": True, "skipped": False}
 
             mock_resolved = {
-                "lat": 35.96, "lon": -83.92, "source": "gps",
+                "lat": 35.96,
+                "lon": -83.92,
+                "source": "gps",
                 "deployment_name": None,
-                "gps_data": {"has_fix": True, "latitude": 35.96, "longitude": -83.92,
-                             "altitude": None, "fix_mode": 3, "gpstime": 0,
-                             "satellites_used": 0, "hdop": 99.99, "pdop": 99.99},
+                "gps_data": {
+                    "has_fix": True,
+                    "latitude": 35.96,
+                    "longitude": -83.92,
+                    "altitude": None,
+                    "fix_mode": 3,
+                    "gpstime": 0,
+                    "satellites_used": 0,
+                    "hdop": 99.99,
+                    "pdop": 99.99,
+                },
             }
 
-            with patch.object(
-                gps_exif_tagger, "process_single_photo", side_effect=track_processing
-            ), patch(
-                "webui.cli.gps_exif_tagger.resolve_coordinates",
-                return_value=mock_resolved,
+            with (
+                patch.object(gps_exif_tagger, "process_single_photo", side_effect=track_processing),
+                patch(
+                    "webui.cli.gps_exif_tagger.resolve_coordinates",
+                    return_value=mock_resolved,
+                ),
             ):
                 gps_exif_tagger.batch_process_directory(
                     tmp_path, logger, pattern="*.jpg", force=False, backup=False, dry_run=False
@@ -310,18 +321,29 @@ class TestBatchProcessing:
                 return {"success": True, "skipped": False}
 
             mock_resolved = {
-                "lat": 35.96, "lon": -83.92, "source": "gps",
+                "lat": 35.96,
+                "lon": -83.92,
+                "source": "gps",
                 "deployment_name": None,
-                "gps_data": {"has_fix": True, "latitude": 35.96, "longitude": -83.92,
-                             "altitude": None, "fix_mode": 3, "gpstime": 0,
-                             "satellites_used": 0, "hdop": 99.99, "pdop": 99.99},
+                "gps_data": {
+                    "has_fix": True,
+                    "latitude": 35.96,
+                    "longitude": -83.92,
+                    "altitude": None,
+                    "fix_mode": 3,
+                    "gpstime": 0,
+                    "satellites_used": 0,
+                    "hdop": 99.99,
+                    "pdop": 99.99,
+                },
             }
 
-            with patch.object(
-                gps_exif_tagger, "process_single_photo", side_effect=track_processing
-            ), patch(
-                "webui.cli.gps_exif_tagger.resolve_coordinates",
-                return_value=mock_resolved,
+            with (
+                patch.object(gps_exif_tagger, "process_single_photo", side_effect=track_processing),
+                patch(
+                    "webui.cli.gps_exif_tagger.resolve_coordinates",
+                    return_value=mock_resolved,
+                ),
             ):
                 gps_exif_tagger.batch_process_directory(
                     tmp_path, logger, pattern="*.jpg", force=False, backup=False, dry_run=False
@@ -928,9 +950,15 @@ class TestResolverIntegration:
                 "source": "deployment",
                 "deployment_name": "Test",
                 "gps_data": {
-                    "has_fix": True, "latitude": 35.96, "longitude": -83.92,
-                    "altitude": None, "fix_mode": 3, "gpstime": 0,
-                    "satellites_used": 0, "hdop": 99.99, "pdop": 99.99,
+                    "has_fix": True,
+                    "latitude": 35.96,
+                    "longitude": -83.92,
+                    "altitude": None,
+                    "fix_mode": 3,
+                    "gpstime": 0,
+                    "satellites_used": 0,
+                    "hdop": 99.99,
+                    "pdop": 99.99,
                 },
             }
 
@@ -959,13 +987,21 @@ class TestResolverIntegration:
             img.save(photo_path)
 
             gps_data = {
-                "has_fix": True, "latitude": 35.96, "longitude": -83.92,
-                "altitude": None, "fix_mode": 3, "gpstime": 0,
-                "satellites_used": 0, "hdop": 99.99, "pdop": 99.99,
+                "has_fix": True,
+                "latitude": 35.96,
+                "longitude": -83.92,
+                "altitude": None,
+                "fix_mode": 3,
+                "gpstime": 0,
+                "satellites_used": 0,
+                "hdop": 99.99,
+                "pdop": 99.99,
             }
 
             result = gps_exif_tagger.process_single_photo(
-                photo_path, logger, gps_data=gps_data,
+                photo_path,
+                logger,
+                gps_data=gps_data,
             )
 
             # Should succeed or at least not error on the gps_data param

--- a/Firmware/docs/plans/2026-02-15-gps-exif-tagger-implementation.md
+++ b/Firmware/docs/plans/2026-02-15-gps-exif-tagger-implementation.md
@@ -1,0 +1,1185 @@
+# GPS EXIF Tagger Improvements (#410) - Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix the GPS EXIF tagger's glob bug, add deployment-aware coordinate resolution, expose coordinate source selection in CLI and web UI.
+
+**Architecture:** New `gps_coordinate_resolver` module orchestrates three coordinate sources (deployment sidecar, controls.txt GPS, manual). The existing tagger calls the resolver per-photo instead of reading controls.txt globally. New API routes expose tagging to the frontend. A settings subsection and gallery banner provide UI control.
+
+**Tech Stack:** Python/Flask backend, React/TanStack Query frontend, piexif for EXIF, existing DeploymentService for sidecar lookups.
+
+**Branch:** `fix/410-gps-exif-tagger`
+
+**Design doc:** `docs/plans/2026-02-15-gps-exif-tagger-improvements.md`
+
+---
+
+### Task 1: Coordinate Resolver Module
+
+**Files:**
+- Create: `webui/backend/lib/gps_coordinate_resolver.py`
+- Test: `Tests/unit/test_gps_coordinate_resolver.py`
+
+**Step 1: Write the failing tests**
+
+```python
+"""Unit tests for gps_coordinate_resolver."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from webui.backend.lib.gps_coordinate_resolver import resolve_coordinates
+
+
+class TestResolveCoordinates:
+    """Test coordinate resolution from multiple sources."""
+
+    def test_deployment_source_returns_coords_from_sidecar(self):
+        """Deployment source uses DeploymentService.find_deployment_for_photo."""
+        mock_metadata = Mock()
+        mock_metadata.latitude = 35.96
+        mock_metadata.longitude = -83.92
+        mock_metadata.deployment_name = "Oak Ridge"
+
+        mock_service = Mock()
+        mock_service.find_deployment_for_photo.return_value = mock_metadata
+
+        result = resolve_coordinates(
+            Path("/photos/2026-02-10/photo.jpg"),
+            sources=("deployment",),
+            deployment_service=mock_service,
+        )
+
+        assert result["lat"] == 35.96
+        assert result["lon"] == -83.92
+        assert result["source"] == "deployment"
+        assert result["deployment_name"] == "Oak Ridge"
+
+    def test_gps_source_reads_controls_txt(self):
+        """GPS source falls back to controls.txt."""
+        mock_gps_data = {
+            "has_fix": True,
+            "latitude": 40.77,
+            "longitude": -73.98,
+            "fix_mode": 3,
+            "gpstime": 1700000000,
+            "altitude": None,
+            "satellites_used": 8,
+            "hdop": 1.2,
+            "pdop": 2.0,
+        }
+
+        with patch(
+            "webui.backend.lib.gps_coordinate_resolver.get_gps_data_from_controls",
+            return_value=mock_gps_data,
+        ):
+            result = resolve_coordinates(
+                Path("/photos/photo.jpg"),
+                sources=("gps",),
+            )
+
+        assert result["lat"] == 40.77
+        assert result["lon"] == -73.98
+        assert result["source"] == "gps"
+
+    def test_manual_source_passes_through(self):
+        """Manual source uses provided coordinates."""
+        result = resolve_coordinates(
+            Path("/photos/photo.jpg"),
+            sources=("manual",),
+            manual_coords={"lat": 51.50, "lon": -0.12},
+        )
+
+        assert result["lat"] == 51.50
+        assert result["lon"] == -0.12
+        assert result["source"] == "manual"
+
+    def test_fallback_chain_skips_failed_sources(self):
+        """If deployment has no sidecar, falls back to GPS."""
+        mock_service = Mock()
+        mock_service.find_deployment_for_photo.return_value = None
+
+        mock_gps_data = {
+            "has_fix": True,
+            "latitude": 40.77,
+            "longitude": -73.98,
+            "fix_mode": 3,
+            "gpstime": 1700000000,
+            "altitude": None,
+            "satellites_used": 8,
+            "hdop": 1.2,
+            "pdop": 2.0,
+        }
+
+        with patch(
+            "webui.backend.lib.gps_coordinate_resolver.get_gps_data_from_controls",
+            return_value=mock_gps_data,
+        ):
+            result = resolve_coordinates(
+                Path("/photos/photo.jpg"),
+                sources=("deployment", "gps"),
+                deployment_service=mock_service,
+            )
+
+        assert result["source"] == "gps"
+
+    def test_returns_none_when_all_sources_fail(self):
+        """Returns None when no source has coordinates."""
+        mock_service = Mock()
+        mock_service.find_deployment_for_photo.return_value = None
+
+        mock_gps_data = {"has_fix": False, "latitude": None, "longitude": None}
+
+        with patch(
+            "webui.backend.lib.gps_coordinate_resolver.get_gps_data_from_controls",
+            return_value=mock_gps_data,
+        ):
+            result = resolve_coordinates(
+                Path("/photos/photo.jpg"),
+                sources=("deployment", "gps"),
+                deployment_service=mock_service,
+            )
+
+        assert result is None
+
+    def test_manual_without_coords_skipped(self):
+        """Manual source is skipped when no coords provided."""
+        result = resolve_coordinates(
+            Path("/photos/photo.jpg"),
+            sources=("manual",),
+            manual_coords=None,
+        )
+
+        assert result is None
+
+    def test_deployment_with_null_coords_skipped(self):
+        """Deployment with null lat/lon is skipped."""
+        mock_metadata = Mock()
+        mock_metadata.latitude = None
+        mock_metadata.longitude = None
+
+        mock_service = Mock()
+        mock_service.find_deployment_for_photo.return_value = mock_metadata
+
+        result = resolve_coordinates(
+            Path("/photos/photo.jpg"),
+            sources=("deployment",),
+            deployment_service=mock_service,
+        )
+
+        assert result is None
+
+    def test_invalid_source_name_raises(self):
+        """Unknown source name raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown coordinate source"):
+            resolve_coordinates(
+                Path("/photos/photo.jpg"),
+                sources=("invalid_source",),
+            )
+
+    def test_gps_data_includes_full_metadata(self):
+        """GPS source result includes full gps_data for embed_gps_exif."""
+        mock_gps_data = {
+            "has_fix": True,
+            "latitude": 40.77,
+            "longitude": -73.98,
+            "fix_mode": 3,
+            "gpstime": 1700000000,
+            "altitude": 42.5,
+            "satellites_used": 8,
+            "hdop": 1.2,
+            "pdop": 2.0,
+        }
+
+        with patch(
+            "webui.backend.lib.gps_coordinate_resolver.get_gps_data_from_controls",
+            return_value=mock_gps_data,
+        ):
+            result = resolve_coordinates(
+                Path("/photos/photo.jpg"),
+                sources=("gps",),
+            )
+
+        assert result["gps_data"]["altitude"] == 42.5
+        assert result["gps_data"]["satellites_used"] == 8
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest Tests/unit/test_gps_coordinate_resolver.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'webui.backend.lib.gps_coordinate_resolver'`
+
+**Step 3: Write the implementation**
+
+```python
+"""Coordinate resolution strategy for GPS EXIF tagging.
+
+Resolves GPS coordinates for a photo by walking a configurable chain of
+sources. Each source is tried in order; the first to return valid
+coordinates wins.
+
+Sources:
+    deployment - Look up deployment sidecar metadata for the photo's directory
+    gps        - Read current GPS fix from controls.txt
+    manual     - User-provided lat/lon pass-through
+"""
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from webui.backend.lib.gps_exif_lib import get_gps_data_from_controls
+
+logger = logging.getLogger(__name__)
+
+VALID_SOURCES = ("deployment", "gps", "manual")
+
+
+def resolve_coordinates(
+    photo_path: Path,
+    sources: tuple[str, ...] = ("deployment", "gps"),
+    manual_coords: dict | None = None,
+    deployment_service: Any | None = None,
+) -> dict | None:
+    """Resolve GPS coordinates for a photo from configured sources.
+
+    Args:
+        photo_path: Path to the photo file.
+        sources: Ordered tuple of source names to try.
+        manual_coords: Dict with 'lat' and 'lon' keys (for manual source).
+        deployment_service: DeploymentService instance (for deployment source).
+            If None and 'deployment' is in sources, that source is skipped.
+
+    Returns:
+        Dict with keys: lat, lon, source, deployment_name (optional), gps_data.
+        None if no source has valid coordinates.
+
+    Raises:
+        ValueError: If an unknown source name is provided.
+    """
+    for source in sources:
+        if source not in VALID_SOURCES:
+            raise ValueError(
+                f"Unknown coordinate source: '{source}'. "
+                f"Valid sources: {', '.join(VALID_SOURCES)}"
+            )
+
+        result = _try_source(source, photo_path, manual_coords, deployment_service)
+        if result is not None:
+            return result
+
+    return None
+
+
+def _try_source(
+    source: str,
+    photo_path: Path,
+    manual_coords: dict | None,
+    deployment_service: Any | None,
+) -> dict | None:
+    """Try a single coordinate source. Returns result dict or None."""
+    if source == "deployment":
+        return _resolve_from_deployment(photo_path, deployment_service)
+    elif source == "gps":
+        return _resolve_from_gps()
+    elif source == "manual":
+        return _resolve_from_manual(manual_coords)
+    return None
+
+
+def _resolve_from_deployment(photo_path: Path, service: Any | None) -> dict | None:
+    """Resolve coordinates from deployment sidecar metadata."""
+    if service is None:
+        return None
+
+    try:
+        metadata = service.find_deployment_for_photo(photo_path)
+    except Exception as e:
+        logger.warning(f"Deployment lookup failed for {photo_path}: {e}")
+        return None
+
+    if metadata is None:
+        return None
+
+    lat = getattr(metadata, "latitude", None)
+    lon = getattr(metadata, "longitude", None)
+    if lat is None or lon is None:
+        return None
+
+    name = getattr(metadata, "deployment_name", None)
+
+    # Build gps_data dict compatible with embed_gps_exif
+    gps_data = {
+        "has_fix": True,
+        "latitude": lat,
+        "longitude": lon,
+        "altitude": getattr(metadata, "altitude", None),
+        "fix_mode": 3,
+        "gpstime": 0,
+        "satellites_used": 0,
+        "hdop": 99.99,
+        "pdop": 99.99,
+    }
+
+    return {
+        "lat": lat,
+        "lon": lon,
+        "source": "deployment",
+        "deployment_name": name,
+        "gps_data": gps_data,
+    }
+
+
+def _resolve_from_gps() -> dict | None:
+    """Resolve coordinates from controls.txt GPS data."""
+    try:
+        gps_data = get_gps_data_from_controls()
+    except Exception as e:
+        logger.warning(f"Failed to read GPS data from controls: {e}")
+        return None
+
+    if not gps_data.get("has_fix", False):
+        return None
+
+    lat = gps_data.get("latitude")
+    lon = gps_data.get("longitude")
+    if lat is None or lon is None:
+        return None
+
+    return {
+        "lat": lat,
+        "lon": lon,
+        "source": "gps",
+        "gps_data": gps_data,
+    }
+
+
+def _resolve_from_manual(coords: dict | None) -> dict | None:
+    """Resolve coordinates from user-provided manual input."""
+    if coords is None:
+        return None
+
+    lat = coords.get("lat")
+    lon = coords.get("lon")
+    if lat is None or lon is None:
+        return None
+
+    gps_data = {
+        "has_fix": True,
+        "latitude": lat,
+        "longitude": lon,
+        "altitude": coords.get("altitude"),
+        "fix_mode": 3,
+        "gpstime": 0,
+        "satellites_used": 0,
+        "hdop": 99.99,
+        "pdop": 99.99,
+    }
+
+    return {
+        "lat": lat,
+        "lon": lon,
+        "source": "manual",
+        "gps_data": gps_data,
+    }
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest Tests/unit/test_gps_coordinate_resolver.py -v`
+Expected: All 9 tests PASS
+
+**Step 5: Commit**
+
+```bash
+git add webui/backend/lib/gps_coordinate_resolver.py Tests/unit/test_gps_coordinate_resolver.py
+git commit -m "feat(gps): add coordinate resolver with deployment/gps/manual sources (#410)"
+```
+
+---
+
+### Task 2: Fix Glob Default and Add CLI Flag
+
+**Files:**
+- Modify: `webui/cli/gps_exif_tagger.py:71` (PATTERN_DEFAULT)
+- Modify: `webui/cli/gps_exif_tagger.py:407-451` (argparse, add --coordinate-source)
+- Test: `Tests/unit/test_gps_exif_tagger_cli.py` (add new test)
+
+**Step 1: Write the failing test**
+
+Add to `Tests/unit/test_gps_exif_tagger_cli.py`:
+
+```python
+def test_default_pattern_is_recursive(self):
+    """Default pattern should match photos in subdirectories."""
+    from webui.cli.gps_exif_tagger import PATTERN_DEFAULT
+    assert "**" in PATTERN_DEFAULT, "Default pattern must be recursive to find photos in date subdirectories"
+
+def test_coordinate_source_flag_accepted(self):
+    """CLI accepts --coordinate-source flag."""
+    from webui.cli.gps_exif_tagger import main
+    import sys
+    with patch.object(sys, "argv", ["tagger", "--mode", "batch", "--coordinate-source", "deployment,gps", "--dry-run"]):
+        # Should parse without error (will fail on missing directory, that's ok)
+        pass
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest Tests/unit/test_gps_exif_tagger_cli.py::test_default_pattern_is_recursive -v`
+Expected: FAIL — `assert "**" in "*.jpg"`
+
+**Step 3: Apply the fixes**
+
+In `webui/cli/gps_exif_tagger.py`:
+
+1. Line 71: Change `PATTERN_DEFAULT = "*.jpg"` to `PATTERN_DEFAULT = "**/*.jpg"`
+
+2. After line 450 (the `--verbose` argument), add:
+
+```python
+    parser.add_argument(
+        "--coordinate-source",
+        default="deployment,gps",
+        help="Comma-separated coordinate sources in priority order (default: deployment,gps). "
+        "Valid sources: deployment, gps, manual",
+    )
+```
+
+3. After line 452 (`args = parser.parse_args()`), add parsing logic:
+
+```python
+    # Parse coordinate sources
+    coordinate_sources = tuple(s.strip() for s in args.coordinate_source.split(","))
+```
+
+4. Pass `coordinate_sources` to `batch_process_directory` and `watch_directory` calls (see Task 3).
+
+**Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest Tests/unit/test_gps_exif_tagger_cli.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add webui/cli/gps_exif_tagger.py Tests/unit/test_gps_exif_tagger_cli.py
+git commit -m "fix(gps): change default glob to **/*.jpg and add --coordinate-source flag (#410)"
+```
+
+---
+
+### Task 3: Integrate Resolver into Tagger
+
+**Files:**
+- Modify: `webui/cli/gps_exif_tagger.py:161-205` (process_single_photo)
+- Modify: `webui/cli/gps_exif_tagger.py:208-285` (batch_process_directory)
+- Modify: `webui/cli/gps_exif_tagger.py:288-404` (watch_directory)
+- Test: `Tests/unit/test_gps_exif_tagger_operations.py` (add resolver tests)
+
+**Step 1: Write the failing test**
+
+Add to `Tests/unit/test_gps_exif_tagger_operations.py`:
+
+```python
+class TestResolverIntegration:
+    """Test that tagger uses coordinate resolver."""
+
+    def test_batch_uses_resolver_per_photo(self):
+        """batch_process_directory calls resolve_coordinates for each photo."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            logger = Mock()
+
+            # Create two photos in subdirectories (tests recursive glob too)
+            subdir = tmp_path / "2026-02-10"
+            subdir.mkdir()
+            for name in ["photo_001.jpg", "photo_002.jpg"]:
+                img = Image.new("RGB", (100, 100), color="white")
+                img.save(subdir / name)
+
+            mock_result = {
+                "lat": 35.96,
+                "lon": -83.92,
+                "source": "deployment",
+                "deployment_name": "Test Deploy",
+                "gps_data": {
+                    "has_fix": True,
+                    "latitude": 35.96,
+                    "longitude": -83.92,
+                    "altitude": None,
+                    "fix_mode": 3,
+                    "gpstime": 0,
+                    "satellites_used": 0,
+                    "hdop": 99.99,
+                    "pdop": 99.99,
+                },
+            }
+
+            with patch(
+                "webui.cli.gps_exif_tagger.resolve_coordinates",
+                return_value=mock_result,
+            ) as mock_resolve:
+                stats = gps_exif_tagger.batch_process_directory(
+                    tmp_path,
+                    logger,
+                    pattern="**/*.jpg",
+                    coordinate_sources=("deployment", "gps"),
+                )
+
+            # Resolver called once per photo
+            assert mock_resolve.call_count == 2
+            assert stats["total"] == 2
+
+    def test_batch_skips_photo_when_resolver_returns_none(self):
+        """Photos are skipped when no coordinate source has data."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            logger = Mock()
+
+            img = Image.new("RGB", (100, 100), color="white")
+            img.save(tmp_path / "photo.jpg")
+
+            with patch(
+                "webui.cli.gps_exif_tagger.resolve_coordinates",
+                return_value=None,
+            ):
+                stats = gps_exif_tagger.batch_process_directory(
+                    tmp_path,
+                    logger,
+                    pattern="**/*.jpg",
+                    coordinate_sources=("deployment", "gps"),
+                )
+
+            assert stats["skipped"] == 1
+
+    def test_batch_stats_include_source_counts(self):
+        """Batch stats track how many photos tagged per source."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            logger = Mock()
+
+            for i in range(3):
+                img = Image.new("RGB", (100, 100), color="white")
+                img.save(tmp_path / f"photo_{i}.jpg")
+
+            mock_result = {
+                "lat": 35.96,
+                "lon": -83.92,
+                "source": "deployment",
+                "gps_data": {
+                    "has_fix": True, "latitude": 35.96, "longitude": -83.92,
+                    "altitude": None, "fix_mode": 3, "gpstime": 0,
+                    "satellites_used": 0, "hdop": 99.99, "pdop": 99.99,
+                },
+            }
+
+            with patch(
+                "webui.cli.gps_exif_tagger.resolve_coordinates",
+                return_value=mock_result,
+            ):
+                stats = gps_exif_tagger.batch_process_directory(
+                    tmp_path,
+                    logger,
+                    pattern="**/*.jpg",
+                    coordinate_sources=("deployment",),
+                )
+
+            assert "source_counts" in stats
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest Tests/unit/test_gps_exif_tagger_operations.py::TestResolverIntegration -v`
+Expected: FAIL — `TypeError: batch_process_directory() got an unexpected keyword argument 'coordinate_sources'`
+
+**Step 3: Implement the integration**
+
+Key changes to `webui/cli/gps_exif_tagger.py`:
+
+1. Add import at top (after existing imports):
+```python
+from webui.backend.lib.gps_coordinate_resolver import resolve_coordinates
+from webui.backend.services.deployment_service import DeploymentService
+```
+
+2. Add module-level deployment service (lazy init):
+```python
+_deployment_service = None
+
+def _get_deployment_service():
+    global _deployment_service
+    if _deployment_service is None:
+        _deployment_service = DeploymentService()
+    return _deployment_service
+```
+
+3. Update `process_single_photo` signature to accept `gps_data`:
+```python
+def process_single_photo(
+    photo_path: Path,
+    logger: logging.Logger,
+    force: bool = False,
+    backup: bool = False,
+    dry_run: bool = False,
+    gps_data: dict | None = None,
+) -> dict[str, Any]:
+```
+And pass `gps_data` to `embed_gps_exif`:
+```python
+    result = embed_gps_exif(photo_path, gps_data=gps_data, backup=backup, dry_run=dry_run)
+```
+
+4. Update `batch_process_directory` to accept and use `coordinate_sources`:
+```python
+def batch_process_directory(
+    directory: Path,
+    logger: logging.Logger,
+    pattern: str = "**/*.jpg",
+    force: bool = False,
+    backup: bool = False,
+    dry_run: bool = False,
+    coordinate_sources: tuple[str, ...] = ("deployment", "gps"),
+) -> dict[str, Any]:
+```
+Add `source_counts` to stats, resolve per photo:
+```python
+    stats = {"total": 0, "tagged": 0, "skipped": 0, "errors": 0, "error_list": [], "source_counts": {}}
+
+    # ... (existing photo finding code) ...
+
+    for photo_path in photo_files:
+        # Resolve coordinates for this specific photo
+        resolved = resolve_coordinates(
+            photo_path,
+            sources=coordinate_sources,
+            deployment_service=_get_deployment_service(),
+        )
+
+        if resolved is None:
+            logger.warning(f"Skipped {photo_path.name} (no coordinates from any source)")
+            stats["skipped"] += 1
+            continue
+
+        source = resolved["source"]
+        source_label = resolved.get("deployment_name", source)
+        logger.debug(f"Using {source} coordinates for {photo_path.name} ({source_label})")
+
+        result = process_single_photo(
+            photo_path, logger, force, backup, dry_run,
+            gps_data=resolved["gps_data"],
+        )
+
+        if result["success"]:
+            stats["tagged"] += 1
+            stats["source_counts"][source] = stats["source_counts"].get(source, 0) + 1
+        elif result["skipped"]:
+            stats["skipped"] += 1
+        elif result["error"]:
+            stats["errors"] += 1
+            stats["error_list"].append((photo_path, result["error"]))
+```
+
+5. Same pattern for `watch_directory` — add `coordinate_sources` param, resolve per photo.
+
+6. Update `main()` to pass parsed sources through to batch/watch calls.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest Tests/unit/test_gps_exif_tagger_operations.py -v`
+Expected: All tests PASS (both new and existing)
+
+**Step 5: Commit**
+
+```bash
+git add webui/cli/gps_exif_tagger.py Tests/unit/test_gps_exif_tagger_operations.py
+git commit -m "feat(gps): integrate coordinate resolver into tagger batch and watch modes (#410)"
+```
+
+---
+
+### Task 4: Update Service File
+
+**Files:**
+- Modify: `webui/services/gps-exif-tagger.service:44,47-53`
+
+**Step 1: Apply changes**
+
+Line 44: `Environment="GPS_EXIF_PATTERN=*.jpg"` → `Environment="GPS_EXIF_PATTERN=**/*.jpg"`
+
+Lines 47-53: Add `--coordinate-source` to ExecStart:
+```ini
+ExecStart=/usr/bin/python3 ${MOTHBOX_HOME}/webui/cli/gps_exif_tagger.py \
+    --mode immediate \
+    --watch \
+    --directory ${MOTHBOX_PHOTOS_DIR} \
+    --interval ${GPS_EXIF_INTERVAL} \
+    --pattern ${GPS_EXIF_PATTERN} \
+    --coordinate-source deployment,gps \
+    --verbose
+```
+
+**Step 2: Commit**
+
+```bash
+git add webui/services/gps-exif-tagger.service
+git commit -m "fix(service): update tagger to recursive glob and deployment-first coords (#410)"
+```
+
+---
+
+### Task 5: API Routes
+
+**Files:**
+- Create: `webui/backend/routes/gps_exif.py`
+- Modify: `webui/backend/app.py:347,370` (register blueprint)
+- Test: `Tests/unit/test_gps_exif_routes.py`
+
+**Step 1: Write the failing tests**
+
+```python
+"""Unit tests for GPS EXIF tagger API routes."""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+from flask import Flask
+
+from webui.backend.routes.gps_exif import gps_exif_bp
+
+
+@pytest.fixture
+def app():
+    """Create test Flask app with GPS EXIF blueprint."""
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(gps_exif_bp, url_prefix="/api/gps-exif")
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+class TestGetStatus:
+    def test_returns_status(self, client):
+        """GET /api/gps-exif/status returns tagger status."""
+        response = client.get("/api/gps-exif/status")
+        assert response.status_code == 200
+        data = response.get_json()
+        assert "coordinate_sources" in data
+
+
+class TestTagPhoto:
+    def test_tag_single_photo(self, client):
+        """POST /api/gps-exif/tag-photo tags a photo."""
+        with patch("webui.backend.routes.gps_exif._tag_single_photo") as mock_tag:
+            mock_tag.return_value = {
+                "success": True,
+                "source_used": "gps",
+                "coordinates": {"lat": 40.77, "lon": -73.98},
+            }
+            response = client.post(
+                "/api/gps-exif/tag-photo",
+                json={"photo_path": "2026-02-10/photo.jpg", "coordinate_source": "gps"},
+            )
+            assert response.status_code == 200
+
+    def test_rejects_missing_photo_path(self, client):
+        """POST /api/gps-exif/tag-photo rejects missing photo_path."""
+        response = client.post("/api/gps-exif/tag-photo", json={})
+        assert response.status_code == 400
+
+
+class TestBatchTag:
+    def test_batch_tag_returns_stats(self, client):
+        """POST /api/gps-exif/batch-tag returns processing stats."""
+        with patch("webui.backend.routes.gps_exif._batch_tag") as mock_batch:
+            mock_batch.return_value = {
+                "total": 5, "tagged": 3, "skipped": 2, "errors": 0,
+                "source_counts": {"deployment": 2, "gps": 1},
+            }
+            response = client.post(
+                "/api/gps-exif/batch-tag",
+                json={"coordinate_sources": ["deployment", "gps"]},
+            )
+            assert response.status_code == 200
+            data = response.get_json()
+            assert data["total"] == 5
+
+
+class TestConfig:
+    def test_get_config(self, client):
+        """GET /api/gps-exif/config returns current configuration."""
+        response = client.get("/api/gps-exif/config")
+        assert response.status_code == 200
+        data = response.get_json()
+        assert "default_sources" in data
+
+    def test_update_config(self, client):
+        """PUT /api/gps-exif/config updates configuration."""
+        with patch("webui.backend.routes.gps_exif._save_config") as mock_save:
+            mock_save.return_value = True
+            response = client.put(
+                "/api/gps-exif/config",
+                json={"default_sources": ["gps"]},
+            )
+            assert response.status_code == 200
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest Tests/unit/test_gps_exif_routes.py -v`
+Expected: FAIL — `ModuleNotFoundError`
+
+**Step 3: Write the route implementation**
+
+Create `webui/backend/routes/gps_exif.py` following the pattern in `routes/gps.py`:
+
+- Blueprint: `gps_exif_bp = Blueprint("gps_exif", __name__)`
+- Routes: `/status`, `/tag-photo`, `/batch-tag`, `/config`
+- Uses `resolve_coordinates` from the resolver module
+- Uses `embed_gps_exif` from gps_exif_lib
+- Path traversal validation on photo paths using `validate_photo_path` pattern from gallery routes
+- Config persisted to `user_preferences.json` (existing preferences infrastructure)
+
+Register in `app.py`:
+- Line 347 area: `from routes.gps_exif import gps_exif_bp`
+- Line 370 area: `app.register_blueprint(gps_exif_bp, url_prefix="/api/gps-exif")`
+
+**Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest Tests/unit/test_gps_exif_routes.py -v`
+Expected: All PASS
+
+**Step 5: Commit**
+
+```bash
+git add webui/backend/routes/gps_exif.py webui/backend/app.py Tests/unit/test_gps_exif_routes.py
+git commit -m "feat(api): add GPS EXIF tagger API routes (#410)"
+```
+
+---
+
+### Task 6: Frontend — API Layer and Query Keys
+
+**Files:**
+- Modify: `webui/frontend/src/utils/api.js:136` (add GPS EXIF API calls)
+- Modify: `webui/frontend/src/utils/queryKeys.js:58` (add query keys)
+- Create: `webui/frontend/src/hooks/useGpsExif.js`
+
+**Step 1: Add API functions**
+
+In `webui/frontend/src/utils/api.js`, after line 136 (GPS APIs section):
+
+```javascript
+// GPS EXIF Tagger APIs
+export const getGpsExifStatus = () => api.get('/gps-exif/status')
+export const getGpsExifConfig = () => api.get('/gps-exif/config')
+export const updateGpsExifConfig = (config) => api.put('/gps-exif/config', config)
+export const tagSinglePhoto = (data) => api.post('/gps-exif/tag-photo', data)
+export const batchTagPhotos = (data) => api.post('/gps-exif/batch-tag', data)
+```
+
+**Step 2: Add query keys**
+
+In `webui/frontend/src/utils/queryKeys.js`, after GPS_CONFIG line 58:
+
+```javascript
+  GPS_EXIF_STATUS: ['gps-exif-status'],
+  GPS_EXIF_CONFIG: ['gps-exif-config'],
+```
+
+**Step 3: Create the hook**
+
+```javascript
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { QUERY_KEYS } from '../utils/queryKeys'
+import {
+  getGpsExifStatus,
+  getGpsExifConfig,
+  updateGpsExifConfig,
+  batchTagPhotos,
+  tagSinglePhoto,
+} from '../utils/api'
+
+export function useGpsExifStatus() {
+  return useQuery({
+    queryKey: QUERY_KEYS.GPS_EXIF_STATUS,
+    queryFn: async () => {
+      const response = await getGpsExifStatus()
+      return response.data
+    },
+    staleTime: 10 * 1000,
+  })
+}
+
+export function useGpsExifConfig() {
+  return useQuery({
+    queryKey: QUERY_KEYS.GPS_EXIF_CONFIG,
+    queryFn: async () => {
+      const response = await getGpsExifConfig()
+      return response.data
+    },
+    staleTime: 60 * 1000,
+  })
+}
+
+export function useUpdateGpsExifConfig() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: updateGpsExifConfig,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.GPS_EXIF_CONFIG })
+    },
+  })
+}
+
+export function useBatchTagPhotos() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: batchTagPhotos,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.GPS_EXIF_STATUS })
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.PHOTOS })
+    },
+  })
+}
+
+export function useTagSinglePhoto() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: tagSinglePhoto,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.GPS_EXIF_STATUS })
+    },
+  })
+}
+```
+
+**Step 4: Commit**
+
+```bash
+git add webui/frontend/src/utils/api.js webui/frontend/src/utils/queryKeys.js webui/frontend/src/hooks/useGpsExif.js
+git commit -m "feat(frontend): add GPS EXIF API layer and TanStack Query hooks (#410)"
+```
+
+---
+
+### Task 7: Frontend — GPS Settings EXIF Subsection
+
+**Files:**
+- Modify: `webui/frontend/src/components/GPSSettings.jsx` (add collapsible EXIF section after line ~491)
+
+**Step 1: Add the EXIF tagging subsection**
+
+Import the hook at top of file:
+```javascript
+import { useGpsExifStatus, useGpsExifConfig, useUpdateGpsExifConfig } from '../hooks/useGpsExif'
+```
+
+Add state for collapsed section:
+```javascript
+const [exifSectionOpen, setExifSectionOpen] = useState(false)
+```
+
+Add hooks:
+```javascript
+const { data: exifStatus } = useGpsExifStatus()
+const { data: exifConfig } = useGpsExifConfig()
+const updateExifConfig = useUpdateGpsExifConfig()
+```
+
+Insert after the GPS configuration inputs section (before Advanced Timeout Configuration), a collapsible card matching the existing nested pattern:
+
+- Header: "GPS EXIF Tagging" with collapse toggle
+- **Default Source** dropdown: options map to `["deployment,gps", "gps", "manual"]`
+- **Status indicator**: green/gray dot + "Running"/"Stopped" from `exifStatus.service_running`
+- **Stats line**: `"{tagged} photos tagged ({source_counts})"` from `exifStatus`
+- **Save** button calls `updateExifConfig.mutate({ default_sources: selectedSources })`
+
+Follow the exact styling pattern of the Advanced Timeout section (nested `div` with `border border-gray-300 rounded-md p-3`).
+
+**Step 2: Build and verify**
+
+Run: `cd webui/frontend && npm run build`
+Expected: Build succeeds
+
+**Step 3: Commit**
+
+```bash
+git add webui/frontend/src/components/GPSSettings.jsx
+git commit -m "feat(ui): add EXIF tagging config to GPS Settings (#410)"
+```
+
+---
+
+### Task 8: Frontend — Gallery GPS Tag Banner
+
+**Files:**
+- Create: `webui/frontend/src/components/Gallery/GpsTagBanner.jsx`
+- Modify: `webui/frontend/src/pages/Gallery.jsx` (insert banner above search bar, ~line 677)
+
+**Step 1: Create the banner component**
+
+Follow the `ActiveScheduleBanner` pattern (amber bg, border, icon, action button):
+
+```jsx
+import { useState } from 'react'
+import { ExclamationTriangleIcon } from '@heroicons/react/24/outline'
+import { useBatchTagPhotos, useGpsExifConfig } from '../../hooks/useGpsExif'
+import toast from 'react-hot-toast'
+
+const SOURCE_OPTIONS = [
+  { value: 'deployment,gps', label: 'Deployment → GPS fallback' },
+  { value: 'gps', label: 'GPS only' },
+  { value: 'manual', label: 'Manual coordinates' },
+]
+
+export default function GpsTagBanner({ untaggedCount, currentDirectory }) {
+  const { data: config } = useGpsExifConfig()
+  const batchTag = useBatchTagPhotos()
+  const [source, setSource] = useState(config?.default_sources?.join(',') || 'deployment,gps')
+  const [manualLat, setManualLat] = useState('')
+  const [manualLon, setManualLon] = useState('')
+
+  if (!untaggedCount || untaggedCount === 0) return null
+
+  const handleTag = () => {
+    const payload = {
+      coordinate_sources: source.split(','),
+      directory: currentDirectory,
+    }
+    if (source === 'manual') {
+      payload.manual_coords = { lat: parseFloat(manualLat), lon: parseFloat(manualLon) }
+    }
+    batchTag.mutate(payload, {
+      onSuccess: (res) => toast.success(`Tagged ${res.data.tagged} photos`),
+      onError: () => toast.error('Tagging failed'),
+    })
+  }
+
+  return (
+    <div className="bg-amber-50 border border-amber-200 rounded-lg p-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <ExclamationTriangleIcon className="h-5 w-5 text-amber-600" />
+          <span className="text-sm font-medium text-amber-900">
+            {untaggedCount} photo{untaggedCount !== 1 ? 's' : ''} without GPS coordinates
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <select
+            value={source}
+            onChange={(e) => setSource(e.target.value)}
+            className="text-sm border border-amber-300 rounded px-2 py-1 bg-white"
+          >
+            {SOURCE_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+          <button
+            onClick={handleTag}
+            disabled={batchTag.isPending}
+            className="px-3 py-1 text-sm bg-amber-600 text-white rounded hover:bg-amber-700 disabled:opacity-50"
+          >
+            {batchTag.isPending ? 'Tagging...' : 'Tag Now'}
+          </button>
+        </div>
+      </div>
+      {source === 'manual' && (
+        <div className="mt-2 flex items-center gap-2">
+          <input type="number" step="any" placeholder="Latitude" value={manualLat}
+            onChange={(e) => setManualLat(e.target.value)}
+            className="text-sm border rounded px-2 py-1 w-32" />
+          <input type="number" step="any" placeholder="Longitude" value={manualLon}
+            onChange={(e) => setManualLon(e.target.value)}
+            className="text-sm border rounded px-2 py-1 w-32" />
+        </div>
+      )}
+    </div>
+  )
+}
+```
+
+**Step 2: Insert into Gallery.jsx**
+
+Import at top:
+```javascript
+import GpsTagBanner from '../components/Gallery/GpsTagBanner'
+```
+
+Import the status hook:
+```javascript
+import { useGpsExifStatus } from '../hooks/useGpsExif'
+```
+
+Add hook call inside the Gallery component:
+```javascript
+const { data: exifStatus } = useGpsExifStatus()
+```
+
+Insert the banner between the header and search bar (~line 677):
+```jsx
+<GpsTagBanner
+  untaggedCount={exifStatus?.untagged_count}
+  currentDirectory={activeFilters?.date}
+/>
+```
+
+**Step 3: Build and verify**
+
+Run: `cd webui/frontend && npm run build`
+Expected: Build succeeds
+
+**Step 4: Commit**
+
+```bash
+git add webui/frontend/src/components/Gallery/GpsTagBanner.jsx webui/frontend/src/pages/Gallery.jsx
+git commit -m "feat(ui): add GPS tag banner to gallery for untagged photos (#410)"
+```
+
+---
+
+### Task 9: Final Integration Test and Cleanup
+
+**Files:**
+- Review all modified files
+- Run full test suite for affected modules
+
+**Step 1: Run backend tests**
+
+```bash
+python3 -m pytest Tests/unit/test_gps_coordinate_resolver.py Tests/unit/test_gps_exif_tagger_operations.py Tests/unit/test_gps_exif_tagger_cli.py Tests/unit/test_gps_exif_routes.py -v
+```
+
+Expected: All PASS
+
+**Step 2: Run linting**
+
+```bash
+python3 -m ruff check webui/backend/lib/gps_coordinate_resolver.py webui/backend/routes/gps_exif.py webui/cli/gps_exif_tagger.py
+```
+
+Expected: No errors
+
+**Step 3: Build frontend**
+
+```bash
+cd webui/frontend && npm run build
+```
+
+Expected: Build succeeds with no errors
+
+**Step 4: Final commit if any cleanup needed**
+
+```bash
+git add -A && git commit -m "chore: cleanup after GPS EXIF tagger improvements (#410)"
+```

--- a/Firmware/docs/plans/2026-02-15-gps-exif-tagger-improvements.md
+++ b/Firmware/docs/plans/2026-02-15-gps-exif-tagger-improvements.md
@@ -1,0 +1,129 @@
+# GPS EXIF Tagger Improvements (#410)
+
+## Summary
+
+Fix the GPS EXIF tagger service's glob bug, add deployment-aware coordinate
+resolution for batch correctness, expose coordinate source selection in the
+CLI and web UI, and update the service configuration.
+
+## Problem
+
+1. **Glob bug**: Default pattern `*.jpg` misses photos in date subdirectories
+   (`photos/YYYY-MM-DD/*.jpg`).
+2. **Batch correctness**: Batch mode applies the device's *current* GPS to all
+   photos regardless of capture date/location. Incorrect when the device has
+   moved between deployments.
+3. **No UI control**: Users cannot choose which coordinate source to use for
+   tagging (deployment metadata vs live GPS vs manual entry).
+
+## Design
+
+### 1. Coordinate Resolution Strategy
+
+New module: `webui/backend/lib/gps_coordinate_resolver.py`
+
+```python
+def resolve_coordinates(
+    photo_path: Path,
+    sources: tuple[str, ...] = ('deployment', 'gps'),
+    manual_coords: dict | None = None,
+) -> dict | None:
+    """Resolve GPS coordinates for a photo from configured sources.
+
+    Returns:
+        {lat, lon, source: 'deployment'|'gps'|'manual', deployment_name?: str}
+        or None if no source has valid coordinates.
+    """
+```
+
+Resolution sources (walked in order, first valid result wins):
+
+| Source | Implementation |
+|--------|---------------|
+| `deployment` | `DeploymentService.find_deployment_for_photo()` - walks directory tree, LRU cached |
+| `gps` | `get_gps_data_from_controls()` - reads controls.txt |
+| `manual` | Pass-through of user-provided lat/lon |
+
+### 2. Tagger Fixes
+
+- Change `PATTERN_DEFAULT` from `"*.jpg"` to `"**/*.jpg"` in
+  `webui/cli/gps_exif_tagger.py`.
+- Modify `batch_process_directory()` and `watch_directory()` to call
+  `resolve_coordinates()` per photo instead of reading controls.txt once.
+- Pass resolved `gps_data` dict into `embed_gps_exif()` via its existing
+  parameter (no signature change needed).
+- Add `--coordinate-source` CLI flag (default: `deployment,gps`).
+- Log which source was used per photo; batch summary reports counts per source.
+
+### 3. API Endpoints
+
+New route file: `webui/backend/routes/gps_exif.py`
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| `GET` | `/api/gps-exif/status` | Service status, tagging stats, per-source breakdown |
+| `POST` | `/api/gps-exif/tag-photo` | Tag single photo with specified coordinate source |
+| `POST` | `/api/gps-exif/batch-tag` | Batch tag with source config and optional date range |
+| `GET` | `/api/gps-exif/config` | Current tagger config (default source chain, pattern) |
+| `PUT` | `/api/gps-exif/config` | Update tagger config (persisted) |
+
+Security: CSRF on POST/PUT, path traversal validation, rate limiting on batch
+(10/min).
+
+### 4. Frontend: GPS Settings Integration
+
+Add an "EXIF Tagging" subsection to the existing `GPSSettings` collapsible card:
+
+- **Default Coordinate Source** dropdown: `Deployment -> GPS fallback` | `GPS only` | `Manual`
+- **Service status** indicator with last-tagged timestamp
+- **Stats row**: tagged count with per-source breakdown
+- Persisted via `PUT /api/gps-exif/config`
+
+### 5. Frontend: Gallery Banner
+
+Contextual banner at top of Gallery when untagged photos exist in current view.
+Follows `ActiveScheduleBanner` pattern.
+
+| State | Color | Content |
+|-------|-------|---------|
+| Untagged photos exist | Amber | Count + "Tag Now" button + source dropdown |
+| Tagging in progress | Blue | Progress indicator + cancel |
+| All tagged | Hidden | Banner disappears |
+
+Source dropdown defaults to Settings config. "Manual" expands inline lat/lon
+input. "Tag Now" calls `POST /api/gps-exif/batch-tag` scoped to current view.
+
+### 6. Service Configuration
+
+Update existing `webui/services/gps-exif-tagger.service`:
+
+- Change `GPS_EXIF_PATTERN=*.jpg` to `GPS_EXIF_PATTERN=**/*.jpg`
+- Add `--coordinate-source deployment,gps` to `ExecStart`
+
+Install/update scripts already handle this service file — no script changes
+needed.
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `webui/backend/lib/gps_coordinate_resolver.py` | **New** - coordinate resolution strategy |
+| `webui/cli/gps_exif_tagger.py` | Fix glob default, add `--coordinate-source`, use resolver |
+| `webui/backend/lib/gps_exif_lib.py` | No changes (existing `gps_data` param sufficient) |
+| `webui/backend/routes/gps_exif.py` | **New** - API endpoints |
+| `webui/frontend/src/components/GPSSettings.jsx` | Add EXIF Tagging subsection |
+| `webui/frontend/src/components/Gallery/GpsTagBanner.jsx` | **New** - gallery banner |
+| `webui/frontend/src/hooks/useGpsExifStatus.js` | **New** - TanStack Query hook |
+| `webui/services/gps-exif-tagger.service` | Update pattern + coordinate source |
+
+## Dependencies
+
+- Existing: `DeploymentService`, `gps_exif_lib`, `deployment_sidecar`
+- No new packages required
+
+## Out of Scope
+
+- #409 (GPS lock contention metrics) - separate concern
+- #382 (scheduler coordinate refresh) - separate subsystem
+- #272 (sensor metadata) - different domain
+- #150 full scope (dashboard panel, batch modal) - this covers a minimal UI only

--- a/Firmware/webui/backend/app.py
+++ b/Firmware/webui/backend/app.py
@@ -345,6 +345,7 @@ from routes.export_presets import export_presets_bp
 from routes.gallery import gallery_bp
 from routes.gpio import gpio_bp
 from routes.gps import gps_bp
+from routes.gps_exif import gps_exif_bp
 from routes.metadata import metadata_bp
 from routes.preferences import preferences_bp
 from routes.presets import presets_bp
@@ -368,6 +369,7 @@ app.register_blueprint(scheduler_ui_bp, url_prefix="/api/scheduler/ui")
 app.register_blueprint(presets_bp, url_prefix="/api/presets")
 app.register_blueprint(preferences_bp, url_prefix="/api/preferences")
 app.register_blueprint(gps_bp, url_prefix="/api/gps")
+app.register_blueprint(gps_exif_bp, url_prefix="/api/gps-exif")
 app.register_blueprint(metadata_bp, url_prefix="/api/metadata")
 app.register_blueprint(sidecar_bp, url_prefix="/api/sidecar")
 app.register_blueprint(deployment_bp, url_prefix="/api/deployment")

--- a/Firmware/webui/backend/lib/gps_coordinate_resolver.py
+++ b/Firmware/webui/backend/lib/gps_coordinate_resolver.py
@@ -59,8 +59,7 @@ def resolve_coordinates(
     for source in sources:
         if source not in VALID_SOURCES:
             raise ValueError(
-                f"Unknown source '{source}'. "
-                f"Valid sources: {', '.join(VALID_SOURCES)}"
+                f"Unknown source '{source}'. Valid sources: {', '.join(VALID_SOURCES)}"
             )
 
     # Dispatch table for source resolvers

--- a/Firmware/webui/backend/lib/gps_coordinate_resolver.py
+++ b/Firmware/webui/backend/lib/gps_coordinate_resolver.py
@@ -1,0 +1,217 @@
+"""GPS coordinate resolver for Mothbox photos.
+
+Resolves GPS coordinates by walking a configurable chain of sources.
+Each source is tried in order; the first to return valid coordinates wins.
+
+Sources:
+    - deployment: Reads lat/lon from a deployment sidecar (deployment.json)
+    - gps: Reads current GPS fix from controls.txt
+    - manual: Pass-through from user-supplied coordinates
+
+Usage:
+    >>> result = resolve_coordinates(
+    ...     photo_path=Path("/photos/test.jpg"),
+    ...     sources=("deployment", "gps"),
+    ...     deployment_service=deployment_service,
+    ... )
+    >>> if result:
+    ...     print(f"{result['source']}: {result['lat']}, {result['lon']}")
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from webui.backend.lib.gps_exif_lib import get_gps_data_from_controls
+
+# Valid source names that can appear in the sources tuple
+VALID_SOURCES = ("deployment", "gps", "manual")
+
+
+def resolve_coordinates(
+    photo_path: Path,
+    sources: tuple[str, ...] = ("deployment", "gps"),
+    manual_coords: dict[str, float] | None = None,
+    deployment_service: Any = None,
+) -> dict | None:
+    """Resolve GPS coordinates for a photo by trying sources in order.
+
+    Walks the source chain and returns the first valid result. Each source
+    resolver either returns a result dict or None to indicate it cannot
+    provide coordinates.
+
+    Args:
+        photo_path: Path to the photo file.
+        sources: Ordered tuple of source names to try.
+        manual_coords: Dict with "lat" and "lon" keys for manual source.
+        deployment_service: DeploymentService instance for deployment source.
+            Passed via dependency injection to avoid module-level import.
+
+    Returns:
+        Dict with keys: lat, lon, source, deployment_name, gps_data.
+        None if no source could provide valid coordinates.
+
+    Raises:
+        ValueError: If an unknown source name is in the sources tuple.
+    """
+    # Validate all source names up front
+    for source in sources:
+        if source not in VALID_SOURCES:
+            raise ValueError(
+                f"Unknown source '{source}'. "
+                f"Valid sources: {', '.join(VALID_SOURCES)}"
+            )
+
+    # Dispatch table for source resolvers
+    resolvers = {
+        "deployment": lambda: _resolve_deployment(photo_path, deployment_service),
+        "gps": lambda: _resolve_gps(),
+        "manual": lambda: _resolve_manual(manual_coords),
+    }
+
+    # Walk the chain; first valid result wins
+    for source in sources:
+        result = resolvers[source]()
+        if result is not None:
+            return result
+
+    return None
+
+
+def _resolve_deployment(
+    photo_path: Path,
+    deployment_service: Any,
+) -> dict | None:
+    """Resolve coordinates from deployment sidecar metadata.
+
+    Args:
+        photo_path: Path to the photo file.
+        deployment_service: DeploymentService instance (may be None).
+
+    Returns:
+        Result dict or None if deployment has no valid coordinates.
+    """
+    if deployment_service is None:
+        return None
+
+    metadata = deployment_service.find_deployment_for_photo(photo_path)
+    if metadata is None:
+        return None
+
+    lat = metadata.latitude
+    lon = metadata.longitude
+    if lat is None or lon is None:
+        return None
+
+    # Build a gps_data dict compatible with embed_gps_exif
+    gps_data = _build_gps_data(
+        latitude=lat,
+        longitude=lon,
+        altitude=getattr(metadata, "altitude", None),
+    )
+
+    return {
+        "lat": lat,
+        "lon": lon,
+        "source": "deployment",
+        "deployment_name": getattr(metadata, "deployment_name", None),
+        "gps_data": gps_data,
+    }
+
+
+def _resolve_gps() -> dict | None:
+    """Resolve coordinates from the GPS hardware via controls.txt.
+
+    Returns:
+        Result dict or None if GPS has no valid fix.
+    """
+    gps_data = get_gps_data_from_controls()
+
+    if not gps_data.get("has_fix", False):
+        return None
+
+    lat = gps_data.get("latitude")
+    lon = gps_data.get("longitude")
+    if lat is None or lon is None:
+        return None
+
+    return {
+        "lat": lat,
+        "lon": lon,
+        "source": "gps",
+        "deployment_name": None,
+        "gps_data": gps_data,
+    }
+
+
+def _resolve_manual(
+    manual_coords: dict[str, float] | None,
+) -> dict | None:
+    """Resolve coordinates from user-supplied manual values.
+
+    Args:
+        manual_coords: Dict with "lat" and "lon" keys, or None.
+
+    Returns:
+        Result dict or None if manual_coords is None or missing keys.
+    """
+    if manual_coords is None:
+        return None
+
+    lat = manual_coords.get("lat")
+    lon = manual_coords.get("lon")
+    if lat is None or lon is None:
+        return None
+
+    # Build a gps_data dict compatible with embed_gps_exif
+    gps_data = _build_gps_data(latitude=lat, longitude=lon)
+
+    return {
+        "lat": lat,
+        "lon": lon,
+        "source": "manual",
+        "deployment_name": None,
+        "gps_data": gps_data,
+    }
+
+
+def _build_gps_data(
+    latitude: float,
+    longitude: float,
+    altitude: float | None = None,
+    fix_mode: int = 3,
+    gpstime: int = 0,
+    satellites_used: int = 0,
+    hdop: float = 99.99,
+    pdop: float = 99.99,
+) -> dict:
+    """Build a gps_data dict compatible with embed_gps_exif.
+
+    This creates the same structure returned by get_gps_data_from_controls()
+    so it can be passed directly to embed_gps_exif(gps_data=...).
+
+    Args:
+        latitude: Decimal latitude.
+        longitude: Decimal longitude.
+        altitude: Altitude in meters (optional).
+        fix_mode: GPS fix mode (0=none, 2=2D, 3=3D). Defaults to 3.
+        gpstime: Unix timestamp from GPS. Defaults to 0.
+        satellites_used: Number of satellites. Defaults to 0.
+        hdop: Horizontal dilution of precision. Defaults to 99.99.
+        pdop: Position dilution of precision. Defaults to 99.99.
+
+    Returns:
+        Dict matching the structure of get_gps_data_from_controls() output.
+    """
+    return {
+        "has_fix": True,
+        "latitude": latitude,
+        "longitude": longitude,
+        "altitude": altitude,
+        "fix_mode": fix_mode,
+        "gpstime": gpstime,
+        "satellites_used": satellites_used,
+        "hdop": hdop,
+        "pdop": pdop,
+    }

--- a/Firmware/webui/backend/routes/gps_exif.py
+++ b/Firmware/webui/backend/routes/gps_exif.py
@@ -1,0 +1,435 @@
+"""GPS EXIF tagger API endpoints.
+
+Provides REST API for GPS EXIF tagging operations on Mothbox photos.
+Supports single-photo tagging, batch processing, and configuration management.
+
+Blueprint: gps_exif_bp
+URL Prefix: /api/gps-exif
+
+Endpoints:
+- GET    /status       - Return tagger status and statistics
+- POST   /tag-photo    - Tag a single photo with GPS EXIF data
+- POST   /batch-tag    - Batch tag photos in a directory
+- GET    /config       - Get current tagger configuration
+- PUT    /config       - Update tagger configuration
+
+Security:
+- CSRF protection (Flask-WTF) on all state-changing endpoints
+- Path traversal protection on all file paths
+- Input validation on all request parameters
+- Sanitized error messages (no stack trace exposure)
+"""
+
+import json
+import logging
+import subprocess
+from pathlib import Path
+
+from flask import Blueprint, jsonify, request
+
+from mothbox_paths import CONFIG_DIR, PHOTOS_DIR
+from webui.backend.lib.gps_coordinate_resolver import VALID_SOURCES, resolve_coordinates
+from webui.backend.lib.gps_exif_lib import embed_gps_exif
+
+logger = logging.getLogger(__name__)
+
+gps_exif_bp = Blueprint("gps_exif", __name__)
+
+# Default configuration for the GPS EXIF tagger
+DEFAULT_CONFIG = {
+    "default_sources": ["deployment", "gps"],
+    "pattern": "**/*.jpg",
+}
+
+
+def _get_config_file() -> Path:
+    """Return the path to the GPS EXIF tagger config file."""
+    return CONFIG_DIR / "gps_exif_config.json"
+
+
+def _load_config() -> dict:
+    """Load GPS EXIF tagger config, falling back to defaults.
+
+    Returns:
+        dict with keys: default_sources, pattern
+    """
+    config_file = _get_config_file()
+    try:
+        if config_file.exists():
+            with open(config_file) as f:
+                saved = json.load(f)
+            # Merge with defaults for any missing keys
+            return {**DEFAULT_CONFIG, **saved}
+    except (OSError, json.JSONDecodeError) as e:
+        logger.warning("Could not load GPS EXIF config, using defaults: %s", e)
+
+    return DEFAULT_CONFIG.copy()
+
+
+def _save_config(config: dict) -> None:
+    """Save GPS EXIF tagger config to disk.
+
+    Args:
+        config: Configuration dict to persist.
+
+    Raises:
+        OSError: If the file cannot be written.
+    """
+    config_file = _get_config_file()
+    config_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(config_file, "w") as f:
+        json.dump(config, f, indent=2)
+
+
+def _validate_relative_path(user_path: str, base_dir: Path) -> Path | None:
+    """Validate a user-supplied path is relative and under base_dir.
+
+    Args:
+        user_path: User-supplied relative path string.
+        base_dir: Base directory the path must resolve under.
+
+    Returns:
+        Resolved Path if valid, or None if the path is invalid.
+    """
+    # Reject absolute paths
+    if user_path.startswith(("/", "\\")):
+        return None
+
+    # Reject obvious traversal attempts
+    if ".." in user_path:
+        return None
+
+    # Resolve the full path and check it stays under base_dir
+    resolved = (base_dir / user_path).resolve()
+    base_resolved = base_dir.resolve()
+
+    if not resolved.is_relative_to(base_resolved):
+        return None
+
+    return resolved
+
+
+# ============================================================================
+# GET /status
+# ============================================================================
+
+
+@gps_exif_bp.route("/status", methods=["GET"])
+def get_status():
+    """Return GPS EXIF tagger status and statistics.
+
+    Response:
+        {
+            "coordinate_sources": ["deployment", "gps", "manual"],
+            "service_running": bool | null,
+            "stats": { "photos_dir_exists": bool }
+        }
+    """
+    try:
+        # Check systemd service status (non-critical, return null on failure)
+        service_running = None
+        try:
+            result = subprocess.run(
+                ["systemctl", "is-active", "gps-exif-tagger"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            service_running = result.stdout.strip() == "active"
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+            # Not on a system with systemd, or service doesn't exist
+            service_running = None
+
+        # Basic stats
+        stats = {
+            "photos_dir_exists": PHOTOS_DIR.exists(),
+        }
+
+        return jsonify(
+            {
+                "coordinate_sources": list(VALID_SOURCES),
+                "service_running": service_running,
+                "stats": stats,
+            }
+        )
+    except Exception:
+        logger.exception("Failed to get GPS EXIF tagger status")
+        return jsonify({"error": "Failed to get GPS EXIF tagger status"}), 500
+
+
+# ============================================================================
+# POST /tag-photo
+# ============================================================================
+
+
+@gps_exif_bp.route("/tag-photo", methods=["POST"])
+def tag_photo():
+    """Tag a single photo with GPS EXIF data.
+
+    Request body:
+        {
+            "photo_path": "2026-02-10/photo.jpg",
+            "coordinate_source": "deployment",
+            "manual_coords": {"lat": ..., "lon": ...}
+        }
+
+    Response:
+        {
+            "success": true,
+            "source_used": "deployment",
+            "coordinates": {"lat": ..., "lon": ...}
+        }
+    """
+    try:
+        data = request.get_json(silent=True)
+    except Exception:
+        data = None
+
+    if not data:
+        return jsonify({"error": "No data provided"}), 400
+
+    # Validate photo_path is present and non-empty
+    photo_path_str = data.get("photo_path")
+    if not photo_path_str or not isinstance(photo_path_str, str) or not photo_path_str.strip():
+        return jsonify({"error": "photo_path is required"}), 400
+
+    photo_path_str = photo_path_str.strip()
+
+    # Validate path (no traversal, relative, under PHOTOS_DIR)
+    resolved_path = _validate_relative_path(photo_path_str, PHOTOS_DIR)
+    if resolved_path is None:
+        return jsonify({"error": "Invalid path: path traversal not allowed"}), 400
+
+    # Check file exists
+    if not resolved_path.exists():
+        return jsonify({"error": f"Photo not found: {photo_path_str}"}), 404
+
+    # Determine coordinate source(s)
+    source_str = data.get("coordinate_source", "deployment")
+    if isinstance(source_str, str):
+        sources = (source_str,)
+    elif isinstance(source_str, list):
+        sources = tuple(source_str)
+    else:
+        sources = ("deployment",)
+
+    manual_coords = data.get("manual_coords")
+
+    try:
+        # Lazy import to avoid circular dependency
+        from webui.backend.services.deployment_service import DeploymentService
+
+        deployment_service = DeploymentService()
+
+        resolved = resolve_coordinates(
+            photo_path=resolved_path,
+            sources=sources,
+            manual_coords=manual_coords,
+            deployment_service=deployment_service,
+        )
+
+        if resolved is None:
+            return (
+                jsonify(
+                    {
+                        "error": "No coordinates available from the specified source(s)",
+                        "sources_tried": list(sources),
+                    }
+                ),
+                400,
+            )
+
+        # Embed GPS EXIF
+        result = embed_gps_exif(resolved_path, gps_data=resolved["gps_data"])
+
+        if not result["success"]:
+            error_msg = result.get("error", "Unknown error during GPS EXIF embedding")
+            return jsonify({"error": error_msg}), 500
+
+        return jsonify(
+            {
+                "success": True,
+                "source_used": resolved["source"],
+                "coordinates": {
+                    "lat": resolved["lat"],
+                    "lon": resolved["lon"],
+                },
+            }
+        )
+
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+    except Exception:
+        logger.exception("Failed to tag photo: %s", photo_path_str)
+        return jsonify({"error": "Failed to tag photo"}), 500
+
+
+# ============================================================================
+# POST /batch-tag
+# ============================================================================
+
+
+@gps_exif_bp.route("/batch-tag", methods=["POST"])
+def batch_tag():
+    """Batch tag photos in a directory.
+
+    Request body:
+        {
+            "coordinate_sources": ["deployment", "gps"],
+            "pattern": "**/*.jpg",
+            "directory": "2026-02-10",
+            "force": false,
+            "dry_run": false
+        }
+
+    Response:
+        {
+            "total": N,
+            "tagged": N,
+            "skipped": N,
+            "errors": N,
+            "source_counts": {...}
+        }
+    """
+    try:
+        data = request.get_json(silent=True) or {}
+    except Exception:
+        data = {}
+
+    # Determine target directory
+    directory_str = data.get("directory")
+    if directory_str:
+        resolved_dir = _validate_relative_path(directory_str, PHOTOS_DIR)
+        if resolved_dir is None:
+            return jsonify({"error": "Invalid directory: path traversal not allowed"}), 400
+        target_dir = resolved_dir
+    else:
+        target_dir = PHOTOS_DIR
+
+    # Parse options
+    coordinate_sources = data.get("coordinate_sources", ["deployment", "gps"])
+    if not isinstance(coordinate_sources, list):
+        return jsonify({"error": "coordinate_sources must be a list"}), 400
+
+    pattern = data.get("pattern", "**/*.jpg")
+    force = bool(data.get("force", False))
+    dry_run = bool(data.get("dry_run", False))
+
+    try:
+        from webui.cli.gps_exif_tagger import batch_process_directory
+
+        # Create a logger for the batch process
+        batch_logger = logging.getLogger("gps_exif_tagger.batch")
+
+        stats = batch_process_directory(
+            target_dir,
+            batch_logger,
+            pattern=pattern,
+            force=force,
+            backup=False,
+            dry_run=dry_run,
+            coordinate_sources=tuple(coordinate_sources),
+        )
+
+        return jsonify(
+            {
+                "total": stats["total"],
+                "tagged": stats["tagged"],
+                "skipped": stats["skipped"],
+                "errors": stats["errors"],
+                "source_counts": stats.get("source_counts", {}),
+            }
+        )
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+    except Exception:
+        logger.exception("Batch tagging failed")
+        return jsonify({"error": "Batch tagging failed"}), 500
+
+
+# ============================================================================
+# GET /config
+# ============================================================================
+
+
+@gps_exif_bp.route("/config", methods=["GET"])
+def get_config():
+    """Return current GPS EXIF tagger configuration.
+
+    Response:
+        {
+            "default_sources": ["deployment", "gps"],
+            "pattern": "**/*.jpg"
+        }
+    """
+    try:
+        config = _load_config()
+        return jsonify(config)
+    except Exception:
+        logger.exception("Failed to get GPS EXIF config")
+        return jsonify({"error": "Failed to get GPS EXIF config"}), 500
+
+
+# ============================================================================
+# PUT /config
+# ============================================================================
+
+
+@gps_exif_bp.route("/config", methods=["PUT"])
+def update_config():
+    """Update GPS EXIF tagger configuration.
+
+    Request body:
+        {
+            "default_sources": ["gps"],
+            "pattern": "**/*.jpg"
+        }
+
+    Response:
+        {
+            "success": true,
+            "config": {...}
+        }
+    """
+    try:
+        data = request.get_json(silent=True)
+    except Exception:
+        data = None
+
+    if not data:
+        return jsonify({"error": "No data provided"}), 400
+
+    # Validate default_sources if provided
+    if "default_sources" in data:
+        sources = data["default_sources"]
+        if not isinstance(sources, list) or len(sources) == 0:
+            return jsonify({"error": "default_sources must be a non-empty list"}), 400
+
+        for source in sources:
+            if source not in VALID_SOURCES:
+                return (
+                    jsonify(
+                        {
+                            "error": f"Invalid source '{source}'. "
+                            f"Valid sources: {', '.join(VALID_SOURCES)}"
+                        }
+                    ),
+                    400,
+                )
+
+    # Build updated config
+    current = _load_config()
+
+    if "default_sources" in data:
+        current["default_sources"] = data["default_sources"]
+
+    if "pattern" in data:
+        current["pattern"] = data["pattern"]
+
+    try:
+        _save_config(current)
+    except OSError:
+        logger.exception("Failed to save GPS EXIF config")
+        return jsonify({"error": "Failed to save configuration"}), 500
+
+    return jsonify({"success": True, "config": current})

--- a/Firmware/webui/backend/routes/gps_exif.py
+++ b/Firmware/webui/backend/routes/gps_exif.py
@@ -215,6 +215,17 @@ def tag_photo():
 
     manual_coords = data.get("manual_coords")
 
+    # Validate manual coordinates if provided
+    if manual_coords is not None:
+        if not isinstance(manual_coords, dict):
+            return jsonify({"error": "manual_coords must be an object with lat and lon"}), 400
+        lat = manual_coords.get("lat")
+        lon = manual_coords.get("lon")
+        if not isinstance(lat, (int, float)) or not isinstance(lon, (int, float)):
+            return jsonify({"error": "manual_coords.lat and .lon must be numbers"}), 400
+        if lat < -90 or lat > 90 or lon < -180 or lon > 180:
+            return jsonify({"error": "lat must be -90..90, lon must be -180..180"}), 400
+
     try:
         # Lazy import to avoid circular dependency
         from webui.backend.services.deployment_service import DeploymentService

--- a/Firmware/webui/backend/routes/gps_exif.py
+++ b/Firmware/webui/backend/routes/gps_exif.py
@@ -314,6 +314,18 @@ def batch_tag():
     pattern = data.get("pattern", "**/*.jpg")
     force = bool(data.get("force", False))
     dry_run = bool(data.get("dry_run", False))
+    manual_coords = data.get("manual_coords")
+
+    # Validate manual coordinates if provided
+    if manual_coords is not None:
+        if not isinstance(manual_coords, dict):
+            return jsonify({"error": "manual_coords must be an object with lat and lon"}), 400
+        lat = manual_coords.get("lat")
+        lon = manual_coords.get("lon")
+        if not isinstance(lat, (int, float)) or not isinstance(lon, (int, float)):
+            return jsonify({"error": "manual_coords.lat and .lon must be numbers"}), 400
+        if lat < -90 or lat > 90 or lon < -180 or lon > 180:
+            return jsonify({"error": "lat must be -90..90, lon must be -180..180"}), 400
 
     try:
         from webui.cli.gps_exif_tagger import batch_process_directory
@@ -329,6 +341,7 @@ def batch_tag():
             backup=False,
             dry_run=dry_run,
             coordinate_sources=tuple(coordinate_sources),
+            manual_coords=manual_coords,
         )
 
         return jsonify(

--- a/Firmware/webui/cli/gps_exif_tagger.py
+++ b/Firmware/webui/cli/gps_exif_tagger.py
@@ -68,7 +68,7 @@ __all__ = [
 # Default configuration constants
 POLL_INTERVAL_DEFAULT = 10  # Default polling interval in seconds for watch mode
 POLL_INTERVAL_MIN = 1  # Minimum polling interval (prevents CPU spinning)
-PATTERN_DEFAULT = "*.jpg"  # Default file pattern for photo matching
+PATTERN_DEFAULT = "**/*.jpg"  # Default file pattern for photo matching
 JPEG_QUALITY_DEFAULT = 95  # JPEG quality for re-encoding (in lib, referenced here for docs)
 LOG_FORMAT = "[%(asctime)s] [%(levelname)s] %(message)s"  # Log message format
 LOG_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"  # Log timestamp format
@@ -448,8 +448,17 @@ def main():
         "--force", action="store_true", help="Re-tag photos even if already have GPS EXIF"
     )
     parser.add_argument("--verbose", "-v", action="store_true", help="Enable verbose logging")
+    parser.add_argument(
+        "--coordinate-source",
+        default="deployment,gps",
+        help="Comma-separated coordinate sources in priority order (default: deployment,gps). "
+        "Valid sources: deployment, gps, manual",
+    )
 
     args = parser.parse_args()
+
+    # Parse coordinate sources (wired into batch/watch calls in a follow-up)
+    coordinate_sources = tuple(s.strip() for s in args.coordinate_source.split(","))  # noqa: F841
 
     # Setup logging
     logger = setup_logging(args.verbose)

--- a/Firmware/webui/cli/gps_exif_tagger.py
+++ b/Firmware/webui/cli/gps_exif_tagger.py
@@ -48,11 +48,13 @@ if str(_firmware_root) not in sys.path:
     sys.path.insert(0, str(_firmware_root))
 
 from mothbox_paths import PHOTOS_DIR, get_hardware_config
+from webui.backend.lib.gps_coordinate_resolver import resolve_coordinates
 from webui.backend.lib.gps_exif_lib import (
     embed_gps_exif,
     get_gps_data_from_controls,
     is_already_tagged,
 )
+from webui.backend.services.deployment_service import DeploymentService
 
 # Module exports
 __all__ = [
@@ -63,6 +65,18 @@ __all__ = [
     "watch_directory",
     "main",
 ]
+
+
+# Lazy-initialized deployment service for coordinate resolver
+_deployment_service = None
+
+
+def _get_deployment_service():
+    """Get or create the shared DeploymentService instance."""
+    global _deployment_service
+    if _deployment_service is None:
+        _deployment_service = DeploymentService()
+    return _deployment_service
 
 
 # Default configuration constants
@@ -164,6 +178,7 @@ def process_single_photo(
     force: bool = False,
     backup: bool = False,
     dry_run: bool = False,
+    gps_data: dict | None = None,
 ) -> dict[str, Any]:
     """Process a single photo for GPS EXIF tagging.
 
@@ -173,6 +188,7 @@ def process_single_photo(
         force: If True, re-tag even if already tagged
         backup: If True, create backup before modifying
         dry_run: If True, don't modify files
+        gps_data: Pre-resolved GPS data dict (or None to read from controls.txt)
 
     Returns:
         dict: Processing result from embed_gps_exif()
@@ -191,7 +207,7 @@ def process_single_photo(
 
     # Embed GPS EXIF
     logger.debug(f"Processing {photo_path.name}...")
-    result = embed_gps_exif(photo_path, backup=backup, dry_run=dry_run)
+    result = embed_gps_exif(photo_path, gps_data=gps_data, backup=backup, dry_run=dry_run)
 
     # Log result
     if result["success"]:
@@ -212,6 +228,7 @@ def batch_process_directory(
     force: bool = False,
     backup: bool = False,
     dry_run: bool = False,
+    coordinate_sources: tuple[str, ...] = ("deployment", "gps"),
 ) -> dict[str, Any]:
     """Process all photos in directory (batch mode).
 
@@ -222,6 +239,7 @@ def batch_process_directory(
         force: If True, re-tag already tagged photos
         backup: If True, create backups
         dry_run: If True, don't modify files
+        coordinate_sources: Ordered tuple of coordinate source names to try
 
     Returns:
         dict: Batch processing statistics:
@@ -230,9 +248,17 @@ def batch_process_directory(
             - skipped (int): Photos skipped (no GPS or already tagged)
             - errors (int): Photos that failed to process
             - error_list (list): List of (path, error_message) tuples
+            - source_counts (dict): Count of photos tagged per source
     """
     # Initialize statistics
-    stats = {"total": 0, "tagged": 0, "skipped": 0, "errors": 0, "error_list": []}
+    stats = {
+        "total": 0,
+        "tagged": 0,
+        "skipped": 0,
+        "errors": 0,
+        "error_list": [],
+        "source_counts": {},
+    }
 
     # Find all photos matching pattern
     logger.info(f"Scanning {directory} for {pattern} files...")
@@ -265,10 +291,31 @@ def batch_process_directory(
 
     # Process each photo
     for photo_path in photo_files:
-        result = process_single_photo(photo_path, logger, force, backup, dry_run)
+        # Resolve coordinates from the configured source chain
+        resolved = resolve_coordinates(
+            photo_path,
+            sources=coordinate_sources,
+            deployment_service=_get_deployment_service(),
+        )
+
+        if resolved is None:
+            logger.warning(
+                f"Skipping {photo_path.name} (no coordinates from sources: "
+                f"{', '.join(coordinate_sources)})"
+            )
+            stats["skipped"] += 1
+            continue
+
+        source = resolved["source"]
+        logger.debug(f"Resolved coordinates for {photo_path.name} from '{source}'")
+
+        result = process_single_photo(
+            photo_path, logger, force, backup, dry_run, gps_data=resolved["gps_data"]
+        )
 
         if result["success"]:
             stats["tagged"] += 1
+            stats["source_counts"][source] = stats["source_counts"].get(source, 0) + 1
         elif result["skipped"]:
             stats["skipped"] += 1
         elif result["error"]:
@@ -281,6 +328,8 @@ def batch_process_directory(
     logger.info(f"  Tagged: {stats['tagged']}")
     logger.info(f"  Skipped: {stats['skipped']}")
     logger.info(f"  Errors: {stats['errors']}")
+    if stats["source_counts"]:
+        logger.info(f"  Sources: {stats['source_counts']}")
 
     return stats
 
@@ -291,6 +340,7 @@ def watch_directory(
     pattern: str = "*.jpg",
     interval: int = 10,
     backup: bool = False,
+    coordinate_sources: tuple[str, ...] = ("deployment", "gps"),
 ) -> None:
     """Monitor directory and tag new photos (immediate mode).
 
@@ -302,6 +352,7 @@ def watch_directory(
         pattern: Glob pattern for photo files
         interval: Polling interval in seconds (must be >= 1)
         backup: If True, create backups
+        coordinate_sources: Ordered tuple of coordinate source names to try
 
     Implementation:
         - Track last modification times of all photos
@@ -364,6 +415,25 @@ def watch_directory(
                             logger.debug(f"Skipping unstable file: {photo_path.name}")
                             continue
 
+                        # Resolve coordinates from the configured source chain
+                        resolved = resolve_coordinates(
+                            photo_path,
+                            sources=coordinate_sources,
+                            deployment_service=_get_deployment_service(),
+                        )
+
+                        if resolved is None:
+                            logger.warning(
+                                f"Skipping {photo_path.name} (no coordinates from sources: "
+                                f"{', '.join(coordinate_sources)})"
+                            )
+                            continue
+
+                        source = resolved["source"]
+                        logger.debug(
+                            f"Resolved coordinates for {photo_path.name} from '{source}'"
+                        )
+
                         # Process the photo (use try-except to handle TOCTOU race condition)
                         # File could still be deleted/moved between stability check and processing
                         try:
@@ -373,11 +443,14 @@ def watch_directory(
                                 force=False,  # Never force in watch mode
                                 backup=backup,
                                 dry_run=False,
+                                gps_data=resolved["gps_data"],
                             )
 
                             # Log result
                             if result["success"]:
-                                logger.info(f"✓ Tagged {photo_path.name}")
+                                logger.info(
+                                    f"Tagged {photo_path.name} (source: {source})"
+                                )
                             elif result["skipped"]:
                                 logger.debug(f"Skipped {photo_path.name}")
 
@@ -457,8 +530,8 @@ def main():
 
     args = parser.parse_args()
 
-    # Parse coordinate sources (wired into batch/watch calls in a follow-up)
-    coordinate_sources = tuple(s.strip() for s in args.coordinate_source.split(","))  # noqa: F841
+    # Parse coordinate sources
+    coordinate_sources = tuple(s.strip() for s in args.coordinate_source.split(","))
 
     # Setup logging
     logger = setup_logging(args.verbose)
@@ -506,6 +579,7 @@ def main():
                 pattern=args.pattern,
                 interval=args.interval,
                 backup=args.backup,
+                coordinate_sources=coordinate_sources,
             )
         else:
             # Batch mode
@@ -516,6 +590,7 @@ def main():
                 force=args.force,
                 backup=args.backup,
                 dry_run=args.dry_run,
+                coordinate_sources=coordinate_sources,
             )
 
             # Exit with error code if errors occurred

--- a/Firmware/webui/cli/gps_exif_tagger.py
+++ b/Firmware/webui/cli/gps_exif_tagger.py
@@ -382,13 +382,13 @@ def watch_directory(
         while True:
             # Find all photos matching pattern (case-insensitive)
             photo_files = []
-            for ext in [
-                pattern,
-                pattern.replace(".jpg", ".JPG"),
-                pattern.replace(".jpg", ".jpeg"),
-                pattern.replace(".jpg", ".JPEG"),
-            ]:
-                photo_files.extend(directory.glob(ext))
+            if "." in pattern:
+                base_pattern, ext = pattern.rsplit(".", 1)
+                for variant in [pattern, f"{base_pattern}.{ext.upper()}"]:
+                    photo_files.extend(directory.glob(variant))
+            else:
+                photo_files.extend(directory.glob(pattern))
+            photo_files = list(dict.fromkeys(photo_files))
 
             # Filter out symlinks (security: prevent directory traversal attacks)
             # Only process regular files within the intended directory

--- a/Firmware/webui/cli/gps_exif_tagger.py
+++ b/Firmware/webui/cli/gps_exif_tagger.py
@@ -229,6 +229,7 @@ def batch_process_directory(
     backup: bool = False,
     dry_run: bool = False,
     coordinate_sources: tuple[str, ...] = ("deployment", "gps"),
+    manual_coords: dict[str, float] | None = None,
 ) -> dict[str, Any]:
     """Process all photos in directory (batch mode).
 
@@ -240,6 +241,7 @@ def batch_process_directory(
         backup: If True, create backups
         dry_run: If True, don't modify files
         coordinate_sources: Ordered tuple of coordinate source names to try
+        manual_coords: Dict with "lat" and "lon" for manual source
 
     Returns:
         dict: Batch processing statistics:
@@ -295,6 +297,7 @@ def batch_process_directory(
         resolved = resolve_coordinates(
             photo_path,
             sources=coordinate_sources,
+            manual_coords=manual_coords,
             deployment_service=_get_deployment_service(),
         )
 
@@ -430,9 +433,7 @@ def watch_directory(
                             continue
 
                         source = resolved["source"]
-                        logger.debug(
-                            f"Resolved coordinates for {photo_path.name} from '{source}'"
-                        )
+                        logger.debug(f"Resolved coordinates for {photo_path.name} from '{source}'")
 
                         # Process the photo (use try-except to handle TOCTOU race condition)
                         # File could still be deleted/moved between stability check and processing
@@ -448,9 +449,7 @@ def watch_directory(
 
                             # Log result
                             if result["success"]:
-                                logger.info(
-                                    f"Tagged {photo_path.name} (source: {source})"
-                                )
+                                logger.info(f"Tagged {photo_path.name} (source: {source})")
                             elif result["skipped"]:
                                 logger.debug(f"Skipped {photo_path.name}")
 

--- a/Firmware/webui/frontend/src/components/GPSSettings.jsx
+++ b/Firmware/webui/frontend/src/components/GPSSettings.jsx
@@ -9,6 +9,7 @@ import { useState, useEffect, useMemo } from 'react'
 import toast from 'react-hot-toast'
 import CollapsibleCard from './CollapsibleCard'
 import ConfirmDialog from './common/ConfirmDialog'
+import { useGpsExifStatus, useGpsExifConfig, useUpdateGpsExifConfig } from '../hooks/useGpsExif'
 
 export default function GPSSettings() {
   const queryClient = useQueryClient()
@@ -19,6 +20,19 @@ export default function GPSSettings() {
   const [validationErrors, setValidationErrors] = useState({})
   const [showRestartConfirm, setShowRestartConfirm] = useState(false)
   const [gpsPrecision, setGpsPrecisionState] = useState(() => getGpsPrecision())
+  const [exifSectionOpen, setExifSectionOpen] = useState(false)
+  const [selectedSource, setSelectedSource] = useState('deployment,gps')
+
+  const { data: exifStatus } = useGpsExifStatus()
+  const { data: exifConfig } = useGpsExifConfig()
+  const updateExifConfig = useUpdateGpsExifConfig()
+
+  // Update selected source when config loads
+  useEffect(() => {
+    if (exifConfig?.default_sources) {
+      setSelectedSource(exifConfig.default_sources.join(','))
+    }
+  }, [exifConfig])
 
   // Handle precision change
   const handlePrecisionChange = (newPrecision) => {
@@ -487,6 +501,73 @@ export default function GPSSettings() {
                 <p className="text-xs text-gray-500 mt-1">
                   Controls decimal places shown for GPS coordinates throughout the UI (display only - does not affect GPS accuracy)
                 </p>
+              </div>
+
+              {/* EXIF Tagging Configuration */}
+              <div className="border border-gray-300 rounded-md p-3">
+                <div
+                  className="flex justify-between items-center cursor-pointer select-none"
+                  onClick={() => setExifSectionOpen(!exifSectionOpen)}
+                >
+                  <h5 className="text-sm font-medium text-gray-700">EXIF Tagging</h5>
+                  <span className="text-gray-500 text-sm">
+                    {exifSectionOpen ? '▼' : '▶'}
+                  </span>
+                </div>
+
+                {exifSectionOpen && (
+                  <div className="mt-3 space-y-3">
+                    {/* Default Coordinate Source */}
+                    <div>
+                      <label className="block text-xs font-medium text-gray-700 mb-1">
+                        Default Coordinate Source
+                      </label>
+                      <select
+                        value={selectedSource}
+                        onChange={(e) => setSelectedSource(e.target.value)}
+                        aria-label="Default Coordinate Source"
+                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+                      >
+                        <option value="deployment,gps">Deployment → GPS fallback</option>
+                        <option value="gps">GPS only</option>
+                        <option value="manual">Manual coordinates</option>
+                      </select>
+                      <p className="text-xs text-gray-500 mt-1">
+                        Where to get GPS coordinates for tagging photos
+                      </p>
+                    </div>
+
+                    {/* Service Status */}
+                    {exifStatus?.service_status && (
+                      <div className="text-xs text-gray-600">
+                        <span className="font-medium">Service:</span>{' '}
+                        <span className={
+                          exifStatus.service_status === 'running' ? 'text-green-600 font-medium' :
+                          exifStatus.service_status === 'stopped' ? 'text-yellow-600' :
+                          'text-gray-600'
+                        }>
+                          {exifStatus.service_status}
+                        </span>
+                      </div>
+                    )}
+
+                    {/* Tagged Count */}
+                    {exifStatus?.tagged_count != null && (
+                      <div className="text-xs text-gray-600">
+                        <span className="font-medium">Photos tagged:</span> {exifStatus.tagged_count}
+                      </div>
+                    )}
+
+                    {/* Save Button */}
+                    <button
+                      onClick={() => updateExifConfig.mutate({ default_sources: selectedSource.split(',') })}
+                      disabled={updateExifConfig.isPending}
+                      className="w-full px-3 py-1.5 text-sm bg-green-600 text-white rounded hover:bg-green-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
+                    >
+                      {updateExifConfig.isPending ? 'Saving...' : 'Save'}
+                    </button>
+                  </div>
+                )}
               </div>
 
               {/* Advanced Timeout Configuration */}

--- a/Firmware/webui/frontend/src/components/Gallery/GpsTagBanner.jsx
+++ b/Firmware/webui/frontend/src/components/Gallery/GpsTagBanner.jsx
@@ -1,0 +1,99 @@
+import { useState } from 'react'
+import { ExclamationTriangleIcon } from '@heroicons/react/24/outline'
+import { useBatchTagPhotos, useGpsExifConfig } from '../../hooks/useGpsExif'
+import toast from 'react-hot-toast'
+
+const SOURCE_OPTIONS = [
+  { value: 'deployment,gps', label: 'Deployment \u2192 GPS fallback' },
+  { value: 'gps', label: 'GPS only' },
+  { value: 'manual', label: 'Manual coordinates' },
+]
+
+export default function GpsTagBanner({ untaggedCount, currentDirectory }) {
+  const { data: config } = useGpsExifConfig()
+  const batchTag = useBatchTagPhotos()
+  const [source, setSource] = useState(null)
+  const [manualLat, setManualLat] = useState('')
+  const [manualLon, setManualLon] = useState('')
+
+  // Use config default or fallback
+  const effectiveSource = source ?? config?.default_sources?.join(',') ?? 'deployment,gps'
+
+  if (!untaggedCount || untaggedCount === 0) return null
+
+  const handleTag = () => {
+    const payload = {
+      coordinate_sources: effectiveSource.split(','),
+    }
+    if (currentDirectory) {
+      payload.directory = currentDirectory
+    }
+    if (effectiveSource === 'manual') {
+      const lat = parseFloat(manualLat)
+      const lon = parseFloat(manualLon)
+      if (isNaN(lat) || isNaN(lon)) {
+        toast.error('Please enter valid latitude and longitude')
+        return
+      }
+      payload.manual_coords = { lat, lon }
+    }
+    batchTag.mutate(payload, {
+      onSuccess: (res) => {
+        const data = res.data
+        toast.success(`Tagged ${data.tagged} of ${data.total} photos`)
+      },
+      onError: () => toast.error('Tagging failed'),
+    })
+  }
+
+  return (
+    <div className="bg-amber-50 border border-amber-200 rounded-lg p-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <ExclamationTriangleIcon className="h-5 w-5 text-amber-600" />
+          <span className="text-sm font-medium text-amber-900">
+            {untaggedCount} photo{untaggedCount !== 1 ? 's' : ''} without GPS coordinates
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <select
+            value={effectiveSource}
+            onChange={(e) => setSource(e.target.value)}
+            className="text-sm border border-amber-300 rounded px-2 py-1 bg-white"
+          >
+            {SOURCE_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+          <button
+            onClick={handleTag}
+            disabled={batchTag.isPending}
+            className="px-3 py-1 text-sm bg-amber-600 text-white rounded hover:bg-amber-700 disabled:opacity-50"
+          >
+            {batchTag.isPending ? 'Tagging...' : 'Tag Now'}
+          </button>
+        </div>
+      </div>
+      {effectiveSource === 'manual' && (
+        <div className="mt-2 flex items-center gap-2">
+          <input
+            type="number"
+            step="any"
+            placeholder="Latitude"
+            value={manualLat}
+            onChange={(e) => setManualLat(e.target.value)}
+            className="text-sm border rounded px-2 py-1 w-32"
+          />
+          <input
+            type="number"
+            step="any"
+            placeholder="Longitude"
+            value={manualLon}
+            onChange={(e) => setManualLon(e.target.value)}
+            className="text-sm border rounded px-2 py-1 w-32"
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/Firmware/webui/frontend/src/components/Gallery/GpsTagBanner.jsx
+++ b/Firmware/webui/frontend/src/components/Gallery/GpsTagBanner.jsx
@@ -22,13 +22,14 @@ export default function GpsTagBanner({ untaggedCount, currentDirectory }) {
   if (!untaggedCount || untaggedCount === 0) return null
 
   const handleTag = () => {
+    const sources = effectiveSource.split(',')
     const payload = {
-      coordinate_sources: effectiveSource.split(','),
+      coordinate_sources: sources,
     }
     if (currentDirectory) {
       payload.directory = currentDirectory
     }
-    if (effectiveSource === 'manual') {
+    if (sources.includes('manual')) {
       const lat = parseFloat(manualLat)
       const lon = parseFloat(manualLon)
       if (isNaN(lat) || isNaN(lon)) {
@@ -74,7 +75,7 @@ export default function GpsTagBanner({ untaggedCount, currentDirectory }) {
           </button>
         </div>
       </div>
-      {effectiveSource === 'manual' && (
+      {effectiveSource.split(',').includes('manual') && (
         <div className="mt-2 flex items-center gap-2">
           <input
             type="number"

--- a/Firmware/webui/frontend/src/components/Gallery/GpsTagBanner.jsx
+++ b/Firmware/webui/frontend/src/components/Gallery/GpsTagBanner.jsx
@@ -36,6 +36,10 @@ export default function GpsTagBanner({ untaggedCount, currentDirectory }) {
         toast.error('Please enter valid latitude and longitude')
         return
       }
+      if (lat < -90 || lat > 90 || lon < -180 || lon > 180) {
+        toast.error('Latitude must be -90 to 90, longitude -180 to 180')
+        return
+      }
       payload.manual_coords = { lat, lon }
     }
     batchTag.mutate(payload, {

--- a/Firmware/webui/frontend/src/hooks/useGpsExif.js
+++ b/Firmware/webui/frontend/src/hooks/useGpsExif.js
@@ -1,0 +1,62 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { QUERY_KEYS } from '../utils/queryKeys'
+import {
+  getGpsExifStatus,
+  getGpsExifConfig,
+  updateGpsExifConfig,
+  batchTagPhotos,
+  tagSinglePhoto,
+} from '../utils/api'
+
+export function useGpsExifStatus() {
+  return useQuery({
+    queryKey: QUERY_KEYS.GPS_EXIF_STATUS,
+    queryFn: async () => {
+      const response = await getGpsExifStatus()
+      return response.data
+    },
+    staleTime: 10 * 1000,
+  })
+}
+
+export function useGpsExifConfig() {
+  return useQuery({
+    queryKey: QUERY_KEYS.GPS_EXIF_CONFIG,
+    queryFn: async () => {
+      const response = await getGpsExifConfig()
+      return response.data
+    },
+    staleTime: 60 * 1000,
+  })
+}
+
+export function useUpdateGpsExifConfig() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (config) => updateGpsExifConfig(config),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.GPS_EXIF_CONFIG })
+    },
+  })
+}
+
+export function useBatchTagPhotos() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (data) => batchTagPhotos(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.GPS_EXIF_STATUS })
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.PHOTOS })
+    },
+  })
+}
+
+export function useTagSinglePhoto() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (data) => tagSinglePhoto(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.GPS_EXIF_STATUS })
+    },
+  })
+}

--- a/Firmware/webui/frontend/src/hooks/useGpsExif.js
+++ b/Firmware/webui/frontend/src/hooks/useGpsExif.js
@@ -57,6 +57,7 @@ export function useTagSinglePhoto() {
     mutationFn: (data) => tagSinglePhoto(data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.GPS_EXIF_STATUS })
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.PHOTOS })
     },
   })
 }

--- a/Firmware/webui/frontend/src/pages/Gallery.jsx
+++ b/Firmware/webui/frontend/src/pages/Gallery.jsx
@@ -40,6 +40,8 @@ import { useFilters } from '../hooks/useFilters'
 import { combineWithUserSearch } from '../utils/filterQueryBuilder'
 import { GALLERY_CONFIG, GALLERY_MESSAGES } from '../constants/config'
 import { formatErrorMessage } from '../utils/helpers'
+import GpsTagBanner from '../components/Gallery/GpsTagBanner'
+import { useGpsExifStatus } from '../hooks/useGpsExif'
 import toast from 'react-hot-toast'
 
 /**
@@ -58,6 +60,9 @@ function GalleryContent() {
 
   // Filter state from useFilters hook
   const { searchQuery: filterQuery, hasFilters } = useFilters()
+
+  // GPS EXIF status for untagged photo banner
+  const { data: exifStatus } = useGpsExifStatus()
 
   // Combine user search query with filter query
   const combinedQuery = useMemo(() => {
@@ -674,6 +679,12 @@ function GalleryContent() {
             )}
           </div>
         </div>
+
+        {/* GPS Tag Banner */}
+        <GpsTagBanner
+          untaggedCount={exifStatus?.untagged_count}
+          currentDirectory={undefined}
+        />
 
         {/* Search Bar */}
         <div className="flex gap-2">

--- a/Firmware/webui/frontend/src/utils/api.js
+++ b/Firmware/webui/frontend/src/utils/api.js
@@ -135,6 +135,13 @@ export const syncGps = () => api.post('/gps/sync')
 export const getGpsConfig = () => api.get('/gps/config')
 export const updateGpsConfig = (config) => api.put('/gps/config', config)
 
+// GPS EXIF Tagger APIs
+export const getGpsExifStatus = () => api.get('/gps-exif/status')
+export const getGpsExifConfig = () => api.get('/gps-exif/config')
+export const updateGpsExifConfig = (config) => api.put('/gps-exif/config', config)
+export const tagSinglePhoto = (data) => api.post('/gps-exif/tag-photo', data)
+export const batchTagPhotos = (data) => api.post('/gps-exif/batch-tag', data)
+
 // Sidecar Metadata APIs
 export const getAllTags = (params = {}) => api.get('/sidecar/tags', { params })
 export const getAllSpecies = (params = {}) => api.get('/sidecar/species', { params })

--- a/Firmware/webui/frontend/src/utils/queryKeys.js
+++ b/Firmware/webui/frontend/src/utils/queryKeys.js
@@ -56,6 +56,8 @@ export const QUERY_KEYS = {
   CAMERA_SETTINGS: ['camera-settings'],
   WEBUI_SETTINGS: ['webui-settings'],
   GPS_CONFIG: ['gps-config'],
+  GPS_EXIF_STATUS: ['gps-exif-status'],
+  GPS_EXIF_CONFIG: ['gps-exif-config'],
 
   // System information (kebab-case compound names)
   SYSTEM_INFO: ['system-info'],

--- a/Firmware/webui/services/gps-exif-tagger.service
+++ b/Firmware/webui/services/gps-exif-tagger.service
@@ -41,7 +41,7 @@ Environment="MOTHBOX_GROUP=pi"
 
 # Service parameters (configurable)
 Environment="GPS_EXIF_INTERVAL=10"
-Environment="GPS_EXIF_PATTERN=*.jpg"
+Environment="GPS_EXIF_PATTERN=**/*.jpg"
 
 # Main service command (uses environment variables)
 ExecStart=/usr/bin/python3 ${MOTHBOX_HOME}/webui/cli/gps_exif_tagger.py \
@@ -50,6 +50,7 @@ ExecStart=/usr/bin/python3 ${MOTHBOX_HOME}/webui/cli/gps_exif_tagger.py \
     --directory ${MOTHBOX_PHOTOS_DIR} \
     --interval ${GPS_EXIF_INTERVAL} \
     --pattern ${GPS_EXIF_PATTERN} \
+    --coordinate-source deployment,gps \
     --verbose
 
 # Restart policy with crash loop protection


### PR DESCRIPTION
## Summary

- **Fix glob bug**: Default pattern changed from `*.jpg` to `**/*.jpg` so photos in date subdirectories (`photos/YYYY-MM-DD/*.jpg`) are found
- **Deployment-aware coordinates**: New `gps_coordinate_resolver.py` resolves GPS coordinates per-photo from a configurable source chain (deployment sidecar → live GPS → manual entry), preventing incorrect batch tagging when the device has moved between deployments
- **API endpoints**: 5 new endpoints at `/api/gps-exif/*` for status, single/batch tagging, and config CRUD
- **GPS Settings UI**: Collapsible "EXIF Tagging" section with default coordinate source dropdown, service status indicator, and tagged photo count
- **Gallery banner**: Amber contextual banner when untagged photos exist, with source selector and "Tag Now" action
- **Service file updated**: Recursive glob pattern and `--coordinate-source deployment,gps` flag

## Files Changed (15 files, +1762/-6)

### Backend
| File | Change |
|------|--------|
| `webui/backend/lib/gps_coordinate_resolver.py` | **New** — coordinate resolution strategy module |
| `webui/cli/gps_exif_tagger.py` | Fix glob default, add `--coordinate-source`, integrate resolver |
| `webui/backend/routes/gps_exif.py` | **New** — 5 API endpoints with CSRF, path traversal protection |
| `webui/backend/app.py` | Register `gps_exif_bp` blueprint |
| `webui/services/gps-exif-tagger.service` | Update pattern + coordinate source flag |

### Frontend
| File | Change |
|------|--------|
| `webui/frontend/src/hooks/useGpsExif.js` | **New** — 5 TanStack Query hooks |
| `webui/frontend/src/utils/api.js` | 5 GPS EXIF API functions |
| `webui/frontend/src/utils/queryKeys.js` | 2 new query keys |
| `webui/frontend/src/components/GPSSettings.jsx` | EXIF Tagging collapsible section |
| `webui/frontend/src/components/Gallery/GpsTagBanner.jsx` | **New** — amber banner component |
| `webui/frontend/src/pages/Gallery.jsx` | Import and render GpsTagBanner |

### Tests
| File | Tests |
|------|-------|
| `Tests/unit/test_gps_coordinate_resolver.py` | **New** — 9 tests |
| `Tests/unit/test_gps_exif_tagger_cli.py` | +2 tests (recursive glob, coordinate-source flag) |
| `Tests/unit/test_gps_exif_tagger_operations.py` | +4 tests (resolver integration) |
| `Tests/unit/test_gps_exif_routes.py` | **New** — 17 tests |

## Test plan

- [x] 82/82 backend tests passing (`pytest Tests/unit/test_gps_coordinate_resolver.py test_gps_exif_tagger_cli.py test_gps_exif_tagger_operations.py test_gps_exif_routes.py`)
- [x] Ruff lint clean on all new/modified Python files
- [x] Frontend build succeeds (1446 modules, no errors)
- [ ] Manual test: verify Gallery banner appears when untagged photos exist
- [ ] Manual test: verify GPS Settings EXIF section saves/loads config
- [ ] Manual test: verify batch tagging with deployment source resolves correct coordinates