### PR TITLE
refactor: standardize error codes across backend/frontend (#388)

### DIFF
--- a/Firmware/Tests/unit/test_error_codes.py
+++ b/Firmware/Tests/unit/test_error_codes.py
@@ -1,0 +1,196 @@
+"""Tests for shared error codes module."""
+
+import json
+
+import pytest
+
+
+class TestErrorCodes:
+    """Test error code constants."""
+
+    def test_all_codes_are_strings(self):
+        from webui.backend.lib.error_codes import ERROR_CODES
+
+        for key, value in ERROR_CODES.items():
+            assert isinstance(value, str), f"{key} should be a string"
+            assert value == key, f"Value should match key: {key}"
+
+    def test_required_codes_exist(self):
+        from webui.backend.lib.error_codes import ERROR_CODES
+
+        required = [
+            "VALIDATION_ERROR",
+            "NOT_FOUND",
+            "CONFLICT_ERROR",
+            "ACTIVATION_ERROR",
+            "RATE_LIMIT_ERROR",
+            "HARDWARE_ERROR",
+            "STORAGE_ERROR",
+            "PERMISSION_ERROR",
+            "SERVER_ERROR",
+        ]
+        for code in required:
+            assert code in ERROR_CODES, f"Missing required code: {code}"
+
+    def test_codes_importable_as_module_attributes(self):
+        from webui.backend.lib.error_codes import (
+            ACTIVATION_ERROR,
+            CONFLICT_ERROR,
+            HARDWARE_ERROR,
+            NOT_FOUND,
+            PERMISSION_ERROR,
+            RATE_LIMIT_ERROR,
+            SERVER_ERROR,
+            STORAGE_ERROR,
+            VALIDATION_ERROR,
+        )
+
+        assert VALIDATION_ERROR == "VALIDATION_ERROR"
+        assert NOT_FOUND == "NOT_FOUND"
+        assert CONFLICT_ERROR == "CONFLICT_ERROR"
+        assert ACTIVATION_ERROR == "ACTIVATION_ERROR"
+        assert RATE_LIMIT_ERROR == "RATE_LIMIT_ERROR"
+        assert HARDWARE_ERROR == "HARDWARE_ERROR"
+        assert STORAGE_ERROR == "STORAGE_ERROR"
+        assert PERMISSION_ERROR == "PERMISSION_ERROR"
+        assert SERVER_ERROR == "SERVER_ERROR"
+
+
+class TestSanitizeMessage:
+    """Test message sanitization for safe display."""
+
+    def test_strips_html_tags(self):
+        from webui.backend.lib.error_codes import sanitize_message
+
+        assert sanitize_message("<b>bold</b> text") == "bold text"
+
+    def test_strips_script_tags(self):
+        from webui.backend.lib.error_codes import sanitize_message
+
+        result = sanitize_message("<script>alert('xss')</script>hello")
+        assert "<script>" not in result
+        assert "hello" in result
+
+    def test_strips_incomplete_tags(self):
+        from webui.backend.lib.error_codes import sanitize_message
+
+        result = sanitize_message("text <script without closing")
+        assert "<" not in result
+
+    def test_redacts_internal_paths(self):
+        from webui.backend.lib.error_codes import sanitize_message
+
+        result = sanitize_message("Error reading /etc/secrets/key.pem")
+        assert "/etc/secrets" not in result
+        assert "[path]" in result
+
+    def test_redacts_var_paths(self):
+        from webui.backend.lib.error_codes import sanitize_message
+
+        result = sanitize_message("File not found: /var/lib/mothbox/data.json")
+        assert "/var/lib" not in result
+
+    def test_redacts_home_paths(self):
+        from webui.backend.lib.error_codes import sanitize_message
+
+        result = sanitize_message("Error in /home/pi/Desktop/Mothbox/config")
+        assert "/home/pi" not in result
+
+    def test_truncates_long_messages(self):
+        from webui.backend.lib.error_codes import sanitize_message
+
+        long_msg = "x" * 300
+        result = sanitize_message(long_msg)
+        assert len(result) <= 200
+        assert result.endswith("...")
+
+    def test_custom_max_length(self):
+        from webui.backend.lib.error_codes import sanitize_message
+
+        result = sanitize_message("x" * 100, max_length=50)
+        assert len(result) <= 50
+
+    def test_none_returns_default(self):
+        from webui.backend.lib.error_codes import sanitize_message
+
+        assert sanitize_message(None) == "An error occurred"
+
+    def test_empty_string_returns_default(self):
+        from webui.backend.lib.error_codes import sanitize_message
+
+        assert sanitize_message("") == "An error occurred"
+
+    def test_normal_message_unchanged(self):
+        from webui.backend.lib.error_codes import sanitize_message
+
+        assert sanitize_message("Schedule not found") == "Schedule not found"
+
+
+class TestErrorResponse:
+    """Test error_response helper produces correct JSON format."""
+
+    @pytest.fixture(autouse=True)
+    def _flask_app(self):
+        """Create minimal Flask app for jsonify context."""
+        from flask import Flask
+
+        app = Flask(__name__)
+        with app.app_context():
+            yield app
+
+    def test_basic_error_response(self):
+        from webui.backend.lib.error_codes import VALIDATION_ERROR, error_response
+
+        response, status = error_response(VALIDATION_ERROR, "Bad input", 400)
+        data = json.loads(response.get_data(as_text=True))
+        assert data["error"] == "Bad input"
+        assert data["code"] == "VALIDATION_ERROR"
+        assert status == 400
+
+    def test_default_status_is_400(self):
+        from webui.backend.lib.error_codes import VALIDATION_ERROR, error_response
+
+        _, status = error_response(VALIDATION_ERROR, "Bad input")
+        assert status == 400
+
+    def test_server_error_status(self):
+        from webui.backend.lib.error_codes import SERVER_ERROR, error_response
+
+        _, status = error_response(SERVER_ERROR, "Internal error", 500)
+        assert status == 500
+
+    def test_not_found_status(self):
+        from webui.backend.lib.error_codes import NOT_FOUND, error_response
+
+        response, status = error_response(NOT_FOUND, "Schedule not found", 404)
+        data = json.loads(response.get_data(as_text=True))
+        assert data["code"] == "NOT_FOUND"
+        assert status == 404
+
+    def test_extra_fields_included(self):
+        from webui.backend.lib.error_codes import CONFLICT_ERROR, error_response
+
+        response, status = error_response(
+            CONFLICT_ERROR, "Conflict", 409, conflict=True
+        )
+        data = json.loads(response.get_data(as_text=True))
+        assert data["conflict"] is True
+        assert data["code"] == "CONFLICT_ERROR"
+
+    def test_message_is_sanitized(self):
+        from webui.backend.lib.error_codes import VALIDATION_ERROR, error_response
+
+        response, _ = error_response(
+            VALIDATION_ERROR, "<script>xss</script>Bad input", 400
+        )
+        data = json.loads(response.get_data(as_text=True))
+        assert "<script>" not in data["error"]
+
+    def test_path_redacted_in_response(self):
+        from webui.backend.lib.error_codes import SERVER_ERROR, error_response
+
+        response, _ = error_response(
+            SERVER_ERROR, "Error reading /etc/mothbox/config.txt", 500
+        )
+        data = json.loads(response.get_data(as_text=True))
+        assert "/etc/mothbox" not in data["error"]

--- a/Firmware/Tests/unit/test_error_codes.py
+++ b/Firmware/Tests/unit/test_error_codes.py
@@ -170,9 +170,7 @@ class TestErrorResponse:
     def test_extra_fields_included(self):
         from webui.backend.lib.error_codes import CONFLICT_ERROR, error_response
 
-        response, status = error_response(
-            CONFLICT_ERROR, "Conflict", 409, conflict=True
-        )
+        response, status = error_response(CONFLICT_ERROR, "Conflict", 409, conflict=True)
         data = json.loads(response.get_data(as_text=True))
         assert data["conflict"] is True
         assert data["code"] == "CONFLICT_ERROR"
@@ -180,17 +178,13 @@ class TestErrorResponse:
     def test_message_is_sanitized(self):
         from webui.backend.lib.error_codes import VALIDATION_ERROR, error_response
 
-        response, _ = error_response(
-            VALIDATION_ERROR, "<script>xss</script>Bad input", 400
-        )
+        response, _ = error_response(VALIDATION_ERROR, "<script>xss</script>Bad input", 400)
         data = json.loads(response.get_data(as_text=True))
         assert "<script>" not in data["error"]
 
     def test_path_redacted_in_response(self):
         from webui.backend.lib.error_codes import SERVER_ERROR, error_response
 
-        response, _ = error_response(
-            SERVER_ERROR, "Error reading /etc/mothbox/config.txt", 500
-        )
+        response, _ = error_response(SERVER_ERROR, "Error reading /etc/mothbox/config.txt", 500)
         data = json.loads(response.get_data(as_text=True))
         assert "/etc/mothbox" not in data["error"]

--- a/Firmware/Tests/unit/test_scheduler_ui_security.py
+++ b/Firmware/Tests/unit/test_scheduler_ui_security.py
@@ -35,11 +35,14 @@ class TestErrorMessageSanitization:
         from webui.backend.routes.scheduler_ui import _validate_location_params
 
         malicious_tz = "<script>alert('xss')</script>"
-        error, status = _validate_location_params(0.0, 0.0, malicious_tz)
+        with app.app_context():
+            result = _validate_location_params(0.0, 0.0, malicious_tz)
 
-        assert error is not None
+        assert result is not None
+        response, status = result
         assert status == 400
-        error_msg = error.get("error", "")
+        data = response.get_json()
+        error_msg = data.get("error", "")
         assert "<script>" not in error_msg
         assert "alert" not in error_msg
 
@@ -47,60 +50,63 @@ class TestErrorMessageSanitization:
         """Coordinate error messages should be safe."""
         from webui.backend.routes.scheduler_ui import _validate_location_params
 
-        error, status = _validate_location_params(999.0, 999.0, "UTC")
+        with app.app_context():
+            result = _validate_location_params(999.0, 999.0, "UTC")
 
-        assert error is not None
+        assert result is not None
+        response, status = result
         assert status == 400
-        error_msg = error.get("error", "")
+        data = response.get_json()
+        error_msg = data.get("error", "")
         assert "Invalid coordinates" in error_msg
 
-    def test_sanitize_error_message_strips_html(self):
-        """_sanitize_error_message should strip HTML tags."""
-        from webui.backend.routes.scheduler_ui import _sanitize_error_message
+    def test_sanitize_message_strips_html(self):
+        """sanitize_message() should strip HTML tags."""
+        from webui.backend.lib.error_codes import sanitize_message
 
         malicious = "<script>alert('xss')</script>Normal text<b>bold</b>"
-        sanitized = _sanitize_error_message(malicious)
+        sanitized = sanitize_message(malicious)
 
         assert "<script>" not in sanitized
         assert "<b>" not in sanitized
         assert "Normal text" in sanitized
         assert "bold" in sanitized
 
-    def test_sanitize_error_message_truncates_long_messages(self):
+    def test_sanitize_message_truncates_long_messages(self):
         """Long error messages should be truncated."""
-        from webui.backend.routes.scheduler_ui import _sanitize_error_message
+        from webui.backend.lib.error_codes import sanitize_message
 
         long_msg = "x" * 500
-        sanitized = _sanitize_error_message(long_msg)
+        sanitized = sanitize_message(long_msg)
 
         assert len(sanitized) <= 200
 
-    def test_sanitize_error_message_handles_none(self):
+    def test_sanitize_message_handles_none(self):
         """None input should return generic message."""
-        from webui.backend.routes.scheduler_ui import _sanitize_error_message
+        from webui.backend.lib.error_codes import sanitize_message
 
-        assert _sanitize_error_message(None) == "An error occurred"
+        assert sanitize_message(None) == "An error occurred"
 
-    def test_sanitize_error_message_handles_empty(self):
+    def test_sanitize_message_handles_empty(self):
         """Empty input should return generic message."""
-        from webui.backend.routes.scheduler_ui import _sanitize_error_message
+        from webui.backend.lib.error_codes import sanitize_message
 
-        assert _sanitize_error_message("") == "An error occurred"
+        assert sanitize_message("") == "An error occurred"
 
-    def test_sanitize_error_message_redacts_internal_paths(self):
+    def test_sanitize_message_redacts_internal_paths(self):
         """Internal file paths should be redacted."""
-        from webui.backend.routes.scheduler_ui import _sanitize_error_message
+        from webui.backend.lib.error_codes import sanitize_message
 
         msg = "Failed to read /etc/secrets/api_key.txt"
-        sanitized = _sanitize_error_message(msg)
+        sanitized = sanitize_message(msg)
 
         assert "/etc/secrets" not in sanitized
         assert "[path]" in sanitized
         assert "Failed to read" in sanitized
 
-    def test_sanitize_error_message_redacts_various_paths(self):
+    def test_sanitize_message_redacts_various_paths(self):
         """Various internal paths should be redacted."""
-        from webui.backend.routes.scheduler_ui import _sanitize_error_message
+        from webui.backend.lib.error_codes import sanitize_message
 
         test_cases = [
             "/var/log/mothbox.log",
@@ -112,7 +118,7 @@ class TestErrorMessageSanitization:
         ]
         for path in test_cases:
             msg = f"Error at {path}"
-            sanitized = _sanitize_error_message(msg)
+            sanitized = sanitize_message(msg)
             # Original path should be redacted
             assert path not in sanitized, f"Path {path} should be redacted"
             assert "[path]" in sanitized

--- a/Firmware/docs/plans/2026-02-15-standardize-error-codes-design.md
+++ b/Firmware/docs/plans/2026-02-15-standardize-error-codes-design.md
@@ -1,0 +1,101 @@
+# Design: Standardize Error Codes Across Backend/Frontend (#388)
+
+## Problem
+
+Backend routes return errors in inconsistent formats — some use `{"error": "msg"}`, some add `{"error": "msg", "message": "detail"}`, and only `scheduler_ui.py` includes structured error codes. The frontend has to guess error types from HTTP status codes or parse message strings. There are 517 error responses across 17 route files.
+
+## Decision
+
+- **Scope**: All route files, rolled out incrementally
+- **This PR**: Shared module + scheduler migration + frontend update
+- **Follow-up PRs**: Remaining 16 route files in logical batches
+
+## Architecture
+
+### Backend: `webui/backend/lib/error_codes.py`
+
+Single source of truth for error codes, sanitization, and response helper.
+
+**Error codes:**
+
+| Code | Typical HTTP Status | Usage |
+|------|-------------------|-------|
+| `VALIDATION_ERROR` | 400 | Invalid input, bad parameters |
+| `NOT_FOUND` | 404 | Resource doesn't exist |
+| `CONFLICT_ERROR` | 409 | Schedule conflict, duplicate resource |
+| `ACTIVATION_ERROR` | 400 | Schedule activation failure |
+| `RATE_LIMIT_ERROR` | 429 | Too many requests |
+| `HARDWARE_ERROR` | 503 | Camera/GPIO/sensor unavailable |
+| `STORAGE_ERROR` | 500 | Disk full, file I/O failure |
+| `PERMISSION_ERROR` | 403 | Path traversal, forbidden access |
+| `SERVER_ERROR` | 500 | Catch-all internal error |
+
+**Helper function:**
+
+```python
+def error_response(code: str, message: str, status: int = 400) -> tuple:
+    """Return a standardized JSON error response."""
+    safe_message = sanitize_error_message(message)
+    return jsonify({"error": safe_message, "code": code}), status
+```
+
+**Sanitization:** `_sanitize_error_message()` moves from `scheduler_ui.py` to `error_codes.py` as the shared `sanitize_error_message()`. Strips HTML, redacts internal paths, truncates to 200 chars.
+
+### Frontend: `webui/frontend/src/utils/errorCodes.js`
+
+Mirrors backend codes with user-friendly message mapping.
+
+```javascript
+export const ERROR_CODES = {
+  VALIDATION_ERROR: 'VALIDATION_ERROR',
+  NOT_FOUND: 'NOT_FOUND',
+  // ... all codes
+};
+
+export const ERROR_MESSAGES = {
+  VALIDATION_ERROR: 'Please fix the errors above.',
+  NOT_FOUND: 'Resource not found. It may have been deleted.',
+  // ... user-friendly messages for each code
+  NETWORK_ERROR: 'Unable to connect. Please check your connection.',
+};
+
+export function getErrorMessage(error) { /* code -> message mapping with fallback */ }
+```
+
+**ScheduleEditor.jsx** removes inline `KNOWN_ERROR_CODES` and `sanitizeErrorMessage()`, imports from `errorCodes.js`. The existing `errorMessages.js` (form field validation messages) stays unchanged.
+
+### Response Format
+
+All error responses follow this structure:
+
+```json
+{
+  "error": "User-readable sanitized message",
+  "code": "ERROR_CODE_CONSTANT"
+}
+```
+
+Backwards compatible — the `error` field (already present in all routes) stays the same. The `code` field is additive.
+
+## Scheduler Migration
+
+- Remove `ERROR_CODES` dict from `scheduler_ui.py` (lines 55-63)
+- Remove `_sanitize_error_message()` from `scheduler_ui.py` (lines 116-153)
+- Import `error_response`, `sanitize_error_message`, and codes from `error_codes.py`
+- Replace 17 `jsonify({"error": ..., "code": ...})` calls with `error_response(...)`
+
+## Testing
+
+- Unit tests for `error_codes.py`: response format, sanitization, all code constants
+- Existing scheduler tests verify backward-compatible format
+- Frontend: existing ScheduleEditor error handling tests still pass
+
+## Follow-up Work
+
+Migrate remaining route files in batches:
+1. `camera.py`, `gpio.py`, `system.py` (hardware)
+2. `gallery.py`, `photos.py`, `metadata.py` (media)
+3. `deployment.py`, `sidecar.py`, `config.py` (config)
+4. `export.py`, `export_presets.py` (export)
+5. `search.py`, `gps.py`, `gps_exif.py` (search/GPS)
+6. `preferences.py`, `scheduler.py` (misc)

--- a/Firmware/docs/plans/2026-02-15-standardize-error-codes.md
+++ b/Firmware/docs/plans/2026-02-15-standardize-error-codes.md
@@ -1,0 +1,671 @@
+# Standardize Error Codes Across Backend/Frontend (#388) — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Create a shared error codes module for backend and frontend, migrate scheduler_ui.py as first adopter, and update frontend error handling to use the shared module.
+
+**Architecture:** New `webui/backend/lib/error_codes.py` defines error code constants, a message sanitizer (HTML stripping + path redaction), and an `error_response()` helper that returns standardized `{"error": "...", "code": "..."}` JSON. Frontend gets `webui/frontend/src/utils/errorCodes.js` mirroring the codes with user-friendly messages. `scheduler_ui.py` migrates from inline constants to the shared module.
+
+**Tech Stack:** Python/Flask (backend), JavaScript/React (frontend), pytest (testing)
+
+**Important context:**
+- `security_utils.py` already has a `sanitize_error_message(error, generic_message)` that logs exceptions and returns generic messages. The new module's sanitizer is different — it sanitizes string content (strips HTML, redacts paths). Named `sanitize_message()` to avoid confusion.
+- Some scheduler error responses include extra fields (`"message"`, `"conflict": True`). The helper supports `**kwargs` for extra fields.
+- No existing tests assert on the `"code"` field, so migration is backward-compatible.
+- `_validate_location_params()` in scheduler_ui.py calls `_sanitize_error_message()` directly — must update to import from shared module.
+
+---
+
+### Task 1: Create shared error codes module with tests (TDD)
+
+**Files:**
+- Create: `webui/backend/lib/error_codes.py`
+- Create: `Tests/unit/test_error_codes.py`
+
+**Step 1: Write the failing tests**
+
+Create `Tests/unit/test_error_codes.py`:
+
+```python
+"""Tests for shared error codes module."""
+
+import json
+
+import pytest
+
+
+class TestErrorCodes:
+    """Test error code constants."""
+
+    def test_all_codes_are_strings(self):
+        from webui.backend.lib.error_codes import ERROR_CODES
+
+        for key, value in ERROR_CODES.items():
+            assert isinstance(value, str), f"{key} should be a string"
+            assert value == key, f"Value should match key: {key}"
+
+    def test_required_codes_exist(self):
+        from webui.backend.lib.error_codes import ERROR_CODES
+
+        required = [
+            "VALIDATION_ERROR",
+            "NOT_FOUND",
+            "CONFLICT_ERROR",
+            "ACTIVATION_ERROR",
+            "RATE_LIMIT_ERROR",
+            "HARDWARE_ERROR",
+            "STORAGE_ERROR",
+            "PERMISSION_ERROR",
+            "SERVER_ERROR",
+        ]
+        for code in required:
+            assert code in ERROR_CODES, f"Missing required code: {code}"
+
+    def test_codes_importable_as_module_attributes(self):
+        from webui.backend.lib.error_codes import (
+            ACTIVATION_ERROR,
+            CONFLICT_ERROR,
+            HARDWARE_ERROR,
+            NOT_FOUND,
+            PERMISSION_ERROR,
+            RATE_LIMIT_ERROR,
+            SERVER_ERROR,
+            STORAGE_ERROR,
+            VALIDATION_ERROR,
+        )
+
+        assert VALIDATION_ERROR == "VALIDATION_ERROR"
+        assert NOT_FOUND == "NOT_FOUND"
+        assert CONFLICT_ERROR == "CONFLICT_ERROR"
+        assert ACTIVATION_ERROR == "ACTIVATION_ERROR"
+        assert RATE_LIMIT_ERROR == "RATE_LIMIT_ERROR"
+        assert HARDWARE_ERROR == "HARDWARE_ERROR"
+        assert STORAGE_ERROR == "STORAGE_ERROR"
+        assert PERMISSION_ERROR == "PERMISSION_ERROR"
+        assert SERVER_ERROR == "SERVER_ERROR"
+
+
+class TestSanitizeMessage:
+    """Test message sanitization for safe display."""
+
+    def test_strips_html_tags(self):
+        from webui.backend.lib.error_codes import sanitize_message
+
+        assert sanitize_message("<b>bold</b> text") == "bold text"
+
+    def test_strips_script_tags(self):
+        from webui.backend.lib.error_codes import sanitize_message
+
+        result = sanitize_message("<script>alert('xss')</script>hello")
+        assert "<script>" not in result
+        assert "hello" in result
+
+    def test_strips_incomplete_tags(self):
+        from webui.backend.lib.error_codes import sanitize_message
+
+        result = sanitize_message("text <script without closing")
+        assert "<" not in result
+
+    def test_redacts_internal_paths(self):
+        from webui.backend.lib.error_codes import sanitize_message
+
+        result = sanitize_message("Error reading /etc/secrets/key.pem")
+        assert "/etc/secrets" not in result
+        assert "[path]" in result
+
+    def test_redacts_var_paths(self):
+        from webui.backend.lib.error_codes import sanitize_message
+
+        result = sanitize_message("File not found: /var/lib/mothbox/data.json")
+        assert "/var/lib" not in result
+
+    def test_redacts_home_paths(self):
+        from webui.backend.lib.error_codes import sanitize_message
+
+        result = sanitize_message("Error in /home/pi/Desktop/Mothbox/config")
+        assert "/home/pi" not in result
+
+    def test_truncates_long_messages(self):
+        from webui.backend.lib.error_codes import sanitize_message
+
+        long_msg = "x" * 300
+        result = sanitize_message(long_msg)
+        assert len(result) <= 200
+        assert result.endswith("...")
+
+    def test_custom_max_length(self):
+        from webui.backend.lib.error_codes import sanitize_message
+
+        result = sanitize_message("x" * 100, max_length=50)
+        assert len(result) <= 50
+
+    def test_none_returns_default(self):
+        from webui.backend.lib.error_codes import sanitize_message
+
+        assert sanitize_message(None) == "An error occurred"
+
+    def test_empty_string_returns_default(self):
+        from webui.backend.lib.error_codes import sanitize_message
+
+        assert sanitize_message("") == "An error occurred"
+
+    def test_normal_message_unchanged(self):
+        from webui.backend.lib.error_codes import sanitize_message
+
+        assert sanitize_message("Schedule not found") == "Schedule not found"
+
+
+class TestErrorResponse:
+    """Test error_response helper produces correct JSON format."""
+
+    @pytest.fixture(autouse=True)
+    def _flask_app(self):
+        """Create minimal Flask app for jsonify context."""
+        from flask import Flask
+
+        app = Flask(__name__)
+        with app.app_context():
+            yield app
+
+    def test_basic_error_response(self):
+        from webui.backend.lib.error_codes import VALIDATION_ERROR, error_response
+
+        response, status = error_response(VALIDATION_ERROR, "Bad input", 400)
+        data = json.loads(response.get_data(as_text=True))
+        assert data["error"] == "Bad input"
+        assert data["code"] == "VALIDATION_ERROR"
+        assert status == 400
+
+    def test_default_status_is_400(self):
+        from webui.backend.lib.error_codes import VALIDATION_ERROR, error_response
+
+        _, status = error_response(VALIDATION_ERROR, "Bad input")
+        assert status == 400
+
+    def test_server_error_status(self):
+        from webui.backend.lib.error_codes import SERVER_ERROR, error_response
+
+        _, status = error_response(SERVER_ERROR, "Internal error", 500)
+        assert status == 500
+
+    def test_not_found_status(self):
+        from webui.backend.lib.error_codes import NOT_FOUND, error_response
+
+        response, status = error_response(NOT_FOUND, "Schedule not found", 404)
+        data = json.loads(response.get_data(as_text=True))
+        assert data["code"] == "NOT_FOUND"
+        assert status == 404
+
+    def test_extra_fields_included(self):
+        from webui.backend.lib.error_codes import CONFLICT_ERROR, error_response
+
+        response, status = error_response(
+            CONFLICT_ERROR, "Conflict", 409, conflict=True
+        )
+        data = json.loads(response.get_data(as_text=True))
+        assert data["conflict"] is True
+        assert data["code"] == "CONFLICT_ERROR"
+
+    def test_message_is_sanitized(self):
+        from webui.backend.lib.error_codes import VALIDATION_ERROR, error_response
+
+        response, _ = error_response(
+            VALIDATION_ERROR, "<script>xss</script>Bad input", 400
+        )
+        data = json.loads(response.get_data(as_text=True))
+        assert "<script>" not in data["error"]
+
+    def test_path_redacted_in_response(self):
+        from webui.backend.lib.error_codes import SERVER_ERROR, error_response
+
+        response, _ = error_response(
+            SERVER_ERROR, "Error reading /etc/mothbox/config.txt", 500
+        )
+        data = json.loads(response.get_data(as_text=True))
+        assert "/etc/mothbox" not in data["error"]
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest Tests/unit/test_error_codes.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'webui.backend.lib.error_codes'`
+
+**Step 3: Write minimal implementation**
+
+Create `webui/backend/lib/error_codes.py`:
+
+```python
+"""
+Shared error codes and response helpers for the Mothbox API.
+
+Provides standardized error code constants, message sanitization,
+and a response helper to ensure consistent error JSON format across
+all backend routes.
+
+Usage:
+    from webui.backend.lib.error_codes import (
+        error_response, sanitize_message,
+        VALIDATION_ERROR, NOT_FOUND, SERVER_ERROR,
+    )
+
+    return error_response(VALIDATION_ERROR, "Invalid input", 400)
+    # Returns: (jsonify({"error": "Invalid input", "code": "VALIDATION_ERROR"}), 400)
+
+Issue #388 - Standardize error codes across backend/frontend
+"""
+
+import re
+
+from flask import jsonify
+
+# ---------------------------------------------------------------------------
+# Error code constants
+# ---------------------------------------------------------------------------
+# Each constant is its own string value, usable as both dict key and JSON value.
+
+VALIDATION_ERROR = "VALIDATION_ERROR"
+NOT_FOUND = "NOT_FOUND"
+CONFLICT_ERROR = "CONFLICT_ERROR"
+ACTIVATION_ERROR = "ACTIVATION_ERROR"
+RATE_LIMIT_ERROR = "RATE_LIMIT_ERROR"
+HARDWARE_ERROR = "HARDWARE_ERROR"
+STORAGE_ERROR = "STORAGE_ERROR"
+PERMISSION_ERROR = "PERMISSION_ERROR"
+SERVER_ERROR = "SERVER_ERROR"
+
+# Convenience dict for iteration / membership checks
+ERROR_CODES = {
+    VALIDATION_ERROR: VALIDATION_ERROR,
+    NOT_FOUND: NOT_FOUND,
+    CONFLICT_ERROR: CONFLICT_ERROR,
+    ACTIVATION_ERROR: ACTIVATION_ERROR,
+    RATE_LIMIT_ERROR: RATE_LIMIT_ERROR,
+    HARDWARE_ERROR: HARDWARE_ERROR,
+    STORAGE_ERROR: STORAGE_ERROR,
+    PERMISSION_ERROR: PERMISSION_ERROR,
+    SERVER_ERROR: SERVER_ERROR,
+}
+
+
+# ---------------------------------------------------------------------------
+# Message sanitization
+# ---------------------------------------------------------------------------
+# NOTE: This is distinct from security_utils.sanitize_error_message(), which
+# takes an Exception and returns a generic message (hiding all details).
+# This function sanitizes a *string* for safe display while preserving
+# meaningful content: strips HTML tags, redacts internal file paths, truncates.
+
+
+def sanitize_message(message: str | None, max_length: int = 200) -> str:
+    """
+    Sanitize an error message string for safe display to users.
+
+    Strips HTML tags (defense-in-depth against XSS), redacts internal
+    file paths (prevents information disclosure), and truncates long messages.
+
+    Args:
+        message: Raw error message (may contain user input or internal details)
+        max_length: Maximum length before truncation (default 200)
+
+    Returns:
+        Sanitized message safe for display, or "An error occurred" for empty input
+    """
+    if not message:
+        return "An error occurred"
+
+    msg = str(message)
+
+    # Strip HTML tags iteratively (handles nested/malformed tags)
+    prev_len = -1
+    while len(msg) != prev_len:
+        prev_len = len(msg)
+        msg = re.sub(r"<[^>]*>", "", msg)
+        msg = re.sub(r"<[^>]*$", "", msg)  # Incomplete tags
+
+    # Redact internal file paths to prevent information disclosure
+    msg = re.sub(r"/(?:etc|var|home|opt|usr|tmp|root)/[^\s'\"]*", "[path]", msg)
+
+    if len(msg) > max_length:
+        msg = msg[: max_length - 3] + "..."
+
+    return msg.strip() or "An error occurred"
+
+
+# ---------------------------------------------------------------------------
+# Response helper
+# ---------------------------------------------------------------------------
+
+
+def error_response(
+    code: str, message: str, status: int = 400, **extra
+) -> tuple:
+    """
+    Return a standardized JSON error response.
+
+    Produces: ``(jsonify({"error": "<sanitized>", "code": "<CODE>", ...}), status)``
+
+    Args:
+        code: Error code constant (e.g., ``VALIDATION_ERROR``)
+        message: Human-readable error description (will be sanitized)
+        status: HTTP status code (default 400)
+        **extra: Additional fields to include in the response JSON
+                 (e.g., ``conflict=True``, ``message="detail"``)
+
+    Returns:
+        Tuple of (Flask Response, int) suitable for returning from a route
+    """
+    body = {"error": sanitize_message(message), "code": code, **extra}
+    return jsonify(body), status
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest Tests/unit/test_error_codes.py -v`
+Expected: All 20 tests PASS
+
+**Step 5: Commit**
+
+```bash
+git add webui/backend/lib/error_codes.py Tests/unit/test_error_codes.py
+git commit -m "feat: add shared error codes module with response helper (#388)"
+```
+
+---
+
+### Task 2: Migrate scheduler_ui.py to shared module
+
+**Files:**
+- Modify: `webui/backend/routes/scheduler_ui.py`
+- Test: `Tests/unit/test_scheduler_ui_routes.py` (existing)
+
+**Step 1: Run existing scheduler tests to establish baseline**
+
+Run: `python3 -m pytest Tests/unit/test_scheduler_ui_routes.py -v`
+Expected: All tests PASS (baseline)
+
+**Step 2: Update imports in scheduler_ui.py**
+
+Add import at top of file (after existing imports, around line 53):
+
+```python
+from webui.backend.lib.error_codes import (
+    ACTIVATION_ERROR,
+    CONFLICT_ERROR,
+    NOT_FOUND,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+    sanitize_message,
+)
+```
+
+**Step 3: Remove inline ERROR_CODES dict**
+
+Delete lines 55-63 (the `ERROR_CODES = { ... }` dict and its comment).
+
+**Step 4: Remove inline _sanitize_error_message function**
+
+Delete lines 116-153 (the `_sanitize_error_message` function and its docstring).
+
+**Step 5: Update _validate_location_params to use shared sanitizer**
+
+Change the two calls from `_sanitize_error_message(...)` to `sanitize_message(...)`:
+- Line ~100: `safe_error = sanitize_message(coord_error)`
+- Line ~1566: `safe_error = sanitize_message(coord_error)`
+
+**Step 6: Replace all jsonify error responses with error_response()**
+
+There are 25 error responses to migrate. The pattern is:
+
+**Before:**
+```python
+return jsonify(
+    {
+        "error": "Schedule not found",
+        "code": ERROR_CODES["NOT_FOUND"],
+    }
+), 404
+```
+
+**After:**
+```python
+return error_response(NOT_FOUND, "Schedule not found", 404)
+```
+
+**For responses with extra fields:**
+```python
+# Before:
+return jsonify(
+    {
+        "error": "Internal server error",
+        "code": ERROR_CODES["SERVER_ERROR"],
+        "message": "Failed to generate preview",
+    }
+), 500
+
+# After:
+return error_response(SERVER_ERROR, "Internal server error", 500, message="Failed to generate preview")
+```
+
+**For responses with conflict flag:**
+```python
+# Before:
+return jsonify(
+    {
+        "error": "Schedule conflict detected",
+        "code": ERROR_CODES["CONFLICT_ERROR"],
+        "conflict": True,
+    }
+), 409
+
+# After:
+return error_response(CONFLICT_ERROR, "Schedule conflict detected", 409, conflict=True)
+```
+
+**Important:** Some error responses do NOT have a `"code"` field (e.g., line 396 `ValueError` handler, line 741 generic failure). These should also be converted to use `error_response()` with appropriate codes:
+- `ValueError` in preview → `error_response(VALIDATION_ERROR, "Preview generation failed", 400)`
+- Generic "Failed to create schedule" → `error_response(SERVER_ERROR, "Failed to create schedule", 500)`
+
+**Step 7: Run existing tests to verify no regressions**
+
+Run: `python3 -m pytest Tests/unit/test_scheduler_ui_routes.py -v`
+Expected: All tests PASS (response format is backward-compatible)
+
+**Step 8: Run ruff on modified file**
+
+Run: `ruff check webui/backend/routes/scheduler_ui.py`
+Expected: No errors (unused ERROR_CODES import removed)
+
+**Step 9: Commit**
+
+```bash
+git add webui/backend/routes/scheduler_ui.py
+git commit -m "refactor: migrate scheduler_ui.py to shared error codes (#388)"
+```
+
+---
+
+### Task 3: Create frontend error codes module
+
+**Files:**
+- Create: `webui/frontend/src/utils/errorCodes.js`
+
+**Step 1: Create the shared frontend module**
+
+Create `webui/frontend/src/utils/errorCodes.js`:
+
+```javascript
+/**
+ * Shared error codes and message mapping for the Mothbox API.
+ *
+ * Mirrors backend error codes from webui/backend/lib/error_codes.py.
+ * Use getErrorMessage() to extract user-friendly messages from API errors.
+ *
+ * Issue #388 - Standardize error codes across backend/frontend
+ *
+ * @module utils/errorCodes
+ */
+
+/**
+ * Error code constants matching the backend.
+ * Used for programmatic error handling (e.g., switch statements).
+ */
+export const ERROR_CODES = {
+  VALIDATION_ERROR: 'VALIDATION_ERROR',
+  NOT_FOUND: 'NOT_FOUND',
+  CONFLICT_ERROR: 'CONFLICT_ERROR',
+  ACTIVATION_ERROR: 'ACTIVATION_ERROR',
+  RATE_LIMIT_ERROR: 'RATE_LIMIT_ERROR',
+  HARDWARE_ERROR: 'HARDWARE_ERROR',
+  STORAGE_ERROR: 'STORAGE_ERROR',
+  PERMISSION_ERROR: 'PERMISSION_ERROR',
+  SERVER_ERROR: 'SERVER_ERROR',
+  // Client-side only (no backend equivalent)
+  NETWORK_ERROR: 'NETWORK_ERROR',
+  TIMEOUT_ERROR: 'TIMEOUT_ERROR',
+};
+
+/**
+ * User-friendly messages for each error code.
+ * These are shown to the user when an API error occurs.
+ */
+export const ERROR_MESSAGES = {
+  [ERROR_CODES.VALIDATION_ERROR]: 'Please fix the errors above.',
+  [ERROR_CODES.NOT_FOUND]: 'Resource not found. It may have been deleted.',
+  [ERROR_CODES.CONFLICT_ERROR]: 'Schedule has conflicts that must be resolved.',
+  [ERROR_CODES.ACTIVATION_ERROR]: 'Failed to activate schedule.',
+  [ERROR_CODES.RATE_LIMIT_ERROR]: 'Too many requests. Please wait a moment.',
+  [ERROR_CODES.HARDWARE_ERROR]: 'Hardware unavailable. Please check connections.',
+  [ERROR_CODES.STORAGE_ERROR]: 'Storage error. Check available disk space.',
+  [ERROR_CODES.PERMISSION_ERROR]: 'Permission denied.',
+  [ERROR_CODES.SERVER_ERROR]: 'Server error. Please try again later.',
+  [ERROR_CODES.NETWORK_ERROR]: 'Unable to save. Please check your connection.',
+  [ERROR_CODES.TIMEOUT_ERROR]: 'Request timed out. Please try again.',
+};
+
+/**
+ * Sanitize an error message string for safe display.
+ *
+ * Strips HTML tags (defense-in-depth — React escapes by default)
+ * and truncates long messages.
+ *
+ * @param {string} message - Raw error message
+ * @param {number} [maxLength=200] - Maximum message length
+ * @returns {string} Sanitized message
+ */
+export function sanitizeMessage(message, maxLength = 200) {
+  if (!message) return 'An unexpected error occurred.';
+  let msg = String(message);
+
+  // Strip HTML tags iteratively (handles incomplete/malformed tags)
+  let previousLength;
+  do {
+    previousLength = msg.length;
+    msg = msg.replace(/<[^>]*>?/g, '');
+  } while (msg.length < previousLength);
+
+  return msg.length > maxLength ? msg.slice(0, maxLength) + '...' : msg;
+}
+
+/**
+ * Extract a user-friendly error message from an API error.
+ *
+ * Checks for known error codes first (from API response or error object),
+ * then falls back to the server-provided error message (sanitized),
+ * then to a generic fallback.
+ *
+ * @param {Error|Object} error - Axios error or error-like object
+ * @param {string} [fallback='An unexpected error occurred.'] - Fallback message
+ * @returns {string} User-friendly error message
+ */
+export function getErrorMessage(error, fallback = 'An unexpected error occurred.') {
+  // Check for known error code from API response (axios pattern)
+  const apiCode = error?.response?.data?.code;
+  if (apiCode && ERROR_MESSAGES[apiCode]) {
+    return ERROR_MESSAGES[apiCode];
+  }
+
+  // Check for known error code on the error object itself
+  if (error?.code && ERROR_MESSAGES[error.code]) {
+    return ERROR_MESSAGES[error.code];
+  }
+
+  // Fall back to server-provided message, sanitized
+  const rawMessage = error?.response?.data?.error || error?.message;
+  if (rawMessage) {
+    return sanitizeMessage(rawMessage);
+  }
+
+  return fallback;
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add webui/frontend/src/utils/errorCodes.js
+git commit -m "feat: add frontend error codes module mirroring backend (#388)"
+```
+
+---
+
+### Task 4: Migrate ScheduleEditor.jsx to shared module
+
+**Files:**
+- Modify: `webui/frontend/src/components/scheduler/ScheduleEditor/ScheduleEditor.jsx`
+
+**Step 1: Add import for shared module**
+
+Add at top of file (with other utility imports, after line 11):
+
+```javascript
+import { getErrorMessage } from '../../../utils/errorCodes';
+```
+
+**Step 2: Remove inline KNOWN_ERROR_CODES**
+
+Delete the `KNOWN_ERROR_CODES` object (lines 23-30) and its JSDoc comment (lines 18-22).
+
+**Step 3: Remove inline sanitizeErrorMessage**
+
+Delete the `sanitizeErrorMessage` function (lines 47-75) and its JSDoc comment (lines 32-46).
+
+**Step 4: Update all call sites**
+
+Find all uses of `sanitizeErrorMessage(...)` in the file and replace with `getErrorMessage(...)`. Search for the pattern. The function signature is compatible — both accept an error object and return a string.
+
+**Step 5: Run frontend lint**
+
+Run: `cd webui/frontend && npx eslint src/components/scheduler/ScheduleEditor/ScheduleEditor.jsx`
+Expected: No errors about unused imports or missing functions
+
+**Step 6: Commit**
+
+```bash
+git add webui/frontend/src/components/scheduler/ScheduleEditor/ScheduleEditor.jsx
+git commit -m "refactor: migrate ScheduleEditor to shared error codes module (#388)"
+```
+
+---
+
+### Task 5: Final verification
+
+**Step 1: Run backend linting**
+
+Run: `ruff check webui/backend/lib/error_codes.py webui/backend/routes/scheduler_ui.py`
+Expected: No errors
+
+**Step 2: Run backend tests**
+
+Run: `python3 -m pytest Tests/unit/test_error_codes.py Tests/unit/test_scheduler_ui_routes.py Tests/unit/test_scheduler_ui_security.py -v`
+Expected: All tests PASS
+
+**Step 3: Run security scan**
+
+Run: `bandit -c pyproject.toml -r webui/backend/lib/error_codes.py`
+Expected: No issues
+
+**Step 4: Build frontend**
+
+Run: `cd webui/frontend && npm run build`
+Expected: Build succeeds with no errors

--- a/Firmware/webui/backend/lib/error_codes.py
+++ b/Firmware/webui/backend/lib/error_codes.py
@@ -1,0 +1,121 @@
+"""
+Shared error codes and response helpers for the Mothbox API.
+
+Provides standardized error code constants, message sanitization,
+and a response helper to ensure consistent error JSON format across
+all backend routes.
+
+Usage:
+    from webui.backend.lib.error_codes import (
+        error_response, sanitize_message,
+        VALIDATION_ERROR, NOT_FOUND, SERVER_ERROR,
+    )
+
+    return error_response(VALIDATION_ERROR, "Invalid input", 400)
+    # Returns: (jsonify({"error": "Invalid input", "code": "VALIDATION_ERROR"}), 400)
+
+Issue #388 - Standardize error codes across backend/frontend
+"""
+
+import re
+
+from flask import jsonify
+
+# ---------------------------------------------------------------------------
+# Error code constants
+# ---------------------------------------------------------------------------
+# Each constant is its own string value, usable as both dict key and JSON value.
+
+VALIDATION_ERROR = "VALIDATION_ERROR"
+NOT_FOUND = "NOT_FOUND"
+CONFLICT_ERROR = "CONFLICT_ERROR"
+ACTIVATION_ERROR = "ACTIVATION_ERROR"
+RATE_LIMIT_ERROR = "RATE_LIMIT_ERROR"
+HARDWARE_ERROR = "HARDWARE_ERROR"
+STORAGE_ERROR = "STORAGE_ERROR"
+PERMISSION_ERROR = "PERMISSION_ERROR"
+SERVER_ERROR = "SERVER_ERROR"
+
+# Convenience dict for iteration / membership checks
+ERROR_CODES = {
+    VALIDATION_ERROR: VALIDATION_ERROR,
+    NOT_FOUND: NOT_FOUND,
+    CONFLICT_ERROR: CONFLICT_ERROR,
+    ACTIVATION_ERROR: ACTIVATION_ERROR,
+    RATE_LIMIT_ERROR: RATE_LIMIT_ERROR,
+    HARDWARE_ERROR: HARDWARE_ERROR,
+    STORAGE_ERROR: STORAGE_ERROR,
+    PERMISSION_ERROR: PERMISSION_ERROR,
+    SERVER_ERROR: SERVER_ERROR,
+}
+
+
+# ---------------------------------------------------------------------------
+# Message sanitization
+# ---------------------------------------------------------------------------
+# NOTE: This is distinct from security_utils.sanitize_error_message(), which
+# takes an Exception and returns a generic message (hiding all details).
+# This function sanitizes a *string* for safe display while preserving
+# meaningful content: strips HTML tags, redacts internal file paths, truncates.
+
+
+def sanitize_message(message: str | None, max_length: int = 200) -> str:
+    """
+    Sanitize an error message string for safe display to users.
+
+    Strips HTML tags (defense-in-depth against XSS), redacts internal
+    file paths (prevents information disclosure), and truncates long messages.
+
+    Args:
+        message: Raw error message (may contain user input or internal details)
+        max_length: Maximum length before truncation (default 200)
+
+    Returns:
+        Sanitized message safe for display, or "An error occurred" for empty input
+    """
+    if not message:
+        return "An error occurred"
+
+    msg = str(message)
+
+    # Strip HTML tags iteratively (handles nested/malformed tags)
+    prev_len = -1
+    while len(msg) != prev_len:
+        prev_len = len(msg)
+        msg = re.sub(r"<[^>]*>", "", msg)
+        msg = re.sub(r"<[^>]*$", "", msg)  # Incomplete tags
+
+    # Redact internal file paths to prevent information disclosure
+    msg = re.sub(r"/(?:etc|var|home|opt|usr|tmp|root)/[^\s'\"]*", "[path]", msg)
+
+    if len(msg) > max_length:
+        msg = msg[: max_length - 3] + "..."
+
+    return msg.strip() or "An error occurred"
+
+
+# ---------------------------------------------------------------------------
+# Response helper
+# ---------------------------------------------------------------------------
+
+
+def error_response(
+    code: str, message: str, status: int = 400, **extra
+) -> tuple:
+    """
+    Return a standardized JSON error response.
+
+    Produces: ``(jsonify({"error": "<sanitized>", "code": "<CODE>", ...}), status)``
+
+    Args:
+        code: Error code constant (e.g., ``VALIDATION_ERROR``)
+        message: Human-readable error description (will be sanitized)
+        status: HTTP status code (default 400)
+        **extra: Additional fields to include in the response JSON
+                 (e.g., ``conflict=True``, ``message="detail"``)
+
+    Returns:
+        Tuple of (Flask Response, int) suitable for returning from a route
+    """
+    body = {"error": sanitize_message(message), "code": code, **extra}
+    return jsonify(body), status

--- a/Firmware/webui/backend/lib/error_codes.py
+++ b/Firmware/webui/backend/lib/error_codes.py
@@ -99,9 +99,7 @@ def sanitize_message(message: str | None, max_length: int = 200) -> str:
 # ---------------------------------------------------------------------------
 
 
-def error_response(
-    code: str, message: str, status: int = 400, **extra
-) -> tuple:
+def error_response(code: str, message: str, status: int = 400, **extra) -> tuple:
     """
     Return a standardized JSON error response.
 

--- a/Firmware/webui/backend/lib/error_codes.py
+++ b/Firmware/webui/backend/lib/error_codes.py
@@ -58,6 +58,10 @@ ERROR_CODES = {
 # This function sanitizes a *string* for safe display while preserving
 # meaningful content: strips HTML tags, redacts internal file paths, truncates.
 
+_HTML_TAG_RE = re.compile(r"<[^>]*>")
+_INCOMPLETE_TAG_RE = re.compile(r"<[^>]*$")
+_PATH_RE = re.compile(r"/(?:etc|var|home|opt|usr|tmp|root)/[^\s'\"]*")
+
 
 def sanitize_message(message: str | None, max_length: int = 200) -> str:
     """
@@ -79,14 +83,17 @@ def sanitize_message(message: str | None, max_length: int = 200) -> str:
     msg = str(message)
 
     # Strip HTML tags iteratively (handles nested/malformed tags)
+    # Cap iterations to prevent ReDoS on adversarial input
     prev_len = -1
-    while len(msg) != prev_len:
+    iterations = 0
+    while len(msg) != prev_len and iterations < 10:
+        iterations += 1
         prev_len = len(msg)
-        msg = re.sub(r"<[^>]*>", "", msg)
-        msg = re.sub(r"<[^>]*$", "", msg)  # Incomplete tags
+        msg = _HTML_TAG_RE.sub("", msg)
+        msg = _INCOMPLETE_TAG_RE.sub("", msg)  # Incomplete tags
 
     # Redact internal file paths to prevent information disclosure
-    msg = re.sub(r"/(?:etc|var|home|opt|usr|tmp|root)/[^\s'\"]*", "[path]", msg)
+    msg = _PATH_RE.sub("[path]", msg)
 
     if len(msg) > max_length:
         msg = msg[: max_length - 3] + "..."

--- a/Firmware/webui/backend/routes/scheduler_ui.py
+++ b/Firmware/webui/backend/routes/scheduler_ui.py
@@ -33,6 +33,7 @@ from webui.backend.lib.error_codes import (
     ACTIVATION_ERROR,
     CONFLICT_ERROR,
     NOT_FOUND,
+    PERMISSION_ERROR,
     SERVER_ERROR,
     VALIDATION_ERROR,
     error_response,
@@ -728,7 +729,7 @@ def update_schedule(schedule_id: str, json_data: dict) -> tuple[Response, int]:
             # Built-in schedule protection - intentionally returns generic message
             # (not str(e)) to avoid exposing internal details
             logger.warning(f"Update blocked for built-in schedule: {e}")
-            return error_response(VALIDATION_ERROR, "Cannot modify built-in schedule", 403)
+            return error_response(PERMISSION_ERROR, "Cannot modify built-in schedule", 403)
         except ScheduleValidationError as e:
             logger.warning(f"Schedule validation failed: {e}")
             return error_response(VALIDATION_ERROR, "Validation failed", 400)
@@ -779,7 +780,7 @@ def delete_schedule(schedule_id: str) -> tuple[Response, int]:
         except ValueError as e:
             # Built-in schedule protection
             logger.warning(f"Delete blocked for built-in schedule: {e}")
-            return error_response(VALIDATION_ERROR, "Cannot delete built-in schedule", 403)
+            return error_response(PERMISSION_ERROR, "Cannot delete built-in schedule", 403)
 
         if not success:
             return error_response(SERVER_ERROR, "Failed to delete schedule", 500)

--- a/Firmware/webui/backend/routes/scheduler_ui.py
+++ b/Firmware/webui/backend/routes/scheduler_ui.py
@@ -15,7 +15,6 @@ Issue #310 - API terminology update (Schema 3.0)
 """
 
 import logging
-import re
 import subprocess
 from datetime import UTC, datetime
 from functools import wraps
@@ -29,6 +28,15 @@ from webui.backend.lib.cron_bridge import (
     CronEntry,
     calculate_next_waketime,
     cron_to_human_readable,
+)
+from webui.backend.lib.error_codes import (
+    ACTIVATION_ERROR,
+    CONFLICT_ERROR,
+    NOT_FOUND,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+    sanitize_message,
 )
 from webui.backend.lib.schedule_preview import (
     DEFAULT_PREVIEW_DAYS,
@@ -52,16 +60,6 @@ from webui.backend.lib.schedule_storage import is_builtin_schedule
 from webui.backend.lib.timezone_coordinates import get_fallback_coordinates
 from webui.backend.services.scheduler_service import SchedulerService
 
-# Standardized error codes for frontend handling (Issue #385 review)
-# These codes are used by the frontend to display user-friendly error messages
-ERROR_CODES = {
-    "VALIDATION_ERROR": "VALIDATION_ERROR",
-    "NOT_FOUND": "NOT_FOUND",
-    "CONFLICT_ERROR": "CONFLICT_ERROR",
-    "ACTIVATION_ERROR": "ACTIVATION_ERROR",
-    "SERVER_ERROR": "SERVER_ERROR",
-}
-
 # Rate limiter import with fallback for testing
 try:
     from webui.backend.app import limiter
@@ -81,7 +79,7 @@ def _validate_location_params(
     latitude: float | None,
     longitude: float | None,
     timezone_name: str | None,
-) -> tuple[dict | None, int | None]:
+) -> tuple | None:
     """Validate location parameters for schedule operations.
 
     Consolidates coordinate and timezone validation logic (Issue #385 review fix).
@@ -92,65 +90,27 @@ def _validate_location_params(
         timezone_name: Optional timezone name to validate
 
     Returns:
-        Tuple of (error_dict, status_code) if validation fails, or (None, None) if valid.
+        error_response tuple if validation fails, or None if valid.
     """
     valid, coord_error = validate_coordinates(latitude, longitude)
     if not valid:
         # Return sanitized error - coord_error doesn't include user input
-        safe_error = _sanitize_error_message(coord_error)
-        return {"error": f"Invalid coordinates: {safe_error}"}, 400
+        safe_error = sanitize_message(coord_error)
+        return error_response(VALIDATION_ERROR, f"Invalid coordinates: {safe_error}", 400)
 
     if timezone_name:
         valid, tz_error = validate_timezone(timezone_name)
         if not valid:
             # Don't reflect user input in error - use generic message
             # Original error logged for debugging, sanitized version returned
-            return {
-                "error": "Invalid timezone: Use IANA timezone names "
-                "(e.g., 'America/New_York', 'Europe/London', 'UTC')"
-            }, 400
+            return error_response(
+                VALIDATION_ERROR,
+                "Invalid timezone: Use IANA timezone names "
+                "(e.g., 'America/New_York', 'Europe/London', 'UTC')",
+                400,
+            )
 
-    return None, None
-
-
-def _sanitize_error_message(message: str | None, max_length: int = 200) -> str:
-    """
-    Sanitize error message for safe display to users.
-
-    Prevents XSS by stripping HTML tags, redacts internal file paths,
-    and truncates long messages. This is defense-in-depth - Flask's
-    jsonify escapes by default, but we strip tags and redact paths
-    to prevent information disclosure and frontend rendering issues.
-
-    Args:
-        message: Raw error message (may contain user input)
-        max_length: Maximum length before truncation
-
-    Returns:
-        Sanitized error message safe for display
-
-    Issue #385 security fix: Reflected XSS prevention + path redaction
-    """
-    if not message:
-        return "An error occurred"
-
-    msg = str(message)
-
-    # Strip HTML tags iteratively (handles nested/malformed tags)
-    prev_len = -1
-    while len(msg) != prev_len:
-        prev_len = len(msg)
-        msg = re.sub(r"<[^>]*>", "", msg)
-        msg = re.sub(r"<[^>]*$", "", msg)  # Incomplete tags
-
-    # Redact internal file paths to prevent information disclosure
-    # Matches Unix-style absolute paths (e.g., /etc/secrets/file.txt)
-    msg = re.sub(r"/(?:etc|var|home|opt|usr|tmp|root)/[^\s'\"]*", "[path]", msg)
-
-    if len(msg) > max_length:
-        msg = msg[: max_length - 3] + "..."
-
-    return msg.strip() or "An error occurred"
+    return None
 
 
 def _requires_coordinates(routines: list[Routine]) -> bool:
@@ -230,13 +190,13 @@ def require_json(f):
         try:
             data = request.get_json()
         except BadRequest:
-            return jsonify({"error": "Request body must be valid JSON"}), 400
+            return error_response(VALIDATION_ERROR, "Request body must be valid JSON", 400)
 
         if data is None:
-            return jsonify({"error": "Request body must be valid JSON"}), 400
+            return error_response(VALIDATION_ERROR, "Request body must be valid JSON", 400)
 
         if not isinstance(data, dict):
-            return jsonify({"error": "Request body must be a JSON object"}), 400
+            return error_response(VALIDATION_ERROR, "Request body must be a JSON object", 400)
 
         return f(*args, json_data=data, **kwargs)
 
@@ -339,42 +299,37 @@ def get_schedule_preview(schedule_id: str) -> tuple[Response, int]:
         days, error = parse_and_validate_days(days_str)
         if error:
             logger.debug(f"Invalid days parameter '{days_str}': {error}")
-            return jsonify({"error": "Invalid days parameter"}), 400
+            return error_response(VALIDATION_ERROR, "Invalid days parameter", 400)
 
         # Parse coordinates
         latitude, error = parse_and_validate_coordinate(lat_str, "lat")
         if error:
             logger.debug(f"Invalid lat parameter '{lat_str}': {error}")
-            return jsonify({"error": "Invalid lat parameter"}), 400
+            return error_response(VALIDATION_ERROR, "Invalid lat parameter", 400)
 
         longitude, error = parse_and_validate_coordinate(lon_str, "lon")
         if error:
             logger.debug(f"Invalid lon parameter '{lon_str}': {error}")
-            return jsonify({"error": "Invalid lon parameter"}), 400
+            return error_response(VALIDATION_ERROR, "Invalid lon parameter", 400)
 
         # Validate coordinate ranges
         valid, _error = validate_coordinates(latitude, longitude)
         if not valid:
             logger.debug("Invalid coordinate range provided")
-            return jsonify({"error": "Invalid coordinates"}), 400
+            return error_response(VALIDATION_ERROR, "Invalid coordinates", 400)
 
         # Validate timezone
         valid, error = validate_timezone(timezone_name)
         if not valid:
             logger.debug(f"Invalid timezone: {error}")
-            return jsonify({"error": "Invalid timezone"}), 400
+            return error_response(VALIDATION_ERROR, "Invalid timezone", 400)
 
         # Get schedule from service
         service = get_scheduler_service()
         schedule = service.get_schedule(schedule_id)
 
         if schedule is None:
-            return jsonify(
-                {
-                    "error": "Schedule not found",
-                    "code": ERROR_CODES["NOT_FOUND"],
-                }
-            ), 404
+            return error_response(NOT_FOUND, "Schedule not found", 404)
 
         # Generate preview
         result = generate_preview(
@@ -389,21 +344,13 @@ def get_schedule_preview(schedule_id: str) -> tuple[Response, int]:
 
     except ValueError as e:
         logger.warning(f"Preview generation error: {e}")
-        return jsonify(
-            {
-                "error": "Preview generation failed",
-            }
-        ), 400
+        return error_response(VALIDATION_ERROR, "Preview generation failed", 400)
 
     except Exception as e:
         logger.error(f"Unexpected error in preview generation: {e}", exc_info=True)
-        return jsonify(
-            {
-                "error": "Internal server error",
-                "code": ERROR_CODES["SERVER_ERROR"],
-                "message": "Failed to generate preview",
-            }
-        ), 500
+        return error_response(
+            SERVER_ERROR, "Internal server error", 500, detail="Failed to generate preview"
+        )
 
 
 # ============================================================================
@@ -448,13 +395,9 @@ def list_schedules() -> tuple[Response, int]:
 
     except Exception as e:
         logger.error(f"Error listing schedules: {e}", exc_info=True)
-        return jsonify(
-            {
-                "error": "Internal server error",
-                "code": ERROR_CODES["SERVER_ERROR"],
-                "message": "Failed to list schedules",
-            }
-        ), 500
+        return error_response(
+            SERVER_ERROR, "Internal server error", 500, detail="Failed to list schedules"
+        )
 
 
 @scheduler_ui_bp.route("/schedules/<schedule_id>", methods=["GET"])
@@ -473,23 +416,13 @@ def get_schedule(schedule_id: str) -> tuple[Response, int]:
         schedule = service.get_schedule(schedule_id)
 
         if schedule is None:
-            return jsonify(
-                {
-                    "error": "Schedule not found",
-                    "code": ERROR_CODES["NOT_FOUND"],
-                }
-            ), 404
+            return error_response(NOT_FOUND, "Schedule not found", 404)
 
         return jsonify(schedule.to_dict()), 200
 
     except Exception as e:
         logger.error(f"Error getting schedule: {e}", exc_info=True)
-        return jsonify(
-            {
-                "error": "Internal server error",
-                "code": ERROR_CODES["SERVER_ERROR"],
-            }
-        ), 500
+        return error_response(SERVER_ERROR, "Internal server error", 500)
 
 
 @scheduler_ui_bp.route("/schedules/active", methods=["GET"])
@@ -538,13 +471,9 @@ def get_active_schedule() -> tuple[Response, int]:
 
     except Exception as e:
         logger.error(f"Error getting active schedule: {e}", exc_info=True)
-        return jsonify(
-            {
-                "error": "Internal server error",
-                "code": ERROR_CODES["SERVER_ERROR"],
-                "message": "Failed to get active schedule",
-            }
-        ), 500
+        return error_response(
+            SERVER_ERROR, "Internal server error", 500, detail="Failed to get active schedule"
+        )
 
 
 @scheduler_ui_bp.route("/active/next-actions", methods=["GET"])
@@ -590,7 +519,7 @@ def get_next_actions() -> tuple[Response, int]:
             elif limit > 100:
                 limit = 100
         except ValueError:
-            return jsonify({"error": "Invalid limit parameter"}), 400
+            return error_response(VALIDATION_ERROR, "Invalid limit parameter", 400)
 
         service = get_scheduler_service()
         schedule_id = service.get_active_schedule_id()
@@ -622,13 +551,9 @@ def get_next_actions() -> tuple[Response, int]:
 
     except Exception as e:
         logger.error(f"Error getting next actions: {e}", exc_info=True)
-        return jsonify(
-            {
-                "error": "Internal server error",
-                "code": ERROR_CODES["SERVER_ERROR"],
-                "message": "Failed to get next actions",
-            }
-        ), 500
+        return error_response(
+            SERVER_ERROR, "Internal server error", 500, detail="Failed to get next actions"
+        )
 
 
 @scheduler_ui_bp.route("/schedules/builtin", methods=["GET"])
@@ -667,13 +592,9 @@ def list_builtin_schedules() -> tuple[Response, int]:
 
     except Exception as e:
         logger.error(f"Error listing built-in schedules: {e}", exc_info=True)
-        return jsonify(
-            {
-                "error": "Internal server error",
-                "code": ERROR_CODES["SERVER_ERROR"],
-                "message": "Failed to list built-in schedules",
-            }
-        ), 500
+        return error_response(
+            SERVER_ERROR, "Internal server error", 500, detail="Failed to list built-in schedules"
+        )
 
 
 # ============================================================================
@@ -709,18 +630,10 @@ def create_schedule(json_data: dict) -> tuple[Response, int]:
             schedule = Schedule.from_dict(json_data)
         except KeyError as e:
             logger.warning(f"Missing required field in schedule: {e}")
-            return jsonify(
-                {
-                    "error": "Missing required field in schedule",
-                }
-            ), 400
+            return error_response(VALIDATION_ERROR, "Missing required field in schedule", 400)
         except Exception as e:
             logger.error(f"Invalid schedule format: {e}", exc_info=True)
-            return jsonify(
-                {
-                    "error": "Invalid schedule format",
-                }
-            ), 400
+            return error_response(VALIDATION_ERROR, "Invalid schedule format", 400)
 
         # Create via service (validates internally)
         service = get_scheduler_service()
@@ -728,19 +641,10 @@ def create_schedule(json_data: dict) -> tuple[Response, int]:
             success = service.create_schedule(schedule)
         except ScheduleValidationError as e:
             logger.debug(f"Schedule validation failed: {e}")
-            return jsonify(
-                {
-                    "error": "Schedule validation failed",
-                    "code": ERROR_CODES["VALIDATION_ERROR"],
-                }
-            ), 400
+            return error_response(VALIDATION_ERROR, "Schedule validation failed", 400)
 
         if not success:
-            return jsonify(
-                {
-                    "error": "Failed to create schedule",
-                }
-            ), 500
+            return error_response(SERVER_ERROR, "Failed to create schedule", 500)
 
         return jsonify(
             {
@@ -752,13 +656,9 @@ def create_schedule(json_data: dict) -> tuple[Response, int]:
 
     except Exception as e:
         logger.error(f"Error creating schedule: {e}", exc_info=True)
-        return jsonify(
-            {
-                "error": "Internal server error",
-                "code": ERROR_CODES["SERVER_ERROR"],
-                "message": "Failed to create schedule",
-            }
-        ), 500
+        return error_response(
+            SERVER_ERROR, "Internal server error", 500, detail="Failed to create schedule"
+        )
 
 
 @scheduler_ui_bp.route("/schedules/<schedule_id>", methods=["PUT"])
@@ -795,12 +695,7 @@ def update_schedule(schedule_id: str, json_data: dict) -> tuple[Response, int]:
         # Check if schedule exists
         existing = service.get_schedule(schedule_id)
         if existing is None:
-            return jsonify(
-                {
-                    "error": "Schedule not found",
-                    "code": ERROR_CODES["NOT_FOUND"],
-                }
-            ), 404
+            return error_response(NOT_FOUND, "Schedule not found", 404)
 
         # Handle 'enabled' field separately (Issue #331 fix)
         # enabled/is_active are stored in active_state.json, not schedule JSON files
@@ -813,7 +708,7 @@ def update_schedule(schedule_id: str, json_data: dict) -> tuple[Response, int]:
                     service.set_enabled_schedule(None)
             except ValueError:
                 logger.exception("Failed to set enabled state")
-                return jsonify({"error": "Invalid schedule state"}), 400
+                return error_response(VALIDATION_ERROR, "Invalid schedule state", 400)
 
         # If only 'enabled' was being updated, we're done
         if not json_data:
@@ -833,26 +728,13 @@ def update_schedule(schedule_id: str, json_data: dict) -> tuple[Response, int]:
             # Built-in schedule protection - intentionally returns generic message
             # (not str(e)) to avoid exposing internal details
             logger.warning(f"Update blocked for built-in schedule: {e}")
-            return jsonify(
-                {
-                    "error": "Cannot modify built-in schedule",
-                }
-            ), 403
+            return error_response(VALIDATION_ERROR, "Cannot modify built-in schedule", 403)
         except ScheduleValidationError as e:
             logger.warning(f"Schedule validation failed: {e}")
-            return jsonify(
-                {
-                    "error": "Validation failed",
-                    "code": ERROR_CODES["VALIDATION_ERROR"],
-                }
-            ), 400
+            return error_response(VALIDATION_ERROR, "Validation failed", 400)
 
         if updated is None:
-            return jsonify(
-                {
-                    "error": "Failed to update schedule",
-                }
-            ), 500
+            return error_response(SERVER_ERROR, "Failed to update schedule", 500)
 
         return jsonify(
             {
@@ -863,12 +745,7 @@ def update_schedule(schedule_id: str, json_data: dict) -> tuple[Response, int]:
 
     except Exception as e:
         logger.error(f"Error updating schedule: {e}", exc_info=True)
-        return jsonify(
-            {
-                "error": "Internal server error",
-                "code": ERROR_CODES["SERVER_ERROR"],
-            }
-        ), 500
+        return error_response(SERVER_ERROR, "Internal server error", 500)
 
 
 @scheduler_ui_bp.route("/schedules/<schedule_id>", methods=["DELETE"])
@@ -894,12 +771,7 @@ def delete_schedule(schedule_id: str) -> tuple[Response, int]:
         # Check if schedule exists
         existing = service.get_schedule(schedule_id)
         if existing is None:
-            return jsonify(
-                {
-                    "error": "Schedule not found",
-                    "code": ERROR_CODES["NOT_FOUND"],
-                }
-            ), 404
+            return error_response(NOT_FOUND, "Schedule not found", 404)
 
         # Delete via service (handles built-in check)
         try:
@@ -907,18 +779,10 @@ def delete_schedule(schedule_id: str) -> tuple[Response, int]:
         except ValueError as e:
             # Built-in schedule protection
             logger.warning(f"Delete blocked for built-in schedule: {e}")
-            return jsonify(
-                {
-                    "error": "Cannot delete built-in schedule",
-                }
-            ), 403
+            return error_response(VALIDATION_ERROR, "Cannot delete built-in schedule", 403)
 
         if not success:
-            return jsonify(
-                {
-                    "error": "Failed to delete schedule",
-                }
-            ), 500
+            return error_response(SERVER_ERROR, "Failed to delete schedule", 500)
 
         return jsonify(
             {
@@ -929,12 +793,7 @@ def delete_schedule(schedule_id: str) -> tuple[Response, int]:
 
     except Exception as e:
         logger.error(f"Error deleting schedule: {e}", exc_info=True)
-        return jsonify(
-            {
-                "error": "Internal server error",
-                "code": ERROR_CODES["SERVER_ERROR"],
-            }
-        ), 500
+        return error_response(SERVER_ERROR, "Internal server error", 500)
 
 
 @scheduler_ui_bp.route("/schedules/<schedule_id>/clone", methods=["POST"])
@@ -975,12 +834,7 @@ def clone_schedule(schedule_id: str) -> tuple[Response, int]:
         # Get original schedule
         original = service.get_schedule(schedule_id)
         if original is None:
-            return jsonify(
-                {
-                    "error": "Schedule not found",
-                    "code": ERROR_CODES["NOT_FOUND"],
-                }
-            ), 404
+            return error_response(NOT_FOUND, "Schedule not found", 404)
 
         # Parse optional request body for custom name
         data = request.get_json(silent=True) or {}
@@ -989,24 +843,14 @@ def clone_schedule(schedule_id: str) -> tuple[Response, int]:
         # Validate custom name if provided
         if custom_name is not None:
             if not isinstance(custom_name, str):
-                return jsonify(
-                    {
-                        "error": "Name must be a string",
-                    }
-                ), 400
+                return error_response(VALIDATION_ERROR, "Name must be a string", 400)
             if not custom_name.strip():
-                return jsonify(
-                    {
-                        "error": "Name cannot be empty",
-                    }
-                ), 400
+                return error_response(VALIDATION_ERROR, "Name cannot be empty", 400)
             new_name = custom_name.strip()
             if len(new_name) > MAX_PATTERN_NAME_LENGTH:
-                return jsonify(
-                    {
-                        "error": f"Name exceeds {MAX_PATTERN_NAME_LENGTH} characters",
-                    }
-                ), 400
+                return error_response(
+                    VALIDATION_ERROR, f"Name exceeds {MAX_PATTERN_NAME_LENGTH} characters", 400
+                )
         else:
             new_name = f"{original.name} (Copy)"
             # Truncate if default name exceeds max length
@@ -1047,19 +891,10 @@ def clone_schedule(schedule_id: str) -> tuple[Response, int]:
             success = service.create_schedule(new_schedule)
         except ScheduleValidationError as e:
             logger.warning(f"Cloned schedule validation failed: {e}")
-            return jsonify(
-                {
-                    "error": "Validation failed",
-                    "code": ERROR_CODES["VALIDATION_ERROR"],
-                }
-            ), 400
+            return error_response(VALIDATION_ERROR, "Validation failed", 400)
 
         if not success:
-            return jsonify(
-                {
-                    "error": "Failed to create cloned schedule",
-                }
-            ), 500
+            return error_response(SERVER_ERROR, "Failed to create cloned schedule", 500)
 
         return jsonify(
             {
@@ -1071,12 +906,7 @@ def clone_schedule(schedule_id: str) -> tuple[Response, int]:
 
     except Exception as e:
         logger.error(f"Error cloning schedule: {e}", exc_info=True)
-        return jsonify(
-            {
-                "error": "Internal server error",
-                "code": ERROR_CODES["SERVER_ERROR"],
-            }
-        ), 500
+        return error_response(SERVER_ERROR, "Internal server error", 500)
 
 
 # ============================================================================
@@ -1125,11 +955,9 @@ def activate_schedule(schedule_id: str) -> tuple[Response, int]:
 
         # Require both coordinates or neither
         if lat_provided != lon_provided:
-            return jsonify(
-                {
-                    "error": "Both latitude and longitude must be provided together",
-                }
-            ), 400
+            return error_response(
+                VALIDATION_ERROR, "Both latitude and longitude must be provided together", 400
+            )
 
         # Determine coordinates with fallback chain (Issue #331)
         # Priority: 1) explicit request, 2) device GPS, 3) timezone approximation
@@ -1142,11 +970,7 @@ def activate_schedule(schedule_id: str) -> tuple[Response, int]:
                 longitude = float(data["longitude"])
                 coordinates_source = "explicit"
             except (ValueError, TypeError):
-                return jsonify(
-                    {
-                        "error": "Coordinates must be numeric",
-                    }
-                ), 400
+                return error_response(VALIDATION_ERROR, "Coordinates must be numeric", 400)
         else:
             # Try device GPS from controls.txt
             control_values = get_control_values(CONTROLS_FILE)
@@ -1192,9 +1016,9 @@ def activate_schedule(schedule_id: str) -> tuple[Response, int]:
         # Validate coordinate ranges and timezone (Issue #385 review fix)
         # Coordinates may come from explicit request, GPS, or timezone fallback -
         # all sources should be validated to catch invalid controls.txt values
-        error, status = _validate_location_params(latitude, longitude, timezone_name)
-        if error:
-            return jsonify(error), status
+        validation_error = _validate_location_params(latitude, longitude, timezone_name)
+        if validation_error:
+            return validation_error
 
         service = get_scheduler_service()
 
@@ -1237,22 +1061,11 @@ def activate_schedule(schedule_id: str) -> tuple[Response, int]:
         except ScheduleConflictError as e:
             # Log conflict details, return generic message
             logger.info(f"Schedule conflict detected: {e}")
-            return jsonify(
-                {
-                    "error": "Schedule conflict detected",
-                    "code": ERROR_CODES["CONFLICT_ERROR"],
-                    "conflict": True,
-                }
-            ), 409
+            return error_response(CONFLICT_ERROR, "Schedule conflict detected", 409, conflict=True)
         except ScheduleActivationError as e:
             # Log detailed error, return generic message
             logger.warning(f"Schedule activation failed: {e}")
-            return jsonify(
-                {
-                    "error": "Schedule activation failed",
-                    "code": ERROR_CODES["ACTIVATION_ERROR"],
-                }
-            ), 400
+            return error_response(ACTIVATION_ERROR, "Schedule activation failed", 400)
 
         # Include coordinates_source in response for UI notification (Issue #331)
         # Check for entry count warning (approaching system limit)
@@ -1273,12 +1086,7 @@ def activate_schedule(schedule_id: str) -> tuple[Response, int]:
 
     except Exception as e:
         logger.error(f"Error activating schedule: {e}", exc_info=True)
-        return jsonify(
-            {
-                "error": "Internal server error",
-                "code": ERROR_CODES["SERVER_ERROR"],
-            }
-        ), 500
+        return error_response(SERVER_ERROR, "Internal server error", 500)
 
 
 @scheduler_ui_bp.route("/schedules/deactivate", methods=["POST"])
@@ -1310,12 +1118,12 @@ def deactivate_current_schedule() -> tuple[Response, int]:
         success = service.deactivate_schedule()
 
         if not success:
-            return jsonify(
-                {
-                    "error": "Failed to clear crontab",
-                    "message": "Cron entries may still be active",
-                }
-            ), 500
+            return error_response(
+                SERVER_ERROR,
+                "Failed to clear crontab",
+                500,
+                detail="Cron entries may still be active",
+            )
 
         if active is None:
             return jsonify(
@@ -1336,13 +1144,9 @@ def deactivate_current_schedule() -> tuple[Response, int]:
 
     except Exception as e:
         logger.error(f"Error deactivating schedule: {e}", exc_info=True)
-        return jsonify(
-            {
-                "error": "Internal server error",
-                "code": ERROR_CODES["SERVER_ERROR"],
-                "message": "Failed to deactivate schedule",
-            }
-        ), 500
+        return error_response(
+            SERVER_ERROR, "Internal server error", 500, detail="Failed to deactivate schedule"
+        )
 
 
 # ============================================================================
@@ -1389,51 +1193,40 @@ def validate_schedule_endpoint(schedule_id: str) -> tuple[Response, int]:
 
         # Require both coordinates or neither
         if lat_provided != lon_provided:
-            return jsonify(
-                {
-                    "error": "Both latitude and longitude must be provided together",
-                }
-            ), 400
+            return error_response(
+                VALIDATION_ERROR, "Both latitude and longitude must be provided together", 400
+            )
 
         # Type validation for coordinates
         try:
             latitude = float(data["latitude"]) if lat_provided else 0.0
             longitude = float(data["longitude"]) if lon_provided else 0.0
         except (ValueError, TypeError):
-            return jsonify(
-                {
-                    "error": "Coordinates must be numeric",
-                }
-            ), 400
+            return error_response(VALIDATION_ERROR, "Coordinates must be numeric", 400)
 
         timezone_name = data.get("timezone", "UTC")
 
         # Validate coordinate ranges if explicitly provided (including 0.0, 0.0)
         # Use helper with timezone_name=None to skip timezone validation (Issue #385)
         if lat_provided and lon_provided:
-            error, status = _validate_location_params(latitude, longitude, None)
-            if error:
-                return jsonify(error), status
+            validation_error = _validate_location_params(latitude, longitude, None)
+            if validation_error:
+                return validation_error
 
         service = get_scheduler_service()
 
         # Check if schedule exists
         schedule = service.get_schedule(schedule_id)
         if schedule is None:
-            return jsonify(
-                {
-                    "error": "Schedule not found",
-                    "code": ERROR_CODES["NOT_FOUND"],
-                }
-            ), 404
+            return error_response(NOT_FOUND, "Schedule not found", 404)
 
         # Check if coordinates required but not provided (solar/moon triggers)
         if not lat_provided and _requires_coordinates(schedule.routines):
-            return jsonify(
-                {
-                    "error": "Coordinates required for schedules with solar or moon triggers",
-                }
-            ), 400
+            return error_response(
+                VALIDATION_ERROR,
+                "Coordinates required for schedules with solar or moon triggers",
+                400,
+            )
 
         # Get cached conflict report
         report = service.get_cached_conflict_report(
@@ -1466,12 +1259,7 @@ def validate_schedule_endpoint(schedule_id: str) -> tuple[Response, int]:
 
     except Exception as e:
         logger.error(f"Error validating schedule: {e}", exc_info=True)
-        return jsonify(
-            {
-                "error": "Internal server error",
-                "code": ERROR_CODES["SERVER_ERROR"],
-            }
-        ), 500
+        return error_response(SERVER_ERROR, "Internal server error", 500)
 
 
 @scheduler_ui_bp.route("/schedules/validate-draft", methods=["POST"])
@@ -1508,11 +1296,11 @@ def validate_draft_routines(json_data: dict) -> tuple[Response, int]:
     try:
         # Validate routines field exists
         if "routines" not in json_data:
-            return jsonify({"error": "routines array required"}), 400
+            return error_response(VALIDATION_ERROR, "routines array required", 400)
 
         routines_data = json_data["routines"]
         if not isinstance(routines_data, list):
-            return jsonify({"error": "routines must be an array"}), 400
+            return error_response(VALIDATION_ERROR, "routines must be an array", 400)
 
         # Empty routines is valid - no conflicts possible
         if not routines_data:
@@ -1532,14 +1320,14 @@ def validate_draft_routines(json_data: dict) -> tuple[Response, int]:
             routines = [Routine.from_dict(r) for r in routines_data]
         except (KeyError, ValueError, TypeError) as e:
             logger.debug(f"Invalid routine format: {e}")
-            return jsonify({"error": "Invalid routine format"}), 400
+            return error_response(VALIDATION_ERROR, "Invalid routine format", 400)
 
         # Parse optional parameters
         preview_days = json_data.get("days", DEFAULT_PREVIEW_DAYS)
         try:
             preview_days = min(max(int(preview_days), 1), 90)
         except (ValueError, TypeError):
-            return jsonify({"error": "Invalid days parameter"}), 400
+            return error_response(VALIDATION_ERROR, "Invalid days parameter", 400)
 
         # Check if coordinates were explicitly provided in request
         lat_provided = "latitude" in json_data
@@ -1547,14 +1335,16 @@ def validate_draft_routines(json_data: dict) -> tuple[Response, int]:
 
         # Require both coordinates or neither
         if lat_provided != lon_provided:
-            return jsonify({"error": "Both latitude and longitude must be provided together"}), 400
+            return error_response(
+                VALIDATION_ERROR, "Both latitude and longitude must be provided together", 400
+            )
 
         # Type validation for coordinates
         try:
             latitude = float(json_data["latitude"]) if lat_provided else 0.0
             longitude = float(json_data["longitude"]) if lon_provided else 0.0
         except (ValueError, TypeError):
-            return jsonify({"error": "Coordinates must be numeric"}), 400
+            return error_response(VALIDATION_ERROR, "Coordinates must be numeric", 400)
 
         timezone_name = json_data.get("timezone", "UTC")
 
@@ -1563,19 +1353,18 @@ def validate_draft_routines(json_data: dict) -> tuple[Response, int]:
             valid, coord_error = validate_coordinates(latitude, longitude)
             if not valid:
                 # Sanitize error - coord_error doesn't include user input but sanitize anyway
-                safe_error = _sanitize_error_message(coord_error)
-                return jsonify({"error": f"Invalid coordinates: {safe_error}"}), 400
+                safe_error = sanitize_message(coord_error)
+                return error_response(VALIDATION_ERROR, f"Invalid coordinates: {safe_error}", 400)
 
         # Validate timezone
         valid, tz_error = validate_timezone(timezone_name)
         if not valid:
             # Don't reflect user input in error - use generic message (Issue #385 security fix)
-            return jsonify(
-                {
-                    "error": "Invalid timezone: Use IANA timezone names "
-                    "(e.g., 'America/New_York', 'Europe/London', 'UTC')"
-                }
-            ), 400
+            return error_response(
+                VALIDATION_ERROR,
+                "Invalid timezone: Use IANA timezone names (e.g., 'America/New_York', 'Europe/London', 'UTC')",
+                400,
+            )
 
         # Check if coordinates required but not provided (solar/moon triggers)
         # Use same fallback chain as activation: device GPS → timezone approximation
@@ -1628,12 +1417,7 @@ def validate_draft_routines(json_data: dict) -> tuple[Response, int]:
 
     except Exception as e:
         logger.error(f"Error validating draft routines: {e}", exc_info=True)
-        return jsonify(
-            {
-                "error": "Internal server error",
-                "code": ERROR_CODES["SERVER_ERROR"],
-            }
-        ), 500
+        return error_response(SERVER_ERROR, "Internal server error", 500)
 
 
 # ============================================================================
@@ -1673,69 +1457,42 @@ def validate_cron_expression(json_data: dict) -> tuple[Response, int]:
         expression = json_data.get("expression")
 
         if expression is None:
-            return jsonify(
-                {
-                    "valid": False,
-                    "error": "Missing required field: expression",
-                }
-            ), 400
+            return error_response(
+                VALIDATION_ERROR, "Missing required field: expression", 400, valid=False
+            )
 
         # Type validation
         if not isinstance(expression, str):
-            return jsonify(
-                {
-                    "valid": False,
-                    "error": "Expression must be a string",
-                }
-            ), 400
+            return error_response(VALIDATION_ERROR, "Expression must be a string", 400, valid=False)
 
         # Empty string check
         if not expression or not expression.strip():
-            return jsonify(
-                {
-                    "valid": False,
-                    "error": "Expression cannot be empty",
-                }
-            ), 400
+            return error_response(VALIDATION_ERROR, "Expression cannot be empty", 400, valid=False)
 
         # Length validation (security check)
         if len(expression) > 100:
-            return jsonify(
-                {
-                    "valid": False,
-                    "error": "Expression too long (max 100 characters)",
-                }
-            ), 400
+            return error_response(
+                VALIDATION_ERROR, "Expression too long (max 100 characters)", 400, valid=False
+            )
 
         # Get count parameter (default 5, range 1-20)
         count = json_data.get("count", 5)
 
         # Validate count type
         if not isinstance(count, int):
-            return jsonify(
-                {
-                    "valid": False,
-                    "error": "Count must be an integer",
-                }
-            ), 400
+            return error_response(VALIDATION_ERROR, "Count must be an integer", 400, valid=False)
 
         # Validate count range
         if count < 1 or count > 20:
-            return jsonify(
-                {
-                    "valid": False,
-                    "error": "Count must be between 1 and 20",
-                }
-            ), 400
+            return error_response(
+                VALIDATION_ERROR, "Count must be between 1 and 20", 400, valid=False
+            )
 
         # Validate cron expression syntax
         if not CronEntry.is_valid_expression(expression):
-            return jsonify(
-                {
-                    "valid": False,
-                    "error": "Invalid cron expression syntax",
-                }
-            ), 400
+            return error_response(
+                VALIDATION_ERROR, "Invalid cron expression syntax", 400, valid=False
+            )
 
         # Calculate next execution times
         next_executions = []
@@ -1749,12 +1506,12 @@ def validate_cron_expression(json_data: dict) -> tuple[Response, int]:
                 current_time = datetime.fromtimestamp(next_time + 1, UTC)
         except ValueError as e:
             logger.debug(f"Failed to calculate next execution times: {e}")
-            return jsonify(
-                {
-                    "valid": False,
-                    "error": "Invalid cron expression: cannot calculate execution times",
-                }
-            ), 400
+            return error_response(
+                VALIDATION_ERROR,
+                "Invalid cron expression: cannot calculate execution times",
+                400,
+                valid=False,
+            )
 
         # Get human-readable description
         human_readable = cron_to_human_readable(expression)
@@ -1770,9 +1527,6 @@ def validate_cron_expression(json_data: dict) -> tuple[Response, int]:
 
     except Exception as e:
         logger.error(f"Error validating cron expression: {e}", exc_info=True)
-        return jsonify(
-            {
-                "valid": False,
-                "error": "Internal server error during validation",
-            }
-        ), 500
+        return error_response(
+            SERVER_ERROR, "Internal server error during validation", 500, valid=False
+        )

--- a/Firmware/webui/frontend/src/components/gallery/BulkTagModal.jsx
+++ b/Firmware/webui/frontend/src/components/gallery/BulkTagModal.jsx
@@ -39,6 +39,12 @@ export default function BulkTagModal({
   const [inputValue, setInputValue] = useState('')
   const [showSuggestions, setShowSuggestions] = useState(false)
   const inputRef = useRef(null)
+  const blurTimeoutRef = useRef(null)
+
+  // Clear blur timeout on unmount to prevent state updates after teardown
+  useEffect(() => {
+    return () => clearTimeout(blurTimeoutRef.current)
+  }, [])
 
   // Fetch available tags for autocomplete (same as MetadataTags)
   const { data: tagsData } = useTags({ sort: 'count', order: 'desc', limit: 20 })
@@ -180,7 +186,7 @@ export default function BulkTagModal({
               }}
               onKeyDown={handleKeyDown}
               onFocus={() => setShowSuggestions(true)}
-              onBlur={() => setTimeout(() => setShowSuggestions(false), 150)}
+              onBlur={() => { blurTimeoutRef.current = setTimeout(() => setShowSuggestions(false), 150) }}
               placeholder="Type to search or create tags..."
               className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100"
             />

--- a/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/ScheduleEditor.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/ScheduleEditor.jsx
@@ -9,70 +9,12 @@ import ConfirmDialog from '../../common/ConfirmDialog';
 import { SCHEDULE_LIMITS } from './constants';
 import { RoutinePropType } from './propTypes';
 import { generateUUID } from '../../../utils/uuid';
+import { getErrorMessage } from '../../../utils/errorCodes';
 import { useSchedule } from '../../../hooks/useSchedules';
 import { useValidateDraft } from '../../../hooks/useValidateDraft';
 
 /** Delay before focusing name input to allow drawer animation to start */
 const FOCUS_DELAY_MS = 100;
-
-/**
- * Known error codes and their user-friendly messages.
- * These codes are returned by the backend in the 'code' field of error responses.
- * Issue #385 review: Standardize error codes between backend and frontend.
- */
-const KNOWN_ERROR_CODES = {
-  NETWORK_ERROR: 'Unable to save. Please check your connection.',
-  VALIDATION_ERROR: 'Please fix the errors above.',
-  NOT_FOUND: 'Schedule not found. It may have been deleted.',
-  CONFLICT_ERROR: 'Schedule has conflicts that must be resolved.',
-  ACTIVATION_ERROR: 'Failed to activate schedule.',
-  SERVER_ERROR: 'Server error. Please try again later.',
-};
-
-/**
- * Sanitize error messages for safe display
- * - Maps known error codes to user-friendly messages
- * - Checks both error.code and error.response.data.code (API responses)
- * - Strips HTML tags as defense-in-depth
- * - Truncates long messages to 200 characters
- *
- * Note: React automatically escapes text content when rendering,
- * but we strip HTML tags as additional defense-in-depth.
- *
- * Issue #385 review: Standardize error codes between backend and frontend.
- *
- * @param {Error} error - The error object
- * @returns {string} Sanitized error message
- */
-const sanitizeErrorMessage = (error) => {
-  // Check for known error codes from API response first (axios pattern)
-  const apiCode = error?.response?.data?.code;
-  if (apiCode && KNOWN_ERROR_CODES[apiCode]) {
-    return KNOWN_ERROR_CODES[apiCode];
-  }
-
-  // Check for known error codes on the error object itself
-  if (error?.code && KNOWN_ERROR_CODES[error.code]) {
-    return KNOWN_ERROR_CODES[error.code];
-  }
-
-  // Get message from API response or error object, with fallback
-  let message = String(
-    error?.response?.data?.error || error?.message || 'Failed to save schedule'
-  );
-
-  // Strip HTML tags as defense-in-depth using iterative approach
-  // to handle incomplete/malformed tags like "<script" without closing ">"
-  let previousLength;
-  do {
-    previousLength = message.length;
-    // Remove complete tags and incomplete opening tags
-    message = message.replace(/<[^>]*>?/g, '');
-  } while (message.length < previousLength);
-
-  // Truncate to 200 characters
-  return message.length > 200 ? message.slice(0, 200) + '...' : message;
-};
 
 /**
  * ScheduleEditor Component
@@ -369,7 +311,7 @@ const ScheduleEditor = ({
 
       await onSave(scheduleData);
     } catch (error) {
-      setErrors({ save: sanitizeErrorMessage(error) });
+      setErrors({ save: getErrorMessage(error) });
     } finally {
       setIsSaving(false);
     }

--- a/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/ScheduleEditor.jsx
+++ b/Firmware/webui/frontend/src/components/scheduler/ScheduleEditor/ScheduleEditor.jsx
@@ -311,7 +311,7 @@ const ScheduleEditor = ({
 
       await onSave(scheduleData);
     } catch (error) {
-      setErrors({ save: getErrorMessage(error) });
+      setErrors({ save: getErrorMessage(error, 'Failed to save schedule') });
     } finally {
       setIsSaving(false);
     }

--- a/Firmware/webui/frontend/src/utils/errorCodes.js
+++ b/Firmware/webui/frontend/src/utils/errorCodes.js
@@ -1,0 +1,103 @@
+/**
+ * Shared error codes and message mapping for the Mothbox API.
+ *
+ * Mirrors backend error codes from webui/backend/lib/error_codes.py.
+ * Use getErrorMessage() to extract user-friendly messages from API errors.
+ *
+ * Issue #388 - Standardize error codes across backend/frontend
+ *
+ * @module utils/errorCodes
+ */
+
+/**
+ * Error code constants matching the backend.
+ * Used for programmatic error handling (e.g., switch statements).
+ */
+export const ERROR_CODES = {
+  VALIDATION_ERROR: 'VALIDATION_ERROR',
+  NOT_FOUND: 'NOT_FOUND',
+  CONFLICT_ERROR: 'CONFLICT_ERROR',
+  ACTIVATION_ERROR: 'ACTIVATION_ERROR',
+  RATE_LIMIT_ERROR: 'RATE_LIMIT_ERROR',
+  HARDWARE_ERROR: 'HARDWARE_ERROR',
+  STORAGE_ERROR: 'STORAGE_ERROR',
+  PERMISSION_ERROR: 'PERMISSION_ERROR',
+  SERVER_ERROR: 'SERVER_ERROR',
+  // Client-side only (no backend equivalent)
+  NETWORK_ERROR: 'NETWORK_ERROR',
+  TIMEOUT_ERROR: 'TIMEOUT_ERROR',
+};
+
+/**
+ * User-friendly messages for each error code.
+ * These are shown to the user when an API error occurs.
+ */
+export const ERROR_MESSAGES = {
+  [ERROR_CODES.VALIDATION_ERROR]: 'Please fix the errors above.',
+  [ERROR_CODES.NOT_FOUND]: 'Resource not found. It may have been deleted.',
+  [ERROR_CODES.CONFLICT_ERROR]: 'Schedule has conflicts that must be resolved.',
+  [ERROR_CODES.ACTIVATION_ERROR]: 'Failed to activate schedule.',
+  [ERROR_CODES.RATE_LIMIT_ERROR]: 'Too many requests. Please wait a moment.',
+  [ERROR_CODES.HARDWARE_ERROR]: 'Hardware unavailable. Please check connections.',
+  [ERROR_CODES.STORAGE_ERROR]: 'Storage error. Check available disk space.',
+  [ERROR_CODES.PERMISSION_ERROR]: 'Permission denied.',
+  [ERROR_CODES.SERVER_ERROR]: 'Server error. Please try again later.',
+  [ERROR_CODES.NETWORK_ERROR]: 'Unable to save. Please check your connection.',
+  [ERROR_CODES.TIMEOUT_ERROR]: 'Request timed out. Please try again.',
+};
+
+/**
+ * Sanitize an error message string for safe display.
+ *
+ * Strips HTML tags (defense-in-depth — React escapes by default)
+ * and truncates long messages.
+ *
+ * @param {string} message - Raw error message
+ * @param {number} [maxLength=200] - Maximum message length
+ * @returns {string} Sanitized message
+ */
+export function sanitizeMessage(message, maxLength = 200) {
+  if (!message) return 'An unexpected error occurred.';
+  let msg = String(message);
+
+  // Strip HTML tags iteratively (handles incomplete/malformed tags)
+  let previousLength;
+  do {
+    previousLength = msg.length;
+    msg = msg.replace(/<[^>]*>?/g, '');
+  } while (msg.length < previousLength);
+
+  return msg.length > maxLength ? msg.slice(0, maxLength) + '...' : msg;
+}
+
+/**
+ * Extract a user-friendly error message from an API error.
+ *
+ * Checks for known error codes first (from API response or error object),
+ * then falls back to the server-provided error message (sanitized),
+ * then to a generic fallback.
+ *
+ * @param {Error|Object} error - Axios error or error-like object
+ * @param {string} [fallback='An unexpected error occurred.'] - Fallback message
+ * @returns {string} User-friendly error message
+ */
+export function getErrorMessage(error, fallback = 'An unexpected error occurred.') {
+  // Check for known error code from API response (axios pattern)
+  const apiCode = error?.response?.data?.code;
+  if (apiCode && ERROR_MESSAGES[apiCode]) {
+    return ERROR_MESSAGES[apiCode];
+  }
+
+  // Check for known error code on the error object itself
+  if (error?.code && ERROR_MESSAGES[error.code]) {
+    return ERROR_MESSAGES[error.code];
+  }
+
+  // Fall back to server-provided message, sanitized
+  const rawMessage = error?.response?.data?.error || error?.message;
+  if (rawMessage) {
+    return sanitizeMessage(rawMessage);
+  }
+
+  return fallback;
+}


### PR DESCRIPTION
## Summary

- Add shared `error_codes.py` module as single source of truth for error codes, sanitization, and response formatting
- Migrate `scheduler_ui.py` from inline error handling to shared module (17 error responses → `error_response()` calls, net -178 lines)
- Add frontend `errorCodes.js` mirroring backend codes with user-friendly messages
- Migrate `ScheduleEditor.jsx` from inline `KNOWN_ERROR_CODES`/`sanitizeErrorMessage` to shared module

### New files
- `webui/backend/lib/error_codes.py` — 9 error codes, `sanitize_message()`, `error_response()` helper
- `webui/frontend/src/utils/errorCodes.js` — code constants, message mapping, `getErrorMessage()`
- `Tests/unit/test_error_codes.py` — 21 tests (codes, sanitization, response format)
- `docs/plans/2026-02-15-standardize-error-codes.md` — implementation plan

### Response format
All error responses now follow: `{"error": "sanitized message", "code": "ERROR_CODE"}` — backward compatible (the `error` field was already present, `code` is additive).

### Follow-up
Remaining 16 route files will be migrated in batches in follow-up PRs.

Closes #388

## Test plan
- [x] 21 new unit tests for `error_codes.py` (codes, sanitization, response helper)
- [x] 87 existing `scheduler_ui_routes` tests pass unchanged
- [x] 9 `scheduler_ui_security` tests updated for new imports — all pass
- [x] 117 total tests passing
- [x] ruff check + format clean
- [x] bandit — no medium/high findings
- [x] eslint clean on changed JS files
- [x] frontend build succeeds