### PR TITLE
refactor: migrate media routes to shared error codes (#414)

### DIFF
--- a/Firmware/docs/plans/2026-02-16-migrate-error-codes-design.md
+++ b/Firmware/docs/plans/2026-02-16-migrate-error-codes-design.md
@@ -1,0 +1,71 @@
+# Design: Migrate Remaining Route Files to Shared Error Codes (#414)
+
+## Problem
+
+PR #413 introduced `webui/backend/lib/error_codes.py` and migrated `scheduler_ui.py` as the first route file. The remaining 16 route files still use inline `jsonify({"error": ...})` responses (472 total) and need migration to `error_response()`.
+
+## Decision
+
+- **Approach**: Mechanical replacement with context-aware error code selection
+- **PR strategy**: 7 PRs, one per logical batch
+- **No new constants**: Existing 9 error codes cover all cases
+- **No frontend changes**: Frontend module already exists from PR #413
+
+## Error Code Mapping
+
+| HTTP Status | Error Code | Rationale |
+|---|---|---|
+| 400 | `VALIDATION_ERROR` | Invalid input/parameters |
+| 403 | `PERMISSION_ERROR` | Path traversal, forbidden access |
+| 404 | `NOT_FOUND` | Resource doesn't exist |
+| 408 | `VALIDATION_ERROR` | GPS timeout (gps.py, 1 instance) |
+| 500 (generic) | `SERVER_ERROR` | Catch-all internal errors |
+| 500 (disk/IO) | `STORAGE_ERROR` | Disk full, file write failures |
+| 503 | `HARDWARE_ERROR` | Camera/GPIO/service unavailable |
+
+Context-aware override: When a 500 is clearly about file I/O or disk space, use `STORAGE_ERROR` instead of `SERVER_ERROR`.
+
+## Extra Fields
+
+3 edge cases with extra JSON fields preserved via `**extra` kwargs:
+- `gallery.py`: `error_response(NOT_FOUND, "Series not found", 404, series_id=series_id)`
+- `export.py` (2 places): `error_response(SERVER_ERROR, "ZIP export failed", 500, details=result.errors)`
+
+## Batch Structure
+
+| Batch | Files | Est. Responses | Branch |
+|---|---|---|---|
+| 1 | `camera.py`, `gpio.py`, `system.py` | 18 | `refactor/414-batch1-hardware` |
+| 2 | `gallery.py`, `metadata.py` | 70 | `refactor/414-batch2-media` |
+| 3 | `config.py` | 49 | `refactor/414-batch3-config` |
+| 4 | `export.py`, `export_presets.py` | 139 | `refactor/414-batch4-export` |
+| 5 | `deployment.py`, `sidecar.py` | 125 | `refactor/414-batch5-deployment` |
+| 6 | `search.py`, `gps.py`, `gps_exif.py` | 46 | `refactor/414-batch6-search-gps` |
+| 7 | `preferences.py`, `presets.py`, `scheduler.py` | 33 | `refactor/414-batch7-misc` |
+
+## Per-File Migration Pattern
+
+1. Add `from webui.backend.lib.error_codes import error_response, VALIDATION_ERROR, ...` (only codes used)
+2. Replace `return jsonify({"error": "..."}), 4xx` → `return error_response(CODE, "...", 4xx)`
+3. For extra-field responses, pass via `**extra` kwargs
+4. `ruff check && ruff format` on modified files
+5. Run relevant test files to verify backward compatibility
+
+## Testing Strategy
+
+Each batch runs corresponding test files before PR. The `"error"` field is unchanged (backward compatible). The additive `"code"` field won't break existing assertions.
+
+## What This Does NOT Change
+
+- No new error code constants
+- No frontend changes
+- No changes to `error_codes.py` itself
+- No test file modifications needed
+
+## References
+
+- Design: `docs/plans/2026-02-15-standardize-error-codes-design.md`
+- Shared module: `webui/backend/lib/error_codes.py`
+- Reference migration: `webui/backend/routes/scheduler_ui.py`
+- Initial PR: #413
+- Parent issue: #388

--- a/Firmware/docs/plans/2026-02-16-migrate-error-codes.md
+++ b/Firmware/docs/plans/2026-02-16-migrate-error-codes.md
@@ -1,0 +1,767 @@
+# Migrate Remaining Route Files to Shared Error Codes — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Migrate 472 inline `jsonify({"error": ...})` responses across 16 route files to the shared `error_response()` helper, adding structured error codes to every API error response.
+
+**Architecture:** Each route file gets an import of `error_response` and the specific error code constants it needs from `webui/backend/lib/error_codes.py`. Every `return jsonify({"error": "..."}), status` becomes `return error_response(CODE, "...", status)`. Extra JSON fields pass through via `**extra` kwargs. The `"error"` field is unchanged for backward compatibility; the `"code"` field is additive.
+
+**Tech Stack:** Python/Flask (backend), pytest (testing), ruff (linting)
+
+**Important context:**
+- Reference implementation: `webui/backend/routes/scheduler_ui.py` (already migrated in PR #413)
+- Shared module: `webui/backend/lib/error_codes.py` — provides `error_response()`, `sanitize_message()`, and 9 error code constants
+- Error code mapping: 400→`VALIDATION_ERROR`, 403→`PERMISSION_ERROR`, 404→`NOT_FOUND`, 408→`VALIDATION_ERROR`, 500→`SERVER_ERROR` (or `STORAGE_ERROR` for disk/IO), 503→`HARDWARE_ERROR`
+- Extra-field edge cases: `gallery.py` line 870 has `series_id`, `export.py` lines 984/1128 have `details` — preserved via `**extra`
+- No test changes needed — format is backward compatible (additive `"code"` field)
+- Design doc: `docs/plans/2026-02-16-migrate-error-codes-design.md`
+
+---
+
+### Task 1: Batch 1 — Hardware routes (camera.py, gpio.py, system.py)
+
+**Files:**
+- Modify: `webui/backend/routes/camera.py` (6 error responses)
+- Modify: `webui/backend/routes/gpio.py` (8 error responses)
+- Modify: `webui/backend/routes/system.py` (4 error responses)
+- Test: `Tests/unit/test_camera_routes.py`, `Tests/unit/test_gpio_routes.py`, `Tests/unit/test_system_routes.py`
+
+**Step 1: Create branch**
+
+Run: `git checkout -b refactor/414-batch1-hardware dev`
+
+**Step 2: Run baseline tests**
+
+Run: `python3 -m pytest Tests/unit/test_camera_routes.py Tests/unit/test_gpio_routes.py Tests/unit/test_system_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 3: Migrate camera.py**
+
+Add import at top of file (after existing Flask imports):
+
+```python
+from webui.backend.lib.error_codes import (
+    VALIDATION_ERROR,
+    SERVER_ERROR,
+    error_response,
+)
+```
+
+Replace these 6 error responses:
+
+| Line | Before | After |
+|------|--------|-------|
+| 673 | `return jsonify({"error": "Failed to get camera settings"}), 500` | `return error_response(SERVER_ERROR, "Failed to get camera settings", 500)` |
+| 696 | `return jsonify({"error": f"Invalid setting: {key}"}), 400` | `return error_response(VALIDATION_ERROR, f"Invalid setting: {key}")` |
+| 699 | `return jsonify({"error": f"Invalid value for {key}"}), 400` | `return error_response(VALIDATION_ERROR, f"Invalid value for {key}")` |
+| 701 | `return jsonify({"error": f"Invalid type for {key}"}), 400` | `return error_response(VALIDATION_ERROR, f"Invalid type for {key}")` |
+| 743 | `return jsonify({"error": "Failed to update camera settings"}), 500` | `return error_response(SERVER_ERROR, "Failed to update camera settings", 500)` |
+| 1203 | `return jsonify({"error": "Failed to freeze settings"}), 500` | `return error_response(SERVER_ERROR, "Failed to freeze settings", 500)` |
+
+Note: 400 is the default status for `error_response()`, so omit it for VALIDATION_ERROR calls.
+
+**Step 4: Migrate gpio.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    HARDWARE_ERROR,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Replace these 8 error responses:
+
+| Line | Before | After |
+|------|--------|-------|
+| 30 | `return jsonify({"error": "Failed to get GPIO status"}), 500` | `return error_response(SERVER_ERROR, "Failed to get GPIO status", 500)` |
+| 42 | `return jsonify({"error": "Missing relay or state parameter"}), 400` | `return error_response(VALIDATION_ERROR, "Missing relay or state parameter")` |
+| 44 | `return jsonify({"error": "State must be a boolean value (true/false)"}), 400` | `return error_response(VALIDATION_ERROR, "State must be a boolean value (true/false)")` |
+| 48 | `return jsonify({"error": f"Invalid relay: {relay}"}), 400` | `return error_response(VALIDATION_ERROR, f"Invalid relay: {relay}")` |
+| 63 | `return jsonify({"error": "GPIO daemon not available"}), 503` | `return error_response(HARDWARE_ERROR, "GPIO daemon not available", 503)` |
+| 66 | `return jsonify({"error": "Failed to control GPIO"}), 500` | `return error_response(SERVER_ERROR, "Failed to control GPIO", 500)` |
+| 97 | `return jsonify({"error": "GPIO daemon not available"}), 503` | `return error_response(HARDWARE_ERROR, "GPIO daemon not available", 503)` |
+| 100 | `return jsonify({"error": "Failed to trigger flash"}), 500` | `return error_response(SERVER_ERROR, "Failed to trigger flash", 500)` |
+
+**Step 5: Migrate system.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    SERVER_ERROR,
+    error_response,
+)
+```
+
+Replace these 4 error responses:
+
+| Line | Before | After |
+|------|--------|-------|
+| 144 | `return jsonify({"error": "Failed to get storage info"}), 500` | `return error_response(SERVER_ERROR, "Failed to get storage info", 500)` |
+| 235 | `return jsonify({"error": "Failed to get power status"}), 500` | `return error_response(SERVER_ERROR, "Failed to get power status", 500)` |
+| 275 | `return jsonify({"error": "Failed to get system info"}), 500` | `return error_response(SERVER_ERROR, "Failed to get system info", 500)` |
+| 372 | `return jsonify({"error": "Failed to get diagnostic info"}), 500` | `return error_response(SERVER_ERROR, "Failed to get diagnostic info", 500)` |
+
+**Step 6: Run ruff**
+
+Run: `ruff check webui/backend/routes/camera.py webui/backend/routes/gpio.py webui/backend/routes/system.py && ruff format webui/backend/routes/camera.py webui/backend/routes/gpio.py webui/backend/routes/system.py`
+Expected: Clean (may warn about unused `jsonify` import if all uses removed — unlikely since success responses still use it)
+
+**Step 7: Run tests**
+
+Run: `python3 -m pytest Tests/unit/test_camera_routes.py Tests/unit/test_gpio_routes.py Tests/unit/test_system_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 8: Verify no remaining inline errors**
+
+Run: `grep -n 'jsonify({"error"' webui/backend/routes/camera.py webui/backend/routes/gpio.py webui/backend/routes/system.py`
+Expected: No output (all migrated)
+
+**Step 9: Commit and PR**
+
+```bash
+git add webui/backend/routes/camera.py webui/backend/routes/gpio.py webui/backend/routes/system.py
+git commit -m "$(cat <<'EOF'
+refactor: migrate hardware routes to shared error codes (#414)
+
+Migrate camera.py (6), gpio.py (8), and system.py (4) error responses
+to use error_response() from the shared error codes module.
+
+Batch 1 of 7 for issue #414.
+EOF
+)"
+```
+
+Push and create PR:
+```bash
+git push -u origin refactor/414-batch1-hardware
+gh pr create --base dev --title "refactor: migrate hardware routes to shared error codes (#414)" --body "$(cat <<'EOF'
+## Summary
+- Migrate `camera.py` (6), `gpio.py` (8), and `system.py` (4) error responses to `error_response()`
+- Batch 1 of 7 for #414
+
+## Test plan
+- [x] All existing tests pass (`test_camera_routes.py`, `test_gpio_routes.py`, `test_system_routes.py`)
+- [x] No remaining inline `jsonify({"error"` patterns in migrated files
+- [x] ruff clean
+EOF
+)"
+```
+
+---
+
+### Task 2: Batch 2 — Media routes (gallery.py, metadata.py)
+
+**Files:**
+- Modify: `webui/backend/routes/gallery.py` (~63 error responses)
+- Modify: `webui/backend/routes/metadata.py` (~13 error responses)
+- Test: `Tests/unit/test_gallery_routes.py`, `Tests/unit/test_metadata_routes.py`
+
+**Step 1: Create branch**
+
+Run: `git checkout -b refactor/414-batch2-media dev`
+
+**Step 2: Run baseline tests**
+
+Run: `python3 -m pytest Tests/unit/test_gallery_routes.py Tests/unit/test_metadata_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 3: Migrate gallery.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    HARDWARE_ERROR,
+    NOT_FOUND,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply the error code mapping to all ~63 responses:
+- 400 responses → `error_response(VALIDATION_ERROR, "...", 400)` (omit status since 400 is default)
+- 404 responses → `error_response(NOT_FOUND, "...", 404)`
+- 500 responses → `error_response(SERVER_ERROR, "...", 500)`
+- 503 responses → `error_response(HARDWARE_ERROR, "...", 503)`
+
+**Special case** — line 870 has extra field:
+```python
+# Before:
+return jsonify({"error": "Series not found", "series_id": series_id}), 404
+# After:
+return error_response(NOT_FOUND, "Series not found", 404, series_id=series_id)
+```
+
+**Step 4: Migrate metadata.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    HARDWARE_ERROR,
+    NOT_FOUND,
+    PERMISSION_ERROR,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all ~13 responses:
+- Line 71 (403 "Access denied") → `error_response(PERMISSION_ERROR, "Invalid path: Access denied", 403)`
+- 400 responses → `VALIDATION_ERROR`
+- 404 responses → `NOT_FOUND`
+- 500 responses → `SERVER_ERROR`
+- 503 responses → `HARDWARE_ERROR`
+
+**Step 5: Run ruff**
+
+Run: `ruff check webui/backend/routes/gallery.py webui/backend/routes/metadata.py && ruff format webui/backend/routes/gallery.py webui/backend/routes/metadata.py`
+Expected: Clean
+
+**Step 6: Run tests**
+
+Run: `python3 -m pytest Tests/unit/test_gallery_routes.py Tests/unit/test_metadata_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 7: Verify no remaining inline errors**
+
+Run: `grep -n 'jsonify({"error"' webui/backend/routes/gallery.py webui/backend/routes/metadata.py`
+Expected: No output
+
+**Step 8: Commit and PR**
+
+```bash
+git add webui/backend/routes/gallery.py webui/backend/routes/metadata.py
+git commit -m "$(cat <<'EOF'
+refactor: migrate media routes to shared error codes (#414)
+
+Migrate gallery.py (~63) and metadata.py (~13) error responses
+to use error_response() from the shared error codes module.
+
+Batch 2 of 7 for issue #414.
+EOF
+)"
+git push -u origin refactor/414-batch2-media
+gh pr create --base dev --title "refactor: migrate media routes to shared error codes (#414)" --body "$(cat <<'EOF'
+## Summary
+- Migrate `gallery.py` (~63) and `metadata.py` (~13) error responses to `error_response()`
+- Batch 2 of 7 for #414
+
+## Test plan
+- [x] All existing tests pass (`test_gallery_routes.py`, `test_metadata_routes.py`)
+- [x] No remaining inline `jsonify({"error"` patterns in migrated files
+- [x] ruff clean
+EOF
+)"
+```
+
+---
+
+### Task 3: Batch 3 — Config routes (config.py)
+
+**Files:**
+- Modify: `webui/backend/routes/config.py` (~53 error responses)
+- Test: `Tests/unit/test_config_routes.py`
+
+**Step 1: Create branch**
+
+Run: `git checkout -b refactor/414-batch3-config dev`
+
+**Step 2: Run baseline tests**
+
+Run: `python3 -m pytest Tests/unit/test_config_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 3: Migrate config.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all ~53 responses:
+- All 400 responses → `VALIDATION_ERROR` (default status, omit 400)
+- All 500 responses → `SERVER_ERROR`
+
+This file has no 403/404/503 responses — just validation errors and server errors.
+
+**Step 4: Run ruff**
+
+Run: `ruff check webui/backend/routes/config.py && ruff format webui/backend/routes/config.py`
+Expected: Clean
+
+**Step 5: Run tests**
+
+Run: `python3 -m pytest Tests/unit/test_config_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 6: Verify no remaining inline errors**
+
+Run: `grep -n 'jsonify({"error"' webui/backend/routes/config.py`
+Expected: No output
+
+**Step 7: Commit and PR**
+
+```bash
+git add webui/backend/routes/config.py
+git commit -m "$(cat <<'EOF'
+refactor: migrate config routes to shared error codes (#414)
+
+Migrate config.py (~53) error responses to use error_response()
+from the shared error codes module.
+
+Batch 3 of 7 for issue #414.
+EOF
+)"
+git push -u origin refactor/414-batch3-config
+gh pr create --base dev --title "refactor: migrate config routes to shared error codes (#414)" --body "$(cat <<'EOF'
+## Summary
+- Migrate `config.py` (~53) error responses to `error_response()`
+- Batch 3 of 7 for #414
+
+## Test plan
+- [x] All existing tests pass (`test_config_routes.py`)
+- [x] No remaining inline `jsonify({"error"` patterns
+- [x] ruff clean
+EOF
+)"
+```
+
+---
+
+### Task 4: Batch 4 — Export routes (export.py, export_presets.py)
+
+**Files:**
+- Modify: `webui/backend/routes/export.py` (~125 error responses)
+- Modify: `webui/backend/routes/export_presets.py` (~13 error responses)
+- Test: `Tests/unit/test_export_routes.py`, `Tests/unit/test_export_preset_routes.py`
+
+**Step 1: Create branch**
+
+Run: `git checkout -b refactor/414-batch4-export dev`
+
+**Step 2: Run baseline tests**
+
+Run: `python3 -m pytest Tests/unit/test_export_routes.py Tests/unit/test_export_preset_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 3: Migrate export.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    NOT_FOUND,
+    PERMISSION_ERROR,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all ~125 responses:
+- 400 responses → `VALIDATION_ERROR`
+- 403 responses → `PERMISSION_ERROR`
+- 404 responses → `NOT_FOUND`
+- 500 responses → `SERVER_ERROR`
+
+**Special cases** — lines 984 and 1128 have extra `details` field:
+```python
+# Before:
+return jsonify({"error": "ZIP export failed", "details": result.errors}), 500
+# After:
+return error_response(SERVER_ERROR, "ZIP export failed", 500, details=result.errors)
+```
+
+This is the largest file. Work methodically top-to-bottom.
+
+**Step 4: Migrate export_presets.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    NOT_FOUND,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all ~13 responses.
+
+**Step 5: Run ruff**
+
+Run: `ruff check webui/backend/routes/export.py webui/backend/routes/export_presets.py && ruff format webui/backend/routes/export.py webui/backend/routes/export_presets.py`
+Expected: Clean
+
+**Step 6: Run tests**
+
+Run: `python3 -m pytest Tests/unit/test_export_routes.py Tests/unit/test_export_preset_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 7: Verify no remaining inline errors**
+
+Run: `grep -n 'jsonify({"error"' webui/backend/routes/export.py webui/backend/routes/export_presets.py`
+Expected: No output
+
+**Step 8: Commit and PR**
+
+```bash
+git add webui/backend/routes/export.py webui/backend/routes/export_presets.py
+git commit -m "$(cat <<'EOF'
+refactor: migrate export routes to shared error codes (#414)
+
+Migrate export.py (~125) and export_presets.py (~13) error responses
+to use error_response() from the shared error codes module.
+
+Batch 4 of 7 for issue #414.
+EOF
+)"
+git push -u origin refactor/414-batch4-export
+gh pr create --base dev --title "refactor: migrate export routes to shared error codes (#414)" --body "$(cat <<'EOF'
+## Summary
+- Migrate `export.py` (~125) and `export_presets.py` (~13) error responses to `error_response()`
+- Batch 4 of 7 for #414
+
+## Test plan
+- [x] All existing tests pass (`test_export_routes.py`, `test_export_preset_routes.py`)
+- [x] No remaining inline `jsonify({"error"` patterns in migrated files
+- [x] ruff clean
+EOF
+)"
+```
+
+---
+
+### Task 5: Batch 5 — Deployment routes (deployment.py, sidecar.py)
+
+**Files:**
+- Modify: `webui/backend/routes/deployment.py` (~93 error responses)
+- Modify: `webui/backend/routes/sidecar.py` (~153 error responses)
+- Test: `Tests/unit/test_deployment_routes.py`, `Tests/unit/test_sidecar_routes_filtering.py`
+
+**Step 1: Create branch**
+
+Run: `git checkout -b refactor/414-batch5-deployment dev`
+
+**Step 2: Run baseline tests**
+
+Run: `python3 -m pytest Tests/unit/test_deployment_routes.py Tests/unit/test_sidecar_routes_filtering.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 3: Migrate deployment.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    HARDWARE_ERROR,
+    NOT_FOUND,
+    PERMISSION_ERROR,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all ~93 responses:
+- 400 responses → `VALIDATION_ERROR`
+- 403 responses → `PERMISSION_ERROR`
+- 404 responses → `NOT_FOUND`
+- 500 responses → `SERVER_ERROR`
+- 503 responses → `HARDWARE_ERROR`
+
+**Step 4: Migrate sidecar.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    HARDWARE_ERROR,
+    NOT_FOUND,
+    PERMISSION_ERROR,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all ~153 responses.
+
+**Step 5: Run ruff**
+
+Run: `ruff check webui/backend/routes/deployment.py webui/backend/routes/sidecar.py && ruff format webui/backend/routes/deployment.py webui/backend/routes/sidecar.py`
+Expected: Clean
+
+**Step 6: Run tests**
+
+Run: `python3 -m pytest Tests/unit/test_deployment_routes.py Tests/unit/test_sidecar_routes_filtering.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 7: Verify no remaining inline errors**
+
+Run: `grep -n 'jsonify({"error"' webui/backend/routes/deployment.py webui/backend/routes/sidecar.py`
+Expected: No output
+
+**Step 8: Commit and PR**
+
+```bash
+git add webui/backend/routes/deployment.py webui/backend/routes/sidecar.py
+git commit -m "$(cat <<'EOF'
+refactor: migrate deployment routes to shared error codes (#414)
+
+Migrate deployment.py (~93) and sidecar.py (~153) error responses
+to use error_response() from the shared error codes module.
+
+Batch 5 of 7 for issue #414.
+EOF
+)"
+git push -u origin refactor/414-batch5-deployment
+gh pr create --base dev --title "refactor: migrate deployment routes to shared error codes (#414)" --body "$(cat <<'EOF'
+## Summary
+- Migrate `deployment.py` (~93) and `sidecar.py` (~153) error responses to `error_response()`
+- Batch 5 of 7 for #414
+
+## Test plan
+- [x] All existing tests pass (`test_deployment_routes.py`, `test_sidecar_routes_filtering.py`)
+- [x] No remaining inline `jsonify({"error"` patterns in migrated files
+- [x] ruff clean
+EOF
+)"
+```
+
+---
+
+### Task 6: Batch 6 — Search & GPS routes (search.py, gps.py, gps_exif.py)
+
+**Files:**
+- Modify: `webui/backend/routes/search.py` (10 error responses)
+- Modify: `webui/backend/routes/gps.py` (14 error responses)
+- Modify: `webui/backend/routes/gps_exif.py` (20 error responses)
+- Test: `Tests/unit/test_search_api.py`, `Tests/unit/test_gps_routes.py`, `Tests/unit/test_gps_exif_routes.py`
+
+**Step 1: Create branch**
+
+Run: `git checkout -b refactor/414-batch6-search-gps dev`
+
+**Step 2: Run baseline tests**
+
+Run: `python3 -m pytest Tests/unit/test_search_api.py Tests/unit/test_gps_routes.py Tests/unit/test_gps_exif_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 3: Migrate search.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    HARDWARE_ERROR,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all 10 responses:
+- 400 responses → `VALIDATION_ERROR`
+- 500 responses → `SERVER_ERROR`
+- 503 responses → `HARDWARE_ERROR`
+
+**Step 4: Migrate gps.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all 14 responses:
+- 400 responses → `VALIDATION_ERROR`
+- 408 responses → `VALIDATION_ERROR` (GPS timeout — treated as a request-level validation failure)
+- 500 responses → `SERVER_ERROR`
+
+**Step 5: Migrate gps_exif.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    NOT_FOUND,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all 20 responses.
+
+**Step 6: Run ruff**
+
+Run: `ruff check webui/backend/routes/search.py webui/backend/routes/gps.py webui/backend/routes/gps_exif.py && ruff format webui/backend/routes/search.py webui/backend/routes/gps.py webui/backend/routes/gps_exif.py`
+Expected: Clean
+
+**Step 7: Run tests**
+
+Run: `python3 -m pytest Tests/unit/test_search_api.py Tests/unit/test_gps_routes.py Tests/unit/test_gps_exif_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 8: Verify no remaining inline errors**
+
+Run: `grep -n 'jsonify({"error"' webui/backend/routes/search.py webui/backend/routes/gps.py webui/backend/routes/gps_exif.py`
+Expected: No output
+
+**Step 9: Commit and PR**
+
+```bash
+git add webui/backend/routes/search.py webui/backend/routes/gps.py webui/backend/routes/gps_exif.py
+git commit -m "$(cat <<'EOF'
+refactor: migrate search & GPS routes to shared error codes (#414)
+
+Migrate search.py (10), gps.py (14), and gps_exif.py (20) error
+responses to use error_response() from the shared error codes module.
+
+Batch 6 of 7 for issue #414.
+EOF
+)"
+git push -u origin refactor/414-batch6-search-gps
+gh pr create --base dev --title "refactor: migrate search & GPS routes to shared error codes (#414)" --body "$(cat <<'EOF'
+## Summary
+- Migrate `search.py` (10), `gps.py` (14), and `gps_exif.py` (20) error responses to `error_response()`
+- Batch 6 of 7 for #414
+
+## Test plan
+- [x] All existing tests pass (`test_search_api.py`, `test_gps_routes.py`, `test_gps_exif_routes.py`)
+- [x] No remaining inline `jsonify({"error"` patterns in migrated files
+- [x] ruff clean
+EOF
+)"
+```
+
+---
+
+### Task 7: Batch 7 — Misc routes (preferences.py, presets.py, scheduler.py)
+
+**Files:**
+- Modify: `webui/backend/routes/preferences.py` (9 error responses)
+- Modify: `webui/backend/routes/presets.py` (~21 error responses)
+- Modify: `webui/backend/routes/scheduler.py` (8 error responses)
+- Test: `Tests/unit/test_preferences_routes.py`, `Tests/unit/test_presets_routes.py`, `Tests/unit/test_scheduler_routes.py`
+
+**Step 1: Create branch**
+
+Run: `git checkout -b refactor/414-batch7-misc dev`
+
+**Step 2: Run baseline tests**
+
+Run: `python3 -m pytest Tests/unit/test_preferences_routes.py Tests/unit/test_presets_routes.py Tests/unit/test_scheduler_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 3: Migrate preferences.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all 9 responses.
+
+**Step 4: Migrate presets.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    NOT_FOUND,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all ~21 responses.
+
+**Step 5: Migrate scheduler.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all 8 responses.
+
+**Step 6: Run ruff**
+
+Run: `ruff check webui/backend/routes/preferences.py webui/backend/routes/presets.py webui/backend/routes/scheduler.py && ruff format webui/backend/routes/preferences.py webui/backend/routes/presets.py webui/backend/routes/scheduler.py`
+Expected: Clean
+
+**Step 7: Run tests**
+
+Run: `python3 -m pytest Tests/unit/test_preferences_routes.py Tests/unit/test_presets_routes.py Tests/unit/test_scheduler_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 8: Verify no remaining inline errors**
+
+Run: `grep -n 'jsonify({"error"' webui/backend/routes/preferences.py webui/backend/routes/presets.py webui/backend/routes/scheduler.py`
+Expected: No output
+
+**Step 9: Final sweep — verify zero inline errors across ALL route files**
+
+Run: `grep -rn 'jsonify({"error"' webui/backend/routes/`
+Expected: No output (all 16 files migrated, scheduler_ui.py was already done)
+
+**Step 10: Commit and PR**
+
+```bash
+git add webui/backend/routes/preferences.py webui/backend/routes/presets.py webui/backend/routes/scheduler.py
+git commit -m "$(cat <<'EOF'
+refactor: migrate misc routes to shared error codes (#414)
+
+Migrate preferences.py (9), presets.py (~21), and scheduler.py (8)
+error responses to use error_response() from the shared error codes
+module.
+
+Batch 7 of 7 for issue #414. All 16 route files now use the shared
+error codes module.
+EOF
+)"
+git push -u origin refactor/414-batch7-misc
+gh pr create --base dev --title "refactor: migrate misc routes to shared error codes (#414)" --body "$(cat <<'EOF'
+## Summary
+- Migrate `preferences.py` (9), `presets.py` (~21), and `scheduler.py` (8) error responses to `error_response()`
+- Batch 7 of 7 for #414 — completes the migration
+
+## Test plan
+- [x] All existing tests pass (`test_preferences_routes.py`, `test_presets_routes.py`, `test_scheduler_routes.py`)
+- [x] No remaining inline `jsonify({"error"` patterns in ANY route file
+- [x] ruff clean
+- [x] Final sweep: `grep -rn 'jsonify({"error"' webui/backend/routes/` returns nothing
+EOF
+)"
+```

--- a/Firmware/webui/backend/routes/gallery.py
+++ b/Firmware/webui/backend/routes/gallery.py
@@ -41,6 +41,14 @@ from pathlib import Path
 from constants import MAX_BULK_DELETE, PHOTO_PATTERNS
 from flask import Blueprint, current_app, jsonify, request, send_file
 
+from webui.backend.lib.error_codes import (
+    HARDWARE_ERROR,
+    NOT_FOUND,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+
 # Import will be available when app.py is created
 # For now, using a simple limiter stub
 try:
@@ -149,7 +157,7 @@ def list_photos():
         return jsonify({"photos": photos})
     except Exception as e:
         logger.error(f"Error in list_photos: {e}")
-        return jsonify({"error": "Failed to list photos"}), 500
+        return error_response(SERVER_ERROR, "Failed to list photos", 500)
 
 
 @gallery_bp.route("/photo/<path:photo_path>", methods=["GET"])
@@ -160,16 +168,16 @@ def get_photo(photo_path):
         full_path = validate_photo_path(photo_path, PHOTOS_DIR)
 
         if full_path is None:
-            return jsonify({"error": "Invalid path"}), 400
+            return error_response(VALIDATION_ERROR, "Invalid path")
 
         if not full_path.exists():
-            return jsonify({"error": "Photo not found"}), 404
+            return error_response(NOT_FOUND, "Photo not found", 404)
 
         mimetype = mimetypes.guess_type(str(full_path))[0] or "image/jpeg"
         return send_file(full_path, mimetype=mimetype)
     except Exception as e:
         logger.error(f"Error serving photo {photo_path}: {e}", exc_info=True)
-        return jsonify({"error": "Failed to serve photo"}), 500
+        return error_response(SERVER_ERROR, "Failed to serve photo", 500)
 
 
 @gallery_bp.route("/thumbnail/<path:photo_path>", methods=["GET"])
@@ -180,7 +188,7 @@ def get_thumbnail(photo_path):
         full_photo_path = validate_photo_path(photo_path, PHOTOS_DIR)
 
         if full_photo_path is None:
-            return jsonify({"error": "Invalid path"}), 400
+            return error_response(VALIDATION_ERROR, "Invalid path")
 
         # Get size from query params (default: 256)
         size = request.args.get("size", 256, type=int)
@@ -195,7 +203,7 @@ def get_thumbnail(photo_path):
                 return send_file(thumbnail_path, mimetype="image/jpeg")
             except ThumbnailError as e:
                 current_app.logger.error(f"ThumbnailError: {e}")
-                return jsonify({"error": "Failed to generate thumbnail"}), 400
+                return error_response(VALIDATION_ERROR, "Failed to generate thumbnail")
         else:
             # Fallback to original behavior if cache not available
             import io
@@ -206,7 +214,7 @@ def get_thumbnail(photo_path):
             full_path = full_photo_path
 
             if not full_path.exists():
-                return jsonify({"error": "Photo not found"}), 404
+                return error_response(NOT_FOUND, "Photo not found", 404)
 
             # Generate thumbnail
             img = Image.open(full_path)
@@ -221,10 +229,10 @@ def get_thumbnail(photo_path):
     except (ValueError, RuntimeError):
         # ValueError: Path is outside PHOTOS_DIR
         # RuntimeError: resolve() failed (e.g., symlink loop)
-        return jsonify({"error": "Invalid path"}), 400
+        return error_response(VALIDATION_ERROR, "Invalid path")
     except Exception as e:
         logger.error(f"Error listing photos: {e}")
-        return jsonify({"error": "Internal server error"}), 500
+        return error_response(SERVER_ERROR, "Internal server error", 500)
 
 
 @gallery_bp.route("/photos/paginated", methods=["GET"])
@@ -268,7 +276,9 @@ def list_photos_paginated():
             try:
                 limit = int(limit_str)
             except ValueError:
-                return jsonify({"error": f"Limit must be an integer, got '{limit_str}'"}), 400
+                return error_response(
+                    VALIDATION_ERROR, f"Limit must be an integer, got '{limit_str}'"
+                )
         else:
             limit = 50
 
@@ -277,7 +287,9 @@ def list_photos_paginated():
             try:
                 offset = int(offset_str)
             except ValueError:
-                return jsonify({"error": f"Offset must be an integer, got '{offset_str}'"}), 400
+                return error_response(
+                    VALIDATION_ERROR, f"Offset must be an integer, got '{offset_str}'"
+                )
         else:
             offset = 0
 
@@ -293,26 +305,18 @@ def list_photos_paginated():
             try:
                 start_date = datetime.fromisoformat(start_date_str)
             except (ValueError, TypeError):
-                return (
-                    jsonify(
-                        {
-                            "error": f"Invalid start_date format: '{start_date_str}'. Use ISO format (YYYY-MM-DD)"
-                        }
-                    ),
-                    400,
+                return error_response(
+                    VALIDATION_ERROR,
+                    f"Invalid start_date format: '{start_date_str}'. Use ISO format (YYYY-MM-DD)",
                 )
 
         if end_date_str:
             try:
                 end_date = datetime.fromisoformat(end_date_str)
             except (ValueError, TypeError):
-                return (
-                    jsonify(
-                        {
-                            "error": f"Invalid end_date format: '{end_date_str}'. Use ISO format (YYYY-MM-DD)"
-                        }
-                    ),
-                    400,
+                return error_response(
+                    VALIDATION_ERROR,
+                    f"Invalid end_date format: '{end_date_str}'. Use ISO format (YYYY-MM-DD)",
                 )
 
         # Create photo service and get paginated results
@@ -331,12 +335,12 @@ def list_photos_paginated():
         # Log full error details server-side (CodeQL security requirement)
         logger.error(f"Pagination error: {e}", exc_info=True)
         # Return generic message to user (don't expose internal details)
-        return jsonify({"error": "Invalid pagination parameters"}), 400
+        return error_response(VALIDATION_ERROR, "Invalid pagination parameters")
     except Exception as e:
         # Log full error details server-side
         logger.error(f"Unexpected error in list_photos_paginated: {e}", exc_info=True)
         # Return generic message to user
-        return jsonify({"error": "Internal server error"}), 500
+        return error_response(SERVER_ERROR, "Internal server error", 500)
 
 
 # ============================================================================
@@ -377,17 +381,16 @@ def get_photo_metadata(photo_id):
 
     invalid = requested_categories - VALID_CATEGORIES
     if invalid:
-        return jsonify(
-            {
-                "success": False,
-                "error": f"Invalid category: {', '.join(invalid)}. Valid: {', '.join(sorted(VALID_CATEGORIES))}",
-            }
-        ), 400
+        return error_response(
+            VALIDATION_ERROR,
+            f"Invalid category: {', '.join(invalid)}. Valid: {', '.join(sorted(VALID_CATEGORIES))}",
+            success=False,
+        )
 
     # 2. Resolve photo path with security checks
     photo_path = _resolve_photo_path(photo_id)
     if not photo_path:
-        return jsonify({"success": False, "error": "Photo not found", "photo_id": photo_id}), 404
+        return error_response(NOT_FOUND, "Photo not found", 404, success=False, photo_id=photo_id)
 
     # 3. Try cache first
     cache = get_metadata_cache()
@@ -438,7 +441,7 @@ def get_photo_metadata(photo_id):
             # Log full error details server-side (CodeQL security requirement)
             logger.error(f"Metadata extraction failed for {photo_path}: {e}", exc_info=True)
             # Return generic message to user (don't expose internal details)
-            return jsonify({"success": False, "error": "Failed to read metadata"}), 500
+            return error_response(SERVER_ERROR, "Failed to read metadata", 500, success=False)
 
     # 5. Apply category filtering
     if "all" not in requested_categories:
@@ -487,7 +490,7 @@ def clear_photo_metadata_cache(photo_id):
     # Resolve photo path
     photo_path = _resolve_photo_path(photo_id)
     if not photo_path:
-        return jsonify({"success": False, "error": "Photo not found", "photo_id": photo_id}), 404
+        return error_response(NOT_FOUND, "Photo not found", 404, success=False, photo_id=photo_id)
 
     # Invalidate cache
     cache = get_metadata_cache()
@@ -579,7 +582,7 @@ def cache_stats():
     thumbnail_cache = current_app.config.get("THUMBNAIL_CACHE")
 
     if not thumbnail_cache:
-        return jsonify({"error": "Cache not available"}), 503
+        return error_response(HARDWARE_ERROR, "Cache not available", 503)
 
     stats = thumbnail_cache.get_statistics()
     return jsonify(stats)
@@ -591,7 +594,7 @@ def cache_invalidate():
     thumbnail_cache = current_app.config.get("THUMBNAIL_CACHE")
 
     if not thumbnail_cache:
-        return jsonify({"error": "Cache not available"}), 503
+        return error_response(HARDWARE_ERROR, "Cache not available", 503)
 
     # Get optional photo_path from request JSON
     data = request.get_json() or {}
@@ -604,7 +607,7 @@ def cache_invalidate():
             photo_path = validate_photo_path(photo_path_str, PHOTOS_DIR)
 
             if photo_path is None:
-                return jsonify({"error": "Invalid path"}), 400
+                return error_response(VALIDATION_ERROR, "Invalid path")
 
             thumbnail_cache.invalidate(photo_path, size=size)
             message = f"Invalidated cache for {photo_path_str}"
@@ -616,7 +619,7 @@ def cache_invalidate():
 
     except Exception as e:
         logger.error(f"Cache invalidation error: {e}", exc_info=True)
-        return jsonify({"error": "Cache invalidation failed"}), 400
+        return error_response(VALIDATION_ERROR, "Cache invalidation failed")
 
 
 @gallery_bp.route("/cache/warm", methods=["POST"])
@@ -642,7 +645,7 @@ def cache_warm():
     cache_warmer = current_app.config.get("CACHE_WARMER")
 
     if not cache_warmer:
-        return jsonify({"error": "Cache warmer not available"}), 503
+        return error_response(HARDWARE_ERROR, "Cache warmer not available", 503)
 
     # Get optional parameters from request JSON
     data = request.get_json() or {}
@@ -657,7 +660,7 @@ def cache_warm():
 
     except Exception as e:
         logger.error(f"Error starting cache warming: {e}")
-        return jsonify({"error": "Failed to start cache warming"}), 400
+        return error_response(VALIDATION_ERROR, "Failed to start cache warming")
 
 
 @gallery_bp.route("/cache/warm/status", methods=["GET"])
@@ -678,7 +681,7 @@ def cache_warm_status(task_id=None):
     cache_warmer = current_app.config.get("CACHE_WARMER")
 
     if not cache_warmer:
-        return jsonify({"error": "Cache warmer not available"}), 503
+        return error_response(HARDWARE_ERROR, "Cache warmer not available", 503)
 
     try:
         status = cache_warmer.get_warming_status(task_id)
@@ -686,7 +689,7 @@ def cache_warm_status(task_id=None):
 
     except Exception as e:
         logger.error(f"Error getting warming status: {e}")
-        return jsonify({"error": "Failed to get warming status"}), 400
+        return error_response(VALIDATION_ERROR, "Failed to get warming status")
 
 
 @gallery_bp.route("/cache/warm/cancel/<task_id>", methods=["POST"])
@@ -695,7 +698,7 @@ def cache_warm_cancel(task_id):
     cache_warmer = current_app.config.get("CACHE_WARMER")
 
     if not cache_warmer:
-        return jsonify({"error": "Cache warmer not available"}), 503
+        return error_response(HARDWARE_ERROR, "Cache warmer not available", 503)
 
     try:
         result = cache_warmer.cancel_warming(task_id)
@@ -703,7 +706,7 @@ def cache_warm_cancel(task_id):
 
     except Exception as e:
         logger.error(f"Error cancelling cache warming: {e}")
-        return jsonify({"error": "Failed to cancel warming task"}), 400
+        return error_response(VALIDATION_ERROR, "Failed to cancel warming task")
 
 
 # For testing: allow resetting the cache singleton
@@ -754,7 +757,7 @@ def list_series():
     series_service = current_app.config.get("SERIES_SERVICE")
 
     if not series_service:
-        return jsonify({"error": "Series service not available"}), 503
+        return error_response(HARDWARE_ERROR, "Series service not available", 503)
 
     # Parse pagination parameters
     try:
@@ -762,21 +765,20 @@ def list_series():
         per_page = request.args.get("per_page", 50, type=int)
 
         if page < 1:
-            return jsonify({"error": "Page must be >= 1"}), 400
+            return error_response(VALIDATION_ERROR, "Page must be >= 1")
         if per_page < 1 or per_page > 100:
-            return jsonify({"error": "per_page must be 1-100"}), 400
+            return error_response(VALIDATION_ERROR, "per_page must be 1-100")
 
     except (ValueError, TypeError) as e:
-        return jsonify({"error": f"Invalid pagination parameter: {e}"}), 400
+        return error_response(VALIDATION_ERROR, f"Invalid pagination parameter: {e}")
 
     # Parse type filter
     series_type_filter = request.args.get("type")
     if series_type_filter and series_type_filter not in VALID_SERIES_TYPES:
-        return jsonify(
-            {
-                "error": f"Invalid type: {series_type_filter}. Valid: {', '.join(sorted(VALID_SERIES_TYPES))}"
-            }
-        ), 400
+        return error_response(
+            VALIDATION_ERROR,
+            f"Invalid type: {series_type_filter}. Valid: {', '.join(sorted(VALID_SERIES_TYPES))}",
+        )
 
     try:
         # Get all series from directory
@@ -832,7 +834,7 @@ def list_series():
 
     except Exception as e:
         logger.error(f"Error listing series: {e}", exc_info=True)
-        return jsonify({"error": "Failed to list series"}), 500
+        return error_response(SERVER_ERROR, "Failed to list series", 500)
 
 
 @gallery_bp.route("/series/<series_id>", methods=["GET"])
@@ -857,7 +859,7 @@ def get_series(series_id):
     series_service = current_app.config.get("SERIES_SERVICE")
 
     if not series_service:
-        return jsonify({"error": "Series service not available"}), 503
+        return error_response(HARDWARE_ERROR, "Series service not available", 503)
 
     try:
         # First ensure directory is scanned
@@ -867,7 +869,7 @@ def get_series(series_id):
         series = series_service.get_series_by_id(series_id)
 
         if not series:
-            return jsonify({"error": "Series not found", "series_id": series_id}), 404
+            return error_response(NOT_FOUND, "Series not found", 404, series_id=series_id)
 
         # Convert paths to relative strings
         photos_relative = [
@@ -893,7 +895,7 @@ def get_series(series_id):
 
     except Exception as e:
         logger.error(f"Error getting series {series_id}: {e}", exc_info=True)
-        return jsonify({"error": "Failed to get series"}), 500
+        return error_response(SERVER_ERROR, "Failed to get series", 500)
 
 
 @gallery_bp.route("/series/stats", methods=["GET"])
@@ -911,7 +913,7 @@ def get_series_stats():
     series_service = current_app.config.get("SERIES_SERVICE")
 
     if not series_service:
-        return jsonify({"error": "Series service not available"}), 503
+        return error_response(HARDWARE_ERROR, "Series service not available", 503)
 
     try:
         stats = series_service.get_statistics()
@@ -919,7 +921,7 @@ def get_series_stats():
 
     except Exception as e:
         logger.error(f"Error getting series stats: {e}", exc_info=True)
-        return jsonify({"error": "Failed to get statistics"}), 500
+        return error_response(SERVER_ERROR, "Failed to get statistics", 500)
 
 
 @gallery_bp.route("/series/cache/invalidate", methods=["POST"])
@@ -940,7 +942,7 @@ def invalidate_series_cache():
     series_service = current_app.config.get("SERIES_SERVICE")
 
     if not series_service:
-        return jsonify({"error": "Series service not available"}), 503
+        return error_response(HARDWARE_ERROR, "Series service not available", 503)
 
     try:
         data = request.get_json() or {}
@@ -950,7 +952,7 @@ def invalidate_series_cache():
             # Validate path security
             dir_path = validate_photo_path(directory, PHOTOS_DIR)
             if dir_path is None:
-                return jsonify({"error": "Invalid directory path"}), 400
+                return error_response(VALIDATION_ERROR, "Invalid directory path")
             series_service.invalidate_cache(dir_path)
             message = f"Invalidated series cache for {directory}"
         else:
@@ -961,7 +963,7 @@ def invalidate_series_cache():
 
     except Exception as e:
         logger.error(f"Error invalidating series cache: {e}", exc_info=True)
-        return jsonify({"error": "Failed to invalidate cache"}), 500
+        return error_response(SERVER_ERROR, "Failed to invalidate cache", 500)
 
 
 # ============================================================================
@@ -999,11 +1001,11 @@ def get_photo_locations():
             try:
                 limit = int(limit_str)
             except ValueError:
-                return jsonify({"error": "Limit parameter must be a valid integer"}), 400
+                return error_response(VALIDATION_ERROR, "Limit parameter must be a valid integer")
             if limit <= 0:
-                return jsonify({"error": "Limit must be greater than 0"}), 400
+                return error_response(VALIDATION_ERROR, "Limit must be greater than 0")
             if limit > 10000:
-                return jsonify({"error": "Limit must be 10000 or less"}), 400
+                return error_response(VALIDATION_ERROR, "Limit must be 10000 or less")
         else:
             limit = 1000
 
@@ -1013,7 +1015,7 @@ def get_photo_locations():
 
     except Exception as e:
         logger.error(f"Error getting photo locations: {e}", exc_info=True)
-        return jsonify({"error": "Failed to get photo locations"}), 500
+        return error_response(SERVER_ERROR, "Failed to get photo locations", 500)
 
 
 @gallery_bp.route("/locations/cache/invalidate", methods=["POST"])
@@ -1039,7 +1041,7 @@ def invalidate_locations_cache():
             # Validate path security
             dir_path = validate_photo_path(directory, PHOTOS_DIR)
             if dir_path is None:
-                return jsonify({"error": "Invalid directory path"}), 400
+                return error_response(VALIDATION_ERROR, "Invalid directory path")
             _locations_service.invalidate_cache(dir_path)
             message = f"Invalidated locations cache for {directory}"
         else:
@@ -1050,7 +1052,7 @@ def invalidate_locations_cache():
 
     except Exception as e:
         logger.error(f"Error invalidating locations cache: {e}", exc_info=True)
-        return jsonify({"error": "Failed to invalidate cache"}), 500
+        return error_response(SERVER_ERROR, "Failed to invalidate cache", 500)
 
 
 @gallery_bp.route("/locations/stats", methods=["GET"])
@@ -1074,7 +1076,7 @@ def get_locations_stats():
 
     except Exception as e:
         logger.error(f"Error getting locations stats: {e}", exc_info=True)
-        return jsonify({"error": "Failed to get statistics"}), 500
+        return error_response(SERVER_ERROR, "Failed to get statistics", 500)
 
 
 # ============================================================================
@@ -1112,7 +1114,7 @@ def get_clustered_locations():
     clustering_service = current_app.config.get("CLUSTERING_SERVICE")
 
     if not clustering_service:
-        return jsonify({"error": "Clustering service not available"}), 503
+        return error_response(HARDWARE_ERROR, "Clustering service not available", 503)
 
     try:
         # Parse query parameters
@@ -1125,10 +1127,10 @@ def get_clustered_locations():
             try:
                 radius = int(radius_str)
             except ValueError:
-                return jsonify({"error": "Radius parameter must be a valid integer"}), 400
+                return error_response(VALIDATION_ERROR, "Radius parameter must be a valid integer")
 
             if radius < 0:
-                return jsonify({"error": "Radius must be non-negative"}), 400
+                return error_response(VALIDATION_ERROR, "Radius must be non-negative")
         else:
             radius = None  # Use service default
 
@@ -1137,10 +1139,12 @@ def get_clustered_locations():
             try:
                 min_size = int(min_size_str)
             except ValueError:
-                return jsonify({"error": "min_size parameter must be a valid integer"}), 400
+                return error_response(
+                    VALIDATION_ERROR, "min_size parameter must be a valid integer"
+                )
 
             if min_size < 0:
-                return jsonify({"error": "min_size must be non-negative"}), 400
+                return error_response(VALIDATION_ERROR, "min_size must be non-negative")
         else:
             min_size = None  # Use service default
 
@@ -1245,7 +1249,7 @@ def get_clustered_locations():
 
     except Exception as e:
         logger.error(f"Error getting clustered locations: {e}", exc_info=True)
-        return jsonify({"error": "Failed to get clustered locations"}), 500
+        return error_response(SERVER_ERROR, "Failed to get clustered locations", 500)
 
 
 @gallery_bp.route("/locations/clustered/stats", methods=["GET"])
@@ -1267,7 +1271,7 @@ def get_clustered_locations_stats():
     clustering_service = current_app.config.get("CLUSTERING_SERVICE")
 
     if not clustering_service:
-        return jsonify({"error": "Clustering service not available"}), 503
+        return error_response(HARDWARE_ERROR, "Clustering service not available", 503)
 
     try:
         stats = clustering_service.get_statistics()
@@ -1275,7 +1279,7 @@ def get_clustered_locations_stats():
 
     except Exception as e:
         logger.error(f"Error getting clustering stats: {e}", exc_info=True)
-        return jsonify({"error": "Failed to get statistics"}), 500
+        return error_response(SERVER_ERROR, "Failed to get statistics", 500)
 
 
 @gallery_bp.route("/locations/clustered/cache/invalidate", methods=["POST"])
@@ -1297,7 +1301,7 @@ def invalidate_clustered_locations_cache():
     clustering_service = current_app.config.get("CLUSTERING_SERVICE")
 
     if not clustering_service:
-        return jsonify({"error": "Clustering service not available"}), 503
+        return error_response(HARDWARE_ERROR, "Clustering service not available", 503)
 
     try:
         # Handle missing or empty JSON body gracefully
@@ -1310,7 +1314,7 @@ def invalidate_clustered_locations_cache():
             # Validate path security
             dir_path = validate_photo_path(directory, PHOTOS_DIR)
             if dir_path is None:
-                return jsonify({"error": "Invalid directory path"}), 400
+                return error_response(VALIDATION_ERROR, "Invalid directory path")
             clustering_service.invalidate_cache(dir_path)
             message = f"Invalidated clustering cache for {directory}"
         else:
@@ -1321,7 +1325,7 @@ def invalidate_clustered_locations_cache():
 
     except Exception as e:
         logger.error(f"Error invalidating clustering cache: {e}", exc_info=True)
-        return jsonify({"error": "Failed to invalidate cache"}), 500
+        return error_response(SERVER_ERROR, "Failed to invalidate cache", 500)
 
 
 # ============================================================================
@@ -1362,18 +1366,18 @@ def bulk_delete_photos():
     data = request.get_json()
 
     if not data or "filenames" not in data:
-        return jsonify({"error": "filenames array required"}), 400
+        return error_response(VALIDATION_ERROR, "filenames array required")
 
     filenames = data["filenames"]
 
     if not filenames or not isinstance(filenames, list):
-        return jsonify({"error": "filenames must be non-empty array"}), 400
+        return error_response(VALIDATION_ERROR, "filenames must be non-empty array")
 
     # Deduplicate filenames (preserves first occurrence order)
     filenames = list(dict.fromkeys(filenames))
 
     if len(filenames) > MAX_BULK_DELETE:
-        return jsonify({"error": f"Maximum {MAX_BULK_DELETE} files per request"}), 400
+        return error_response(VALIDATION_ERROR, f"Maximum {MAX_BULK_DELETE} files per request")
 
     success = []
     failed = []

--- a/Firmware/webui/backend/routes/metadata.py
+++ b/Firmware/webui/backend/routes/metadata.py
@@ -23,6 +23,14 @@ from security_utils import sanitize_error_message, validate_photo_path
 from services.metadata_service import MetadataService
 
 from mothbox_paths import PHOTOS_DIR
+from webui.backend.lib.error_codes import (
+    HARDWARE_ERROR,
+    NOT_FOUND,
+    PERMISSION_ERROR,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -68,29 +76,29 @@ def get_photo_metadata(photo_path: str):
         # Path traversal protection with multiple security layers
         full_path = validate_photo_path(photo_path, PHOTOS_DIR)
         if full_path is None:
-            return jsonify({"error": "Invalid path: Access denied"}), 403
+            return error_response(PERMISSION_ERROR, "Invalid path: Access denied", 403)
 
         # Check if photo exists
         if not full_path.exists():
-            return jsonify({"error": "Photo not found"}), 404
+            return error_response(NOT_FOUND, "Photo not found", 404)
 
         # Extract metadata
         metadata = metadata_service.get_photo_metadata(full_path)
 
         # Check if metadata extraction failed
         if "error" in metadata:
-            return jsonify({"error": "Failed to extract metadata"}), 500
+            return error_response(SERVER_ERROR, "Failed to extract metadata", 500)
 
         return jsonify(metadata), 200
 
     except (RuntimeError, OSError) as e:
         # Log full error, return sanitized message
         error_msg = sanitize_error_message(e, "File system error occurred")
-        return jsonify({"error": error_msg}), 500
+        return error_response(SERVER_ERROR, error_msg, 500)
     except Exception as e:
         # Log full error, return sanitized message
         error_msg = sanitize_error_message(e, "Internal server error")
-        return jsonify({"error": error_msg}), 500
+        return error_response(SERVER_ERROR, error_msg, 500)
 
 
 @metadata_bp.route("/batch/metadata", methods=["POST"])
@@ -135,20 +143,20 @@ def get_batch_metadata():
     try:
         # Validate request body
         if not request.is_json:
-            return jsonify({"error": "Request must be JSON"}), 400
+            return error_response(VALIDATION_ERROR, "Request must be JSON")
 
         try:
             data = request.get_json()
         except Exception:
-            return jsonify({"error": "Invalid JSON in request body"}), 400
+            return error_response(VALIDATION_ERROR, "Invalid JSON in request body")
 
         if not data or "photo_paths" not in data:
-            return jsonify({"error": "Missing 'photo_paths' in request body"}), 400
+            return error_response(VALIDATION_ERROR, "Missing 'photo_paths' in request body")
 
         photo_paths = data["photo_paths"]
 
         if not isinstance(photo_paths, list):
-            return jsonify({"error": "'photo_paths' must be an array"}), 400
+            return error_response(VALIDATION_ERROR, "'photo_paths' must be an array")
 
         if len(photo_paths) == 0:
             return jsonify({"results": [], "total": 0, "successful": 0, "failed": 0}), 200
@@ -182,7 +190,7 @@ def get_batch_metadata():
     except Exception as e:
         # Log full error, return sanitized message
         error_msg = sanitize_error_message(e, "Batch processing failed")
-        return jsonify({"error": error_msg}), 500
+        return error_response(SERVER_ERROR, error_msg, 500)
 
 
 # ============================================================================
@@ -239,12 +247,12 @@ def get_tag_autocomplete():
         # Get autocomplete engine
         engine = current_app.config.get("TAG_AUTOCOMPLETE_ENGINE")
         if engine is None:
-            return jsonify({"error": "Service unavailable"}), 503
+            return error_response(HARDWARE_ERROR, "Service unavailable", 503)
 
         # Get query parameter (required)
         query = request.args.get("q")
         if query is None:
-            return jsonify({"error": "Missing required parameter: q"}), 400
+            return error_response(VALIDATION_ERROR, "Missing required parameter: q")
 
         # Get limit parameter (optional, default: 10, max: 50)
         try:
@@ -297,4 +305,4 @@ def get_tag_autocomplete():
     except Exception as e:
         error_msg = sanitize_error_message(e, "Failed to get tag suggestions")
         logger.error(f"Tag autocomplete error: {e}")
-        return jsonify({"error": error_msg}), 500
+        return error_response(SERVER_ERROR, error_msg, 500)


### PR DESCRIPTION
## Summary
- Migrate `gallery.py` (64) and `metadata.py` (13) error responses to `error_response()`
- Extra-field edge cases preserved: `series_id`, `success`, `photo_id` via `**extra` kwargs
- Batch 2 of 7 for #414

## Test plan
- [x] All existing tests pass (`test_gallery_routes.py`, `test_metadata_routes.py`)
- [x] No remaining inline `jsonify({"error"` patterns in migrated files
- [x] ruff clean