### PR TITLE
refactor: migrate config routes to shared error codes (#414)

### DIFF
--- a/Firmware/docs/plans/2026-02-16-migrate-error-codes-design.md
+++ b/Firmware/docs/plans/2026-02-16-migrate-error-codes-design.md
@@ -1,0 +1,71 @@
+# Design: Migrate Remaining Route Files to Shared Error Codes (#414)
+
+## Problem
+
+PR #413 introduced `webui/backend/lib/error_codes.py` and migrated `scheduler_ui.py` as the first route file. The remaining 16 route files still use inline `jsonify({"error": ...})` responses (472 total) and need migration to `error_response()`.
+
+## Decision
+
+- **Approach**: Mechanical replacement with context-aware error code selection
+- **PR strategy**: 7 PRs, one per logical batch
+- **No new constants**: Existing 9 error codes cover all cases
+- **No frontend changes**: Frontend module already exists from PR #413
+
+## Error Code Mapping
+
+| HTTP Status | Error Code | Rationale |
+|---|---|---|
+| 400 | `VALIDATION_ERROR` | Invalid input/parameters |
+| 403 | `PERMISSION_ERROR` | Path traversal, forbidden access |
+| 404 | `NOT_FOUND` | Resource doesn't exist |
+| 408 | `VALIDATION_ERROR` | GPS timeout (gps.py, 1 instance) |
+| 500 (generic) | `SERVER_ERROR` | Catch-all internal errors |
+| 500 (disk/IO) | `STORAGE_ERROR` | Disk full, file write failures |
+| 503 | `HARDWARE_ERROR` | Camera/GPIO/service unavailable |
+
+Context-aware override: When a 500 is clearly about file I/O or disk space, use `STORAGE_ERROR` instead of `SERVER_ERROR`.
+
+## Extra Fields
+
+3 edge cases with extra JSON fields preserved via `**extra` kwargs:
+- `gallery.py`: `error_response(NOT_FOUND, "Series not found", 404, series_id=series_id)`
+- `export.py` (2 places): `error_response(SERVER_ERROR, "ZIP export failed", 500, details=result.errors)`
+
+## Batch Structure
+
+| Batch | Files | Est. Responses | Branch |
+|---|---|---|---|
+| 1 | `camera.py`, `gpio.py`, `system.py` | 18 | `refactor/414-batch1-hardware` |
+| 2 | `gallery.py`, `metadata.py` | 70 | `refactor/414-batch2-media` |
+| 3 | `config.py` | 49 | `refactor/414-batch3-config` |
+| 4 | `export.py`, `export_presets.py` | 139 | `refactor/414-batch4-export` |
+| 5 | `deployment.py`, `sidecar.py` | 125 | `refactor/414-batch5-deployment` |
+| 6 | `search.py`, `gps.py`, `gps_exif.py` | 46 | `refactor/414-batch6-search-gps` |
+| 7 | `preferences.py`, `presets.py`, `scheduler.py` | 33 | `refactor/414-batch7-misc` |
+
+## Per-File Migration Pattern
+
+1. Add `from webui.backend.lib.error_codes import error_response, VALIDATION_ERROR, ...` (only codes used)
+2. Replace `return jsonify({"error": "..."}), 4xx` → `return error_response(CODE, "...", 4xx)`
+3. For extra-field responses, pass via `**extra` kwargs
+4. `ruff check && ruff format` on modified files
+5. Run relevant test files to verify backward compatibility
+
+## Testing Strategy
+
+Each batch runs corresponding test files before PR. The `"error"` field is unchanged (backward compatible). The additive `"code"` field won't break existing assertions.
+
+## What This Does NOT Change
+
+- No new error code constants
+- No frontend changes
+- No changes to `error_codes.py` itself
+- No test file modifications needed
+
+## References
+
+- Design: `docs/plans/2026-02-15-standardize-error-codes-design.md`
+- Shared module: `webui/backend/lib/error_codes.py`
+- Reference migration: `webui/backend/routes/scheduler_ui.py`
+- Initial PR: #413
+- Parent issue: #388

--- a/Firmware/docs/plans/2026-02-16-migrate-error-codes.md
+++ b/Firmware/docs/plans/2026-02-16-migrate-error-codes.md
@@ -1,0 +1,767 @@
+# Migrate Remaining Route Files to Shared Error Codes — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Migrate 472 inline `jsonify({"error": ...})` responses across 16 route files to the shared `error_response()` helper, adding structured error codes to every API error response.
+
+**Architecture:** Each route file gets an import of `error_response` and the specific error code constants it needs from `webui/backend/lib/error_codes.py`. Every `return jsonify({"error": "..."}), status` becomes `return error_response(CODE, "...", status)`. Extra JSON fields pass through via `**extra` kwargs. The `"error"` field is unchanged for backward compatibility; the `"code"` field is additive.
+
+**Tech Stack:** Python/Flask (backend), pytest (testing), ruff (linting)
+
+**Important context:**
+- Reference implementation: `webui/backend/routes/scheduler_ui.py` (already migrated in PR #413)
+- Shared module: `webui/backend/lib/error_codes.py` — provides `error_response()`, `sanitize_message()`, and 9 error code constants
+- Error code mapping: 400→`VALIDATION_ERROR`, 403→`PERMISSION_ERROR`, 404→`NOT_FOUND`, 408→`VALIDATION_ERROR`, 500→`SERVER_ERROR` (or `STORAGE_ERROR` for disk/IO), 503→`HARDWARE_ERROR`
+- Extra-field edge cases: `gallery.py` line 870 has `series_id`, `export.py` lines 984/1128 have `details` — preserved via `**extra`
+- No test changes needed — format is backward compatible (additive `"code"` field)
+- Design doc: `docs/plans/2026-02-16-migrate-error-codes-design.md`
+
+---
+
+### Task 1: Batch 1 — Hardware routes (camera.py, gpio.py, system.py)
+
+**Files:**
+- Modify: `webui/backend/routes/camera.py` (6 error responses)
+- Modify: `webui/backend/routes/gpio.py` (8 error responses)
+- Modify: `webui/backend/routes/system.py` (4 error responses)
+- Test: `Tests/unit/test_camera_routes.py`, `Tests/unit/test_gpio_routes.py`, `Tests/unit/test_system_routes.py`
+
+**Step 1: Create branch**
+
+Run: `git checkout -b refactor/414-batch1-hardware dev`
+
+**Step 2: Run baseline tests**
+
+Run: `python3 -m pytest Tests/unit/test_camera_routes.py Tests/unit/test_gpio_routes.py Tests/unit/test_system_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 3: Migrate camera.py**
+
+Add import at top of file (after existing Flask imports):
+
+```python
+from webui.backend.lib.error_codes import (
+    VALIDATION_ERROR,
+    SERVER_ERROR,
+    error_response,
+)
+```
+
+Replace these 6 error responses:
+
+| Line | Before | After |
+|------|--------|-------|
+| 673 | `return jsonify({"error": "Failed to get camera settings"}), 500` | `return error_response(SERVER_ERROR, "Failed to get camera settings", 500)` |
+| 696 | `return jsonify({"error": f"Invalid setting: {key}"}), 400` | `return error_response(VALIDATION_ERROR, f"Invalid setting: {key}")` |
+| 699 | `return jsonify({"error": f"Invalid value for {key}"}), 400` | `return error_response(VALIDATION_ERROR, f"Invalid value for {key}")` |
+| 701 | `return jsonify({"error": f"Invalid type for {key}"}), 400` | `return error_response(VALIDATION_ERROR, f"Invalid type for {key}")` |
+| 743 | `return jsonify({"error": "Failed to update camera settings"}), 500` | `return error_response(SERVER_ERROR, "Failed to update camera settings", 500)` |
+| 1203 | `return jsonify({"error": "Failed to freeze settings"}), 500` | `return error_response(SERVER_ERROR, "Failed to freeze settings", 500)` |
+
+Note: 400 is the default status for `error_response()`, so omit it for VALIDATION_ERROR calls.
+
+**Step 4: Migrate gpio.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    HARDWARE_ERROR,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Replace these 8 error responses:
+
+| Line | Before | After |
+|------|--------|-------|
+| 30 | `return jsonify({"error": "Failed to get GPIO status"}), 500` | `return error_response(SERVER_ERROR, "Failed to get GPIO status", 500)` |
+| 42 | `return jsonify({"error": "Missing relay or state parameter"}), 400` | `return error_response(VALIDATION_ERROR, "Missing relay or state parameter")` |
+| 44 | `return jsonify({"error": "State must be a boolean value (true/false)"}), 400` | `return error_response(VALIDATION_ERROR, "State must be a boolean value (true/false)")` |
+| 48 | `return jsonify({"error": f"Invalid relay: {relay}"}), 400` | `return error_response(VALIDATION_ERROR, f"Invalid relay: {relay}")` |
+| 63 | `return jsonify({"error": "GPIO daemon not available"}), 503` | `return error_response(HARDWARE_ERROR, "GPIO daemon not available", 503)` |
+| 66 | `return jsonify({"error": "Failed to control GPIO"}), 500` | `return error_response(SERVER_ERROR, "Failed to control GPIO", 500)` |
+| 97 | `return jsonify({"error": "GPIO daemon not available"}), 503` | `return error_response(HARDWARE_ERROR, "GPIO daemon not available", 503)` |
+| 100 | `return jsonify({"error": "Failed to trigger flash"}), 500` | `return error_response(SERVER_ERROR, "Failed to trigger flash", 500)` |
+
+**Step 5: Migrate system.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    SERVER_ERROR,
+    error_response,
+)
+```
+
+Replace these 4 error responses:
+
+| Line | Before | After |
+|------|--------|-------|
+| 144 | `return jsonify({"error": "Failed to get storage info"}), 500` | `return error_response(SERVER_ERROR, "Failed to get storage info", 500)` |
+| 235 | `return jsonify({"error": "Failed to get power status"}), 500` | `return error_response(SERVER_ERROR, "Failed to get power status", 500)` |
+| 275 | `return jsonify({"error": "Failed to get system info"}), 500` | `return error_response(SERVER_ERROR, "Failed to get system info", 500)` |
+| 372 | `return jsonify({"error": "Failed to get diagnostic info"}), 500` | `return error_response(SERVER_ERROR, "Failed to get diagnostic info", 500)` |
+
+**Step 6: Run ruff**
+
+Run: `ruff check webui/backend/routes/camera.py webui/backend/routes/gpio.py webui/backend/routes/system.py && ruff format webui/backend/routes/camera.py webui/backend/routes/gpio.py webui/backend/routes/system.py`
+Expected: Clean (may warn about unused `jsonify` import if all uses removed — unlikely since success responses still use it)
+
+**Step 7: Run tests**
+
+Run: `python3 -m pytest Tests/unit/test_camera_routes.py Tests/unit/test_gpio_routes.py Tests/unit/test_system_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 8: Verify no remaining inline errors**
+
+Run: `grep -n 'jsonify({"error"' webui/backend/routes/camera.py webui/backend/routes/gpio.py webui/backend/routes/system.py`
+Expected: No output (all migrated)
+
+**Step 9: Commit and PR**
+
+```bash
+git add webui/backend/routes/camera.py webui/backend/routes/gpio.py webui/backend/routes/system.py
+git commit -m "$(cat <<'EOF'
+refactor: migrate hardware routes to shared error codes (#414)
+
+Migrate camera.py (6), gpio.py (8), and system.py (4) error responses
+to use error_response() from the shared error codes module.
+
+Batch 1 of 7 for issue #414.
+EOF
+)"
+```
+
+Push and create PR:
+```bash
+git push -u origin refactor/414-batch1-hardware
+gh pr create --base dev --title "refactor: migrate hardware routes to shared error codes (#414)" --body "$(cat <<'EOF'
+## Summary
+- Migrate `camera.py` (6), `gpio.py` (8), and `system.py` (4) error responses to `error_response()`
+- Batch 1 of 7 for #414
+
+## Test plan
+- [x] All existing tests pass (`test_camera_routes.py`, `test_gpio_routes.py`, `test_system_routes.py`)
+- [x] No remaining inline `jsonify({"error"` patterns in migrated files
+- [x] ruff clean
+EOF
+)"
+```
+
+---
+
+### Task 2: Batch 2 — Media routes (gallery.py, metadata.py)
+
+**Files:**
+- Modify: `webui/backend/routes/gallery.py` (~63 error responses)
+- Modify: `webui/backend/routes/metadata.py` (~13 error responses)
+- Test: `Tests/unit/test_gallery_routes.py`, `Tests/unit/test_metadata_routes.py`
+
+**Step 1: Create branch**
+
+Run: `git checkout -b refactor/414-batch2-media dev`
+
+**Step 2: Run baseline tests**
+
+Run: `python3 -m pytest Tests/unit/test_gallery_routes.py Tests/unit/test_metadata_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 3: Migrate gallery.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    HARDWARE_ERROR,
+    NOT_FOUND,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply the error code mapping to all ~63 responses:
+- 400 responses → `error_response(VALIDATION_ERROR, "...", 400)` (omit status since 400 is default)
+- 404 responses → `error_response(NOT_FOUND, "...", 404)`
+- 500 responses → `error_response(SERVER_ERROR, "...", 500)`
+- 503 responses → `error_response(HARDWARE_ERROR, "...", 503)`
+
+**Special case** — line 870 has extra field:
+```python
+# Before:
+return jsonify({"error": "Series not found", "series_id": series_id}), 404
+# After:
+return error_response(NOT_FOUND, "Series not found", 404, series_id=series_id)
+```
+
+**Step 4: Migrate metadata.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    HARDWARE_ERROR,
+    NOT_FOUND,
+    PERMISSION_ERROR,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all ~13 responses:
+- Line 71 (403 "Access denied") → `error_response(PERMISSION_ERROR, "Invalid path: Access denied", 403)`
+- 400 responses → `VALIDATION_ERROR`
+- 404 responses → `NOT_FOUND`
+- 500 responses → `SERVER_ERROR`
+- 503 responses → `HARDWARE_ERROR`
+
+**Step 5: Run ruff**
+
+Run: `ruff check webui/backend/routes/gallery.py webui/backend/routes/metadata.py && ruff format webui/backend/routes/gallery.py webui/backend/routes/metadata.py`
+Expected: Clean
+
+**Step 6: Run tests**
+
+Run: `python3 -m pytest Tests/unit/test_gallery_routes.py Tests/unit/test_metadata_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 7: Verify no remaining inline errors**
+
+Run: `grep -n 'jsonify({"error"' webui/backend/routes/gallery.py webui/backend/routes/metadata.py`
+Expected: No output
+
+**Step 8: Commit and PR**
+
+```bash
+git add webui/backend/routes/gallery.py webui/backend/routes/metadata.py
+git commit -m "$(cat <<'EOF'
+refactor: migrate media routes to shared error codes (#414)
+
+Migrate gallery.py (~63) and metadata.py (~13) error responses
+to use error_response() from the shared error codes module.
+
+Batch 2 of 7 for issue #414.
+EOF
+)"
+git push -u origin refactor/414-batch2-media
+gh pr create --base dev --title "refactor: migrate media routes to shared error codes (#414)" --body "$(cat <<'EOF'
+## Summary
+- Migrate `gallery.py` (~63) and `metadata.py` (~13) error responses to `error_response()`
+- Batch 2 of 7 for #414
+
+## Test plan
+- [x] All existing tests pass (`test_gallery_routes.py`, `test_metadata_routes.py`)
+- [x] No remaining inline `jsonify({"error"` patterns in migrated files
+- [x] ruff clean
+EOF
+)"
+```
+
+---
+
+### Task 3: Batch 3 — Config routes (config.py)
+
+**Files:**
+- Modify: `webui/backend/routes/config.py` (~53 error responses)
+- Test: `Tests/unit/test_config_routes.py`
+
+**Step 1: Create branch**
+
+Run: `git checkout -b refactor/414-batch3-config dev`
+
+**Step 2: Run baseline tests**
+
+Run: `python3 -m pytest Tests/unit/test_config_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 3: Migrate config.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all ~53 responses:
+- All 400 responses → `VALIDATION_ERROR` (default status, omit 400)
+- All 500 responses → `SERVER_ERROR`
+
+This file has no 403/404/503 responses — just validation errors and server errors.
+
+**Step 4: Run ruff**
+
+Run: `ruff check webui/backend/routes/config.py && ruff format webui/backend/routes/config.py`
+Expected: Clean
+
+**Step 5: Run tests**
+
+Run: `python3 -m pytest Tests/unit/test_config_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 6: Verify no remaining inline errors**
+
+Run: `grep -n 'jsonify({"error"' webui/backend/routes/config.py`
+Expected: No output
+
+**Step 7: Commit and PR**
+
+```bash
+git add webui/backend/routes/config.py
+git commit -m "$(cat <<'EOF'
+refactor: migrate config routes to shared error codes (#414)
+
+Migrate config.py (~53) error responses to use error_response()
+from the shared error codes module.
+
+Batch 3 of 7 for issue #414.
+EOF
+)"
+git push -u origin refactor/414-batch3-config
+gh pr create --base dev --title "refactor: migrate config routes to shared error codes (#414)" --body "$(cat <<'EOF'
+## Summary
+- Migrate `config.py` (~53) error responses to `error_response()`
+- Batch 3 of 7 for #414
+
+## Test plan
+- [x] All existing tests pass (`test_config_routes.py`)
+- [x] No remaining inline `jsonify({"error"` patterns
+- [x] ruff clean
+EOF
+)"
+```
+
+---
+
+### Task 4: Batch 4 — Export routes (export.py, export_presets.py)
+
+**Files:**
+- Modify: `webui/backend/routes/export.py` (~125 error responses)
+- Modify: `webui/backend/routes/export_presets.py` (~13 error responses)
+- Test: `Tests/unit/test_export_routes.py`, `Tests/unit/test_export_preset_routes.py`
+
+**Step 1: Create branch**
+
+Run: `git checkout -b refactor/414-batch4-export dev`
+
+**Step 2: Run baseline tests**
+
+Run: `python3 -m pytest Tests/unit/test_export_routes.py Tests/unit/test_export_preset_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 3: Migrate export.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    NOT_FOUND,
+    PERMISSION_ERROR,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all ~125 responses:
+- 400 responses → `VALIDATION_ERROR`
+- 403 responses → `PERMISSION_ERROR`
+- 404 responses → `NOT_FOUND`
+- 500 responses → `SERVER_ERROR`
+
+**Special cases** — lines 984 and 1128 have extra `details` field:
+```python
+# Before:
+return jsonify({"error": "ZIP export failed", "details": result.errors}), 500
+# After:
+return error_response(SERVER_ERROR, "ZIP export failed", 500, details=result.errors)
+```
+
+This is the largest file. Work methodically top-to-bottom.
+
+**Step 4: Migrate export_presets.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    NOT_FOUND,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all ~13 responses.
+
+**Step 5: Run ruff**
+
+Run: `ruff check webui/backend/routes/export.py webui/backend/routes/export_presets.py && ruff format webui/backend/routes/export.py webui/backend/routes/export_presets.py`
+Expected: Clean
+
+**Step 6: Run tests**
+
+Run: `python3 -m pytest Tests/unit/test_export_routes.py Tests/unit/test_export_preset_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 7: Verify no remaining inline errors**
+
+Run: `grep -n 'jsonify({"error"' webui/backend/routes/export.py webui/backend/routes/export_presets.py`
+Expected: No output
+
+**Step 8: Commit and PR**
+
+```bash
+git add webui/backend/routes/export.py webui/backend/routes/export_presets.py
+git commit -m "$(cat <<'EOF'
+refactor: migrate export routes to shared error codes (#414)
+
+Migrate export.py (~125) and export_presets.py (~13) error responses
+to use error_response() from the shared error codes module.
+
+Batch 4 of 7 for issue #414.
+EOF
+)"
+git push -u origin refactor/414-batch4-export
+gh pr create --base dev --title "refactor: migrate export routes to shared error codes (#414)" --body "$(cat <<'EOF'
+## Summary
+- Migrate `export.py` (~125) and `export_presets.py` (~13) error responses to `error_response()`
+- Batch 4 of 7 for #414
+
+## Test plan
+- [x] All existing tests pass (`test_export_routes.py`, `test_export_preset_routes.py`)
+- [x] No remaining inline `jsonify({"error"` patterns in migrated files
+- [x] ruff clean
+EOF
+)"
+```
+
+---
+
+### Task 5: Batch 5 — Deployment routes (deployment.py, sidecar.py)
+
+**Files:**
+- Modify: `webui/backend/routes/deployment.py` (~93 error responses)
+- Modify: `webui/backend/routes/sidecar.py` (~153 error responses)
+- Test: `Tests/unit/test_deployment_routes.py`, `Tests/unit/test_sidecar_routes_filtering.py`
+
+**Step 1: Create branch**
+
+Run: `git checkout -b refactor/414-batch5-deployment dev`
+
+**Step 2: Run baseline tests**
+
+Run: `python3 -m pytest Tests/unit/test_deployment_routes.py Tests/unit/test_sidecar_routes_filtering.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 3: Migrate deployment.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    HARDWARE_ERROR,
+    NOT_FOUND,
+    PERMISSION_ERROR,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all ~93 responses:
+- 400 responses → `VALIDATION_ERROR`
+- 403 responses → `PERMISSION_ERROR`
+- 404 responses → `NOT_FOUND`
+- 500 responses → `SERVER_ERROR`
+- 503 responses → `HARDWARE_ERROR`
+
+**Step 4: Migrate sidecar.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    HARDWARE_ERROR,
+    NOT_FOUND,
+    PERMISSION_ERROR,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all ~153 responses.
+
+**Step 5: Run ruff**
+
+Run: `ruff check webui/backend/routes/deployment.py webui/backend/routes/sidecar.py && ruff format webui/backend/routes/deployment.py webui/backend/routes/sidecar.py`
+Expected: Clean
+
+**Step 6: Run tests**
+
+Run: `python3 -m pytest Tests/unit/test_deployment_routes.py Tests/unit/test_sidecar_routes_filtering.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 7: Verify no remaining inline errors**
+
+Run: `grep -n 'jsonify({"error"' webui/backend/routes/deployment.py webui/backend/routes/sidecar.py`
+Expected: No output
+
+**Step 8: Commit and PR**
+
+```bash
+git add webui/backend/routes/deployment.py webui/backend/routes/sidecar.py
+git commit -m "$(cat <<'EOF'
+refactor: migrate deployment routes to shared error codes (#414)
+
+Migrate deployment.py (~93) and sidecar.py (~153) error responses
+to use error_response() from the shared error codes module.
+
+Batch 5 of 7 for issue #414.
+EOF
+)"
+git push -u origin refactor/414-batch5-deployment
+gh pr create --base dev --title "refactor: migrate deployment routes to shared error codes (#414)" --body "$(cat <<'EOF'
+## Summary
+- Migrate `deployment.py` (~93) and `sidecar.py` (~153) error responses to `error_response()`
+- Batch 5 of 7 for #414
+
+## Test plan
+- [x] All existing tests pass (`test_deployment_routes.py`, `test_sidecar_routes_filtering.py`)
+- [x] No remaining inline `jsonify({"error"` patterns in migrated files
+- [x] ruff clean
+EOF
+)"
+```
+
+---
+
+### Task 6: Batch 6 — Search & GPS routes (search.py, gps.py, gps_exif.py)
+
+**Files:**
+- Modify: `webui/backend/routes/search.py` (10 error responses)
+- Modify: `webui/backend/routes/gps.py` (14 error responses)
+- Modify: `webui/backend/routes/gps_exif.py` (20 error responses)
+- Test: `Tests/unit/test_search_api.py`, `Tests/unit/test_gps_routes.py`, `Tests/unit/test_gps_exif_routes.py`
+
+**Step 1: Create branch**
+
+Run: `git checkout -b refactor/414-batch6-search-gps dev`
+
+**Step 2: Run baseline tests**
+
+Run: `python3 -m pytest Tests/unit/test_search_api.py Tests/unit/test_gps_routes.py Tests/unit/test_gps_exif_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 3: Migrate search.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    HARDWARE_ERROR,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all 10 responses:
+- 400 responses → `VALIDATION_ERROR`
+- 500 responses → `SERVER_ERROR`
+- 503 responses → `HARDWARE_ERROR`
+
+**Step 4: Migrate gps.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all 14 responses:
+- 400 responses → `VALIDATION_ERROR`
+- 408 responses → `VALIDATION_ERROR` (GPS timeout — treated as a request-level validation failure)
+- 500 responses → `SERVER_ERROR`
+
+**Step 5: Migrate gps_exif.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    NOT_FOUND,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all 20 responses.
+
+**Step 6: Run ruff**
+
+Run: `ruff check webui/backend/routes/search.py webui/backend/routes/gps.py webui/backend/routes/gps_exif.py && ruff format webui/backend/routes/search.py webui/backend/routes/gps.py webui/backend/routes/gps_exif.py`
+Expected: Clean
+
+**Step 7: Run tests**
+
+Run: `python3 -m pytest Tests/unit/test_search_api.py Tests/unit/test_gps_routes.py Tests/unit/test_gps_exif_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 8: Verify no remaining inline errors**
+
+Run: `grep -n 'jsonify({"error"' webui/backend/routes/search.py webui/backend/routes/gps.py webui/backend/routes/gps_exif.py`
+Expected: No output
+
+**Step 9: Commit and PR**
+
+```bash
+git add webui/backend/routes/search.py webui/backend/routes/gps.py webui/backend/routes/gps_exif.py
+git commit -m "$(cat <<'EOF'
+refactor: migrate search & GPS routes to shared error codes (#414)
+
+Migrate search.py (10), gps.py (14), and gps_exif.py (20) error
+responses to use error_response() from the shared error codes module.
+
+Batch 6 of 7 for issue #414.
+EOF
+)"
+git push -u origin refactor/414-batch6-search-gps
+gh pr create --base dev --title "refactor: migrate search & GPS routes to shared error codes (#414)" --body "$(cat <<'EOF'
+## Summary
+- Migrate `search.py` (10), `gps.py` (14), and `gps_exif.py` (20) error responses to `error_response()`
+- Batch 6 of 7 for #414
+
+## Test plan
+- [x] All existing tests pass (`test_search_api.py`, `test_gps_routes.py`, `test_gps_exif_routes.py`)
+- [x] No remaining inline `jsonify({"error"` patterns in migrated files
+- [x] ruff clean
+EOF
+)"
+```
+
+---
+
+### Task 7: Batch 7 — Misc routes (preferences.py, presets.py, scheduler.py)
+
+**Files:**
+- Modify: `webui/backend/routes/preferences.py` (9 error responses)
+- Modify: `webui/backend/routes/presets.py` (~21 error responses)
+- Modify: `webui/backend/routes/scheduler.py` (8 error responses)
+- Test: `Tests/unit/test_preferences_routes.py`, `Tests/unit/test_presets_routes.py`, `Tests/unit/test_scheduler_routes.py`
+
+**Step 1: Create branch**
+
+Run: `git checkout -b refactor/414-batch7-misc dev`
+
+**Step 2: Run baseline tests**
+
+Run: `python3 -m pytest Tests/unit/test_preferences_routes.py Tests/unit/test_presets_routes.py Tests/unit/test_scheduler_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 3: Migrate preferences.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all 9 responses.
+
+**Step 4: Migrate presets.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    NOT_FOUND,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all ~21 responses.
+
+**Step 5: Migrate scheduler.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all 8 responses.
+
+**Step 6: Run ruff**
+
+Run: `ruff check webui/backend/routes/preferences.py webui/backend/routes/presets.py webui/backend/routes/scheduler.py && ruff format webui/backend/routes/preferences.py webui/backend/routes/presets.py webui/backend/routes/scheduler.py`
+Expected: Clean
+
+**Step 7: Run tests**
+
+Run: `python3 -m pytest Tests/unit/test_preferences_routes.py Tests/unit/test_presets_routes.py Tests/unit/test_scheduler_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 8: Verify no remaining inline errors**
+
+Run: `grep -n 'jsonify({"error"' webui/backend/routes/preferences.py webui/backend/routes/presets.py webui/backend/routes/scheduler.py`
+Expected: No output
+
+**Step 9: Final sweep — verify zero inline errors across ALL route files**
+
+Run: `grep -rn 'jsonify({"error"' webui/backend/routes/`
+Expected: No output (all 16 files migrated, scheduler_ui.py was already done)
+
+**Step 10: Commit and PR**
+
+```bash
+git add webui/backend/routes/preferences.py webui/backend/routes/presets.py webui/backend/routes/scheduler.py
+git commit -m "$(cat <<'EOF'
+refactor: migrate misc routes to shared error codes (#414)
+
+Migrate preferences.py (9), presets.py (~21), and scheduler.py (8)
+error responses to use error_response() from the shared error codes
+module.
+
+Batch 7 of 7 for issue #414. All 16 route files now use the shared
+error codes module.
+EOF
+)"
+git push -u origin refactor/414-batch7-misc
+gh pr create --base dev --title "refactor: migrate misc routes to shared error codes (#414)" --body "$(cat <<'EOF'
+## Summary
+- Migrate `preferences.py` (9), `presets.py` (~21), and `scheduler.py` (8) error responses to `error_response()`
+- Batch 7 of 7 for #414 — completes the migration
+
+## Test plan
+- [x] All existing tests pass (`test_preferences_routes.py`, `test_presets_routes.py`, `test_scheduler_routes.py`)
+- [x] No remaining inline `jsonify({"error"` patterns in ANY route file
+- [x] ruff clean
+- [x] Final sweep: `grep -rn 'jsonify({"error"' webui/backend/routes/` returns nothing
+EOF
+)"
+```

--- a/Firmware/webui/backend/routes/config.py
+++ b/Firmware/webui/backend/routes/config.py
@@ -32,6 +32,12 @@ from mothbox_paths import (
     SCHEDULE_SETTINGS_FILE,
     get_control_values,
 )
+from webui.backend.lib.error_codes import (
+    NOT_FOUND,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -141,7 +147,7 @@ def get_controls():
         return jsonify(controls)
     except Exception:
         logger.exception("Failed to get controls")
-        return jsonify({"error": "Failed to get controls"}), 500
+        return error_response(SERVER_ERROR, "Failed to get controls", 500)
 
 
 @config_bp.route("/controls", methods=["POST"])
@@ -152,20 +158,20 @@ def update_controls():
         new_controls = request.json
 
         if not isinstance(new_controls, dict):
-            return jsonify({"error": "Invalid request format"}), 400
+            return error_response(VALIDATION_ERROR, "Invalid request format")
 
         # Validate all keys are allowed
         invalid_keys = set(new_controls.keys()) - set(ALLOWED_CONTROLS.keys())
         if invalid_keys:
-            return jsonify({"error": f"Invalid keys: {', '.join(invalid_keys)}"}), 400
+            return error_response(VALIDATION_ERROR, f"Invalid keys: {', '.join(invalid_keys)}")
 
         # Validate all values
         for key, value in new_controls.items():
             try:
                 if not ALLOWED_CONTROLS[key](value):
-                    return jsonify({"error": f"Invalid value for {key}: {value}"}), 400
+                    return error_response(VALIDATION_ERROR, f"Invalid value for {key}: {value}")
             except (ValueError, TypeError):
-                return jsonify({"error": f"Invalid value for {key}: {value}"}), 400
+                return error_response(VALIDATION_ERROR, f"Invalid value for {key}: {value}")
 
         # Sanitize values - remove newlines and carriage returns
         sanitized = {k: str(v).replace("\n", "").replace("\r", "") for k, v in new_controls.items()}
@@ -187,7 +193,7 @@ def update_controls():
                 logger.info(f"Restored backup from {backup_path} after error")
             except Exception as restore_error:
                 logger.error(f"Failed to restore backup: {restore_error}")
-        return jsonify({"error": "Failed to update controls"}), 500
+        return error_response(SERVER_ERROR, "Failed to update controls", 500)
 
 
 @config_bp.route("/schedule", methods=["GET"])
@@ -204,7 +210,7 @@ def get_schedule_settings():
         return jsonify(settings)
     except Exception:
         logger.exception("Failed to get schedule settings")
-        return jsonify({"error": "Failed to get schedule settings"}), 500
+        return error_response(SERVER_ERROR, "Failed to get schedule settings", 500)
 
 
 @config_bp.route("/schedule", methods=["POST"])
@@ -215,7 +221,7 @@ def update_schedule_settings():
         new_settings = request.json
 
         if not isinstance(new_settings, dict):
-            return jsonify({"error": "Invalid request format"}), 400
+            return error_response(VALIDATION_ERROR, "Invalid request format")
 
         # Read existing headers
         with open(SCHEDULE_SETTINGS_FILE) as f:
@@ -225,7 +231,7 @@ def update_schedule_settings():
         # Validate that all keys match existing fieldnames
         invalid_keys = set(new_settings.keys()) - set(fieldnames)
         if invalid_keys:
-            return jsonify({"error": f"Invalid keys: {', '.join(invalid_keys)}"}), 400
+            return error_response(VALIDATION_ERROR, f"Invalid keys: {', '.join(invalid_keys)}")
 
         # Sanitize all values to prevent CSV injection
         sanitized_settings = {k: sanitize_csv_value(v) for k, v in new_settings.items()}
@@ -248,7 +254,7 @@ def update_schedule_settings():
                 logger.info(f"Restored backup from {backup_path} after error")
             except Exception as restore_error:
                 logger.error(f"Failed to restore backup: {restore_error}")
-        return jsonify({"error": "Failed to update schedule settings"}), 500
+        return error_response(SERVER_ERROR, "Failed to update schedule settings", 500)
 
 
 def safe_convert(value: Any, converter: Callable, default: Any) -> Any:
@@ -354,7 +360,7 @@ def get_webui_settings():
         return jsonify(defaults)
     except Exception:
         logger.exception("Failed to get webui settings")
-        return jsonify({"error": "Failed to get webui settings"}), 500
+        return error_response(SERVER_ERROR, "Failed to get webui settings", 500)
 
 
 @config_bp.route("/webui", methods=["POST"])
@@ -409,7 +415,7 @@ def update_webui_settings():
         # Validate all keys are allowed (prevent injection/confusion attacks)
         invalid_keys = set(new_settings.keys()) - ALLOWED_WEBUI_KEYS
         if invalid_keys:
-            return jsonify({"error": f"Invalid keys: {', '.join(invalid_keys)}"}), 400
+            return error_response(VALIDATION_ERROR, f"Invalid keys: {', '.join(invalid_keys)}")
 
         # Load existing settings to merge with updates (preserves unmodified values)
         existing = {}
@@ -425,13 +431,13 @@ def update_webui_settings():
             frame_rate = int(new_settings.get("frame_rate", existing.get("frame_rate", 10)))
             jpeg_quality = int(new_settings.get("jpeg_quality", existing.get("jpeg_quality", 85)))
         except (ValueError, TypeError) as e:
-            return jsonify({"error": f"Invalid stream setting type: {e}"}), 400
+            return error_response(VALIDATION_ERROR, f"Invalid stream setting type: {e}")
 
         stream_mode = new_settings.get("stream_mode", existing.get("stream_mode", "simplejpeg"))
         sensor_mode = new_settings.get("sensor_mode", existing.get("sensor_mode", "auto"))
 
         if not isinstance(sensor_mode, str):
-            return jsonify({"error": "sensor_mode must be a string"}), 400
+            return error_response(VALIDATION_ERROR, "sensor_mode must be a string")
 
         # Validate and convert types - Image quality controls
         try:
@@ -440,7 +446,7 @@ def update_webui_settings():
             contrast = float(new_settings.get("contrast", existing.get("contrast", 1.0)))
             saturation = float(new_settings.get("saturation", existing.get("saturation", 1.0)))
         except (ValueError, TypeError) as e:
-            return jsonify({"error": f"Invalid image quality setting type: {e}"}), 400
+            return error_response(VALIDATION_ERROR, f"Invalid image quality setting type: {e}")
 
         # Validate and convert types - Noise reduction control
         try:
@@ -449,12 +455,12 @@ def update_webui_settings():
             )
             # Ensure it's an integer (reject floats)
             if isinstance(noise_reduction_mode, float) and not noise_reduction_mode.is_integer():
-                return jsonify(
-                    {"error": "noise_reduction_mode must be an integer (0, 1, or 2)"}
-                ), 400
+                return error_response(
+                    VALIDATION_ERROR, "noise_reduction_mode must be an integer (0, 1, or 2)"
+                )
             noise_reduction_mode = int(noise_reduction_mode)
         except (ValueError, TypeError) as e:
-            return jsonify({"error": f"Invalid noise_reduction_mode type: {e}"}), 400
+            return error_response(VALIDATION_ERROR, f"Invalid noise_reduction_mode type: {e}")
 
         # Validate and convert types - Focus controls
         try:
@@ -462,7 +468,7 @@ def update_webui_settings():
             af_speed = int(new_settings.get("af_speed", existing.get("af_speed", 0)))
             af_range = int(new_settings.get("af_range", existing.get("af_range", 0)))
         except (ValueError, TypeError) as e:
-            return jsonify({"error": f"Invalid focus control type: {e}"}), 400
+            return error_response(VALIDATION_ERROR, f"Invalid focus control type: {e}")
 
         # Validate and convert types - White balance controls
         awb_enable = new_settings.get("awb_enable", existing.get("awb_enable", "true"))
@@ -472,7 +478,7 @@ def update_webui_settings():
         try:
             awb_mode = int(new_settings.get("awb_mode", existing.get("awb_mode", 0)))
         except (ValueError, TypeError) as e:
-            return jsonify({"error": f"Invalid white balance mode type: {e}"}), 400
+            return error_response(VALIDATION_ERROR, f"Invalid white balance mode type: {e}")
 
         # Validate and convert types - Colour gains (blue/white saturation fix)
         try:
@@ -483,7 +489,7 @@ def update_webui_settings():
                 new_settings.get("colour_gains_blue", existing.get("colour_gains_blue", 1.500))
             )
         except (ValueError, TypeError) as e:
-            return jsonify({"error": f"Invalid colour gains type: {e}"}), 400
+            return error_response(VALIDATION_ERROR, f"Invalid colour gains type: {e}")
 
         # Validate and convert types - Exposure controls (exposure-metering feature)
         try:
@@ -491,10 +497,12 @@ def update_webui_settings():
                 "ae_metering_mode", existing.get("ae_metering_mode", 0)
             )
             if isinstance(ae_metering_mode, float) and not ae_metering_mode.is_integer():
-                return jsonify({"error": "ae_metering_mode must be an integer (0, 1, or 2)"}), 400
+                return error_response(
+                    VALIDATION_ERROR, "ae_metering_mode must be an integer (0, 1, or 2)"
+                )
             ae_metering_mode = int(ae_metering_mode)
         except (ValueError, TypeError) as e:
-            return jsonify({"error": f"Invalid ae_metering_mode type: {e}"}), 400
+            return error_response(VALIDATION_ERROR, f"Invalid ae_metering_mode type: {e}")
 
         ae_enable = new_settings.get("ae_enable", existing.get("ae_enable", True))
         if isinstance(ae_enable, str):
@@ -508,7 +516,7 @@ def update_webui_settings():
                 new_settings.get("analogue_gain", existing.get("analogue_gain", 8.0))
             )
         except (ValueError, TypeError) as e:
-            return jsonify({"error": f"Invalid exposure settings type: {e}"}), 400
+            return error_response(VALIDATION_ERROR, f"Invalid exposure settings type: {e}")
 
         # Validate and convert types - ISP tuning controls
         use_custom_tuning = new_settings.get(
@@ -543,108 +551,119 @@ def update_webui_settings():
                 )
             )
         except (ValueError, TypeError) as e:
-            return jsonify({"error": f"Invalid focus_peaking_intensity type: {e}"}), 400
+            return error_response(VALIDATION_ERROR, f"Invalid focus_peaking_intensity type: {e}")
 
         focus_peaking_colour = new_settings.get(
             "focus_peaking_colour", existing.get("focus_peaking_colour", "green")
         )
         if not isinstance(focus_peaking_colour, str):
-            return jsonify({"error": "focus_peaking_colour must be a string"}), 400
+            return error_response(VALIDATION_ERROR, "focus_peaking_colour must be a string")
 
         focus_peaking_algorithm = new_settings.get(
             "focus_peaking_algorithm", existing.get("focus_peaking_algorithm", "laplacian")
         )
         if not isinstance(focus_peaking_algorithm, str):
-            return jsonify({"error": "focus_peaking_algorithm must be a string"}), 400
+            return error_response(VALIDATION_ERROR, "focus_peaking_algorithm must be a string")
 
         # Validate ranges - Stream/encoding
         if not (320 <= stream_width <= 1920):
-            return jsonify({"error": "Width must be between 320 and 1920"}), 400
+            return error_response(VALIDATION_ERROR, "Width must be between 320 and 1920")
         if not (240 <= stream_height <= 1080):
-            return jsonify({"error": "Height must be between 240 and 1080"}), 400
+            return error_response(VALIDATION_ERROR, "Height must be between 240 and 1080")
         if not (1 <= frame_rate <= 30):
-            return jsonify({"error": "Frame rate must be between 1 and 30"}), 400
+            return error_response(VALIDATION_ERROR, "Frame rate must be between 1 and 30")
         if not (50 <= jpeg_quality <= 100):
-            return jsonify({"error": "JPEG quality must be between 50 and 100"}), 400
+            return error_response(VALIDATION_ERROR, "JPEG quality must be between 50 and 100")
         if stream_mode not in ["simplejpeg", "mjpeg_hardware"]:
-            return jsonify({"error": "stream_mode must be simplejpeg or mjpeg_hardware"}), 400
+            return error_response(
+                VALIDATION_ERROR, "stream_mode must be simplejpeg or mjpeg_hardware"
+            )
         if sensor_mode not in ["auto", "4:3", "16:9", "full"]:
-            return jsonify({"error": "sensor_mode must be auto, 4:3, 16:9, or full"}), 400
+            return error_response(VALIDATION_ERROR, "sensor_mode must be auto, 4:3, 16:9, or full")
 
         # Validate ranges - Image quality
         # Using picamera2 typical ranges (0.0-4.0) for safety and hardware compatibility
         if not (0.0 <= sharpness <= 4.0):
-            return jsonify({"error": "Sharpness must be between 0.0 and 4.0"}), 400
+            return error_response(VALIDATION_ERROR, "Sharpness must be between 0.0 and 4.0")
         if not (-1.0 <= brightness <= 1.0):
-            return jsonify({"error": "Brightness must be between -1.0 and 1.0"}), 400
+            return error_response(VALIDATION_ERROR, "Brightness must be between -1.0 and 1.0")
         if not (0.0 <= contrast <= 4.0):
-            return jsonify({"error": "Contrast must be between 0.0 and 4.0"}), 400
+            return error_response(VALIDATION_ERROR, "Contrast must be between 0.0 and 4.0")
         if not (0.0 <= saturation <= 4.0):
-            return jsonify({"error": "Saturation must be between 0.0 and 4.0"}), 400
+            return error_response(VALIDATION_ERROR, "Saturation must be between 0.0 and 4.0")
 
         # Validate ranges - Noise reduction
         if noise_reduction_mode not in [0, 1, 2]:
-            return jsonify(
-                {"error": "noise_reduction_mode must be 0 (Off), 1 (Fast), or 2 (High Quality)"}
-            ), 400
+            return error_response(
+                VALIDATION_ERROR,
+                "noise_reduction_mode must be 0 (Off), 1 (Fast), or 2 (High Quality)",
+            )
 
         # Validate ranges - Focus controls
         if af_mode not in [0, 1, 2]:
-            return jsonify(
-                {"error": "AfMode must be 0 (Manual), 1 (Auto Single), or 2 (Continuous)"}
-            ), 400
+            return error_response(
+                VALIDATION_ERROR,
+                "AfMode must be 0 (Manual), 1 (Auto Single), or 2 (Continuous)",
+            )
         if af_speed not in [0, 1]:
-            return jsonify({"error": "AfSpeed must be 0 (Normal) or 1 (Fast)"}), 400
+            return error_response(VALIDATION_ERROR, "AfSpeed must be 0 (Normal) or 1 (Fast)")
         if af_range not in [0, 1, 2]:
-            return jsonify({"error": "AfRange must be 0 (Normal), 1 (Macro), or 2 (Full)"}), 400
+            return error_response(
+                VALIDATION_ERROR, "AfRange must be 0 (Normal), 1 (Macro), or 2 (Full)"
+            )
 
         # Validate ranges - White balance
         if not isinstance(awb_enable, bool):
-            return jsonify({"error": "AwbEnable must be a boolean"}), 400
+            return error_response(VALIDATION_ERROR, "AwbEnable must be a boolean")
         if not (0 <= awb_mode <= 7):
-            return jsonify({"error": "AwbMode must be between 0 and 7"}), 400
+            return error_response(VALIDATION_ERROR, "AwbMode must be between 0 and 7")
 
         # Validate ranges - Colour gains
         if not (0.0 <= colour_gains_red <= 8.0):
-            return jsonify({"error": "Red colour gain must be between 0.0 and 8.0"}), 400
+            return error_response(VALIDATION_ERROR, "Red colour gain must be between 0.0 and 8.0")
         if not (0.0 <= colour_gains_blue <= 8.0):
-            return jsonify({"error": "Blue colour gain must be between 0.0 and 8.0"}), 400
+            return error_response(VALIDATION_ERROR, "Blue colour gain must be between 0.0 and 8.0")
 
         # Validate ranges - Exposure controls (exposure-metering feature)
         if ae_metering_mode not in [0, 1, 2]:
-            return jsonify(
-                {"error": "ae_metering_mode must be 0 (Centre-Weighted), 1 (Spot), or 2 (Matrix)"}
-            ), 400
+            return error_response(
+                VALIDATION_ERROR,
+                "ae_metering_mode must be 0 (Centre-Weighted), 1 (Spot), or 2 (Matrix)",
+            )
         if not isinstance(ae_enable, bool):
-            return jsonify({"error": "ae_enable must be a boolean"}), 400
+            return error_response(VALIDATION_ERROR, "ae_enable must be a boolean")
         if not (100 <= exposure_time <= 200000):
-            return jsonify(
-                {"error": "exposure_time must be between 100 and 200000 microseconds"}
-            ), 400
+            return error_response(
+                VALIDATION_ERROR, "exposure_time must be between 100 and 200000 microseconds"
+            )
         if not (1.0 <= analogue_gain <= 16.0):
-            return jsonify({"error": "analogue_gain must be between 1.0 and 16.0"}), 400
+            return error_response(VALIDATION_ERROR, "analogue_gain must be between 1.0 and 16.0")
 
         # Validate - ISP tuning controls
         if not isinstance(use_custom_tuning, bool):
-            return jsonify({"error": "use_custom_tuning must be a boolean"}), 400
+            return error_response(VALIDATION_ERROR, "use_custom_tuning must be a boolean")
         if not isinstance(lens_shading_enable, bool):
-            return jsonify({"error": "lens_shading_enable must be a boolean"}), 400
+            return error_response(VALIDATION_ERROR, "lens_shading_enable must be a boolean")
         if not isinstance(defect_correction_enable, bool):
-            return jsonify({"error": "defect_correction_enable must be a boolean"}), 400
+            return error_response(VALIDATION_ERROR, "defect_correction_enable must be a boolean")
 
         # Validate - Focus peaking controls
         if not isinstance(focus_peaking_enabled, bool):
-            return jsonify({"error": "focus_peaking_enabled must be a boolean"}), 400
+            return error_response(VALIDATION_ERROR, "focus_peaking_enabled must be a boolean")
         if not (50 <= focus_peaking_intensity <= 200):
-            return jsonify({"error": "focus_peaking_intensity must be between 50 and 200"}), 400
+            return error_response(
+                VALIDATION_ERROR, "focus_peaking_intensity must be between 50 and 200"
+            )
         if focus_peaking_colour not in ["green", "red", "yellow", "cyan", "magenta"]:
-            return jsonify(
-                {"error": "focus_peaking_colour must be green, red, yellow, cyan, or magenta"}
-            ), 400
+            return error_response(
+                VALIDATION_ERROR,
+                "focus_peaking_colour must be green, red, yellow, cyan, or magenta",
+            )
         if focus_peaking_algorithm not in ["laplacian", "sobel", "canny"]:
-            return jsonify(
-                {"error": "focus_peaking_algorithm must be laplacian, sobel, or canny"}
-            ), 400
+            return error_response(
+                VALIDATION_ERROR,
+                "focus_peaking_algorithm must be laplacian, sobel, or canny",
+            )
 
         # Create backup before modification
         backup_path = create_backup(LIVEVIEW_SETTINGS_FILE)
@@ -707,7 +726,7 @@ def update_webui_settings():
                 logger.info(f"Restored backup from {backup_path} after error")
             except Exception as restore_error:
                 logger.error(f"Failed to restore backup: {restore_error}")
-        return jsonify({"error": "Failed to update webui settings"}), 500
+        return error_response(SERVER_ERROR, "Failed to update webui settings", 500)
 
 
 @config_bp.route("/copy-settings", methods=["POST"])
@@ -729,9 +748,10 @@ def copy_settings():
         direction = request_data.get("direction")
 
         if direction not in ["preview_to_capture", "capture_to_preview"]:
-            return jsonify(
-                {"error": 'direction must be "preview_to_capture" or "capture_to_preview"'}
-            ), 400
+            return error_response(
+                VALIDATION_ERROR,
+                'direction must be "preview_to_capture" or "capture_to_preview"',
+            )
 
         logger.info(f"Copy settings requested: {direction}")
 
@@ -774,7 +794,7 @@ def copy_settings():
             from mothbox_paths import get_control_values
 
             if not LIVEVIEW_SETTINGS_FILE.exists():
-                return jsonify({"success": False, "error": "webui_settings.txt not found"}), 404
+                return error_response(NOT_FOUND, "webui_settings.txt not found", 404, success=False)
 
             preview_settings = get_control_values(LIVEVIEW_SETTINGS_FILE)
 
@@ -786,7 +806,9 @@ def copy_settings():
             capture_settings_dict = {}
 
             if not CAMERA_SETTINGS_FILE.exists():
-                return jsonify({"success": False, "error": "camera_settings.csv not found"}), 404
+                return error_response(
+                    NOT_FOUND, "camera_settings.csv not found", 404, success=False
+                )
 
             with open(CAMERA_SETTINGS_FILE) as f:
                 reader = csv.DictReader(f)
@@ -932,4 +954,4 @@ def copy_settings():
 
     except Exception:
         logger.exception("Copy settings error")
-        return jsonify({"success": False, "error": "Failed to copy settings"}), 500
+        return error_response(SERVER_ERROR, "Failed to copy settings", 500, success=False)


### PR DESCRIPTION
## Summary
- Migrate `config.py` (53) error responses to `error_response()`
- Includes 2 NOT_FOUND (404) responses the original plan missed
- Batch 3 of 7 for #414

## Test plan
- [x] All existing tests pass (`test_config_routes.py`)
- [x] No remaining inline `jsonify({"error"` patterns
- [x] ruff clean