### PR TITLE
refactor: migrate export routes to shared error codes (#414)

### DIFF
--- a/Firmware/docs/plans/2026-02-16-migrate-error-codes-design.md
+++ b/Firmware/docs/plans/2026-02-16-migrate-error-codes-design.md
@@ -1,0 +1,71 @@
+# Design: Migrate Remaining Route Files to Shared Error Codes (#414)
+
+## Problem
+
+PR #413 introduced `webui/backend/lib/error_codes.py` and migrated `scheduler_ui.py` as the first route file. The remaining 16 route files still use inline `jsonify({"error": ...})` responses (472 total) and need migration to `error_response()`.
+
+## Decision
+
+- **Approach**: Mechanical replacement with context-aware error code selection
+- **PR strategy**: 7 PRs, one per logical batch
+- **No new constants**: Existing 9 error codes cover all cases
+- **No frontend changes**: Frontend module already exists from PR #413
+
+## Error Code Mapping
+
+| HTTP Status | Error Code | Rationale |
+|---|---|---|
+| 400 | `VALIDATION_ERROR` | Invalid input/parameters |
+| 403 | `PERMISSION_ERROR` | Path traversal, forbidden access |
+| 404 | `NOT_FOUND` | Resource doesn't exist |
+| 408 | `VALIDATION_ERROR` | GPS timeout (gps.py, 1 instance) |
+| 500 (generic) | `SERVER_ERROR` | Catch-all internal errors |
+| 500 (disk/IO) | `STORAGE_ERROR` | Disk full, file write failures |
+| 503 | `HARDWARE_ERROR` | Camera/GPIO/service unavailable |
+
+Context-aware override: When a 500 is clearly about file I/O or disk space, use `STORAGE_ERROR` instead of `SERVER_ERROR`.
+
+## Extra Fields
+
+3 edge cases with extra JSON fields preserved via `**extra` kwargs:
+- `gallery.py`: `error_response(NOT_FOUND, "Series not found", 404, series_id=series_id)`
+- `export.py` (2 places): `error_response(SERVER_ERROR, "ZIP export failed", 500, details=result.errors)`
+
+## Batch Structure
+
+| Batch | Files | Est. Responses | Branch |
+|---|---|---|---|
+| 1 | `camera.py`, `gpio.py`, `system.py` | 18 | `refactor/414-batch1-hardware` |
+| 2 | `gallery.py`, `metadata.py` | 70 | `refactor/414-batch2-media` |
+| 3 | `config.py` | 49 | `refactor/414-batch3-config` |
+| 4 | `export.py`, `export_presets.py` | 139 | `refactor/414-batch4-export` |
+| 5 | `deployment.py`, `sidecar.py` | 125 | `refactor/414-batch5-deployment` |
+| 6 | `search.py`, `gps.py`, `gps_exif.py` | 46 | `refactor/414-batch6-search-gps` |
+| 7 | `preferences.py`, `presets.py`, `scheduler.py` | 33 | `refactor/414-batch7-misc` |
+
+## Per-File Migration Pattern
+
+1. Add `from webui.backend.lib.error_codes import error_response, VALIDATION_ERROR, ...` (only codes used)
+2. Replace `return jsonify({"error": "..."}), 4xx` → `return error_response(CODE, "...", 4xx)`
+3. For extra-field responses, pass via `**extra` kwargs
+4. `ruff check && ruff format` on modified files
+5. Run relevant test files to verify backward compatibility
+
+## Testing Strategy
+
+Each batch runs corresponding test files before PR. The `"error"` field is unchanged (backward compatible). The additive `"code"` field won't break existing assertions.
+
+## What This Does NOT Change
+
+- No new error code constants
+- No frontend changes
+- No changes to `error_codes.py` itself
+- No test file modifications needed
+
+## References
+
+- Design: `docs/plans/2026-02-15-standardize-error-codes-design.md`
+- Shared module: `webui/backend/lib/error_codes.py`
+- Reference migration: `webui/backend/routes/scheduler_ui.py`
+- Initial PR: #413
+- Parent issue: #388

--- a/Firmware/docs/plans/2026-02-16-migrate-error-codes.md
+++ b/Firmware/docs/plans/2026-02-16-migrate-error-codes.md
@@ -1,0 +1,767 @@
+# Migrate Remaining Route Files to Shared Error Codes — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Migrate 472 inline `jsonify({"error": ...})` responses across 16 route files to the shared `error_response()` helper, adding structured error codes to every API error response.
+
+**Architecture:** Each route file gets an import of `error_response` and the specific error code constants it needs from `webui/backend/lib/error_codes.py`. Every `return jsonify({"error": "..."}), status` becomes `return error_response(CODE, "...", status)`. Extra JSON fields pass through via `**extra` kwargs. The `"error"` field is unchanged for backward compatibility; the `"code"` field is additive.
+
+**Tech Stack:** Python/Flask (backend), pytest (testing), ruff (linting)
+
+**Important context:**
+- Reference implementation: `webui/backend/routes/scheduler_ui.py` (already migrated in PR #413)
+- Shared module: `webui/backend/lib/error_codes.py` — provides `error_response()`, `sanitize_message()`, and 9 error code constants
+- Error code mapping: 400→`VALIDATION_ERROR`, 403→`PERMISSION_ERROR`, 404→`NOT_FOUND`, 408→`VALIDATION_ERROR`, 500→`SERVER_ERROR` (or `STORAGE_ERROR` for disk/IO), 503→`HARDWARE_ERROR`
+- Extra-field edge cases: `gallery.py` line 870 has `series_id`, `export.py` lines 984/1128 have `details` — preserved via `**extra`
+- No test changes needed — format is backward compatible (additive `"code"` field)
+- Design doc: `docs/plans/2026-02-16-migrate-error-codes-design.md`
+
+---
+
+### Task 1: Batch 1 — Hardware routes (camera.py, gpio.py, system.py)
+
+**Files:**
+- Modify: `webui/backend/routes/camera.py` (6 error responses)
+- Modify: `webui/backend/routes/gpio.py` (8 error responses)
+- Modify: `webui/backend/routes/system.py` (4 error responses)
+- Test: `Tests/unit/test_camera_routes.py`, `Tests/unit/test_gpio_routes.py`, `Tests/unit/test_system_routes.py`
+
+**Step 1: Create branch**
+
+Run: `git checkout -b refactor/414-batch1-hardware dev`
+
+**Step 2: Run baseline tests**
+
+Run: `python3 -m pytest Tests/unit/test_camera_routes.py Tests/unit/test_gpio_routes.py Tests/unit/test_system_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 3: Migrate camera.py**
+
+Add import at top of file (after existing Flask imports):
+
+```python
+from webui.backend.lib.error_codes import (
+    VALIDATION_ERROR,
+    SERVER_ERROR,
+    error_response,
+)
+```
+
+Replace these 6 error responses:
+
+| Line | Before | After |
+|------|--------|-------|
+| 673 | `return jsonify({"error": "Failed to get camera settings"}), 500` | `return error_response(SERVER_ERROR, "Failed to get camera settings", 500)` |
+| 696 | `return jsonify({"error": f"Invalid setting: {key}"}), 400` | `return error_response(VALIDATION_ERROR, f"Invalid setting: {key}")` |
+| 699 | `return jsonify({"error": f"Invalid value for {key}"}), 400` | `return error_response(VALIDATION_ERROR, f"Invalid value for {key}")` |
+| 701 | `return jsonify({"error": f"Invalid type for {key}"}), 400` | `return error_response(VALIDATION_ERROR, f"Invalid type for {key}")` |
+| 743 | `return jsonify({"error": "Failed to update camera settings"}), 500` | `return error_response(SERVER_ERROR, "Failed to update camera settings", 500)` |
+| 1203 | `return jsonify({"error": "Failed to freeze settings"}), 500` | `return error_response(SERVER_ERROR, "Failed to freeze settings", 500)` |
+
+Note: 400 is the default status for `error_response()`, so omit it for VALIDATION_ERROR calls.
+
+**Step 4: Migrate gpio.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    HARDWARE_ERROR,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Replace these 8 error responses:
+
+| Line | Before | After |
+|------|--------|-------|
+| 30 | `return jsonify({"error": "Failed to get GPIO status"}), 500` | `return error_response(SERVER_ERROR, "Failed to get GPIO status", 500)` |
+| 42 | `return jsonify({"error": "Missing relay or state parameter"}), 400` | `return error_response(VALIDATION_ERROR, "Missing relay or state parameter")` |
+| 44 | `return jsonify({"error": "State must be a boolean value (true/false)"}), 400` | `return error_response(VALIDATION_ERROR, "State must be a boolean value (true/false)")` |
+| 48 | `return jsonify({"error": f"Invalid relay: {relay}"}), 400` | `return error_response(VALIDATION_ERROR, f"Invalid relay: {relay}")` |
+| 63 | `return jsonify({"error": "GPIO daemon not available"}), 503` | `return error_response(HARDWARE_ERROR, "GPIO daemon not available", 503)` |
+| 66 | `return jsonify({"error": "Failed to control GPIO"}), 500` | `return error_response(SERVER_ERROR, "Failed to control GPIO", 500)` |
+| 97 | `return jsonify({"error": "GPIO daemon not available"}), 503` | `return error_response(HARDWARE_ERROR, "GPIO daemon not available", 503)` |
+| 100 | `return jsonify({"error": "Failed to trigger flash"}), 500` | `return error_response(SERVER_ERROR, "Failed to trigger flash", 500)` |
+
+**Step 5: Migrate system.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    SERVER_ERROR,
+    error_response,
+)
+```
+
+Replace these 4 error responses:
+
+| Line | Before | After |
+|------|--------|-------|
+| 144 | `return jsonify({"error": "Failed to get storage info"}), 500` | `return error_response(SERVER_ERROR, "Failed to get storage info", 500)` |
+| 235 | `return jsonify({"error": "Failed to get power status"}), 500` | `return error_response(SERVER_ERROR, "Failed to get power status", 500)` |
+| 275 | `return jsonify({"error": "Failed to get system info"}), 500` | `return error_response(SERVER_ERROR, "Failed to get system info", 500)` |
+| 372 | `return jsonify({"error": "Failed to get diagnostic info"}), 500` | `return error_response(SERVER_ERROR, "Failed to get diagnostic info", 500)` |
+
+**Step 6: Run ruff**
+
+Run: `ruff check webui/backend/routes/camera.py webui/backend/routes/gpio.py webui/backend/routes/system.py && ruff format webui/backend/routes/camera.py webui/backend/routes/gpio.py webui/backend/routes/system.py`
+Expected: Clean (may warn about unused `jsonify` import if all uses removed — unlikely since success responses still use it)
+
+**Step 7: Run tests**
+
+Run: `python3 -m pytest Tests/unit/test_camera_routes.py Tests/unit/test_gpio_routes.py Tests/unit/test_system_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 8: Verify no remaining inline errors**
+
+Run: `grep -n 'jsonify({"error"' webui/backend/routes/camera.py webui/backend/routes/gpio.py webui/backend/routes/system.py`
+Expected: No output (all migrated)
+
+**Step 9: Commit and PR**
+
+```bash
+git add webui/backend/routes/camera.py webui/backend/routes/gpio.py webui/backend/routes/system.py
+git commit -m "$(cat <<'EOF'
+refactor: migrate hardware routes to shared error codes (#414)
+
+Migrate camera.py (6), gpio.py (8), and system.py (4) error responses
+to use error_response() from the shared error codes module.
+
+Batch 1 of 7 for issue #414.
+EOF
+)"
+```
+
+Push and create PR:
+```bash
+git push -u origin refactor/414-batch1-hardware
+gh pr create --base dev --title "refactor: migrate hardware routes to shared error codes (#414)" --body "$(cat <<'EOF'
+## Summary
+- Migrate `camera.py` (6), `gpio.py` (8), and `system.py` (4) error responses to `error_response()`
+- Batch 1 of 7 for #414
+
+## Test plan
+- [x] All existing tests pass (`test_camera_routes.py`, `test_gpio_routes.py`, `test_system_routes.py`)
+- [x] No remaining inline `jsonify({"error"` patterns in migrated files
+- [x] ruff clean
+EOF
+)"
+```
+
+---
+
+### Task 2: Batch 2 — Media routes (gallery.py, metadata.py)
+
+**Files:**
+- Modify: `webui/backend/routes/gallery.py` (~63 error responses)
+- Modify: `webui/backend/routes/metadata.py` (~13 error responses)
+- Test: `Tests/unit/test_gallery_routes.py`, `Tests/unit/test_metadata_routes.py`
+
+**Step 1: Create branch**
+
+Run: `git checkout -b refactor/414-batch2-media dev`
+
+**Step 2: Run baseline tests**
+
+Run: `python3 -m pytest Tests/unit/test_gallery_routes.py Tests/unit/test_metadata_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 3: Migrate gallery.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    HARDWARE_ERROR,
+    NOT_FOUND,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply the error code mapping to all ~63 responses:
+- 400 responses → `error_response(VALIDATION_ERROR, "...", 400)` (omit status since 400 is default)
+- 404 responses → `error_response(NOT_FOUND, "...", 404)`
+- 500 responses → `error_response(SERVER_ERROR, "...", 500)`
+- 503 responses → `error_response(HARDWARE_ERROR, "...", 503)`
+
+**Special case** — line 870 has extra field:
+```python
+# Before:
+return jsonify({"error": "Series not found", "series_id": series_id}), 404
+# After:
+return error_response(NOT_FOUND, "Series not found", 404, series_id=series_id)
+```
+
+**Step 4: Migrate metadata.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    HARDWARE_ERROR,
+    NOT_FOUND,
+    PERMISSION_ERROR,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all ~13 responses:
+- Line 71 (403 "Access denied") → `error_response(PERMISSION_ERROR, "Invalid path: Access denied", 403)`
+- 400 responses → `VALIDATION_ERROR`
+- 404 responses → `NOT_FOUND`
+- 500 responses → `SERVER_ERROR`
+- 503 responses → `HARDWARE_ERROR`
+
+**Step 5: Run ruff**
+
+Run: `ruff check webui/backend/routes/gallery.py webui/backend/routes/metadata.py && ruff format webui/backend/routes/gallery.py webui/backend/routes/metadata.py`
+Expected: Clean
+
+**Step 6: Run tests**
+
+Run: `python3 -m pytest Tests/unit/test_gallery_routes.py Tests/unit/test_metadata_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 7: Verify no remaining inline errors**
+
+Run: `grep -n 'jsonify({"error"' webui/backend/routes/gallery.py webui/backend/routes/metadata.py`
+Expected: No output
+
+**Step 8: Commit and PR**
+
+```bash
+git add webui/backend/routes/gallery.py webui/backend/routes/metadata.py
+git commit -m "$(cat <<'EOF'
+refactor: migrate media routes to shared error codes (#414)
+
+Migrate gallery.py (~63) and metadata.py (~13) error responses
+to use error_response() from the shared error codes module.
+
+Batch 2 of 7 for issue #414.
+EOF
+)"
+git push -u origin refactor/414-batch2-media
+gh pr create --base dev --title "refactor: migrate media routes to shared error codes (#414)" --body "$(cat <<'EOF'
+## Summary
+- Migrate `gallery.py` (~63) and `metadata.py` (~13) error responses to `error_response()`
+- Batch 2 of 7 for #414
+
+## Test plan
+- [x] All existing tests pass (`test_gallery_routes.py`, `test_metadata_routes.py`)
+- [x] No remaining inline `jsonify({"error"` patterns in migrated files
+- [x] ruff clean
+EOF
+)"
+```
+
+---
+
+### Task 3: Batch 3 — Config routes (config.py)
+
+**Files:**
+- Modify: `webui/backend/routes/config.py` (~53 error responses)
+- Test: `Tests/unit/test_config_routes.py`
+
+**Step 1: Create branch**
+
+Run: `git checkout -b refactor/414-batch3-config dev`
+
+**Step 2: Run baseline tests**
+
+Run: `python3 -m pytest Tests/unit/test_config_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 3: Migrate config.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all ~53 responses:
+- All 400 responses → `VALIDATION_ERROR` (default status, omit 400)
+- All 500 responses → `SERVER_ERROR`
+
+This file has no 403/404/503 responses — just validation errors and server errors.
+
+**Step 4: Run ruff**
+
+Run: `ruff check webui/backend/routes/config.py && ruff format webui/backend/routes/config.py`
+Expected: Clean
+
+**Step 5: Run tests**
+
+Run: `python3 -m pytest Tests/unit/test_config_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 6: Verify no remaining inline errors**
+
+Run: `grep -n 'jsonify({"error"' webui/backend/routes/config.py`
+Expected: No output
+
+**Step 7: Commit and PR**
+
+```bash
+git add webui/backend/routes/config.py
+git commit -m "$(cat <<'EOF'
+refactor: migrate config routes to shared error codes (#414)
+
+Migrate config.py (~53) error responses to use error_response()
+from the shared error codes module.
+
+Batch 3 of 7 for issue #414.
+EOF
+)"
+git push -u origin refactor/414-batch3-config
+gh pr create --base dev --title "refactor: migrate config routes to shared error codes (#414)" --body "$(cat <<'EOF'
+## Summary
+- Migrate `config.py` (~53) error responses to `error_response()`
+- Batch 3 of 7 for #414
+
+## Test plan
+- [x] All existing tests pass (`test_config_routes.py`)
+- [x] No remaining inline `jsonify({"error"` patterns
+- [x] ruff clean
+EOF
+)"
+```
+
+---
+
+### Task 4: Batch 4 — Export routes (export.py, export_presets.py)
+
+**Files:**
+- Modify: `webui/backend/routes/export.py` (~125 error responses)
+- Modify: `webui/backend/routes/export_presets.py` (~13 error responses)
+- Test: `Tests/unit/test_export_routes.py`, `Tests/unit/test_export_preset_routes.py`
+
+**Step 1: Create branch**
+
+Run: `git checkout -b refactor/414-batch4-export dev`
+
+**Step 2: Run baseline tests**
+
+Run: `python3 -m pytest Tests/unit/test_export_routes.py Tests/unit/test_export_preset_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 3: Migrate export.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    NOT_FOUND,
+    PERMISSION_ERROR,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all ~125 responses:
+- 400 responses → `VALIDATION_ERROR`
+- 403 responses → `PERMISSION_ERROR`
+- 404 responses → `NOT_FOUND`
+- 500 responses → `SERVER_ERROR`
+
+**Special cases** — lines 984 and 1128 have extra `details` field:
+```python
+# Before:
+return jsonify({"error": "ZIP export failed", "details": result.errors}), 500
+# After:
+return error_response(SERVER_ERROR, "ZIP export failed", 500, details=result.errors)
+```
+
+This is the largest file. Work methodically top-to-bottom.
+
+**Step 4: Migrate export_presets.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    NOT_FOUND,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all ~13 responses.
+
+**Step 5: Run ruff**
+
+Run: `ruff check webui/backend/routes/export.py webui/backend/routes/export_presets.py && ruff format webui/backend/routes/export.py webui/backend/routes/export_presets.py`
+Expected: Clean
+
+**Step 6: Run tests**
+
+Run: `python3 -m pytest Tests/unit/test_export_routes.py Tests/unit/test_export_preset_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 7: Verify no remaining inline errors**
+
+Run: `grep -n 'jsonify({"error"' webui/backend/routes/export.py webui/backend/routes/export_presets.py`
+Expected: No output
+
+**Step 8: Commit and PR**
+
+```bash
+git add webui/backend/routes/export.py webui/backend/routes/export_presets.py
+git commit -m "$(cat <<'EOF'
+refactor: migrate export routes to shared error codes (#414)
+
+Migrate export.py (~125) and export_presets.py (~13) error responses
+to use error_response() from the shared error codes module.
+
+Batch 4 of 7 for issue #414.
+EOF
+)"
+git push -u origin refactor/414-batch4-export
+gh pr create --base dev --title "refactor: migrate export routes to shared error codes (#414)" --body "$(cat <<'EOF'
+## Summary
+- Migrate `export.py` (~125) and `export_presets.py` (~13) error responses to `error_response()`
+- Batch 4 of 7 for #414
+
+## Test plan
+- [x] All existing tests pass (`test_export_routes.py`, `test_export_preset_routes.py`)
+- [x] No remaining inline `jsonify({"error"` patterns in migrated files
+- [x] ruff clean
+EOF
+)"
+```
+
+---
+
+### Task 5: Batch 5 — Deployment routes (deployment.py, sidecar.py)
+
+**Files:**
+- Modify: `webui/backend/routes/deployment.py` (~93 error responses)
+- Modify: `webui/backend/routes/sidecar.py` (~153 error responses)
+- Test: `Tests/unit/test_deployment_routes.py`, `Tests/unit/test_sidecar_routes_filtering.py`
+
+**Step 1: Create branch**
+
+Run: `git checkout -b refactor/414-batch5-deployment dev`
+
+**Step 2: Run baseline tests**
+
+Run: `python3 -m pytest Tests/unit/test_deployment_routes.py Tests/unit/test_sidecar_routes_filtering.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 3: Migrate deployment.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    HARDWARE_ERROR,
+    NOT_FOUND,
+    PERMISSION_ERROR,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all ~93 responses:
+- 400 responses → `VALIDATION_ERROR`
+- 403 responses → `PERMISSION_ERROR`
+- 404 responses → `NOT_FOUND`
+- 500 responses → `SERVER_ERROR`
+- 503 responses → `HARDWARE_ERROR`
+
+**Step 4: Migrate sidecar.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    HARDWARE_ERROR,
+    NOT_FOUND,
+    PERMISSION_ERROR,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all ~153 responses.
+
+**Step 5: Run ruff**
+
+Run: `ruff check webui/backend/routes/deployment.py webui/backend/routes/sidecar.py && ruff format webui/backend/routes/deployment.py webui/backend/routes/sidecar.py`
+Expected: Clean
+
+**Step 6: Run tests**
+
+Run: `python3 -m pytest Tests/unit/test_deployment_routes.py Tests/unit/test_sidecar_routes_filtering.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 7: Verify no remaining inline errors**
+
+Run: `grep -n 'jsonify({"error"' webui/backend/routes/deployment.py webui/backend/routes/sidecar.py`
+Expected: No output
+
+**Step 8: Commit and PR**
+
+```bash
+git add webui/backend/routes/deployment.py webui/backend/routes/sidecar.py
+git commit -m "$(cat <<'EOF'
+refactor: migrate deployment routes to shared error codes (#414)
+
+Migrate deployment.py (~93) and sidecar.py (~153) error responses
+to use error_response() from the shared error codes module.
+
+Batch 5 of 7 for issue #414.
+EOF
+)"
+git push -u origin refactor/414-batch5-deployment
+gh pr create --base dev --title "refactor: migrate deployment routes to shared error codes (#414)" --body "$(cat <<'EOF'
+## Summary
+- Migrate `deployment.py` (~93) and `sidecar.py` (~153) error responses to `error_response()`
+- Batch 5 of 7 for #414
+
+## Test plan
+- [x] All existing tests pass (`test_deployment_routes.py`, `test_sidecar_routes_filtering.py`)
+- [x] No remaining inline `jsonify({"error"` patterns in migrated files
+- [x] ruff clean
+EOF
+)"
+```
+
+---
+
+### Task 6: Batch 6 — Search & GPS routes (search.py, gps.py, gps_exif.py)
+
+**Files:**
+- Modify: `webui/backend/routes/search.py` (10 error responses)
+- Modify: `webui/backend/routes/gps.py` (14 error responses)
+- Modify: `webui/backend/routes/gps_exif.py` (20 error responses)
+- Test: `Tests/unit/test_search_api.py`, `Tests/unit/test_gps_routes.py`, `Tests/unit/test_gps_exif_routes.py`
+
+**Step 1: Create branch**
+
+Run: `git checkout -b refactor/414-batch6-search-gps dev`
+
+**Step 2: Run baseline tests**
+
+Run: `python3 -m pytest Tests/unit/test_search_api.py Tests/unit/test_gps_routes.py Tests/unit/test_gps_exif_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 3: Migrate search.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    HARDWARE_ERROR,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all 10 responses:
+- 400 responses → `VALIDATION_ERROR`
+- 500 responses → `SERVER_ERROR`
+- 503 responses → `HARDWARE_ERROR`
+
+**Step 4: Migrate gps.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all 14 responses:
+- 400 responses → `VALIDATION_ERROR`
+- 408 responses → `VALIDATION_ERROR` (GPS timeout — treated as a request-level validation failure)
+- 500 responses → `SERVER_ERROR`
+
+**Step 5: Migrate gps_exif.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    NOT_FOUND,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all 20 responses.
+
+**Step 6: Run ruff**
+
+Run: `ruff check webui/backend/routes/search.py webui/backend/routes/gps.py webui/backend/routes/gps_exif.py && ruff format webui/backend/routes/search.py webui/backend/routes/gps.py webui/backend/routes/gps_exif.py`
+Expected: Clean
+
+**Step 7: Run tests**
+
+Run: `python3 -m pytest Tests/unit/test_search_api.py Tests/unit/test_gps_routes.py Tests/unit/test_gps_exif_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 8: Verify no remaining inline errors**
+
+Run: `grep -n 'jsonify({"error"' webui/backend/routes/search.py webui/backend/routes/gps.py webui/backend/routes/gps_exif.py`
+Expected: No output
+
+**Step 9: Commit and PR**
+
+```bash
+git add webui/backend/routes/search.py webui/backend/routes/gps.py webui/backend/routes/gps_exif.py
+git commit -m "$(cat <<'EOF'
+refactor: migrate search & GPS routes to shared error codes (#414)
+
+Migrate search.py (10), gps.py (14), and gps_exif.py (20) error
+responses to use error_response() from the shared error codes module.
+
+Batch 6 of 7 for issue #414.
+EOF
+)"
+git push -u origin refactor/414-batch6-search-gps
+gh pr create --base dev --title "refactor: migrate search & GPS routes to shared error codes (#414)" --body "$(cat <<'EOF'
+## Summary
+- Migrate `search.py` (10), `gps.py` (14), and `gps_exif.py` (20) error responses to `error_response()`
+- Batch 6 of 7 for #414
+
+## Test plan
+- [x] All existing tests pass (`test_search_api.py`, `test_gps_routes.py`, `test_gps_exif_routes.py`)
+- [x] No remaining inline `jsonify({"error"` patterns in migrated files
+- [x] ruff clean
+EOF
+)"
+```
+
+---
+
+### Task 7: Batch 7 — Misc routes (preferences.py, presets.py, scheduler.py)
+
+**Files:**
+- Modify: `webui/backend/routes/preferences.py` (9 error responses)
+- Modify: `webui/backend/routes/presets.py` (~21 error responses)
+- Modify: `webui/backend/routes/scheduler.py` (8 error responses)
+- Test: `Tests/unit/test_preferences_routes.py`, `Tests/unit/test_presets_routes.py`, `Tests/unit/test_scheduler_routes.py`
+
+**Step 1: Create branch**
+
+Run: `git checkout -b refactor/414-batch7-misc dev`
+
+**Step 2: Run baseline tests**
+
+Run: `python3 -m pytest Tests/unit/test_preferences_routes.py Tests/unit/test_presets_routes.py Tests/unit/test_scheduler_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 3: Migrate preferences.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all 9 responses.
+
+**Step 4: Migrate presets.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    NOT_FOUND,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all ~21 responses.
+
+**Step 5: Migrate scheduler.py**
+
+Add import at top of file:
+
+```python
+from webui.backend.lib.error_codes import (
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
+```
+
+Apply mapping to all 8 responses.
+
+**Step 6: Run ruff**
+
+Run: `ruff check webui/backend/routes/preferences.py webui/backend/routes/presets.py webui/backend/routes/scheduler.py && ruff format webui/backend/routes/preferences.py webui/backend/routes/presets.py webui/backend/routes/scheduler.py`
+Expected: Clean
+
+**Step 7: Run tests**
+
+Run: `python3 -m pytest Tests/unit/test_preferences_routes.py Tests/unit/test_presets_routes.py Tests/unit/test_scheduler_routes.py -v --tb=short -q`
+Expected: All tests PASS
+
+**Step 8: Verify no remaining inline errors**
+
+Run: `grep -n 'jsonify({"error"' webui/backend/routes/preferences.py webui/backend/routes/presets.py webui/backend/routes/scheduler.py`
+Expected: No output
+
+**Step 9: Final sweep — verify zero inline errors across ALL route files**
+
+Run: `grep -rn 'jsonify({"error"' webui/backend/routes/`
+Expected: No output (all 16 files migrated, scheduler_ui.py was already done)
+
+**Step 10: Commit and PR**
+
+```bash
+git add webui/backend/routes/preferences.py webui/backend/routes/presets.py webui/backend/routes/scheduler.py
+git commit -m "$(cat <<'EOF'
+refactor: migrate misc routes to shared error codes (#414)
+
+Migrate preferences.py (9), presets.py (~21), and scheduler.py (8)
+error responses to use error_response() from the shared error codes
+module.
+
+Batch 7 of 7 for issue #414. All 16 route files now use the shared
+error codes module.
+EOF
+)"
+git push -u origin refactor/414-batch7-misc
+gh pr create --base dev --title "refactor: migrate misc routes to shared error codes (#414)" --body "$(cat <<'EOF'
+## Summary
+- Migrate `preferences.py` (9), `presets.py` (~21), and `scheduler.py` (8) error responses to `error_response()`
+- Batch 7 of 7 for #414 — completes the migration
+
+## Test plan
+- [x] All existing tests pass (`test_preferences_routes.py`, `test_presets_routes.py`, `test_scheduler_routes.py`)
+- [x] No remaining inline `jsonify({"error"` patterns in ANY route file
+- [x] ruff clean
+- [x] Final sweep: `grep -rn 'jsonify({"error"' webui/backend/routes/` returns nothing
+EOF
+)"
+```

--- a/Firmware/webui/backend/routes/export.py
+++ b/Firmware/webui/backend/routes/export.py
@@ -41,6 +41,13 @@ from pathlib import Path
 from flask import Blueprint, Response, current_app, jsonify, request
 
 from mothbox_paths import PHOTOS_DIR
+from webui.backend.lib.error_codes import (
+    NOT_FOUND,
+    PERMISSION_ERROR,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
 from webui.backend.security_utils import validate_photo_path
 from webui.backend.services.export_metadata_service import (
     ExportFormat,
@@ -136,17 +143,19 @@ def get_export_metadata(photo_path: str):
         # Get service from app config
         service = current_app.config.get("EXPORT_METADATA_SERVICE")
         if service is None:
-            return jsonify({"error": "Export service not available"}), 500
+            return error_response(SERVER_ERROR, "Export service not available", 500)
 
         # Validate path to prevent traversal attacks
         validated_path = validate_photo_path(photo_path, PHOTOS_DIR)
         if validated_path is None:
-            return jsonify({"error": "Invalid path"}), 403
+            return error_response(PERMISSION_ERROR, "Invalid path", 403)
 
         # Get format parameter (default: json)
         format_param = request.args.get("format", "json").lower()
         if format_param not in ("json", "csv", "darwin_core"):
-            return jsonify({"error": "Invalid format. Use 'json', 'csv', or 'darwin_core'"}), 400
+            return error_response(
+                VALIDATION_ERROR, "Invalid format. Use 'json', 'csv', or 'darwin_core'"
+            )
 
         # Get export metadata
         result = service.get_export_metadata(validated_path)
@@ -155,11 +164,11 @@ def get_export_metadata(photo_path: str):
         if isinstance(result, dict) and "error" in result:
             error_msg = result["error"]
             if error_msg == "Photo not found":
-                return jsonify(result), 404
+                return error_response(NOT_FOUND, "Photo not found", 404)
             elif error_msg == "Permission denied":
-                return jsonify(result), 403
+                return error_response(PERMISSION_ERROR, "Permission denied", 403)
             else:
-                return jsonify(result), 500
+                return error_response(SERVER_ERROR, error_msg, 500)
 
         # Transform to requested format
         if isinstance(result, ExportMetadata):
@@ -167,13 +176,12 @@ def get_export_metadata(photo_path: str):
                 # Validate for Darwin Core first
                 validation = service.validate_for_format(result, ExportFormat.DARWIN_CORE)
                 if not validation.is_valid:
-                    return jsonify(
-                        {
-                            "error": "Darwin Core validation failed",
-                            "missing_fields": validation.missing_fields,
-                            "warnings": validation.warnings,
-                        }
-                    ), 400
+                    return error_response(
+                        VALIDATION_ERROR,
+                        "Darwin Core validation failed",
+                        missing_fields=validation.missing_fields,
+                        warnings=validation.warnings,
+                    )
 
                 transformed = service.transform_to_darwin_core(result)
                 # Include warnings if any
@@ -189,7 +197,7 @@ def get_export_metadata(photo_path: str):
 
     except Exception as e:
         logger.error("Error getting export metadata for %s: %s", photo_path, e, exc_info=True)
-        return jsonify({"error": "Failed to get export metadata"}), 500
+        return error_response(SERVER_ERROR, "Failed to get export metadata", 500)
 
 
 @export_bp.route("/metadata/batch", methods=["POST"])
@@ -230,28 +238,28 @@ def get_batch_export_metadata():
         # Get service from app config
         service = current_app.config.get("EXPORT_METADATA_SERVICE")
         if service is None:
-            return jsonify({"error": "Export service not available"}), 500
+            return error_response(SERVER_ERROR, "Export service not available", 500)
 
         # Validate request body
         if not request.is_json:
-            return jsonify({"error": "Request must be JSON"}), 400
+            return error_response(VALIDATION_ERROR, "Request must be JSON")
 
         try:
             data = request.get_json()
         except Exception:
-            return jsonify({"error": "Invalid JSON in request body"}), 400
+            return error_response(VALIDATION_ERROR, "Invalid JSON in request body")
 
         if not data or "photo_paths" not in data:
-            return jsonify({"error": "Missing 'photo_paths' in request body"}), 400
+            return error_response(VALIDATION_ERROR, "Missing 'photo_paths' in request body")
 
         photo_paths = data["photo_paths"]
 
         if not isinstance(photo_paths, list):
-            return jsonify({"error": "'photo_paths' must be an array"}), 400
+            return error_response(VALIDATION_ERROR, "'photo_paths' must be an array")
 
         # Validate all paths are non-empty strings
         if not all(isinstance(p, str) and p.strip() for p in photo_paths):
-            return jsonify({"error": "All photo_paths must be non-empty strings"}), 400
+            return error_response(VALIDATION_ERROR, "All photo_paths must be non-empty strings")
 
         if len(photo_paths) == 0:
             return jsonify({"results": [], "total": 0, "successful": 0, "failed": 0}), 200
@@ -260,14 +268,15 @@ def get_batch_export_metadata():
         max_batch_size = current_app.config.get("EXPORT_MAX_BATCH_SIZE", 1000)
 
         if len(photo_paths) > max_batch_size:
-            return jsonify(
-                {"error": f"Batch size exceeds maximum limit of {max_batch_size} photos"}
-            ), 400
+            return error_response(
+                VALIDATION_ERROR,
+                f"Batch size exceeds maximum limit of {max_batch_size} photos",
+            )
 
         # Get format parameter (default: json)
         format_param = data.get("format", "json").lower()
         if format_param not in ("json", "csv"):
-            return jsonify({"error": "Invalid format. Use 'json' or 'csv'"}), 400
+            return error_response(VALIDATION_ERROR, "Invalid format. Use 'json' or 'csv'")
 
         # Validate and resolve all paths with security checks
         resolved_paths = []
@@ -303,7 +312,7 @@ def get_batch_export_metadata():
 
     except Exception as e:
         logger.error("Error in batch export metadata: %s", e, exc_info=True)
-        return jsonify({"error": "Batch processing failed"}), 500
+        return error_response(SERVER_ERROR, "Batch processing failed", 500)
 
 
 # ============================================================================
@@ -408,7 +417,7 @@ def list_export_formats():
 
     except Exception as e:
         logger.error("Error listing formats: %s", e, exc_info=True)
-        return jsonify({"error": "Failed to list formats"}), 500
+        return error_response(SERVER_ERROR, "Failed to list formats", 500)
 
 
 @export_bp.route("/stats", methods=["GET"])
@@ -435,7 +444,7 @@ def get_export_stats():
         # Get service from app config
         service = current_app.config.get("EXPORT_METADATA_SERVICE")
         if service is None:
-            return jsonify({"error": "Export service not available"}), 500
+            return error_response(SERVER_ERROR, "Export service not available", 500)
 
         # Get statistics
         stats = service.get_statistics()
@@ -444,7 +453,7 @@ def get_export_stats():
 
     except Exception as e:
         logger.error("Error getting export stats: %s", e, exc_info=True)
-        return jsonify({"error": "Failed to get statistics"}), 500
+        return error_response(SERVER_ERROR, "Failed to get statistics", 500)
 
 
 @export_bp.route("/stats/reset", methods=["POST"])
@@ -471,7 +480,7 @@ def reset_export_stats():
         # Get service from app config
         service = current_app.config.get("EXPORT_METADATA_SERVICE")
         if service is None:
-            return jsonify({"error": "Export service not available"}), 500
+            return error_response(SERVER_ERROR, "Export service not available", 500)
 
         # Reset statistics
         service.reset_statistics()
@@ -480,7 +489,7 @@ def reset_export_stats():
 
     except Exception as e:
         logger.error("Error resetting export stats: %s", e, exc_info=True)
-        return jsonify({"error": "Failed to reset statistics"}), 500
+        return error_response(SERVER_ERROR, "Failed to reset statistics", 500)
 
 
 # ============================================================================
@@ -578,41 +587,46 @@ def export_darwin_core_batch():
         # Get service from app config
         service = current_app.config.get("EXPORT_METADATA_SERVICE")
         if service is None:
-            return jsonify({"error": "Export service not available"}), 500
+            return error_response(SERVER_ERROR, "Export service not available", 500)
 
         # Validate request body
         if not request.is_json:
-            return jsonify({"error": "Request must be JSON"}), 400
+            return error_response(VALIDATION_ERROR, "Request must be JSON")
 
         try:
             data = request.get_json()
         except Exception:
-            return jsonify({"error": "Invalid JSON in request body"}), 400
+            return error_response(VALIDATION_ERROR, "Invalid JSON in request body")
 
         if not data or "photo_paths" not in data:
-            return jsonify({"error": "Missing 'photo_paths' in request body"}), 400
+            return error_response(VALIDATION_ERROR, "Missing 'photo_paths' in request body")
 
         photo_paths = data["photo_paths"]
 
         if not isinstance(photo_paths, list):
-            return jsonify({"error": "'photo_paths' must be an array"}), 400
+            return error_response(VALIDATION_ERROR, "'photo_paths' must be an array")
 
         # Validate all paths are non-empty strings
         if not all(isinstance(p, str) and p.strip() for p in photo_paths):
-            return jsonify({"error": "All photo_paths must be non-empty strings"}), 400
+            return error_response(VALIDATION_ERROR, "All photo_paths must be non-empty strings")
 
         if len(photo_paths) == 0:
-            return jsonify(
-                {"error": "No photos provided", "csv_data": "", "headers": [], "row_count": 0}
-            ), 400
+            return error_response(
+                VALIDATION_ERROR,
+                "No photos provided",
+                csv_data="",
+                headers=[],
+                row_count=0,
+            )
 
         # Get configurable batch size limit
         max_batch_size = current_app.config.get("EXPORT_MAX_BATCH_SIZE", 1000)
 
         if len(photo_paths) > max_batch_size:
-            return jsonify(
-                {"error": f"Batch size exceeds maximum limit of {max_batch_size} photos"}
-            ), 400
+            return error_response(
+                VALIDATION_ERROR,
+                f"Batch size exceeds maximum limit of {max_batch_size} photos",
+            )
 
         # Options
         validate = data.get("validate", True)
@@ -694,7 +708,7 @@ def export_darwin_core_batch():
 
     except Exception as e:
         logger.error("Error in Darwin Core batch export: %s", e, exc_info=True)
-        return jsonify({"error": "Darwin Core batch export failed"}), 500
+        return error_response(SERVER_ERROR, "Darwin Core batch export failed", 500)
 
 
 @export_bp.route("/darwin-core/deployment/<path:deployment_path>", methods=["GET"])
@@ -728,23 +742,23 @@ def export_deployment_darwin_core(deployment_path: str):
         # Get service from app config
         service = current_app.config.get("EXPORT_METADATA_SERVICE")
         if service is None:
-            return jsonify({"error": "Export service not available"}), 500
+            return error_response(SERVER_ERROR, "Export service not available", 500)
 
         # Validate path to prevent traversal attacks
         from pathlib import Path
 
         validated_path = validate_photo_path(deployment_path, PHOTOS_DIR)
         if validated_path is None:
-            return jsonify({"error": "Invalid path"}), 403
+            return error_response(PERMISSION_ERROR, "Invalid path", 403)
 
         deployment_dir = Path(validated_path)
 
         # Check if directory exists
         if not deployment_dir.exists():
-            return jsonify({"error": "Deployment directory not found"}), 404
+            return error_response(NOT_FOUND, "Deployment directory not found", 404)
 
         if not deployment_dir.is_dir():
-            return jsonify({"error": "Path is not a directory"}), 400
+            return error_response(VALIDATION_ERROR, "Path is not a directory")
 
         # Query parameters
         validate = request.args.get("validate", "true").lower() == "true"
@@ -754,14 +768,13 @@ def export_deployment_darwin_core(deployment_path: str):
         photo_paths = find_photos_in_directory(deployment_dir)
 
         if not photo_paths:
-            return jsonify(
-                {
-                    "error": "No photos found in deployment directory",
-                    "csv_data": "",
-                    "headers": [],
-                    "row_count": 0,
-                }
-            ), 400
+            return error_response(
+                VALIDATION_ERROR,
+                "No photos found in deployment directory",
+                csv_data="",
+                headers=[],
+                row_count=0,
+            )
 
         # Collect metadata for all photos
         metadata_list = []
@@ -838,7 +851,7 @@ def export_deployment_darwin_core(deployment_path: str):
 
     except Exception as e:
         logger.error("Error in Darwin Core deployment export: %s", e, exc_info=True)
-        return jsonify({"error": "Darwin Core deployment export failed"}), 500
+        return error_response(SERVER_ERROR, "Darwin Core deployment export failed", 500)
 
 
 # ============================================================================
@@ -892,49 +905,48 @@ def export_inaturalist_batch():
         # Get service from app config
         service = current_app.config.get("EXPORT_METADATA_SERVICE")
         if service is None:
-            return jsonify({"error": "Export service not available"}), 500
+            return error_response(SERVER_ERROR, "Export service not available", 500)
 
         # Validate request body
         if not request.is_json:
-            return jsonify({"error": "Request must be JSON"}), 400
+            return error_response(VALIDATION_ERROR, "Request must be JSON")
 
         try:
             data = request.get_json()
         except Exception:
-            return jsonify({"error": "Invalid JSON in request body"}), 400
+            return error_response(VALIDATION_ERROR, "Invalid JSON in request body")
 
         if not data or "photo_paths" not in data:
-            return jsonify(
-                {
-                    "error": "No photos specified",
-                    "details": "photo_paths array is required and must not be empty",
-                }
-            ), 400
+            return error_response(
+                VALIDATION_ERROR,
+                "No photos specified",
+                details="photo_paths array is required and must not be empty",
+            )
 
         photo_paths = data["photo_paths"]
 
         if not isinstance(photo_paths, list):
-            return jsonify({"error": "'photo_paths' must be an array"}), 400
+            return error_response(VALIDATION_ERROR, "'photo_paths' must be an array")
 
         # Validate all paths are non-empty strings
         if not all(isinstance(p, str) and p.strip() for p in photo_paths):
-            return jsonify({"error": "All photo_paths must be non-empty strings"}), 400
+            return error_response(VALIDATION_ERROR, "All photo_paths must be non-empty strings")
 
         if len(photo_paths) == 0:
-            return jsonify(
-                {
-                    "error": "No photos specified",
-                    "details": "photo_paths array is required and must not be empty",
-                }
-            ), 400
+            return error_response(
+                VALIDATION_ERROR,
+                "No photos specified",
+                details="photo_paths array is required and must not be empty",
+            )
 
         # Get configurable batch size limit
         max_batch_size = current_app.config.get("EXPORT_MAX_BATCH_SIZE", 1000)
 
         if len(photo_paths) > max_batch_size:
-            return jsonify(
-                {"error": f"Batch size exceeds maximum limit of {max_batch_size} photos"}
-            ), 400
+            return error_response(
+                VALIDATION_ERROR,
+                f"Batch size exceeds maximum limit of {max_batch_size} photos",
+            )
 
         # Parse options
         from webui.backend.lib.zip_export import ZipExportOptions
@@ -955,12 +967,12 @@ def export_inaturalist_batch():
             # Path traversal protection
             validated_path = validate_photo_path(photo_path, PHOTOS_DIR)
             if validated_path is None:
-                return jsonify(
-                    {
-                        "error": "Invalid path",
-                        "details": f"Path validation failed for: {photo_path}",
-                    }
-                ), 403
+                return error_response(
+                    PERMISSION_ERROR,
+                    "Invalid path",
+                    403,
+                    details=f"Path validation failed for: {photo_path}",
+                )
             resolved_paths.append(Path(validated_path))
 
         # Create temporary file for ZIP
@@ -981,7 +993,7 @@ def export_inaturalist_batch():
                 # Clean up temp file on error
                 if output_path.exists():
                     output_path.unlink()
-                return jsonify({"error": "ZIP export failed", "details": result.errors}), 500
+                return error_response(SERVER_ERROR, "ZIP export failed", 500, details=result.errors)
 
             # Determine response format based on Accept header
             accept = request.headers.get("Accept", "application/json")
@@ -1029,11 +1041,11 @@ def export_inaturalist_batch():
             # Clean up temp file on error
             if output_path.exists():
                 output_path.unlink()
-            return jsonify({"error": "ZIP export failed"}), 500
+            return error_response(SERVER_ERROR, "ZIP export failed", 500)
 
     except Exception as e:
         logger.error("Error in iNaturalist batch export: %s", e, exc_info=True)
-        return jsonify({"error": "iNaturalist batch export failed"}), 500
+        return error_response(SERVER_ERROR, "iNaturalist batch export failed", 500)
 
 
 @export_bp.route("/inaturalist/deployment/<path:deployment_path>", methods=["GET"])
@@ -1070,23 +1082,23 @@ def export_deployment_inaturalist(deployment_path: str):
         # Get service from app config
         service = current_app.config.get("EXPORT_METADATA_SERVICE")
         if service is None:
-            return jsonify({"error": "Export service not available"}), 500
+            return error_response(SERVER_ERROR, "Export service not available", 500)
 
         # Validate path to prevent traversal attacks
         from pathlib import Path
 
         validated_path = validate_photo_path(deployment_path, PHOTOS_DIR)
         if validated_path is None:
-            return jsonify({"error": "Invalid path"}), 403
+            return error_response(PERMISSION_ERROR, "Invalid path", 403)
 
         deployment_dir = Path(validated_path)
 
         # Check if directory exists
         if not deployment_dir.exists():
-            return jsonify({"error": "Deployment directory not found"}), 404
+            return error_response(NOT_FOUND, "Deployment directory not found", 404)
 
         if not deployment_dir.is_dir():
-            return jsonify({"error": "Path is not a directory"}), 400
+            return error_response(VALIDATION_ERROR, "Path is not a directory")
 
         # Query parameters
         include_xmp = request.args.get("include_xmp", "true").lower() == "true"
@@ -1097,7 +1109,7 @@ def export_deployment_inaturalist(deployment_path: str):
         photo_paths = find_photos_in_directory(deployment_dir)
 
         if not photo_paths:
-            return jsonify({"error": "No photos found in deployment directory"}), 400
+            return error_response(VALIDATION_ERROR, "No photos found in deployment directory")
 
         # Create export options
         from webui.backend.lib.zip_export import ZipExportOptions
@@ -1125,7 +1137,7 @@ def export_deployment_inaturalist(deployment_path: str):
                 # Clean up temp file on error
                 if output_path.exists():
                     output_path.unlink()
-                return jsonify({"error": "ZIP export failed", "details": result.errors}), 500
+                return error_response(SERVER_ERROR, "ZIP export failed", 500, details=result.errors)
 
             # Determine response format based on Accept header
             accept = request.headers.get("Accept", "application/json")
@@ -1175,11 +1187,11 @@ def export_deployment_inaturalist(deployment_path: str):
             # Clean up temp file on error
             if output_path.exists():
                 output_path.unlink()
-            return jsonify({"error": "ZIP export failed"}), 500
+            return error_response(SERVER_ERROR, "ZIP export failed", 500)
 
     except Exception as e:
         logger.error("Error in iNaturalist deployment export: %s", e, exc_info=True)
-        return jsonify({"error": "iNaturalist deployment export failed"}), 500
+        return error_response(SERVER_ERROR, "iNaturalist deployment export failed", 500)
 
 
 @export_bp.route("/inaturalist/preview", methods=["POST"])
@@ -1226,39 +1238,40 @@ def preview_inaturalist_export():
         # Get service from app config
         service = current_app.config.get("EXPORT_METADATA_SERVICE")
         if service is None:
-            return jsonify({"error": "Export service not available"}), 500
+            return error_response(SERVER_ERROR, "Export service not available", 500)
 
         # Validate request body
         if not request.is_json:
-            return jsonify({"error": "Request must be JSON"}), 400
+            return error_response(VALIDATION_ERROR, "Request must be JSON")
 
         try:
             data = request.get_json()
         except Exception:
-            return jsonify({"error": "Invalid JSON in request body"}), 400
+            return error_response(VALIDATION_ERROR, "Invalid JSON in request body")
 
         if not data or "photo_paths" not in data:
-            return jsonify({"error": "Missing 'photo_paths' in request body"}), 400
+            return error_response(VALIDATION_ERROR, "Missing 'photo_paths' in request body")
 
         photo_paths = data["photo_paths"]
 
         if not isinstance(photo_paths, list):
-            return jsonify({"error": "'photo_paths' must be an array"}), 400
+            return error_response(VALIDATION_ERROR, "'photo_paths' must be an array")
 
         # Validate all paths are non-empty strings
         if not all(isinstance(p, str) and p.strip() for p in photo_paths):
-            return jsonify({"error": "All photo_paths must be non-empty strings"}), 400
+            return error_response(VALIDATION_ERROR, "All photo_paths must be non-empty strings")
 
         if len(photo_paths) == 0:
-            return jsonify({"error": "No photos provided"}), 400
+            return error_response(VALIDATION_ERROR, "No photos provided")
 
         # Get configurable batch size limit
         max_batch_size = current_app.config.get("EXPORT_MAX_BATCH_SIZE", 1000)
 
         if len(photo_paths) > max_batch_size:
-            return jsonify(
-                {"error": f"Batch size exceeds maximum limit of {max_batch_size} photos"}
-            ), 400
+            return error_response(
+                VALIDATION_ERROR,
+                f"Batch size exceeds maximum limit of {max_batch_size} photos",
+            )
 
         # Validate and resolve paths
         from pathlib import Path
@@ -1358,7 +1371,7 @@ def preview_inaturalist_export():
 
     except Exception as e:
         logger.error("Error in iNaturalist preview: %s", e, exc_info=True)
-        return jsonify({"error": "Preview failed"}), 500
+        return error_response(SERVER_ERROR, "Preview failed", 500)
 
 
 # ============================================================================
@@ -1468,19 +1481,19 @@ def export_single_json(photo_path: str):
         # Get service from app config
         service = current_app.config.get("EXPORT_METADATA_SERVICE")
         if service is None:
-            return jsonify({"error": "Export service not available"}), 500
+            return error_response(SERVER_ERROR, "Export service not available", 500)
 
         # Validate path to prevent traversal attacks
         validated_path = validate_photo_path(photo_path, PHOTOS_DIR)
         if validated_path is None:
-            return jsonify({"error": "Invalid path"}), 403
+            return error_response(PERMISSION_ERROR, "Invalid path", 403)
 
         # Parse field filtering parameters
         try:
             fields, exclude = _parse_field_filter_params(request)
         except ValueError as e:
             logger.warning(f"Invalid field filter params: {e}")
-            return jsonify({"error": "Invalid field filter parameters"}), 400
+            return error_response(VALIDATION_ERROR, "Invalid field filter parameters")
 
         # Get export metadata
         result = service.get_export_metadata(validated_path)
@@ -1519,7 +1532,7 @@ def export_single_json(photo_path: str):
 
     except Exception as e:
         logger.error("Error exporting JSON for %s: %s", photo_path, e, exc_info=True)
-        return jsonify({"error": "Failed to export JSON metadata"}), 500
+        return error_response(SERVER_ERROR, "Failed to export JSON metadata", 500)
 
 
 @export_bp.route("/json/batch", methods=["POST"])
@@ -1566,28 +1579,28 @@ def export_batch_json():
         # Get service from app config
         service = current_app.config.get("EXPORT_METADATA_SERVICE")
         if service is None:
-            return jsonify({"error": "Export service not available"}), 500
+            return error_response(SERVER_ERROR, "Export service not available", 500)
 
         # Validate request body
         if not request.is_json:
-            return jsonify({"error": "Request must be JSON"}), 400
+            return error_response(VALIDATION_ERROR, "Request must be JSON")
 
         try:
             data = request.get_json()
         except Exception:
-            return jsonify({"error": "Invalid JSON in request body"}), 400
+            return error_response(VALIDATION_ERROR, "Invalid JSON in request body")
 
         if not data or "photo_paths" not in data:
-            return jsonify({"error": "Missing 'photo_paths' in request body"}), 400
+            return error_response(VALIDATION_ERROR, "Missing 'photo_paths' in request body")
 
         photo_paths = data["photo_paths"]
 
         if not isinstance(photo_paths, list):
-            return jsonify({"error": "'photo_paths' must be an array"}), 400
+            return error_response(VALIDATION_ERROR, "'photo_paths' must be an array")
 
         # Validate all paths are non-empty strings
         if not all(isinstance(p, str) and p.strip() for p in photo_paths):
-            return jsonify({"error": "All photo_paths must be non-empty strings"}), 400
+            return error_response(VALIDATION_ERROR, "All photo_paths must be non-empty strings")
 
         if len(photo_paths) == 0:
             return jsonify(
@@ -1598,16 +1611,17 @@ def export_batch_json():
         max_batch_size = current_app.config.get("EXPORT_MAX_BATCH_SIZE", 1000)
 
         if len(photo_paths) > max_batch_size:
-            return jsonify(
-                {"error": f"Batch size exceeds maximum limit of {max_batch_size} photos"}
-            ), 400
+            return error_response(
+                VALIDATION_ERROR,
+                f"Batch size exceeds maximum limit of {max_batch_size} photos",
+            )
 
         # Parse field filtering parameters
         try:
             fields, exclude = _parse_field_filter_params(request)
         except ValueError as e:
             logger.warning(f"Invalid field filter params: {e}")
-            return jsonify({"error": "Invalid field filter parameters"}), 400
+            return error_response(VALIDATION_ERROR, "Invalid field filter parameters")
 
         # Collect metadata for all photos
         results = []
@@ -1659,7 +1673,7 @@ def export_batch_json():
 
     except Exception as e:
         logger.error("Error in batch JSON export: %s", e, exc_info=True)
-        return jsonify({"error": "Batch JSON export failed"}), 500
+        return error_response(SERVER_ERROR, "Batch JSON export failed", 500)
 
 
 @export_bp.route("/json/deployment/<path:deployment_path>", methods=["GET"])
@@ -1690,40 +1704,39 @@ def export_deployment_json(deployment_path: str):
         # Get service from app config
         service = current_app.config.get("EXPORT_METADATA_SERVICE")
         if service is None:
-            return jsonify({"error": "Export service not available"}), 500
+            return error_response(SERVER_ERROR, "Export service not available", 500)
 
         # Validate path to prevent traversal attacks
         validated_path = validate_photo_path(deployment_path, PHOTOS_DIR)
         if validated_path is None:
-            return jsonify({"error": "Invalid path"}), 403
+            return error_response(PERMISSION_ERROR, "Invalid path", 403)
 
         deployment_dir = Path(validated_path)
         if not deployment_dir.exists():
-            return jsonify({"error": "Deployment directory not found"}), 404
+            return error_response(NOT_FOUND, "Deployment directory not found", 404)
 
         if not deployment_dir.is_dir():
-            return jsonify({"error": "Path is not a directory"}), 400
+            return error_response(VALIDATION_ERROR, "Path is not a directory")
 
         # Parse field filtering parameters
         try:
             fields, exclude = _parse_field_filter_params(request)
         except ValueError as e:
             logger.warning(f"Invalid field filter params: {e}")
-            return jsonify({"error": "Invalid field filter parameters"}), 400
+            return error_response(VALIDATION_ERROR, "Invalid field filter parameters")
 
         # Find all photos in deployment directory
         photo_files = find_photos_in_directory(deployment_dir)
 
         if not photo_files:
-            return jsonify(
-                {
-                    "error": "No photos found in deployment directory",
-                    "results": [],
-                    "total": 0,
-                    "successful": 0,
-                    "failed": 0,
-                }
-            ), 400
+            return error_response(
+                VALIDATION_ERROR,
+                "No photos found in deployment directory",
+                results=[],
+                total=0,
+                successful=0,
+                failed=0,
+            )
 
         # Collect metadata for all photos
         results = []
@@ -1778,7 +1791,7 @@ def export_deployment_json(deployment_path: str):
         logger.error(
             "Error in deployment JSON export for %s: %s", deployment_path, e, exc_info=True
         )
-        return jsonify({"error": "Deployment JSON export failed"}), 500
+        return error_response(SERVER_ERROR, "Deployment JSON export failed", 500)
 
 
 # ============================================================================
@@ -1901,46 +1914,47 @@ def export_batch_csv():
         # Get service from app config
         service = current_app.config.get("EXPORT_METADATA_SERVICE")
         if service is None:
-            return jsonify({"error": "Export service not available"}), 500
+            return error_response(SERVER_ERROR, "Export service not available", 500)
 
         # Validate request body
         if not request.is_json:
-            return jsonify({"error": "Request must be JSON"}), 400
+            return error_response(VALIDATION_ERROR, "Request must be JSON")
 
         try:
             data = request.get_json()
         except Exception:
-            return jsonify({"error": "Invalid JSON in request body"}), 400
+            return error_response(VALIDATION_ERROR, "Invalid JSON in request body")
 
         if not data or "photo_paths" not in data:
-            return jsonify({"error": "Missing 'photo_paths' in request body"}), 400
+            return error_response(VALIDATION_ERROR, "Missing 'photo_paths' in request body")
 
         photo_paths = data["photo_paths"]
 
         if not isinstance(photo_paths, list):
-            return jsonify({"error": "'photo_paths' must be an array"}), 400
+            return error_response(VALIDATION_ERROR, "'photo_paths' must be an array")
 
         # Validate all paths are non-empty strings
         if not all(isinstance(p, str) and p.strip() for p in photo_paths):
-            return jsonify({"error": "All photo_paths must be non-empty strings"}), 400
+            return error_response(VALIDATION_ERROR, "All photo_paths must be non-empty strings")
 
         if len(photo_paths) == 0:
-            return jsonify({"error": "No photos provided"}), 400
+            return error_response(VALIDATION_ERROR, "No photos provided")
 
         # Get configurable batch size limit
         max_batch_size = current_app.config.get("EXPORT_MAX_BATCH_SIZE", 1000)
 
         if len(photo_paths) > max_batch_size:
-            return jsonify(
-                {"error": f"Batch size exceeds maximum limit of {max_batch_size} photos"}
-            ), 400
+            return error_response(
+                VALIDATION_ERROR,
+                f"Batch size exceeds maximum limit of {max_batch_size} photos",
+            )
 
         # Parse field filtering parameters
         try:
             fields, exclude = _parse_field_filter_params(request)
         except ValueError as e:
             logger.warning(f"Invalid field filter params: {e}")
-            return jsonify({"error": "Invalid field filter parameters"}), 400
+            return error_response(VALIDATION_ERROR, "Invalid field filter parameters")
 
         include_bom = data.get("include_bom", False)
 
@@ -2018,7 +2032,7 @@ def export_batch_csv():
 
     except Exception as e:
         logger.error("Error in batch CSV export: %s", e, exc_info=True)
-        return jsonify({"error": "Batch CSV export failed"}), 500
+        return error_response(SERVER_ERROR, "Batch CSV export failed", 500)
 
 
 @export_bp.route("/csv/deployment/<path:deployment_path>", methods=["GET"])
@@ -2050,26 +2064,26 @@ def export_deployment_csv(deployment_path: str):
         # Get service from app config
         service = current_app.config.get("EXPORT_METADATA_SERVICE")
         if service is None:
-            return jsonify({"error": "Export service not available"}), 500
+            return error_response(SERVER_ERROR, "Export service not available", 500)
 
         # Validate path to prevent traversal attacks
         validated_path = validate_photo_path(deployment_path, PHOTOS_DIR)
         if validated_path is None:
-            return jsonify({"error": "Invalid path"}), 403
+            return error_response(PERMISSION_ERROR, "Invalid path", 403)
 
         deployment_dir = Path(validated_path)
         if not deployment_dir.exists():
-            return jsonify({"error": "Deployment directory not found"}), 404
+            return error_response(NOT_FOUND, "Deployment directory not found", 404)
 
         if not deployment_dir.is_dir():
-            return jsonify({"error": "Path is not a directory"}), 400
+            return error_response(VALIDATION_ERROR, "Path is not a directory")
 
         # Parse field filtering parameters
         try:
             fields, exclude = _parse_field_filter_params(request)
         except ValueError as e:
             logger.warning(f"Invalid field filter params: {e}")
-            return jsonify({"error": "Invalid field filter parameters"}), 400
+            return error_response(VALIDATION_ERROR, "Invalid field filter parameters")
 
         include_bom = request.args.get("include_bom", "false").lower() == "true"
 
@@ -2077,15 +2091,14 @@ def export_deployment_csv(deployment_path: str):
         photo_files = find_photos_in_directory(deployment_dir)
 
         if not photo_files:
-            return jsonify(
-                {
-                    "error": "No photos found in deployment directory",
-                    "csv_data": "",
-                    "headers": [],
-                    "row_count": 0,
-                    "total": 0,
-                }
-            ), 400
+            return error_response(
+                VALIDATION_ERROR,
+                "No photos found in deployment directory",
+                csv_data="",
+                headers=[],
+                row_count=0,
+                total=0,
+            )
 
         # Get headers (filtered if needed)
         headers = _get_generic_csv_headers(fields, exclude)
@@ -2162,7 +2175,7 @@ def export_deployment_csv(deployment_path: str):
 
     except Exception as e:
         logger.error("Error in deployment CSV export for %s: %s", deployment_path, e, exc_info=True)
-        return jsonify({"error": "Deployment CSV export failed"}), 500
+        return error_response(SERVER_ERROR, "Deployment CSV export failed", 500)
 
 
 # ============================================================================
@@ -2234,14 +2247,14 @@ def aggregate_photos():
     try:
         data = request.get_json()
         if not data:
-            return jsonify({"error": "Request body required"}), 400
+            return error_response(VALIDATION_ERROR, "Request body required")
 
         # Get tolerance parameter (default 50m)
         tolerance_m = data.get("tolerance_m", 50.0)
 
         # Validate tolerance
         if not isinstance(tolerance_m, (int, float)) or tolerance_m < 0:
-            return jsonify({"error": "tolerance_m must be a non-negative number"}), 400
+            return error_response(VALIDATION_ERROR, "tolerance_m must be a non-negative number")
 
         # Get photo paths (either from filter or explicit list)
         photo_paths = []
@@ -2250,7 +2263,7 @@ def aggregate_photos():
             # Explicit photo paths provided
             raw_paths = data["photo_paths"]
             if not isinstance(raw_paths, list):
-                return jsonify({"error": "photo_paths must be a list"}), 400
+                return error_response(VALIDATION_ERROR, "photo_paths must be a list")
 
             # Validate and resolve paths
             for path_str in raw_paths:
@@ -2258,36 +2271,36 @@ def aggregate_photos():
                     # Use validate_photo_path for security
                     resolved_path = validate_photo_path(path_str, PHOTOS_DIR)
                     if resolved_path is None:
-                        return jsonify({"error": f"Invalid photo path: {path_str}"}), 400
+                        return error_response(VALIDATION_ERROR, f"Invalid photo path: {path_str}")
                     photo_paths.append(resolved_path)
                 except (ValueError, PermissionError) as e:
                     logger.warning(f"Invalid photo path: {e}")
-                    return jsonify({"error": "Invalid photo path"}), 400
+                    return error_response(VALIDATION_ERROR, "Invalid photo path")
 
         elif "filter" in data:
             # Filter provided - collect photos
             filter_data = data["filter"]
             if not isinstance(filter_data, dict):
-                return jsonify({"error": "filter must be an object"}), 400
+                return error_response(VALIDATION_ERROR, "filter must be an object")
 
             # Parse filter
             try:
                 job_filter = ExportJobFilter.from_dict(filter_data)
             except Exception as e:
                 logger.warning(f"Invalid export filter: {e}")
-                return jsonify({"error": "Invalid filter"}), 400
+                return error_response(VALIDATION_ERROR, "Invalid filter")
 
             # Use export job service to collect photos
             # This reuses existing filter logic (date, deployment, tags, series, species)
             service = current_app.config.get("EXPORT_JOB_SERVICE")
             if service is None:
                 logger.warning("EXPORT_JOB_SERVICE not configured, functionality may be limited")
-                return jsonify({"error": "Service not properly configured"}), 500
+                return error_response(SERVER_ERROR, "Service not properly configured", 500)
 
             photo_paths = service._collect_photos(job_filter)
 
         else:
-            return jsonify({"error": "Either 'filter' or 'photo_paths' required"}), 400
+            return error_response(VALIDATION_ERROR, "Either 'filter' or 'photo_paths' required")
 
         # Aggregate metadata
         result = aggregate_photo_metadata(photo_paths, tolerance_m=tolerance_m)
@@ -2310,7 +2323,7 @@ def aggregate_photos():
 
     except Exception as e:
         logger.error("Error aggregating photo metadata: %s", e, exc_info=True)
-        return jsonify({"error": "Photo aggregation failed"}), 500
+        return error_response(SERVER_ERROR, "Photo aggregation failed", 500)
 
 
 # ============================================================================
@@ -2402,7 +2415,7 @@ def create_export_job():
 
     service = current_app.config.get("EXPORT_JOB_SERVICE")
     if service is None:
-        return jsonify({"error": "Export job service not available"}), 500
+        return error_response(SERVER_ERROR, "Export job service not available", 500)
 
     try:
         data = request.get_json() or {}
@@ -2416,11 +2429,11 @@ def create_export_job():
         if preset_name:
             preset_manager = current_app.config.get("EXPORT_PRESET_MANAGER")
             if not preset_manager:
-                return jsonify({"error": "Preset manager not configured"}), 500
+                return error_response(SERVER_ERROR, "Preset manager not configured", 500)
 
             preset = preset_manager.get_preset(preset_name)
             if preset is None:
-                return jsonify({"error": f"Preset not found: '{preset_name}'"}), 400
+                return error_response(VALIDATION_ERROR, f"Preset not found: '{preset_name}'")
 
             # Extract preset filter as dict for merging
             if preset.filter:
@@ -2432,17 +2445,16 @@ def create_export_job():
         if not format_str and preset:
             format_str = preset.export_format.value
         if not format_str:
-            return jsonify({"error": "format field is required"}), 400
+            return error_response(VALIDATION_ERROR, "format field is required")
 
         try:
             format_enum = ExportJobFormat(format_str)
         except ValueError:
             valid_formats = [f.value for f in ExportJobFormat]
-            return jsonify(
-                {
-                    "error": f"Invalid format: {format_str}. Must be one of: {', '.join(valid_formats)}"
-                }
-            ), 400
+            return error_response(
+                VALIDATION_ERROR,
+                f"Invalid format: {format_str}. Must be one of: {', '.join(valid_formats)}",
+            )
 
         # Parse filter: merge preset filter with explicit filter
         # Explicit values override preset values
@@ -2466,12 +2478,11 @@ def create_export_job():
         }
         invalid_fields = set(filter_data.keys()) - valid_filter_fields
         if invalid_fields:
-            return jsonify(
-                {
-                    "error": f"Invalid filter fields: {', '.join(invalid_fields)}. "
-                    f"Valid fields: {', '.join(sorted(valid_filter_fields))}"
-                }
-            ), 400
+            return error_response(
+                VALIDATION_ERROR,
+                f"Invalid filter fields: {', '.join(invalid_fields)}. "
+                f"Valid fields: {', '.join(sorted(valid_filter_fields))}",
+            )
 
         # Validate date format (ISO 8601: YYYY-MM-DD)
         from webui.backend.lib.date_utils import validate_date_string
@@ -2481,7 +2492,7 @@ def create_export_job():
             if date_value is not None:
                 is_valid, error_msg = validate_date_string(date_value)
                 if not is_valid:
-                    return jsonify({"error": f"Invalid {date_field}: {error_msg}"}), 400
+                    return error_response(VALIDATION_ERROR, f"Invalid {date_field}: {error_msg}")
 
         # Validate date_start <= date_end if both provided
         if filter_data.get("date_start") and filter_data.get("date_end"):
@@ -2490,7 +2501,9 @@ def create_export_job():
             start = date.fromisoformat(filter_data["date_start"])
             end = date.fromisoformat(filter_data["date_end"])
             if start > end:
-                return jsonify({"error": "date_start must be before or equal to date_end"}), 400
+                return error_response(
+                    VALIDATION_ERROR, "date_start must be before or equal to date_end"
+                )
 
         # Validate series_type is a valid SeriesType enum value
         series_type_val = filter_data.get("series_type")
@@ -2501,9 +2514,10 @@ def create_export_job():
                 SeriesType(series_type_val)
             except ValueError:
                 valid = [st.value for st in SeriesType]
-                return jsonify(
-                    {"error": f"Invalid series_type: '{series_type_val}'. Must be one of: {valid}"}
-                ), 400
+                return error_response(
+                    VALIDATION_ERROR,
+                    f"Invalid series_type: '{series_type_val}'. Must be one of: {valid}",
+                )
 
         filter_obj = ExportJobFilter(
             date_start=filter_data.get("date_start"),
@@ -2525,11 +2539,13 @@ def create_export_job():
         ttl_seconds = data.get("ttl_seconds")
         if ttl_seconds is not None:
             if not isinstance(ttl_seconds, int):
-                return jsonify({"error": "ttl_seconds must be an integer"}), 400
+                return error_response(VALIDATION_ERROR, "ttl_seconds must be an integer")
             if ttl_seconds < 60:
-                return jsonify({"error": "ttl_seconds must be at least 60 seconds"}), 400
+                return error_response(VALIDATION_ERROR, "ttl_seconds must be at least 60 seconds")
             if ttl_seconds > 86400:
-                return jsonify({"error": "ttl_seconds cannot exceed 86400 seconds (24 hours)"}), 400
+                return error_response(
+                    VALIDATION_ERROR, "ttl_seconds cannot exceed 86400 seconds (24 hours)"
+                )
 
         # Create job
         job = service.create_job(
@@ -2551,10 +2567,10 @@ def create_export_job():
 
     except ValueError as e:
         logger.warning(f"Invalid export job parameters: {e}")
-        return jsonify({"error": "Invalid export job parameters"}), 400
+        return error_response(VALIDATION_ERROR, "Invalid export job parameters")
     except Exception as e:
         logger.error("Error creating export job: %s", e, exc_info=True)
-        return jsonify({"error": "Failed to create export job"}), 500
+        return error_response(SERVER_ERROR, "Failed to create export job", 500)
 
 
 @export_bp.route("/jobs", methods=["GET"])
@@ -2587,7 +2603,7 @@ def list_export_jobs():
 
     service = current_app.config.get("EXPORT_JOB_SERVICE")
     if service is None:
-        return jsonify({"error": "Export job service not available"}), 500
+        return error_response(SERVER_ERROR, "Export job service not available", 500)
 
     try:
         # Parse status filter (optional)
@@ -2598,19 +2614,17 @@ def list_export_jobs():
                 status = ExportJobStatus(status_str)
             except ValueError:
                 valid_statuses = [s.value for s in ExportJobStatus]
-                return jsonify(
-                    {
-                        "error": f"Invalid status: {status_str}. "
-                        f"Must be one of: {', '.join(valid_statuses)}"
-                    }
-                ), 400
+                return error_response(
+                    VALIDATION_ERROR,
+                    f"Invalid status: {status_str}. Must be one of: {', '.join(valid_statuses)}",
+                )
 
         # Parse pagination parameters
         try:
             limit = int(request.args.get("limit", 50))
             offset = int(request.args.get("offset", 0))
         except ValueError:
-            return jsonify({"error": "limit and offset must be integers"}), 400
+            return error_response(VALIDATION_ERROR, "limit and offset must be integers")
 
         # Cap limit at 100
         limit = min(limit, 100)
@@ -2632,7 +2646,7 @@ def list_export_jobs():
 
     except Exception as e:
         logger.error("Error listing export jobs: %s", e, exc_info=True)
-        return jsonify({"error": "Failed to list export jobs"}), 500
+        return error_response(SERVER_ERROR, "Failed to list export jobs", 500)
 
 
 @export_bp.route("/jobs/<job_id>", methods=["GET"])
@@ -2670,19 +2684,19 @@ def get_export_job_status(job_id: str):
     """
     service = current_app.config.get("EXPORT_JOB_SERVICE")
     if service is None:
-        return jsonify({"error": "Export job service not available"}), 500
+        return error_response(SERVER_ERROR, "Export job service not available", 500)
 
     try:
         job = service.get_job(job_id)
 
         if job is None:
-            return jsonify({"error": f"Job not found: {job_id}"}), 404
+            return error_response(NOT_FOUND, f"Job not found: {job_id}", 404)
 
         return jsonify(_serialize_job(job)), 200
 
     except Exception as e:
         logger.error("Error getting export job %s: %s", job_id, e, exc_info=True)
-        return jsonify({"error": "Failed to get export job status"}), 500
+        return error_response(SERVER_ERROR, "Failed to get export job status", 500)
 
 
 @export_bp.route("/jobs/<job_id>/download", methods=["GET"])
@@ -2714,26 +2728,23 @@ def download_export_job_result(job_id: str):
 
     service = current_app.config.get("EXPORT_JOB_SERVICE")
     if service is None:
-        return jsonify({"error": "Export job service not available"}), 500
+        return error_response(SERVER_ERROR, "Export job service not available", 500)
 
     try:
         job = service.get_job(job_id)
 
         if job is None:
-            return jsonify({"error": f"Job not found: {job_id}"}), 404
+            return error_response(NOT_FOUND, f"Job not found: {job_id}", 404)
 
         if job.status != ExportJobStatus.COMPLETED:
-            return jsonify(
-                {
-                    "error": "Job not completed",
-                    "status": job.status.value,
-                }
-            ), 400
+            return error_response(
+                VALIDATION_ERROR, "Job not completed", job_status=job.status.value
+            )
 
         output_path = service.get_download_path(job_id)
 
         if output_path is None or not output_path.exists():
-            return jsonify({"error": "Output file not found"}), 404
+            return error_response(NOT_FOUND, "Output file not found", 404)
 
         # Determine mimetype from format
         mimetypes = {
@@ -2752,7 +2763,7 @@ def download_export_job_result(job_id: str):
 
     except Exception as e:
         logger.error("Error downloading export job %s: %s", job_id, e, exc_info=True)
-        return jsonify({"error": "Failed to download export result"}), 500
+        return error_response(SERVER_ERROR, "Failed to download export result", 500)
 
 
 @export_bp.route("/jobs/<job_id>", methods=["DELETE"])
@@ -2782,13 +2793,13 @@ def delete_export_job(job_id: str):
     """
     service = current_app.config.get("EXPORT_JOB_SERVICE")
     if service is None:
-        return jsonify({"error": "Export job service not available"}), 500
+        return error_response(SERVER_ERROR, "Export job service not available", 500)
 
     try:
         success = service.delete_job(job_id)
 
         if not success:
-            return jsonify({"error": f"Job not found: {job_id}"}), 404
+            return error_response(NOT_FOUND, f"Job not found: {job_id}", 404)
 
         return jsonify(
             {
@@ -2799,10 +2810,10 @@ def delete_export_job(job_id: str):
 
     except ValueError as e:
         logger.warning(f"Invalid job ID for deletion: {e}")
-        return jsonify({"error": "Invalid job ID"}), 400
+        return error_response(VALIDATION_ERROR, "Invalid job ID")
     except Exception as e:
         logger.error("Error deleting export job %s: %s", job_id, e, exc_info=True)
-        return jsonify({"error": "Failed to delete export job"}), 500
+        return error_response(SERVER_ERROR, "Failed to delete export job", 500)
 
 
 @export_bp.route("/jobs/<job_id>/cancel", methods=["POST"])
@@ -2832,13 +2843,13 @@ def cancel_export_job(job_id: str):
     """
     service = current_app.config.get("EXPORT_JOB_SERVICE")
     if service is None:
-        return jsonify({"error": "Export job service not available"}), 500
+        return error_response(SERVER_ERROR, "Export job service not available", 500)
 
     try:
         success = service.cancel_job(job_id)
 
         if not success:
-            return jsonify({"error": f"Job not found: {job_id}"}), 404
+            return error_response(NOT_FOUND, f"Job not found: {job_id}", 404)
 
         return jsonify(
             {
@@ -2849,7 +2860,7 @@ def cancel_export_job(job_id: str):
 
     except ValueError as e:
         logger.warning(f"Invalid job ID for cancellation: {e}")
-        return jsonify({"error": "Invalid job ID"}), 400
+        return error_response(VALIDATION_ERROR, "Invalid job ID")
     except Exception as e:
         logger.error("Error cancelling export job %s: %s", job_id, e, exc_info=True)
-        return jsonify({"error": "Failed to cancel export job"}), 500
+        return error_response(SERVER_ERROR, "Failed to cancel export job", 500)

--- a/Firmware/webui/backend/routes/export.py
+++ b/Firmware/webui/backend/routes/export.py
@@ -2737,9 +2737,7 @@ def download_export_job_result(job_id: str):
             return error_response(NOT_FOUND, f"Job not found: {job_id}", 404)
 
         if job.status != ExportJobStatus.COMPLETED:
-            return error_response(
-                VALIDATION_ERROR, "Job not completed", status=job.status.value
-            )
+            return error_response(VALIDATION_ERROR, "Job not completed", status=job.status.value)
 
         output_path = service.get_download_path(job_id)
 

--- a/Firmware/webui/backend/routes/export.py
+++ b/Firmware/webui/backend/routes/export.py
@@ -2737,7 +2737,9 @@ def download_export_job_result(job_id: str):
             return error_response(NOT_FOUND, f"Job not found: {job_id}", 404)
 
         if job.status != ExportJobStatus.COMPLETED:
-            return error_response(VALIDATION_ERROR, "Job not completed", status=job.status.value)
+            return error_response(
+                VALIDATION_ERROR, "Job not completed", job_status=job.status.value
+            )
 
         output_path = service.get_download_path(job_id)
 

--- a/Firmware/webui/backend/routes/export.py
+++ b/Firmware/webui/backend/routes/export.py
@@ -2738,7 +2738,7 @@ def download_export_job_result(job_id: str):
 
         if job.status != ExportJobStatus.COMPLETED:
             return error_response(
-                VALIDATION_ERROR, "Job not completed", job_status=job.status.value
+                VALIDATION_ERROR, "Job not completed", status=job.status.value
             )
 
         output_path = service.get_download_path(job_id)

--- a/Firmware/webui/backend/routes/export_presets.py
+++ b/Firmware/webui/backend/routes/export_presets.py
@@ -19,6 +19,12 @@ from flask import Blueprint, current_app, jsonify, request
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 
+from webui.backend.lib.error_codes import (
+    NOT_FOUND,
+    SERVER_ERROR,
+    VALIDATION_ERROR,
+    error_response,
+)
 from webui.backend.lib.export_job_types import ExportJobFilter, ExportJobFormat
 from webui.backend.lib.export_preset_types import ExportPreset, ExportPresetCategory
 
@@ -60,7 +66,7 @@ def list_export_presets():
         return jsonify({"presets": presets, "counts": counts})
     except Exception:
         logger.exception("Error listing export presets")
-        return jsonify({"error": "Failed to list export presets"}), 500
+        return error_response(SERVER_ERROR, "Failed to list export presets", 500)
 
 
 @export_presets_bp.route("/<name>", methods=["GET"])
@@ -79,13 +85,13 @@ def get_export_preset(name: str):
         preset = preset_manager.get_preset(name)
 
         if not preset:
-            return jsonify({"error": f"Preset '{name}' not found"}), 404
+            return error_response(NOT_FOUND, f"Preset '{name}' not found", 404)
 
         # Convert ExportPreset to dict for JSON response
         return jsonify(preset.to_dict())
     except Exception:
         logger.exception("Error getting export preset '%s'", name)
-        return jsonify({"error": "Failed to get export preset"}), 500
+        return error_response(SERVER_ERROR, "Failed to get export preset", 500)
 
 
 @export_presets_bp.route("", methods=["POST"], strict_slashes=False)
@@ -116,33 +122,34 @@ def create_export_preset():
         data = request.json
 
         if not data:
-            return jsonify({"error": "No data provided"}), 400
+            return error_response(VALIDATION_ERROR, "No data provided")
 
         # Validate required fields
         name = data.get("name", "").strip()
         if not name:
-            return jsonify({"error": "Preset name is required"}), 400
+            return error_response(VALIDATION_ERROR, "Preset name is required")
 
         display_name = data.get("display_name", "").strip()
         if not display_name:
-            return jsonify({"error": "Preset display_name is required"}), 400
+            return error_response(VALIDATION_ERROR, "Preset display_name is required")
 
         export_format_str = data.get("export_format", "").strip()
         if not export_format_str:
-            return jsonify({"error": "Preset export_format is required"}), 400
+            return error_response(VALIDATION_ERROR, "Preset export_format is required")
 
         # Validate export format
         try:
             export_format = ExportJobFormat(export_format_str)
         except ValueError:
             valid_formats = [f.value for f in ExportJobFormat]
-            return jsonify(
-                {"error": f"Invalid export_format. Must be one of: {valid_formats}"}
-            ), 400
+            return error_response(
+                VALIDATION_ERROR,
+                f"Invalid export_format. Must be one of: {valid_formats}",
+            )
 
         # Reject built-in category
         if data.get("category") == "built-in":
-            return jsonify({"error": "Cannot create preset with built-in category"}), 400
+            return error_response(VALIDATION_ERROR, "Cannot create preset with built-in category")
 
         # Build filter from request
         filter_data = data.get("filter", {})
@@ -166,11 +173,11 @@ def create_export_preset():
         if success:
             return jsonify({"success": True, "message": message, "name": name}), 201
         else:
-            return jsonify({"error": message}), 400
+            return error_response(VALIDATION_ERROR, message)
 
     except Exception:
         logger.exception("Error creating export preset")
-        return jsonify({"error": "Failed to create export preset"}), 500
+        return error_response(SERVER_ERROR, "Failed to create export preset", 500)
 
 
 @export_presets_bp.route("/<name>", methods=["DELETE"])
@@ -193,12 +200,12 @@ def delete_export_preset(name: str):
         else:
             # Determine appropriate status code
             if "not found" in message.lower():
-                return jsonify({"error": message}), 404
+                return error_response(NOT_FOUND, message, 404)
             elif "built-in" in message.lower():
-                return jsonify({"error": message}), 400
+                return error_response(VALIDATION_ERROR, message)
             else:
-                return jsonify({"error": message}), 400
+                return error_response(VALIDATION_ERROR, message)
 
     except Exception:
         logger.exception("Error deleting export preset '%s'", name)
-        return jsonify({"error": "Failed to delete export preset"}), 500
+        return error_response(SERVER_ERROR, "Failed to delete export preset", 500)


### PR DESCRIPTION
## Summary
- Migrate `export.py` (~110) and `export_presets.py` (13) error responses to `error_response()`
- Extra-field edge cases preserved: `details`, `csv_data`, `headers`, `row_count`, `missing_fields`, `warnings`, `status` via `**extra` kwargs
- Batch 4 of 7 for #414

## Test plan
- [x] All existing tests pass (`test_export_routes.py`, `test_export_preset_routes.py`)
- [x] No remaining inline `jsonify({"error"` patterns in migrated files
- [x] ruff clean