### PR TITLE
fix: auto-detect RTC wakealarm availability (#375)

### DIFF
--- a/Firmware/Tests/unit/test_cron_bridge.py
+++ b/Firmware/Tests/unit/test_cron_bridge.py
@@ -1,5 +1,6 @@
 """Unit tests for cron_bridge module - Subtask 1: Data structures."""
 
+import os
 from datetime import date, datetime, timedelta
 from unittest.mock import mock_open, patch
 
@@ -9,6 +10,7 @@ import pytest
 from webui.backend.lib.cron_bridge import (
     CronBridgeResult,
     CronEntry,
+    _rtc_available,
     apply_to_system,
     calculate_next_from_entries,
     calculate_next_waketime,
@@ -830,26 +832,29 @@ class TestRTCWakealarm:
     def test_set_rtc_wakealarm_writes_to_sysfs(self):
         """set_rtc_wakealarm writes epoch to /sys/class/rtc/rtc0/wakealarm."""
         m = mock_open()
-        with patch("builtins.open", m):
-            epoch = 1718463600
-            result = set_rtc_wakealarm(epoch)
-            assert result is True
-            m.assert_called_with("/sys/class/rtc/rtc0/wakealarm", "w")
-            m().write.assert_called_with(str(epoch))
+        with patch("webui.backend.lib.cron_bridge._rtc_available", return_value=True):
+            with patch("builtins.open", m):
+                epoch = 1718463600
+                result = set_rtc_wakealarm(epoch)
+                assert result is True
+                m.assert_called_with("/sys/class/rtc/rtc0/wakealarm", "w")
+                m().write.assert_called_with(str(epoch))
 
     def test_clear_rtc_wakealarm_writes_zero(self):
         """clear_rtc_wakealarm writes 0 to clear existing alarm."""
         m = mock_open()
-        with patch("builtins.open", m):
-            result = clear_rtc_wakealarm()
-            assert result is True
-            m().write.assert_called_with("0")
+        with patch("webui.backend.lib.cron_bridge._rtc_available", return_value=True):
+            with patch("builtins.open", m):
+                result = clear_rtc_wakealarm()
+                assert result is True
+                m().write.assert_called_with("0")
 
     def test_set_rtc_wakealarm_handles_permission_error(self):
         """set_rtc_wakealarm returns False on permission error."""
-        with patch("builtins.open", side_effect=PermissionError("No permission")):
-            result = set_rtc_wakealarm(1718463600)
-            assert result is False
+        with patch("webui.backend.lib.cron_bridge._rtc_available", return_value=True):
+            with patch("builtins.open", side_effect=PermissionError("No permission")):
+                result = set_rtc_wakealarm(1718463600)
+                assert result is False
 
     def test_calculate_next_waketime_with_day_of_week(self):
         """calculate_next_waketime handles day-of-week restrictions."""
@@ -876,9 +881,10 @@ class TestRTCWakealarm:
 
     def test_clear_rtc_wakealarm_handles_file_not_found(self):
         """clear_rtc_wakealarm returns False on file not found error."""
-        with patch("builtins.open", side_effect=FileNotFoundError("File not found")):
-            result = clear_rtc_wakealarm()
-            assert result is False
+        with patch("webui.backend.lib.cron_bridge._rtc_available", return_value=True):
+            with patch("builtins.open", side_effect=FileNotFoundError("File not found")):
+                result = clear_rtc_wakealarm()
+                assert result is False
 
     def test_calculate_next_waketime_handles_complex_expression(self):
         """calculate_next_waketime handles complex cron expressions."""
@@ -888,6 +894,52 @@ class TestRTCWakealarm:
         # Should be 9:30 same day
         expected = int(datetime(2024, 6, 17, 9, 30, 0).timestamp())
         assert abs(next_wake - expected) < 60
+
+    def test_rtc_available_returns_true_when_writable(self):
+        """_rtc_available returns True when RTC file is writable."""
+        with patch("webui.backend.lib.cron_bridge.os.access", return_value=True):
+            _rtc_available.cache_clear()
+            assert _rtc_available() is True
+
+    def test_rtc_available_returns_false_when_not_writable(self):
+        """_rtc_available returns False when RTC file is not writable."""
+        with patch("webui.backend.lib.cron_bridge.os.access", return_value=False):
+            _rtc_available.cache_clear()
+            assert _rtc_available() is False
+
+    def test_rtc_available_checks_correct_path(self):
+        """_rtc_available checks the RTC_WAKEALARM_PATH with W_OK."""
+        with patch("webui.backend.lib.cron_bridge.os.access", return_value=True) as mock_access:
+            _rtc_available.cache_clear()
+            _rtc_available()
+            mock_access.assert_called_once_with("/sys/class/rtc/rtc0/wakealarm", os.W_OK)
+
+    def test_set_rtc_skips_when_not_available(self):
+        """set_rtc_wakealarm returns True without writing when RTC unavailable."""
+        with patch("webui.backend.lib.cron_bridge._rtc_available", return_value=False):
+            m = mock_open()
+            with patch("builtins.open", m):
+                result = set_rtc_wakealarm(1718463600)
+                assert result is True
+                m.assert_not_called()
+
+    def test_clear_rtc_skips_when_not_available(self):
+        """clear_rtc_wakealarm returns True without writing when RTC unavailable."""
+        with patch("webui.backend.lib.cron_bridge._rtc_available", return_value=False):
+            m = mock_open()
+            with patch("builtins.open", m):
+                result = clear_rtc_wakealarm()
+                assert result is True
+                m.assert_not_called()
+
+    def test_set_rtc_writes_when_available(self):
+        """set_rtc_wakealarm proceeds normally when RTC is available."""
+        with patch("webui.backend.lib.cron_bridge._rtc_available", return_value=True):
+            m = mock_open()
+            with patch("builtins.open", m):
+                result = set_rtc_wakealarm(1718463600)
+                assert result is True
+                m.assert_called_once()
 
 
 class TestApplyToSystem:

--- a/Firmware/Tests/unit/test_cron_bridge.py
+++ b/Firmware/Tests/unit/test_cron_bridge.py
@@ -4,13 +4,12 @@ import os
 from datetime import date, datetime, timedelta
 from unittest.mock import mock_open, patch
 
-import pytz
 import pytest
+import pytz
 
 from webui.backend.lib.cron_bridge import (
     CronBridgeResult,
     CronEntry,
-    _rtc_available,
     apply_to_system,
     calculate_next_from_entries,
     calculate_next_waketime,
@@ -28,6 +27,7 @@ from webui.backend.lib.cron_bridge import (
     routine_to_cron,
     routine_to_cron_entries,
     routine_to_dated_cron,
+    rtc_available,
     schedule_to_cron,
     sensor_trigger_to_cron,
     set_rtc_wakealarm,
@@ -832,29 +832,35 @@ class TestRTCWakealarm:
     def test_set_rtc_wakealarm_writes_to_sysfs(self):
         """set_rtc_wakealarm writes epoch to /sys/class/rtc/rtc0/wakealarm."""
         m = mock_open()
-        with patch("webui.backend.lib.cron_bridge._rtc_available", return_value=True):
-            with patch("builtins.open", m):
-                epoch = 1718463600
-                result = set_rtc_wakealarm(epoch)
-                assert result is True
-                m.assert_called_with("/sys/class/rtc/rtc0/wakealarm", "w")
-                m().write.assert_called_with(str(epoch))
+        with (
+            patch("webui.backend.lib.cron_bridge.rtc_available", return_value=True),
+            patch("builtins.open", m),
+        ):
+            epoch = 1718463600
+            result = set_rtc_wakealarm(epoch)
+            assert result is True
+            m.assert_called_with("/sys/class/rtc/rtc0/wakealarm", "w")
+            m().write.assert_called_with(str(epoch))
 
     def test_clear_rtc_wakealarm_writes_zero(self):
         """clear_rtc_wakealarm writes 0 to clear existing alarm."""
         m = mock_open()
-        with patch("webui.backend.lib.cron_bridge._rtc_available", return_value=True):
-            with patch("builtins.open", m):
-                result = clear_rtc_wakealarm()
-                assert result is True
-                m().write.assert_called_with("0")
+        with (
+            patch("webui.backend.lib.cron_bridge.rtc_available", return_value=True),
+            patch("builtins.open", m),
+        ):
+            result = clear_rtc_wakealarm()
+            assert result is True
+            m().write.assert_called_with("0")
 
     def test_set_rtc_wakealarm_handles_permission_error(self):
         """set_rtc_wakealarm returns False on permission error."""
-        with patch("webui.backend.lib.cron_bridge._rtc_available", return_value=True):
-            with patch("builtins.open", side_effect=PermissionError("No permission")):
-                result = set_rtc_wakealarm(1718463600)
-                assert result is False
+        with (
+            patch("webui.backend.lib.cron_bridge.rtc_available", return_value=True),
+            patch("builtins.open", side_effect=PermissionError("No permission")),
+        ):
+            result = set_rtc_wakealarm(1718463600)
+            assert result is False
 
     def test_calculate_next_waketime_with_day_of_week(self):
         """calculate_next_waketime handles day-of-week restrictions."""
@@ -881,10 +887,12 @@ class TestRTCWakealarm:
 
     def test_clear_rtc_wakealarm_handles_file_not_found(self):
         """clear_rtc_wakealarm returns False on file not found error."""
-        with patch("webui.backend.lib.cron_bridge._rtc_available", return_value=True):
-            with patch("builtins.open", side_effect=FileNotFoundError("File not found")):
-                result = clear_rtc_wakealarm()
-                assert result is False
+        with (
+            patch("webui.backend.lib.cron_bridge.rtc_available", return_value=True),
+            patch("builtins.open", side_effect=FileNotFoundError("File not found")),
+        ):
+            result = clear_rtc_wakealarm()
+            assert result is False
 
     def test_calculate_next_waketime_handles_complex_expression(self):
         """calculate_next_waketime handles complex cron expressions."""
@@ -896,27 +904,37 @@ class TestRTCWakealarm:
         assert abs(next_wake - expected) < 60
 
     def test_rtc_available_returns_true_when_writable(self):
-        """_rtc_available returns True when RTC file is writable."""
+        """rtc_available returns True when RTC file is writable."""
         with patch("webui.backend.lib.cron_bridge.os.access", return_value=True):
-            _rtc_available.cache_clear()
-            assert _rtc_available() is True
+            rtc_available.cache_clear()
+            assert rtc_available() is True
 
     def test_rtc_available_returns_false_when_not_writable(self):
-        """_rtc_available returns False when RTC file is not writable."""
+        """rtc_available returns False when RTC file is not writable."""
         with patch("webui.backend.lib.cron_bridge.os.access", return_value=False):
-            _rtc_available.cache_clear()
-            assert _rtc_available() is False
+            rtc_available.cache_clear()
+            assert rtc_available() is False
 
     def test_rtc_available_checks_correct_path(self):
-        """_rtc_available checks the RTC_WAKEALARM_PATH with W_OK."""
+        """rtc_available checks the RTC_WAKEALARM_PATH with W_OK."""
         with patch("webui.backend.lib.cron_bridge.os.access", return_value=True) as mock_access:
-            _rtc_available.cache_clear()
-            _rtc_available()
+            rtc_available.cache_clear()
+            rtc_available()
             mock_access.assert_called_once_with("/sys/class/rtc/rtc0/wakealarm", os.W_OK)
+
+    def test_rtc_available_returns_false_when_path_missing(self):
+        """rtc_available returns False when the sysfs path does not exist.
+
+        os.access(..., os.W_OK) returns False for both non-existent and
+        non-writable paths, so this scenario is handled by the same check.
+        """
+        with patch("webui.backend.lib.cron_bridge.os.access", return_value=False):
+            rtc_available.cache_clear()
+            assert rtc_available() is False
 
     def test_set_rtc_skips_when_not_available(self):
         """set_rtc_wakealarm returns True without writing when RTC unavailable."""
-        with patch("webui.backend.lib.cron_bridge._rtc_available", return_value=False):
+        with patch("webui.backend.lib.cron_bridge.rtc_available", return_value=False):
             m = mock_open()
             with patch("builtins.open", m):
                 result = set_rtc_wakealarm(1718463600)
@@ -925,7 +943,7 @@ class TestRTCWakealarm:
 
     def test_clear_rtc_skips_when_not_available(self):
         """clear_rtc_wakealarm returns True without writing when RTC unavailable."""
-        with patch("webui.backend.lib.cron_bridge._rtc_available", return_value=False):
+        with patch("webui.backend.lib.cron_bridge.rtc_available", return_value=False):
             m = mock_open()
             with patch("builtins.open", m):
                 result = clear_rtc_wakealarm()
@@ -934,7 +952,7 @@ class TestRTCWakealarm:
 
     def test_set_rtc_writes_when_available(self):
         """set_rtc_wakealarm proceeds normally when RTC is available."""
-        with patch("webui.backend.lib.cron_bridge._rtc_available", return_value=True):
+        with patch("webui.backend.lib.cron_bridge.rtc_available", return_value=True):
             m = mock_open()
             with patch("builtins.open", m):
                 result = set_rtc_wakealarm(1718463600)
@@ -1079,7 +1097,7 @@ class TestApplyToSystem:
 
     def test_apply_adds_meta_cron_entries(self):
         """apply_to_system adds @reboot and weekly meta-cron entries (Issue #398)."""
-        from unittest.mock import MagicMock, call, patch
+        from unittest.mock import MagicMock, patch
 
         entries = [CronEntry(expression="0 21 * * *", command="cmd1", comment="Mothbox: test")]
         with patch("webui.backend.lib.cron_bridge.CronTab") as mock_crontab_class:
@@ -2258,7 +2276,7 @@ class TestRoutineToCronDispatcher:
         # Both should cover the same times
         pattern_hours = {int(e.expression.split()[1]) for e in pattern_entries}
         # Pattern should cover hours 18-23 and 0-6
-        expected_hours = set(range(18, 24)) | set(range(0, 7))
+        expected_hours = set(range(18, 24)) | set(range(7))
         assert pattern_hours == expected_hours
 
 

--- a/Firmware/webui/backend/lib/cron_bridge.py
+++ b/Firmware/webui/backend/lib/cron_bridge.py
@@ -48,7 +48,9 @@ logger = logging.getLogger(__name__)
 
 # Constants (MAX_CRON_ENTRIES imported from webui.backend.constants)
 CRON_COMMENT_PREFIX: Final[str] = "Mothbox:"
-RTC_WAKEALARM_PATH: Final[str] = "/sys/class/rtc/rtc0/wakealarm"  # Requires write permission (root or udev rule)
+RTC_WAKEALARM_PATH: Final[str] = (
+    "/sys/class/rtc/rtc0/wakealarm"  # Requires write permission (root or udev rule)
+)
 LUNAR_CYCLE_DAYS: Final[int] = 30  # Minimum days to look ahead for moon phase schedules
 
 

--- a/Firmware/webui/backend/lib/cron_bridge.py
+++ b/Firmware/webui/backend/lib/cron_bridge.py
@@ -48,22 +48,27 @@ logger = logging.getLogger(__name__)
 
 # Constants (MAX_CRON_ENTRIES imported from webui.backend.constants)
 CRON_COMMENT_PREFIX: Final[str] = "Mothbox:"
-RTC_WAKEALARM_PATH: Final[str] = "/sys/class/rtc/rtc0/wakealarm"
+RTC_WAKEALARM_PATH: Final[str] = "/sys/class/rtc/rtc0/wakealarm"  # Requires write permission (root or udev rule)
 LUNAR_CYCLE_DAYS: Final[int] = 30  # Minimum days to look ahead for moon phase schedules
 
 
 @lru_cache(maxsize=1)
-def _rtc_available() -> bool:
+def rtc_available() -> bool:
     """Check if RTC wakealarm is writable (cached).
 
     Returns True if the process can write to the RTC sysfs file.
     Result is cached for the lifetime of the process since RTC
     availability doesn't change at runtime.
+
+    Note:
+        ``os.access(..., os.W_OK)`` returns False both when the path
+        does not exist and when it exists but is not writable, so this
+        single check covers both cases.
     """
     available = os.access(RTC_WAKEALARM_PATH, os.W_OK)
     if not available:
         logger.info(
-            "RTC wakealarm not available at %s (not writable), "
+            "RTC wakealarm not available at %s (not writable or does not exist), "
             "RTC wake features will be skipped",
             RTC_WAKEALARM_PATH,
         )
@@ -1438,13 +1443,17 @@ def set_rtc_wakealarm(epoch_time: int) -> bool:
 
     Reference: Scheduler.py lines 702-716
 
+    If the RTC sysfs file is unavailable (missing or not writable),
+    this is a silent no-op that returns True so callers can proceed
+    without special-casing non-RTC hardware.
+
     Args:
         epoch_time: Unix timestamp for wakeup
 
     Returns:
-        True if successful, False on error
+        True if successful or RTC unavailable, False on write error
     """
-    if not _rtc_available():
+    if not rtc_available():
         return True
     try:
         with open(RTC_WAKEALARM_PATH, "w") as f:
@@ -1459,12 +1468,15 @@ def set_rtc_wakealarm(epoch_time: int) -> bool:
 def clear_rtc_wakealarm() -> bool:
     """Clear existing RTC wakealarm.
 
-    Writes "0" to clear the alarm.
+    Writes "0" to clear the alarm.  If the RTC sysfs file is
+    unavailable (missing or not writable), this is a silent no-op
+    that returns True so callers can proceed without special-casing
+    non-RTC hardware.
 
     Returns:
-        True if successful, False on error
+        True if successful or RTC unavailable, False on write error
     """
-    if not _rtc_available():
+    if not rtc_available():
         return True
     try:
         with open(RTC_WAKEALARM_PATH, "w") as f:

--- a/Firmware/webui/backend/lib/cron_bridge.py
+++ b/Firmware/webui/backend/lib/cron_bridge.py
@@ -8,8 +8,10 @@ Issue: #215
 """
 
 import logging
+import os
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
+from functools import lru_cache
 from typing import Final
 
 import pytz
@@ -48,6 +50,24 @@ logger = logging.getLogger(__name__)
 CRON_COMMENT_PREFIX: Final[str] = "Mothbox:"
 RTC_WAKEALARM_PATH: Final[str] = "/sys/class/rtc/rtc0/wakealarm"
 LUNAR_CYCLE_DAYS: Final[int] = 30  # Minimum days to look ahead for moon phase schedules
+
+
+@lru_cache(maxsize=1)
+def _rtc_available() -> bool:
+    """Check if RTC wakealarm is writable (cached).
+
+    Returns True if the process can write to the RTC sysfs file.
+    Result is cached for the lifetime of the process since RTC
+    availability doesn't change at runtime.
+    """
+    available = os.access(RTC_WAKEALARM_PATH, os.W_OK)
+    if not available:
+        logger.info(
+            "RTC wakealarm not available at %s (not writable), "
+            "RTC wake features will be skipped",
+            RTC_WAKEALARM_PATH,
+        )
+    return available
 
 
 @dataclass
@@ -1424,6 +1444,8 @@ def set_rtc_wakealarm(epoch_time: int) -> bool:
     Returns:
         True if successful, False on error
     """
+    if not _rtc_available():
+        return True
     try:
         with open(RTC_WAKEALARM_PATH, "w") as f:
             f.write(str(epoch_time))
@@ -1442,6 +1464,8 @@ def clear_rtc_wakealarm() -> bool:
     Returns:
         True if successful, False on error
     """
+    if not _rtc_available():
+        return True
     try:
         with open(RTC_WAKEALARM_PATH, "w") as f:
             f.write("0")


### PR DESCRIPTION
## Summary

- Add cached `_rtc_available()` function that checks `os.access()` for RTC writability
- Gate `set_rtc_wakealarm()` and `clear_rtc_wakealarm()` on availability check
- Log at `info` level (not `error`) when RTC is unavailable — eliminates noisy `Permission denied` logs on every schedule activation

## Details

The RTC wakealarm file (`/sys/class/rtc/rtc0/wakealarm`) requires root privileges to write. On always-on deployments running as the `pi` user, every schedule activation logged a `Permission denied` error. This was confusing and noisy.

The fix uses `os.access(path, os.W_OK)` cached with `@lru_cache(maxsize=1)` since RTC availability doesn't change at runtime. When unavailable, the functions return `True` (not an error) and log a single info message.

No configuration changes needed — the existing `set_rtc` parameter in `apply_to_system()` is preserved for programmatic control.

Closes #375

## Test plan

- [x] 6 new unit tests for `_rtc_available()` and gating behavior
- [x] 4 existing tests updated with `_rtc_available` mock
- [x] All 25 RTC + ApplyToSystem tests pass
- [x] `ruff check` clean