### PR TITLE
feat: unify AutoCalibration and AfMode into Focus Strategy card (#397)

### DIFF
--- a/Firmware/CLAUDE.md
+++ b/Firmware/CLAUDE.md
@@ -213,6 +213,10 @@ Two camera workflows:
 
 **Important**: Camera can only be used by ONE workflow at a time. Tests/code must properly release camera between operations.
 
+### Focus Strategy UI
+
+The Settings page uses a unified Focus Strategy card that maps a single dropdown to two CSV fields (`AutoCalibration` + `AfMode`). Frontend constants are in `CAMERA_SETTINGS` (`webui/frontend/src/constants/config.js`). The card prevents invalid state combinations (e.g., AutoCalibration=1 with AfMode=2).
+
 ## Common Development Commands
 
 ### Testing

--- a/Firmware/webui/docs/CAMERA_USER_GUIDE.md
+++ b/Firmware/webui/docs/CAMERA_USER_GUIDE.md
@@ -283,6 +283,34 @@ The live view shows a real-time preview of what the camera sees at approximately
 
 ---
 
+## Focus Strategy
+
+The Focus Strategy card on the Settings page provides a unified interface for configuring how the camera focuses. It combines AutoCalibration and Focus Mode into a single dropdown.
+
+### Focus Modes
+
+| Mode | Best For | How It Works |
+|------|----------|--------------|
+| **Auto-Calibrate** | Unattended operation | Periodically runs autofocus and saves the result. Uses calibrated position for captures. |
+| **Manual Focus** | Fixed camera-to-subject distance | You set an exact focus distance in diopters (0=far, 10=near). |
+| **Autofocus (Single)** | Varying distances | Runs autofocus once before each capture. |
+| **Autofocus (Continuous)** | Moving subjects | Continuously adjusts focus. Uses more power. |
+
+### When to Use Which Mode
+
+- **Most moth traps**: Use **Auto-Calibrate** with a 600-second interval. The camera will periodically re-optimize focus for changing conditions.
+- **Fixed setup on a flat surface**: Use **Manual Focus** at the known distance to your target.
+- **Variable distances**: Use **Autofocus (Single)** for a focus check before each capture.
+- **Live monitoring**: Use **Autofocus (Continuous)** when viewing the live preview and wanting real-time focus tracking.
+
+### Troubleshooting
+
+- **Blurry photos in Auto-Calibrate**: Try a shorter calibration interval (e.g., 60 seconds). The flash must work for calibration to succeed.
+- **Focus hunting in Continuous mode**: Switch to Single or reduce Focus Speed to Normal (Accurate).
+- **Macro subjects out of focus**: Set Focus Range to "Macro (10cm - 50cm)" in AF modes, or use Manual Focus at 7-10 diopters.
+
+---
+
 ## Settings: Test vs Production
 
 ### Test Photo / Instant Capture

--- a/Firmware/webui/frontend/e2e/tests/camera-focus-strategy.spec.js
+++ b/Firmware/webui/frontend/e2e/tests/camera-focus-strategy.spec.js
@@ -1,0 +1,132 @@
+/**
+ * Focus Strategy Card Tests
+ *
+ * Tests for the Focus Strategy card on the Settings page:
+ * - Card visibility and default expanded state
+ * - Mode dropdown with all 4 options
+ * - Conditional sub-controls per focus mode
+ * - Slider interaction and display updates
+ */
+
+import { test, expect } from '@playwright/test'
+import { isRateLimited, TIMEOUTS } from '../fixtures/test-helpers.js'
+
+test.describe('Focus Strategy Card', () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to settings page
+    await page.goto('/settings')
+    await page.waitForLoadState('networkidle')
+
+    // Check for rate limiting before each test
+    if (await isRateLimited(page)) {
+      test.skip(true, 'Rate limited by server (50/hour)')
+    }
+  })
+
+  test('card is visible and expanded by default', async ({ page }) => {
+    // The CollapsibleCard button with title should be visible
+    const cardButton = page.locator('button', { has: page.locator('h4:has-text("Focus Strategy")') })
+    await expect(cardButton).toBeVisible({ timeout: TIMEOUTS.NETWORK })
+    await expect(cardButton).toHaveAttribute('aria-expanded', 'true')
+
+    // Inner content (data-testid) should be visible since card starts expanded
+    const cardContent = page.locator('[data-testid="focus-strategy-card"]')
+    await expect(cardContent).toBeVisible()
+  })
+
+  test('mode dropdown has all 4 options', async ({ page }) => {
+    const dropdown = page.locator('[data-testid="focus-mode-select"]')
+    await expect(dropdown).toBeVisible({ timeout: TIMEOUTS.NETWORK })
+
+    const options = dropdown.locator('option')
+    const count = await options.count()
+    expect(count).toBe(4)
+
+    // Verify option values match CAMERA_SETTINGS.FOCUS_MODES constants
+    const values = await options.evaluateAll(opts => opts.map(o => o.value))
+    expect(values).toEqual(['auto-calibrate', 'manual', 'af-single', 'af-continuous'])
+  })
+
+  test('auto-calibrate mode shows interval slider and position display', async ({ page }) => {
+    const dropdown = page.locator('[data-testid="focus-mode-select"]')
+    await expect(dropdown).toBeVisible({ timeout: TIMEOUTS.NETWORK })
+
+    await dropdown.selectOption('auto-calibrate')
+    await page.waitForTimeout(TIMEOUTS.TRANSITION)
+
+    await expect(page.locator('[data-testid="calibration-interval-slider"]')).toBeVisible()
+    await expect(page.locator('[data-testid="calibration-position-display"]')).toBeVisible()
+
+    // Manual-only and AF-only controls should NOT be visible
+    await expect(page.locator('[data-testid="lens-position-slider"]')).not.toBeVisible()
+    await expect(page.locator('[data-testid="af-range-select"]')).not.toBeVisible()
+    await expect(page.locator('[data-testid="af-speed-select"]')).not.toBeVisible()
+  })
+
+  test('manual mode shows lens position slider', async ({ page }) => {
+    const dropdown = page.locator('[data-testid="focus-mode-select"]')
+    await expect(dropdown).toBeVisible({ timeout: TIMEOUTS.NETWORK })
+
+    await dropdown.selectOption('manual')
+    await page.waitForTimeout(TIMEOUTS.TRANSITION)
+
+    await expect(page.locator('[data-testid="lens-position-slider"]')).toBeVisible()
+
+    // Other sub-controls should NOT be visible
+    await expect(page.locator('[data-testid="calibration-interval-slider"]')).not.toBeVisible()
+    await expect(page.locator('[data-testid="calibration-position-display"]')).not.toBeVisible()
+    await expect(page.locator('[data-testid="af-range-select"]')).not.toBeVisible()
+    await expect(page.locator('[data-testid="af-speed-select"]')).not.toBeVisible()
+  })
+
+  test('af-single mode shows range and speed dropdowns', async ({ page }) => {
+    const dropdown = page.locator('[data-testid="focus-mode-select"]')
+    await expect(dropdown).toBeVisible({ timeout: TIMEOUTS.NETWORK })
+
+    await dropdown.selectOption('af-single')
+    await page.waitForTimeout(TIMEOUTS.TRANSITION)
+
+    await expect(page.locator('[data-testid="af-range-select"]')).toBeVisible()
+    await expect(page.locator('[data-testid="af-speed-select"]')).toBeVisible()
+
+    // Other sub-controls should NOT be visible
+    await expect(page.locator('[data-testid="calibration-interval-slider"]')).not.toBeVisible()
+    await expect(page.locator('[data-testid="calibration-position-display"]')).not.toBeVisible()
+    await expect(page.locator('[data-testid="lens-position-slider"]')).not.toBeVisible()
+  })
+
+  test('af-continuous mode shows range and speed dropdowns', async ({ page }) => {
+    const dropdown = page.locator('[data-testid="focus-mode-select"]')
+    await expect(dropdown).toBeVisible({ timeout: TIMEOUTS.NETWORK })
+
+    await dropdown.selectOption('af-continuous')
+    await page.waitForTimeout(TIMEOUTS.TRANSITION)
+
+    await expect(page.locator('[data-testid="af-range-select"]')).toBeVisible()
+    await expect(page.locator('[data-testid="af-speed-select"]')).toBeVisible()
+
+    // Other sub-controls should NOT be visible
+    await expect(page.locator('[data-testid="calibration-interval-slider"]')).not.toBeVisible()
+    await expect(page.locator('[data-testid="calibration-position-display"]')).not.toBeVisible()
+    await expect(page.locator('[data-testid="lens-position-slider"]')).not.toBeVisible()
+  })
+
+  test('calibration interval slider updates display value', async ({ page }) => {
+    const dropdown = page.locator('[data-testid="focus-mode-select"]')
+    await expect(dropdown).toBeVisible({ timeout: TIMEOUTS.NETWORK })
+
+    await dropdown.selectOption('auto-calibrate')
+    await page.waitForTimeout(TIMEOUTS.TRANSITION)
+
+    const slider = page.locator('[data-testid="calibration-interval-slider"]')
+    await expect(slider).toBeVisible()
+
+    // Set slider to a known value
+    await slider.fill('300')
+    await page.waitForTimeout(TIMEOUTS.TRANSITION)
+
+    // Label should reflect new value
+    const label = page.locator('text=Calibration Interval: Every 300 seconds')
+    await expect(label).toBeVisible()
+  })
+})

--- a/Firmware/webui/frontend/src/constants/config.js
+++ b/Firmware/webui/frontend/src/constants/config.js
@@ -522,5 +522,7 @@ export const CAMERA_SETTINGS = {
   },
   AF_MODE_VALUES: { MANUAL: '0', SINGLE: '1', CONTINUOUS: '2' },
   AF_RANGE_VALUES: { NORMAL: '0', MACRO: '1', FULL: '2' },
+  AF_RANGE_DEFAULT: '1',   // Macro - optimal for insect photography
   AF_SPEED_VALUES: { NORMAL: '0', FAST: '1' },
+  AF_SPEED_DEFAULT: '1',   // Fast
 }

--- a/Firmware/webui/frontend/src/constants/config.js
+++ b/Firmware/webui/frontend/src/constants/config.js
@@ -499,3 +499,28 @@ export const SCHEDULER_LAYOUT_CONFIG = {
   DEFAULT_GRID: 'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4',
   SIDEBAR_GRID: 'flex flex-col space-y-3',
 }
+
+/**
+ * Camera settings constants for the Focus Strategy card.
+ * Sync with backend constants.py (FB_MIN_DIOPTERS, FB_MAX_DIOPTERS, AF_MODE_*).
+ *
+ * @property {Object} LENS_POSITION - Lens position slider bounds (diopters)
+ * @property {Object} CALIBRATION_INTERVAL - Auto-calibration period slider bounds (seconds)
+ * @property {Object} FOCUS_MODES - Focus mode identifiers used in UI logic
+ * @property {Object} AF_MODE_VALUES - AfMode register values sent to backend
+ * @property {Object} AF_RANGE_VALUES - AfRange register values sent to backend
+ * @property {Object} AF_SPEED_VALUES - AfSpeed register values sent to backend
+ */
+export const CAMERA_SETTINGS = {
+  LENS_POSITION: { MIN: 0, MAX: 10, STEP: 0.1, DEFAULT: 0.5 },
+  CALIBRATION_INTERVAL: { MIN: 1, MAX: 1000, DEFAULT: 600 },
+  FOCUS_MODES: {
+    AUTO_CALIBRATE: 'auto-calibrate',
+    MANUAL: 'manual',
+    AF_SINGLE: 'af-single',
+    AF_CONTINUOUS: 'af-continuous',
+  },
+  AF_MODE_VALUES: { MANUAL: '0', SINGLE: '1', CONTINUOUS: '2' },
+  AF_RANGE_VALUES: { NORMAL: '0', MACRO: '1', FULL: '2' },
+  AF_SPEED_VALUES: { NORMAL: '0', FAST: '1' },
+}

--- a/Firmware/webui/frontend/src/pages/Settings.jsx
+++ b/Firmware/webui/frontend/src/pages/Settings.jsx
@@ -1445,11 +1445,12 @@ export default function Settings() {
               {/* Focus Strategy Card */}
               <CollapsibleCard
                 id="cameraFocusStrategy"
-                title="🎯 Focus Strategy"
+                title="Focus Strategy"
                 isCollapsed={collapsedCards.cameraFocusStrategy}
                 onToggle={toggleCard}
                 className="settings-card"
               >
+              <div data-testid="focus-strategy-card">
 
               {/* Focus Mode Selector */}
               <div className="settings-form-group">
@@ -1458,6 +1459,7 @@ export default function Settings() {
                 </label>
                 <select
                   id="focus_mode"
+                  data-testid="focus-mode-select"
                   aria-label="Focus strategy mode"
                   aria-describedby="focus-mode-help"
                   value={focusMode}
@@ -1488,6 +1490,7 @@ export default function Settings() {
                     </label>
                     <input
                       type="range"
+                      data-testid="calibration-interval-slider"
                       aria-label="Calibration interval in seconds"
                       aria-describedby="calibration-interval-help"
                       min={CAMERA_SETTINGS.CALIBRATION_INTERVAL.MIN}
@@ -1498,7 +1501,7 @@ export default function Settings() {
                     />
                     <div className="flex justify-between settings-help-text">
                       <span>{CAMERA_SETTINGS.CALIBRATION_INTERVAL.MIN}</span>
-                      <span>100</span>
+                      <span>500</span>
                       <span>{CAMERA_SETTINGS.CALIBRATION_INTERVAL.MAX}</span>
                     </div>
                     <p id="calibration-interval-help" className="settings-help-text">
@@ -1507,7 +1510,7 @@ export default function Settings() {
                   </div>
 
                   {/* Show current calibrated position as read-only */}
-                  <div className="settings-form-group">
+                  <div className="settings-form-group" data-testid="calibration-position-display">
                     <label className="settings-label">
                       Current Calibrated Position: {parseFloat(cameraForm.LensPosition || CAMERA_SETTINGS.LENS_POSITION.DEFAULT).toFixed(2)} diopters
                     </label>
@@ -1537,6 +1540,7 @@ export default function Settings() {
                   </label>
                   <input
                     type="range"
+                    data-testid="lens-position-slider"
                     aria-label="Focus position in diopters"
                     aria-describedby="lens-position-help"
                     min={CAMERA_SETTINGS.LENS_POSITION.MIN}
@@ -1566,6 +1570,7 @@ export default function Settings() {
                     </label>
                     <select
                       id="af_range_capture"
+                      data-testid="af-range-select"
                       value={cameraForm.AfRange || CAMERA_SETTINGS.AF_RANGE_VALUES.MACRO}
                       onChange={(e) => updateCameraForm({ AfRange: e.target.value})}
                       className="settings-select"
@@ -1582,6 +1587,7 @@ export default function Settings() {
                     </label>
                     <select
                       id="af_speed_capture"
+                      data-testid="af-speed-select"
                       value={cameraForm.AfSpeed || CAMERA_SETTINGS.AF_SPEED_VALUES.FAST}
                       onChange={(e) => updateCameraForm({ AfSpeed: e.target.value})}
                       className="settings-select"
@@ -1593,6 +1599,7 @@ export default function Settings() {
                 </div>
               )}
 
+              </div>
               </CollapsibleCard>
 
               {/* Image Format Card */}

--- a/Firmware/webui/frontend/src/pages/Settings.jsx
+++ b/Firmware/webui/frontend/src/pages/Settings.jsx
@@ -25,11 +25,10 @@ export default function Settings() {
     diagnosticHardware: true,
     // Camera Settings - common expanded, advanced collapsed
     cameraPreset: false,
-    cameraAutoCalibration: false,
+    cameraFocusStrategy: false,
     cameraExposure: false,
     cameraHDR: true,
     cameraFocusBracket: true,
-    cameraFocus: false,
     cameraFormat: false,
     cameraAdvanced: true,
     // Live View Settings - common expanded, advanced collapsed
@@ -245,6 +244,26 @@ export default function Settings() {
   const updateCameraForm = (updates) => {
     isDirtyRef.current.camera = true
     setCameraForm(prev => ({ ...prev, ...updates }))
+  }
+
+  // Derive focus mode from AutoCalibration + AfMode combination
+  const getFocusMode = () => {
+    const autoCal = cameraForm.AutoCalibration === '1' || cameraForm.AutoCalibration === 1
+    if (autoCal) return 'auto-calibrate'
+    const afMode = String(cameraForm.AfMode || '0')
+    if (afMode === '1') return 'af-single'
+    if (afMode === '2') return 'af-continuous'
+    return 'manual'
+  }
+
+  const handleFocusModeChange = (mode) => {
+    const updates = {
+      'auto-calibrate':  { AutoCalibration: '1', AfMode: '0' },
+      'manual':          { AutoCalibration: '0', AfMode: '0' },
+      'af-single':       { AutoCalibration: '0', AfMode: '1' },
+      'af-continuous':   { AutoCalibration: '0', AfMode: '2' },
+    }
+    updateCameraForm(updates[mode])
   }
 
   const updateWebuiForm = (updates) => {
@@ -945,63 +964,6 @@ export default function Settings() {
           <div className="space-y-2">
             {/* Grid container for settings cards */}
             <div className="settings-grid">
-              {/* Auto-Calibration Card */}
-              <CollapsibleCard
-                id="cameraAutoCalibration"
-                title="🔧 Auto-Calibration"
-                isCollapsed={collapsedCards.cameraAutoCalibration}
-                onToggle={toggleCard}
-                className="settings-card"
-              >
-                <div className="p-2 bg-green-50 border border-green-200 rounded">
-              <p className="settings-help-text mb-2">
-                Auto optimize exposure, gain, focus
-              </p>
-
-              <div className="space-y-2">
-                {/* Auto-Calibration Enable */}
-                <div>
-                  <label className="flex items-center">
-                    <input
-                      type="checkbox"
-                      checked={cameraForm.AutoCalibration === '1' || cameraForm.AutoCalibration === 1}
-                      onChange={(e) => updateCameraForm({ AutoCalibration: e.target.checked ? '1' : '0'})}
-                      className="settings-checkbox text-green-600"
-                    />
-                    <span className="ml-1 settings-label mb-0">
-                      Enable Auto-Calibration
-                    </span>
-                  </label>
-                </div>
-
-                {/* Auto-Calibration Period */}
-                {(cameraForm.AutoCalibration === '1' || cameraForm.AutoCalibration === 1) && (
-                  <div>
-                    <label className="settings-label">
-                      Frequency: Every {cameraForm.AutoCalibrationPeriod || 600} seconds
-                    </label>
-                    <input
-                      type="range"
-                      min="1"
-                      max="1000"
-                      value={cameraForm.AutoCalibrationPeriod || 600}
-                      onChange={(e) => setCameraForm({ ...cameraForm, AutoCalibrationPeriod: e.target.value })}
-                      className="w-full cursor-pointer"
-                    />
-                    <div className="flex justify-between settings-help-text">
-                      <span>1</span>
-                      <span>100</span>
-                      <span>1000</span>
-                    </div>
-                    <p className="settings-help-text">
-                      More frequent = better adaptation
-                    </p>
-                  </div>
-                )}
-              </div>
-                </div>
-              </CollapsibleCard>
-
               {/* Exposure Card */}
               <CollapsibleCard
                 id="cameraExposure"
@@ -1471,34 +1433,86 @@ export default function Settings() {
 
             {/* Third row of grid */}
             <div className="settings-grid">
-              {/* Focus Controls Card */}
+              {/* Focus Strategy Card */}
               <CollapsibleCard
-                id="cameraFocus"
-                title="🎯 Focus"
-                isCollapsed={collapsedCards.cameraFocus}
+                id="cameraFocusStrategy"
+                title="🎯 Focus Strategy"
+                isCollapsed={collapsedCards.cameraFocusStrategy}
                 onToggle={toggleCard}
                 className="settings-card"
               >
 
-              {/* Focus Mode */}
+              {/* Focus Mode Selector */}
               <div className="settings-form-group">
-                <label htmlFor="af_mode_capture" className="settings-label">
+                <label htmlFor="focus_mode" className="settings-label">
                   Focus Mode
                 </label>
                 <select
-                  id="af_mode_capture"
-                  value={cameraForm.AfMode || '0'}
-                  onChange={(e) => updateCameraForm({ AfMode: e.target.value})}
+                  id="focus_mode"
+                  value={getFocusMode()}
+                  onChange={(e) => handleFocusModeChange(e.target.value)}
                   className="settings-select"
                 >
-                  <option value="0">Manual Focus</option>
-                  <option value="1">Auto Focus (Single)</option>
-                  <option value="2">Auto Focus (Continuous)</option>
+                  <option value="auto-calibrate">Auto-Calibrate</option>
+                  <option value="manual">Manual Focus</option>
+                  <option value="af-single">Autofocus (Single)</option>
+                  <option value="af-continuous">Autofocus (Continuous)</option>
                 </select>
+                <p className="settings-help-text">
+                  {getFocusMode() === 'auto-calibrate' && 'Automatically optimizes focus position periodically. Recommended for unattended operation.'}
+                  {getFocusMode() === 'manual' && 'Set a fixed focus distance. Best when camera-to-subject distance is constant.'}
+                  {getFocusMode() === 'af-single' && 'Runs autofocus once before each capture. Good for varying distances.'}
+                  {getFocusMode() === 'af-continuous' && 'Continuously adjusts focus. Uses more power but adapts to movement.'}
+                </p>
               </div>
 
-              {/* Lens Position (if manual) */}
-              {cameraForm.AfMode === '0' && (
+              {/* Auto-Calibrate sub-controls */}
+              {getFocusMode() === 'auto-calibrate' && (
+                <div className="p-2 bg-green-50 border border-green-200 rounded space-y-2">
+                  <div className="settings-form-group">
+                    <label className="settings-label">
+                      Calibration Interval: Every {cameraForm.AutoCalibrationPeriod || 600} seconds
+                    </label>
+                    <input
+                      type="range"
+                      min="1"
+                      max="1000"
+                      value={cameraForm.AutoCalibrationPeriod || 600}
+                      onChange={(e) => setCameraForm({ ...cameraForm, AutoCalibrationPeriod: e.target.value })}
+                      className="w-full cursor-pointer"
+                    />
+                    <div className="flex justify-between settings-help-text">
+                      <span>1</span>
+                      <span>100</span>
+                      <span>1000</span>
+                    </div>
+                    <p className="settings-help-text">
+                      More frequent = better adaptation to changing conditions
+                    </p>
+                  </div>
+
+                  {/* Show current calibrated position as read-only */}
+                  <div className="settings-form-group">
+                    <label className="settings-label">
+                      Current Calibrated Position: {parseFloat(cameraForm.LensPosition || 0.5).toFixed(2)} diopters
+                    </label>
+                    <div className="w-full bg-gray-200 rounded h-2">
+                      <div
+                        className="bg-green-500 rounded h-2"
+                        style={{ width: `${(parseFloat(cameraForm.LensPosition || 0.5) / 10) * 100}%` }}
+                      />
+                    </div>
+                    <div className="flex justify-between settings-help-text">
+                      <span>0 (Far)</span>
+                      <span>5</span>
+                      <span>10 (Near)</span>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* Manual Focus sub-controls */}
+              {getFocusMode() === 'manual' && (
                 <div className="settings-form-group">
                   <label className="settings-label">
                     Focus Position: {parseFloat(cameraForm.LensPosition || 0.5).toFixed(2)} diopters
@@ -1518,43 +1532,47 @@ export default function Settings() {
                     <span>10 (Near)</span>
                   </div>
                   <p className="settings-help-text">
-                    Higher values = closer focus distance. Use auto-calibrate to find optimal value.
+                    Higher values = closer focus distance.
                   </p>
                 </div>
               )}
 
-              {/* Focus Range */}
-              <div className="settings-form-group">
-                <label htmlFor="af_range_capture" className="settings-label">
-                  Focus Range
-                </label>
-                <select
-                  id="af_range_capture"
-                  value={cameraForm.AfRange || '1'}
-                  onChange={(e) => updateCameraForm({ AfRange: e.target.value})}
-                  className="settings-select"
-                >
-                  <option value="0">Normal (0.5m - infinity)</option>
-                  <option value="1">Macro (10cm - 50cm) - For insects</option>
-                  <option value="2">Full (10cm - infinity)</option>
-                </select>
-              </div>
+              {/* Autofocus sub-controls (Single or Continuous) */}
+              {(getFocusMode() === 'af-single' || getFocusMode() === 'af-continuous') && (
+                <div className="space-y-2">
+                  <div className="settings-form-group">
+                    <label htmlFor="af_range_capture" className="settings-label">
+                      Focus Range
+                    </label>
+                    <select
+                      id="af_range_capture"
+                      value={cameraForm.AfRange || '1'}
+                      onChange={(e) => updateCameraForm({ AfRange: e.target.value})}
+                      className="settings-select"
+                    >
+                      <option value="0">Normal (0.5m - infinity)</option>
+                      <option value="1">Macro (10cm - 50cm) - For insects</option>
+                      <option value="2">Full (10cm - infinity)</option>
+                    </select>
+                  </div>
 
-              {/* Focus Speed */}
-              <div className="settings-form-group">
-                <label htmlFor="af_speed_capture" className="settings-label">
-                  Focus Speed
-                </label>
-                <select
-                  id="af_speed_capture"
-                  value={cameraForm.AfSpeed || '1'}
-                  onChange={(e) => updateCameraForm({ AfSpeed: e.target.value})}
-                  className="settings-select"
-                >
-                  <option value="0">Normal (Accurate)</option>
-                  <option value="1">Fast</option>
-                </select>
-              </div>
+                  <div className="settings-form-group">
+                    <label htmlFor="af_speed_capture" className="settings-label">
+                      Focus Speed
+                    </label>
+                    <select
+                      id="af_speed_capture"
+                      value={cameraForm.AfSpeed || '1'}
+                      onChange={(e) => updateCameraForm({ AfSpeed: e.target.value})}
+                      className="settings-select"
+                    >
+                      <option value="0">Normal (Accurate)</option>
+                      <option value="1">Fast</option>
+                    </select>
+                  </div>
+                </div>
+              )}
+
               </CollapsibleCard>
 
               {/* Image Format Card */}

--- a/Firmware/webui/frontend/src/pages/Settings.jsx
+++ b/Firmware/webui/frontend/src/pages/Settings.jsx
@@ -247,16 +247,24 @@ export default function Settings() {
     setCameraForm(prev => ({ ...prev, ...updates }))
   }
 
-  // Derive focus mode from AutoCalibration + AfMode combination
+  /**
+   * Derives the unified focus mode from AutoCalibration and AfMode CSV values.
+   * @returns {'auto-calibrate'|'manual'|'af-single'|'af-continuous'}
+   */
   const focusMode = (() => {
-    const autoCal = cameraForm.AutoCalibration === '1' || cameraForm.AutoCalibration === 1
+    const autoCal = String(cameraForm.AutoCalibration ?? '0') === '1'
     if (autoCal) return CAMERA_SETTINGS.FOCUS_MODES.AUTO_CALIBRATE
-    const afMode = String(cameraForm.AfMode || CAMERA_SETTINGS.AF_MODE_VALUES.MANUAL)
+    const afMode = String(cameraForm.AfMode ?? CAMERA_SETTINGS.AF_MODE_VALUES.MANUAL)
     if (afMode === CAMERA_SETTINGS.AF_MODE_VALUES.SINGLE) return CAMERA_SETTINGS.FOCUS_MODES.AF_SINGLE
     if (afMode === CAMERA_SETTINGS.AF_MODE_VALUES.CONTINUOUS) return CAMERA_SETTINGS.FOCUS_MODES.AF_CONTINUOUS
     return CAMERA_SETTINGS.FOCUS_MODES.MANUAL
   })()
 
+  /**
+   * Updates both AutoCalibration and AfMode CSV fields atomically
+   * when the user selects a new focus mode from the dropdown.
+   * @param {'auto-calibrate'|'manual'|'af-single'|'af-continuous'} mode
+   */
   const handleFocusModeChange = (mode) => {
     const updates = {
       [CAMERA_SETTINGS.FOCUS_MODES.AUTO_CALIBRATE]:  { AutoCalibration: '1', AfMode: CAMERA_SETTINGS.AF_MODE_VALUES.MANUAL },
@@ -1481,7 +1489,7 @@ export default function Settings() {
                       min={CAMERA_SETTINGS.CALIBRATION_INTERVAL.MIN}
                       max={CAMERA_SETTINGS.CALIBRATION_INTERVAL.MAX}
                       value={cameraForm.AutoCalibrationPeriod || CAMERA_SETTINGS.CALIBRATION_INTERVAL.DEFAULT}
-                      onChange={(e) => setCameraForm({ ...cameraForm, AutoCalibrationPeriod: e.target.value })}
+                      onChange={(e) => updateCameraForm({ AutoCalibrationPeriod: e.target.value })}
                       className="w-full cursor-pointer"
                     />
                     <div className="flex justify-between settings-help-text">
@@ -1502,7 +1510,7 @@ export default function Settings() {
                     <div className="w-full bg-gray-200 rounded h-2">
                       <div
                         className="bg-green-500 rounded h-2"
-                        style={{ width: `${(parseFloat(cameraForm.LensPosition || CAMERA_SETTINGS.LENS_POSITION.DEFAULT) / CAMERA_SETTINGS.LENS_POSITION.MAX) * 100}%` }}
+                        style={{ width: `${(Math.min(Math.max(parseFloat(cameraForm.LensPosition || CAMERA_SETTINGS.LENS_POSITION.DEFAULT), CAMERA_SETTINGS.LENS_POSITION.MIN), CAMERA_SETTINGS.LENS_POSITION.MAX) / CAMERA_SETTINGS.LENS_POSITION.MAX) * 100}%` }}
                       />
                     </div>
                     <div className="flex justify-between settings-help-text">
@@ -1510,6 +1518,9 @@ export default function Settings() {
                       <span>{CAMERA_SETTINGS.LENS_POSITION.MAX / 2}</span>
                       <span>{CAMERA_SETTINGS.LENS_POSITION.MAX} (Near)</span>
                     </div>
+                    <p className="settings-help-text">
+                      Updated after each calibration cycle
+                    </p>
                   </div>
                 </div>
               )}
@@ -1526,7 +1537,7 @@ export default function Settings() {
                     max={CAMERA_SETTINGS.LENS_POSITION.MAX}
                     step={CAMERA_SETTINGS.LENS_POSITION.STEP}
                     value={cameraForm.LensPosition || CAMERA_SETTINGS.LENS_POSITION.DEFAULT}
-                    onChange={(e) => setCameraForm({ ...cameraForm, LensPosition: e.target.value })}
+                    onChange={(e) => updateCameraForm({ LensPosition: e.target.value })}
                     className="w-full cursor-pointer"
                   />
                   <div className="flex justify-between settings-help-text">

--- a/Firmware/webui/frontend/src/pages/Settings.jsx
+++ b/Firmware/webui/frontend/src/pages/Settings.jsx
@@ -1458,6 +1458,8 @@ export default function Settings() {
                 </label>
                 <select
                   id="focus_mode"
+                  aria-label="Focus strategy mode"
+                  aria-describedby="focus-mode-help"
                   value={focusMode}
                   onChange={(e) => handleFocusModeChange(e.target.value)}
                   className="settings-select"
@@ -1467,7 +1469,7 @@ export default function Settings() {
                   <option value={CAMERA_SETTINGS.FOCUS_MODES.AF_SINGLE}>Autofocus (Single)</option>
                   <option value={CAMERA_SETTINGS.FOCUS_MODES.AF_CONTINUOUS}>Autofocus (Continuous)</option>
                 </select>
-                <p className="settings-help-text">
+                <p id="focus-mode-help" className="settings-help-text">
                   {{
                     [CAMERA_SETTINGS.FOCUS_MODES.AUTO_CALIBRATE]: 'Automatically optimizes focus position periodically. Recommended for unattended operation.',
                     [CAMERA_SETTINGS.FOCUS_MODES.MANUAL]: 'Set a fixed focus distance. Best when camera-to-subject distance is constant.',
@@ -1486,6 +1488,8 @@ export default function Settings() {
                     </label>
                     <input
                       type="range"
+                      aria-label="Calibration interval in seconds"
+                      aria-describedby="calibration-interval-help"
                       min={CAMERA_SETTINGS.CALIBRATION_INTERVAL.MIN}
                       max={CAMERA_SETTINGS.CALIBRATION_INTERVAL.MAX}
                       value={cameraForm.AutoCalibrationPeriod || CAMERA_SETTINGS.CALIBRATION_INTERVAL.DEFAULT}
@@ -1497,7 +1501,7 @@ export default function Settings() {
                       <span>100</span>
                       <span>{CAMERA_SETTINGS.CALIBRATION_INTERVAL.MAX}</span>
                     </div>
-                    <p className="settings-help-text">
+                    <p id="calibration-interval-help" className="settings-help-text">
                       More frequent = better adaptation to changing conditions
                     </p>
                   </div>
@@ -1533,6 +1537,8 @@ export default function Settings() {
                   </label>
                   <input
                     type="range"
+                    aria-label="Focus position in diopters"
+                    aria-describedby="lens-position-help"
                     min={CAMERA_SETTINGS.LENS_POSITION.MIN}
                     max={CAMERA_SETTINGS.LENS_POSITION.MAX}
                     step={CAMERA_SETTINGS.LENS_POSITION.STEP}
@@ -1545,7 +1551,7 @@ export default function Settings() {
                     <span>{CAMERA_SETTINGS.LENS_POSITION.MAX / 2}</span>
                     <span>{CAMERA_SETTINGS.LENS_POSITION.MAX} (Near)</span>
                   </div>
-                  <p className="settings-help-text">
+                  <p id="lens-position-help" className="settings-help-text">
                     Higher values = closer focus distance.
                   </p>
                 </div>

--- a/Firmware/webui/frontend/src/pages/Settings.jsx
+++ b/Firmware/webui/frontend/src/pages/Settings.jsx
@@ -279,7 +279,9 @@ export default function Settings() {
       [CAMERA_SETTINGS.FOCUS_MODES.AF_SINGLE]:       { AutoCalibration: '0', AfMode: CAMERA_SETTINGS.AF_MODE_VALUES.SINGLE },
       [CAMERA_SETTINGS.FOCUS_MODES.AF_CONTINUOUS]:    { AutoCalibration: '0', AfMode: CAMERA_SETTINGS.AF_MODE_VALUES.CONTINUOUS },
     }
-    updateCameraForm(updates[mode])
+    const update = updates[mode]
+    if (!update) return
+    updateCameraForm(update)
   }
 
   const updateWebuiForm = (updates) => {

--- a/Firmware/webui/frontend/src/pages/Settings.jsx
+++ b/Firmware/webui/frontend/src/pages/Settings.jsx
@@ -247,6 +247,13 @@ export default function Settings() {
     setCameraForm(prev => ({ ...prev, ...updates }))
   }
 
+  /** Clamps a lens position value to [MIN, MAX] and returns a 0-100 percentage. */
+  const lensPositionPercent = (raw) => {
+    const { MIN, MAX, DEFAULT } = CAMERA_SETTINGS.LENS_POSITION
+    const value = Math.min(Math.max(parseFloat(raw || DEFAULT), MIN), MAX)
+    return ((value - MIN) / (MAX - MIN)) * 100
+  }
+
   /**
    * Derives the unified focus mode from AutoCalibration and AfMode CSV values.
    * @returns {'auto-calibrate'|'manual'|'af-single'|'af-continuous'}
@@ -1517,7 +1524,7 @@ export default function Settings() {
                     <div className="w-full bg-gray-200 rounded h-2">
                       <div
                         className="bg-green-500 rounded h-2"
-                        style={{ width: `${(Math.min(Math.max(parseFloat(cameraForm.LensPosition || CAMERA_SETTINGS.LENS_POSITION.DEFAULT), CAMERA_SETTINGS.LENS_POSITION.MIN), CAMERA_SETTINGS.LENS_POSITION.MAX) / CAMERA_SETTINGS.LENS_POSITION.MAX) * 100}%` }}
+                        style={{ width: `${lensPositionPercent(cameraForm.LensPosition)}%` }}
                       />
                     </div>
                     <div className="flex justify-between settings-help-text">
@@ -1571,7 +1578,7 @@ export default function Settings() {
                     <select
                       id="af_range_capture"
                       data-testid="af-range-select"
-                      value={cameraForm.AfRange || CAMERA_SETTINGS.AF_RANGE_VALUES.MACRO}
+                      value={cameraForm.AfRange || CAMERA_SETTINGS.AF_RANGE_DEFAULT}
                       onChange={(e) => updateCameraForm({ AfRange: e.target.value})}
                       className="settings-select"
                     >
@@ -1588,7 +1595,7 @@ export default function Settings() {
                     <select
                       id="af_speed_capture"
                       data-testid="af-speed-select"
-                      value={cameraForm.AfSpeed || CAMERA_SETTINGS.AF_SPEED_VALUES.FAST}
+                      value={cameraForm.AfSpeed || CAMERA_SETTINGS.AF_SPEED_DEFAULT}
                       onChange={(e) => updateCameraForm({ AfSpeed: e.target.value})}
                       className="settings-select"
                     >

--- a/Firmware/webui/frontend/src/pages/Settings.jsx
+++ b/Firmware/webui/frontend/src/pages/Settings.jsx
@@ -4,6 +4,7 @@ import { QUERY_KEYS } from '../utils/queryKeys'
 import { useState, useEffect, useRef } from 'react'
 import { io } from 'socket.io-client'
 import toast from 'react-hot-toast'
+import { CAMERA_SETTINGS } from '../constants/config'
 import SavePresetModal from '../components/SavePresetModal'
 import GPSSettings from '../components/GPSSettings'
 import CollapsibleCard from '../components/CollapsibleCard'
@@ -249,19 +250,19 @@ export default function Settings() {
   // Derive focus mode from AutoCalibration + AfMode combination
   const focusMode = (() => {
     const autoCal = cameraForm.AutoCalibration === '1' || cameraForm.AutoCalibration === 1
-    if (autoCal) return 'auto-calibrate'
-    const afMode = String(cameraForm.AfMode || '0')
-    if (afMode === '1') return 'af-single'
-    if (afMode === '2') return 'af-continuous'
-    return 'manual'
+    if (autoCal) return CAMERA_SETTINGS.FOCUS_MODES.AUTO_CALIBRATE
+    const afMode = String(cameraForm.AfMode || CAMERA_SETTINGS.AF_MODE_VALUES.MANUAL)
+    if (afMode === CAMERA_SETTINGS.AF_MODE_VALUES.SINGLE) return CAMERA_SETTINGS.FOCUS_MODES.AF_SINGLE
+    if (afMode === CAMERA_SETTINGS.AF_MODE_VALUES.CONTINUOUS) return CAMERA_SETTINGS.FOCUS_MODES.AF_CONTINUOUS
+    return CAMERA_SETTINGS.FOCUS_MODES.MANUAL
   })()
 
   const handleFocusModeChange = (mode) => {
     const updates = {
-      'auto-calibrate':  { AutoCalibration: '1', AfMode: '0' },
-      'manual':          { AutoCalibration: '0', AfMode: '0' },
-      'af-single':       { AutoCalibration: '0', AfMode: '1' },
-      'af-continuous':   { AutoCalibration: '0', AfMode: '2' },
+      [CAMERA_SETTINGS.FOCUS_MODES.AUTO_CALIBRATE]:  { AutoCalibration: '1', AfMode: CAMERA_SETTINGS.AF_MODE_VALUES.MANUAL },
+      [CAMERA_SETTINGS.FOCUS_MODES.MANUAL]:          { AutoCalibration: '0', AfMode: CAMERA_SETTINGS.AF_MODE_VALUES.MANUAL },
+      [CAMERA_SETTINGS.FOCUS_MODES.AF_SINGLE]:       { AutoCalibration: '0', AfMode: CAMERA_SETTINGS.AF_MODE_VALUES.SINGLE },
+      [CAMERA_SETTINGS.FOCUS_MODES.AF_CONTINUOUS]:    { AutoCalibration: '0', AfMode: CAMERA_SETTINGS.AF_MODE_VALUES.CONTINUOUS },
     }
     updateCameraForm(updates[mode])
   }
@@ -1453,40 +1454,40 @@ export default function Settings() {
                   onChange={(e) => handleFocusModeChange(e.target.value)}
                   className="settings-select"
                 >
-                  <option value="auto-calibrate">Auto-Calibrate</option>
-                  <option value="manual">Manual Focus</option>
-                  <option value="af-single">Autofocus (Single)</option>
-                  <option value="af-continuous">Autofocus (Continuous)</option>
+                  <option value={CAMERA_SETTINGS.FOCUS_MODES.AUTO_CALIBRATE}>Auto-Calibrate</option>
+                  <option value={CAMERA_SETTINGS.FOCUS_MODES.MANUAL}>Manual Focus</option>
+                  <option value={CAMERA_SETTINGS.FOCUS_MODES.AF_SINGLE}>Autofocus (Single)</option>
+                  <option value={CAMERA_SETTINGS.FOCUS_MODES.AF_CONTINUOUS}>Autofocus (Continuous)</option>
                 </select>
                 <p className="settings-help-text">
                   {{
-                    'auto-calibrate': 'Automatically optimizes focus position periodically. Recommended for unattended operation.',
-                    'manual': 'Set a fixed focus distance. Best when camera-to-subject distance is constant.',
-                    'af-single': 'Runs autofocus once before each capture. Good for varying distances.',
-                    'af-continuous': 'Continuously adjusts focus. Uses more power but adapts to movement.',
+                    [CAMERA_SETTINGS.FOCUS_MODES.AUTO_CALIBRATE]: 'Automatically optimizes focus position periodically. Recommended for unattended operation.',
+                    [CAMERA_SETTINGS.FOCUS_MODES.MANUAL]: 'Set a fixed focus distance. Best when camera-to-subject distance is constant.',
+                    [CAMERA_SETTINGS.FOCUS_MODES.AF_SINGLE]: 'Runs autofocus once before each capture. Good for varying distances.',
+                    [CAMERA_SETTINGS.FOCUS_MODES.AF_CONTINUOUS]: 'Continuously adjusts focus. Uses more power but adapts to movement.',
                   }[focusMode]}
                 </p>
               </div>
 
               {/* Auto-Calibrate sub-controls */}
-              {focusMode === 'auto-calibrate' && (
+              {focusMode === CAMERA_SETTINGS.FOCUS_MODES.AUTO_CALIBRATE && (
                 <div className="p-2 bg-green-50 border border-green-200 rounded space-y-2">
                   <div className="settings-form-group">
                     <label className="settings-label">
-                      Calibration Interval: Every {cameraForm.AutoCalibrationPeriod || 600} seconds
+                      Calibration Interval: Every {cameraForm.AutoCalibrationPeriod || CAMERA_SETTINGS.CALIBRATION_INTERVAL.DEFAULT} seconds
                     </label>
                     <input
                       type="range"
-                      min="1"
-                      max="1000"
-                      value={cameraForm.AutoCalibrationPeriod || 600}
+                      min={CAMERA_SETTINGS.CALIBRATION_INTERVAL.MIN}
+                      max={CAMERA_SETTINGS.CALIBRATION_INTERVAL.MAX}
+                      value={cameraForm.AutoCalibrationPeriod || CAMERA_SETTINGS.CALIBRATION_INTERVAL.DEFAULT}
                       onChange={(e) => setCameraForm({ ...cameraForm, AutoCalibrationPeriod: e.target.value })}
                       className="w-full cursor-pointer"
                     />
                     <div className="flex justify-between settings-help-text">
-                      <span>1</span>
+                      <span>{CAMERA_SETTINGS.CALIBRATION_INTERVAL.MIN}</span>
                       <span>100</span>
-                      <span>1000</span>
+                      <span>{CAMERA_SETTINGS.CALIBRATION_INTERVAL.MAX}</span>
                     </div>
                     <p className="settings-help-text">
                       More frequent = better adaptation to changing conditions
@@ -1496,42 +1497,42 @@ export default function Settings() {
                   {/* Show current calibrated position as read-only */}
                   <div className="settings-form-group">
                     <label className="settings-label">
-                      Current Calibrated Position: {parseFloat(cameraForm.LensPosition || 0.5).toFixed(2)} diopters
+                      Current Calibrated Position: {parseFloat(cameraForm.LensPosition || CAMERA_SETTINGS.LENS_POSITION.DEFAULT).toFixed(2)} diopters
                     </label>
                     <div className="w-full bg-gray-200 rounded h-2">
                       <div
                         className="bg-green-500 rounded h-2"
-                        style={{ width: `${(parseFloat(cameraForm.LensPosition || 0.5) / 10) * 100}%` }}
+                        style={{ width: `${(parseFloat(cameraForm.LensPosition || CAMERA_SETTINGS.LENS_POSITION.DEFAULT) / CAMERA_SETTINGS.LENS_POSITION.MAX) * 100}%` }}
                       />
                     </div>
                     <div className="flex justify-between settings-help-text">
-                      <span>0 (Far)</span>
-                      <span>5</span>
-                      <span>10 (Near)</span>
+                      <span>{CAMERA_SETTINGS.LENS_POSITION.MIN} (Far)</span>
+                      <span>{CAMERA_SETTINGS.LENS_POSITION.MAX / 2}</span>
+                      <span>{CAMERA_SETTINGS.LENS_POSITION.MAX} (Near)</span>
                     </div>
                   </div>
                 </div>
               )}
 
               {/* Manual Focus sub-controls */}
-              {focusMode === 'manual' && (
+              {focusMode === CAMERA_SETTINGS.FOCUS_MODES.MANUAL && (
                 <div className="settings-form-group">
                   <label className="settings-label">
-                    Focus Position: {parseFloat(cameraForm.LensPosition || 0.5).toFixed(2)} diopters
+                    Focus Position: {parseFloat(cameraForm.LensPosition || CAMERA_SETTINGS.LENS_POSITION.DEFAULT).toFixed(2)} diopters
                   </label>
                   <input
                     type="range"
-                    min="0"
-                    max="10"
-                    step="0.1"
-                    value={cameraForm.LensPosition || 0.5}
+                    min={CAMERA_SETTINGS.LENS_POSITION.MIN}
+                    max={CAMERA_SETTINGS.LENS_POSITION.MAX}
+                    step={CAMERA_SETTINGS.LENS_POSITION.STEP}
+                    value={cameraForm.LensPosition || CAMERA_SETTINGS.LENS_POSITION.DEFAULT}
                     onChange={(e) => setCameraForm({ ...cameraForm, LensPosition: e.target.value })}
                     className="w-full cursor-pointer"
                   />
                   <div className="flex justify-between settings-help-text">
-                    <span>0 (Far)</span>
-                    <span>5</span>
-                    <span>10 (Near)</span>
+                    <span>{CAMERA_SETTINGS.LENS_POSITION.MIN} (Far)</span>
+                    <span>{CAMERA_SETTINGS.LENS_POSITION.MAX / 2}</span>
+                    <span>{CAMERA_SETTINGS.LENS_POSITION.MAX} (Near)</span>
                   </div>
                   <p className="settings-help-text">
                     Higher values = closer focus distance.
@@ -1540,7 +1541,7 @@ export default function Settings() {
               )}
 
               {/* Autofocus sub-controls (Single or Continuous) */}
-              {(focusMode === 'af-single' || focusMode === 'af-continuous') && (
+              {(focusMode === CAMERA_SETTINGS.FOCUS_MODES.AF_SINGLE || focusMode === CAMERA_SETTINGS.FOCUS_MODES.AF_CONTINUOUS) && (
                 <div className="space-y-2">
                   <div className="settings-form-group">
                     <label htmlFor="af_range_capture" className="settings-label">
@@ -1548,13 +1549,13 @@ export default function Settings() {
                     </label>
                     <select
                       id="af_range_capture"
-                      value={cameraForm.AfRange || '1'}
+                      value={cameraForm.AfRange || CAMERA_SETTINGS.AF_RANGE_VALUES.MACRO}
                       onChange={(e) => updateCameraForm({ AfRange: e.target.value})}
                       className="settings-select"
                     >
-                      <option value="0">Normal (0.5m - infinity)</option>
-                      <option value="1">Macro (10cm - 50cm) - For insects</option>
-                      <option value="2">Full (10cm - infinity)</option>
+                      <option value={CAMERA_SETTINGS.AF_RANGE_VALUES.NORMAL}>Normal (0.5m - infinity)</option>
+                      <option value={CAMERA_SETTINGS.AF_RANGE_VALUES.MACRO}>Macro (10cm - 50cm) - For insects</option>
+                      <option value={CAMERA_SETTINGS.AF_RANGE_VALUES.FULL}>Full (10cm - infinity)</option>
                     </select>
                   </div>
 
@@ -1564,12 +1565,12 @@ export default function Settings() {
                     </label>
                     <select
                       id="af_speed_capture"
-                      value={cameraForm.AfSpeed || '1'}
+                      value={cameraForm.AfSpeed || CAMERA_SETTINGS.AF_SPEED_VALUES.FAST}
                       onChange={(e) => updateCameraForm({ AfSpeed: e.target.value})}
                       className="settings-select"
                     >
-                      <option value="0">Normal (Accurate)</option>
-                      <option value="1">Fast</option>
+                      <option value={CAMERA_SETTINGS.AF_SPEED_VALUES.NORMAL}>Normal (Accurate)</option>
+                      <option value={CAMERA_SETTINGS.AF_SPEED_VALUES.FAST}>Fast</option>
                     </select>
                   </div>
                 </div>

--- a/Firmware/webui/frontend/src/pages/Settings.jsx
+++ b/Firmware/webui/frontend/src/pages/Settings.jsx
@@ -247,14 +247,14 @@ export default function Settings() {
   }
 
   // Derive focus mode from AutoCalibration + AfMode combination
-  const getFocusMode = () => {
+  const focusMode = (() => {
     const autoCal = cameraForm.AutoCalibration === '1' || cameraForm.AutoCalibration === 1
     if (autoCal) return 'auto-calibrate'
     const afMode = String(cameraForm.AfMode || '0')
     if (afMode === '1') return 'af-single'
     if (afMode === '2') return 'af-continuous'
     return 'manual'
-  }
+  })()
 
   const handleFocusModeChange = (mode) => {
     const updates = {
@@ -1449,7 +1449,7 @@ export default function Settings() {
                 </label>
                 <select
                   id="focus_mode"
-                  value={getFocusMode()}
+                  value={focusMode}
                   onChange={(e) => handleFocusModeChange(e.target.value)}
                   className="settings-select"
                 >
@@ -1459,15 +1459,17 @@ export default function Settings() {
                   <option value="af-continuous">Autofocus (Continuous)</option>
                 </select>
                 <p className="settings-help-text">
-                  {getFocusMode() === 'auto-calibrate' && 'Automatically optimizes focus position periodically. Recommended for unattended operation.'}
-                  {getFocusMode() === 'manual' && 'Set a fixed focus distance. Best when camera-to-subject distance is constant.'}
-                  {getFocusMode() === 'af-single' && 'Runs autofocus once before each capture. Good for varying distances.'}
-                  {getFocusMode() === 'af-continuous' && 'Continuously adjusts focus. Uses more power but adapts to movement.'}
+                  {{
+                    'auto-calibrate': 'Automatically optimizes focus position periodically. Recommended for unattended operation.',
+                    'manual': 'Set a fixed focus distance. Best when camera-to-subject distance is constant.',
+                    'af-single': 'Runs autofocus once before each capture. Good for varying distances.',
+                    'af-continuous': 'Continuously adjusts focus. Uses more power but adapts to movement.',
+                  }[focusMode]}
                 </p>
               </div>
 
               {/* Auto-Calibrate sub-controls */}
-              {getFocusMode() === 'auto-calibrate' && (
+              {focusMode === 'auto-calibrate' && (
                 <div className="p-2 bg-green-50 border border-green-200 rounded space-y-2">
                   <div className="settings-form-group">
                     <label className="settings-label">
@@ -1512,7 +1514,7 @@ export default function Settings() {
               )}
 
               {/* Manual Focus sub-controls */}
-              {getFocusMode() === 'manual' && (
+              {focusMode === 'manual' && (
                 <div className="settings-form-group">
                   <label className="settings-label">
                     Focus Position: {parseFloat(cameraForm.LensPosition || 0.5).toFixed(2)} diopters
@@ -1538,7 +1540,7 @@ export default function Settings() {
               )}
 
               {/* Autofocus sub-controls (Single or Continuous) */}
-              {(getFocusMode() === 'af-single' || getFocusMode() === 'af-continuous') && (
+              {(focusMode === 'af-single' || focusMode === 'af-continuous') && (
                 <div className="space-y-2">
                   <div className="settings-form-group">
                     <label htmlFor="af_range_capture" className="settings-label">
@@ -1657,7 +1659,7 @@ export default function Settings() {
             <div className="settings-card space-y-2">
               <div className="settings-info-box bg-yellow-50 border-yellow-200">
               <p className="text-xs text-yellow-800">
-                <strong>Note:</strong> Full-resolution captures only. Use Auto-Calibration or Camera page to test.
+                <strong>Note:</strong> Full-resolution captures only. Use Auto-Calibrate mode or Camera page to test.
               </p>
               </div>
             </div>


### PR DESCRIPTION
## Summary

- Replace separate Auto-Calibration and Focus cards with a unified "Focus Strategy" card
- Single dropdown with 4 modes: Auto-Calibrate, Manual Focus, Autofocus (Single), Autofocus (Continuous)
- Conditional sub-controls render based on selected mode
- Prevents conflicting AutoCalibration + AfMode combinations

## Details

The old UI had AutoCalibration and AfMode as independent settings in separate cards. When AutoCalibration was ON, TakePhoto.py overrode AfMode to Manual — but the UI didn't reflect this, letting users set conflicting combinations.

The new Focus Strategy card uses a single mode dropdown that atomically sets both `AutoCalibration` and `AfMode` CSV fields. Each mode shows only its relevant sub-controls:

- **Auto-Calibrate**: calibration interval slider + read-only calibrated position bar
- **Manual Focus**: LensPosition slider (0-10 diopters)
- **Autofocus (Single/Continuous)**: AfRange and AfSpeed dropdowns

Frontend-only change — no backend modifications. The underlying CSV fields remain the same.

Also fixes: stale "Auto-Calibration" text reference updated to "Auto-Calibrate mode".

Closes #397

## Test plan

- [x] `npm run build` passes with no errors
- [x] Old card IDs (`cameraAutoCalibration`, `cameraFocus`) fully removed
- [x] New card (`cameraFocusStrategy`) properly wired in collapsed state
- [x] No E2E tests reference the removed card IDs
- [ ] Manual verification: switch between all 4 modes, verify sub-controls appear/disappear
- [ ] Manual verification: save settings, reload page, verify mode persists correctly