### PR TITLE
test: frontend infrastructure & testing gaps (#408, #406, #68)

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,0 +1,61 @@
+name: Frontend Tests
+
+on:
+  push:
+    branches: [main, dev]
+    paths:
+      - 'Firmware/webui/frontend/**'
+      - '.github/workflows/frontend-tests.yml'
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - 'Firmware/webui/frontend/**'
+      - '.github/workflows/frontend-tests.yml'
+
+defaults:
+  run:
+    working-directory: Firmware/webui/frontend
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [1, 2, 3, 4]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: Firmware/webui/frontend/package-lock.json
+
+      - run: npm ci
+
+      - name: Run tests (shard ${{ matrix.shard }}/4)
+        run: npx vitest run --shard=${{ matrix.shard }}/4 --reporter=verbose
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: Firmware/webui/frontend/package-lock.json
+
+      - run: npm ci
+
+      - name: Run coverage
+        run: npx vitest run --coverage --reporter=verbose
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: Firmware/webui/frontend/coverage/
+          retention-days: 14

--- a/Firmware/docs/plans/2026-02-18-tier2-frontend-infra-design.md
+++ b/Firmware/docs/plans/2026-02-18-tier2-frontend-infra-design.md
@@ -1,0 +1,73 @@
+# Tier 2 Frontend Infrastructure & Testing Design
+
+**Date**: 2026-02-18
+**Branch**: `test/tier2-frontend-infra`
+**Issues**: #408, #406, #68
+
+## Issue #408: Lock File Cleanup at Startup
+
+### Problem
+Two cleanup functions exist (`schedule_storage.cleanup_temp_files()`, `deployment_sidecar.cleanup_temp_files()`) but are never called. Orphaned `.lock` files accumulate in `CONFIG_DIR/schedules/` and `PHOTOS_DIR/` after crashes.
+
+### Solution
+Call both during Flask app initialization in `app.py` with try/except so failures don't block startup. Both use a 1-hour age threshold and are already tested.
+
+### Files
+- `webui/backend/app.py` — ~5 lines in initialization
+
+---
+
+## Issue #406: Frontend Testing Infrastructure
+
+### Item 1: CI Pipeline
+Create `.github/workflows/frontend-tests.yml`:
+- Trigger on push/PR to `main` and `dev`
+- Node.js setup, install deps
+- 4 parallel test shards (scripts exist in package.json)
+- Upload coverage report
+- Fail on threshold violation
+
+### Item 2: Coverage Threshold
+Add to `vitest.config.js`:
+- 70% statements, lines, functions
+- 60% branches
+- Conservative starting point, tighten later
+
+### Item 3: Hook Tests
+- `useSelection` (~3 tests): inside/outside provider, context value, error on missing provider
+- `useValidateDraft` (~10-15 tests): debouncing, query caching, routine filtering, error states, reset
+
+### Item 4: Page Test Audit
+Quick pass through `src/pages/` to identify zero-coverage pages. Add basic tests if gaps found.
+
+### Files
+- `.github/workflows/frontend-tests.yml` (new)
+- `webui/frontend/vitest.config.js` (modify)
+- `webui/frontend/src/hooks/__tests__/useSelection.test.jsx` (new)
+- `webui/frontend/src/hooks/__tests__/useValidateDraft.test.jsx` (new)
+
+---
+
+## Issue #68: SavePresetModal Tests
+
+### Problem
+`SavePresetModal.jsx` is the only preset component without a test file.
+
+### Solution
+~10-15 tests covering: render states, name validation, description field, workflow selector, save behavior, settings validation errors, close/cancel.
+
+### Files
+- `webui/frontend/src/components/__tests__/SavePresetModal.test.jsx` (new)
+
+---
+
+## Branch Strategy
+
+Single branch `test/tier2-frontend-infra`, 5-6 commits:
+
+1. `fix(backend): wire up orphaned lock cleanup at startup (#408)`
+2. `ci(frontend): add GitHub Actions workflow with 4-shard parallelization (#406)`
+3. `test(frontend): add coverage threshold to vitest config (#406)`
+4. `test(frontend): add tests for useSelection and useValidateDraft hooks (#406)`
+5. `test(frontend): audit page components for coverage gaps (#406)` (if gaps found)
+6. `test(frontend): add tests for SavePresetModal (#68)`

--- a/Firmware/docs/plans/2026-02-18-tier2-frontend-infra.md
+++ b/Firmware/docs/plans/2026-02-18-tier2-frontend-infra.md
@@ -1,0 +1,802 @@
+# Tier 2 Frontend Infrastructure Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Wire up orphaned lock cleanup, add frontend CI pipeline with coverage thresholds, and fill remaining test gaps for hooks, pages, and preset components.
+
+**Architecture:** Six independent tasks: one backend startup fix, one CI workflow file, one vitest config change, and three test files. No cross-dependencies between tasks.
+
+**Tech Stack:** Python/Flask (backend), GitHub Actions (CI), Vitest/React Testing Library (frontend tests)
+
+---
+
+## Task 1: Wire Up Lock Cleanup at Startup (#408)
+
+**Files:**
+- Modify: `webui/backend/app.py` (~line 300, after service initialization)
+
+**Step 1: Add lock cleanup calls**
+
+After the deployment service initialization block (around line 310), add:
+
+```python
+# Clean up orphaned lock files from previous sessions (#408)
+# These functions already exist and are tested — we just need to invoke them at startup.
+try:
+    from webui.backend.lib.schedule_storage import cleanup_temp_files as cleanup_schedule_locks
+
+    removed = cleanup_schedule_locks()
+    if removed > 0:
+        logger.info(f"Cleaned up {removed} orphaned schedule lock file(s)")
+except Exception as e:
+    logger.warning(f"Schedule lock cleanup failed (non-fatal): {e}")
+
+try:
+    from webui.backend.lib.deployment_sidecar import cleanup_temp_files as cleanup_deployment_locks
+
+    removed = cleanup_deployment_locks(PHOTOS_DIR)
+    if removed > 0:
+        logger.info(f"Cleaned up {removed} orphaned deployment lock file(s)")
+except Exception as e:
+    logger.warning(f"Deployment lock cleanup failed (non-fatal): {e}")
+```
+
+Note: `PHOTOS_DIR` is already imported at line 131 (`from mothbox_paths import PHOTOS_DIR, THUMBNAIL_CACHE_DIR`).
+
+**Step 2: Verify the app still starts**
+
+Run: `cd /home/zane/projects/Mothbox/Firmware/webui/backend && MOTHBOX_ENV=test python3 -c "import app; print('OK')"`
+Expected: No import errors (may warn about missing hardware — that's fine)
+
+**Step 3: Lint**
+
+Run: `ruff check webui/backend/app.py`
+Expected: No new errors
+
+**Step 4: Commit**
+
+```bash
+git add webui/backend/app.py
+git commit -m "fix(backend): wire up orphaned lock cleanup at startup (#408)"
+```
+
+---
+
+## Task 2: Add GitHub Actions CI Workflow (#406)
+
+**Files:**
+- Create: `.github/workflows/frontend-tests.yml`
+
+**Step 1: Create the workflow file**
+
+```yaml
+name: Frontend Tests
+
+on:
+  push:
+    branches: [main, dev]
+    paths:
+      - 'Firmware/webui/frontend/**'
+      - '.github/workflows/frontend-tests.yml'
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - 'Firmware/webui/frontend/**'
+      - '.github/workflows/frontend-tests.yml'
+
+defaults:
+  run:
+    working-directory: Firmware/webui/frontend
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [1, 2, 3, 4]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: Firmware/webui/frontend/package-lock.json
+
+      - run: npm ci
+
+      - name: Run tests (shard ${{ matrix.shard }}/4)
+        run: npx vitest run --shard=${{ matrix.shard }}/4 --reporter=verbose
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: Firmware/webui/frontend/package-lock.json
+
+      - run: npm ci
+
+      - name: Run coverage
+        run: npx vitest run --coverage --reporter=verbose
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: Firmware/webui/frontend/coverage/
+          retention-days: 14
+```
+
+**Step 2: Verify YAML syntax**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/frontend-tests.yml'))" 2>&1 || echo "Install pyyaml or skip — YAML syntax is simple enough to verify visually"`
+
+**Step 3: Commit**
+
+```bash
+git add .github/workflows/frontend-tests.yml
+git commit -m "ci(frontend): add GitHub Actions workflow with 4-shard parallelization (#406)"
+```
+
+---
+
+## Task 3: Add Coverage Threshold (#406)
+
+**Files:**
+- Modify: `webui/frontend/vitest.config.js:42-48`
+
+**Step 1: Add thresholds to coverage config**
+
+Replace lines 42-48:
+
+```javascript
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+      exclude: [
+        'node_modules/',
+        'src/setupTests.js',
+      ]
+    }
+```
+
+With:
+
+```javascript
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+      exclude: [
+        'node_modules/',
+        'src/setupTests.js',
+      ],
+      thresholds: {
+        statements: 70,
+        branches: 60,
+        functions: 70,
+        lines: 70,
+      },
+    }
+```
+
+**Step 2: Verify thresholds don't break current coverage**
+
+Run: `cd /home/zane/projects/Mothbox/Firmware/webui/frontend && npx vitest run --coverage 2>&1 | tail -20`
+Expected: Coverage passes (current coverage should be well above 70%)
+
+**Step 3: Commit**
+
+```bash
+git add webui/frontend/vitest.config.js
+git commit -m "test(frontend): add coverage threshold to vitest config (#406)"
+```
+
+---
+
+## Task 4: Add Tests for useSelection and useValidateDraft (#406)
+
+**Files:**
+- Create: `webui/frontend/src/hooks/__tests__/useSelection.test.jsx`
+- Create: `webui/frontend/src/hooks/__tests__/useValidateDraft.test.jsx`
+
+### useSelection Tests
+
+`useSelection` is a thin wrapper around `SelectionContext`. It returns the context value or throws if used outside the provider.
+
+The `SelectionContext` provides: `isSelectMode`, `selectedPhotos` (Set), `selectedCount`, `selectedArray`, `toggleSelectMode`, `selectPhoto`, `deselectPhoto`, `togglePhoto`, `selectRange`, `selectAll`, `deselectAll`, `isSelected`.
+
+```jsx
+import { describe, it, expect } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import React from 'react'
+import useSelection from '../useSelection'
+import { SelectionProvider } from '../../contexts/SelectionContext'
+
+const wrapper = ({ children }) => (
+  <SelectionProvider>{children}</SelectionProvider>
+)
+
+describe('useSelection', () => {
+  it('throws when used outside SelectionProvider', () => {
+    // Suppress console.error for expected error
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    expect(() => renderHook(() => useSelection())).toThrow(
+      'useSelection must be used within SelectionProvider'
+    )
+    spy.mockRestore()
+  })
+
+  it('returns context value when inside SelectionProvider', () => {
+    const { result } = renderHook(() => useSelection(), { wrapper })
+    expect(result.current).toBeDefined()
+    expect(result.current.isSelectMode).toBe(false)
+    expect(result.current.selectedCount).toBe(0)
+    expect(typeof result.current.toggleSelectMode).toBe('function')
+    expect(typeof result.current.selectPhoto).toBe('function')
+    expect(typeof result.current.deselectPhoto).toBe('function')
+    expect(typeof result.current.isSelected).toBe('function')
+  })
+
+  it('provides all expected context properties', () => {
+    const { result } = renderHook(() => useSelection(), { wrapper })
+    const expectedKeys = [
+      'isSelectMode', 'selectedPhotos', 'lastClickedIndex',
+      'selectedCount', 'selectedArray',
+      'toggleSelectMode', 'selectPhoto', 'deselectPhoto',
+      'togglePhoto', 'selectRange', 'selectAll', 'deselectAll', 'isSelected',
+    ]
+    expectedKeys.forEach(key => {
+      expect(result.current).toHaveProperty(key)
+    })
+  })
+})
+```
+
+### useValidateDraft Tests
+
+This hook uses React Query and debouncing. Follow the pattern from `useSchedules.test.jsx`: mock the API module, wrap with `QueryClientProvider`, use `waitFor` for async assertions.
+
+```jsx
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import React from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useValidateDraft } from '../useValidateDraft'
+import * as schedulerApi from '../../utils/schedulerApi'
+
+vi.mock('../../utils/schedulerApi')
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+  return ({ children }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+const validRoutine = {
+  trigger: { trigger_type: 'interval' },
+  actions: [{ type: 'takephoto' }],
+}
+
+describe('useValidateDraft', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('returns initial state', () => {
+    const { result } = renderHook(() => useValidateDraft(), {
+      wrapper: createWrapper(),
+    })
+    expect(result.current.conflictReport).toBeNull()
+    expect(result.current.isValidating).toBe(false)
+    expect(result.current.isError).toBe(false)
+    expect(result.current.error).toBeNull()
+    expect(typeof result.current.validateDraft).toBe('function')
+    expect(typeof result.current.reset).toBe('function')
+  })
+
+  it('debounces validation calls', () => {
+    const { result } = renderHook(() => useValidateDraft(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.validateDraft([validRoutine])
+    })
+
+    // API should NOT be called immediately
+    expect(schedulerApi.validateDraftRoutines).not.toHaveBeenCalled()
+  })
+
+  it('triggers validation after debounce delay', async () => {
+    const mockResponse = { data: { conflicts: [], total_conflicts: 0 } }
+    schedulerApi.validateDraftRoutines.mockResolvedValue(mockResponse)
+
+    const { result } = renderHook(() => useValidateDraft(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.validateDraft([validRoutine])
+    })
+
+    // Advance past debounce delay (400ms)
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    await waitFor(() => {
+      expect(schedulerApi.validateDraftRoutines).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('filters routines without trigger_type or actions', async () => {
+    const mockResponse = { data: { conflicts: [], total_conflicts: 0 } }
+    schedulerApi.validateDraftRoutines.mockResolvedValue(mockResponse)
+
+    const { result } = renderHook(() => useValidateDraft(), {
+      wrapper: createWrapper(),
+    })
+
+    const routines = [
+      validRoutine,
+      { trigger: {}, actions: [{ type: 'takephoto' }] },       // no trigger_type
+      { trigger: { trigger_type: 'interval' }, actions: [] },   // no actions
+      null,                                                       // null
+    ]
+
+    act(() => {
+      result.current.validateDraft(routines)
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    await waitFor(() => {
+      expect(schedulerApi.validateDraftRoutines).toHaveBeenCalledTimes(1)
+      const callArgs = schedulerApi.validateDraftRoutines.mock.calls[0][0]
+      expect(callArgs.routines).toHaveLength(1)
+    })
+  })
+
+  it('does not call API when all routines are invalid', () => {
+    const { result } = renderHook(() => useValidateDraft(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.validateDraft([{ trigger: {}, actions: [] }])
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    // Should not call API since no valid routines
+    expect(schedulerApi.validateDraftRoutines).not.toHaveBeenCalled()
+  })
+
+  it('passes options to API call', async () => {
+    const mockResponse = { data: { conflicts: [], total_conflicts: 0 } }
+    schedulerApi.validateDraftRoutines.mockResolvedValue(mockResponse)
+
+    const { result } = renderHook(
+      () => useValidateDraft({ days: 3, latitude: 9.0, longitude: -79.5, timezone: 'America/Panama' }),
+      { wrapper: createWrapper() }
+    )
+
+    act(() => {
+      result.current.validateDraft([validRoutine])
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    await waitFor(() => {
+      const callArgs = schedulerApi.validateDraftRoutines.mock.calls[0][0]
+      expect(callArgs.days).toBe(3)
+      expect(callArgs.latitude).toBe(9.0)
+      expect(callArgs.longitude).toBe(-79.5)
+      expect(callArgs.timezone).toBe('America/Panama')
+    })
+  })
+
+  it('returns conflict report after validation', async () => {
+    const mockReport = {
+      conflicts: [{ type: 'time_overlap', severity: 'warning' }],
+      total_conflicts: 1,
+    }
+    schedulerApi.validateDraftRoutines.mockResolvedValue({ data: mockReport })
+
+    const { result } = renderHook(() => useValidateDraft(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.validateDraft([validRoutine])
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    await waitFor(() => {
+      expect(result.current.conflictReport).toEqual(mockReport)
+    })
+  })
+
+  it('handles API errors', async () => {
+    schedulerApi.validateDraftRoutines.mockRejectedValue(new Error('Network error'))
+
+    const { result } = renderHook(() => useValidateDraft(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.validateDraft([validRoutine])
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true)
+      expect(result.current.error).toBeTruthy()
+    })
+  })
+
+  it('resets state when reset is called', async () => {
+    const mockResponse = { data: { conflicts: [], total_conflicts: 0 } }
+    schedulerApi.validateDraftRoutines.mockResolvedValue(mockResponse)
+
+    const { result } = renderHook(() => useValidateDraft(), {
+      wrapper: createWrapper(),
+    })
+
+    // Trigger validation
+    act(() => {
+      result.current.validateDraft([validRoutine])
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    await waitFor(() => {
+      expect(result.current.conflictReport).toBeDefined()
+    })
+
+    // Reset
+    act(() => {
+      result.current.reset()
+    })
+
+    await waitFor(() => {
+      expect(result.current.conflictReport).toBeNull()
+    })
+  })
+
+  it('cancels pending debounce on reset', () => {
+    const { result } = renderHook(() => useValidateDraft(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.validateDraft([validRoutine])
+    })
+
+    // Reset before debounce fires
+    act(() => {
+      result.current.reset()
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(schedulerApi.validateDraftRoutines).not.toHaveBeenCalled()
+  })
+
+  it('handles null/undefined routines array', () => {
+    const { result } = renderHook(() => useValidateDraft(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.validateDraft(null)
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(schedulerApi.validateDraftRoutines).not.toHaveBeenCalled()
+  })
+})
+```
+
+**Step 1: Create both test files**
+
+Write the files above.
+
+**Step 2: Run useSelection tests**
+
+Run: `cd /home/zane/projects/Mothbox/Firmware/webui/frontend && npx vitest run src/hooks/__tests__/useSelection.test.jsx`
+Expected: 3 tests PASS
+
+**Step 3: Run useValidateDraft tests**
+
+Run: `cd /home/zane/projects/Mothbox/Firmware/webui/frontend && npx vitest run src/hooks/__tests__/useValidateDraft.test.jsx`
+Expected: 10 tests PASS
+
+**Step 4: Commit**
+
+```bash
+git add webui/frontend/src/hooks/__tests__/useSelection.test.jsx \
+        webui/frontend/src/hooks/__tests__/useValidateDraft.test.jsx
+git commit -m "test(frontend): add tests for useSelection and useValidateDraft hooks (#406)"
+```
+
+---
+
+## Task 5: Page Test Audit — GPIO and MapPage (#406)
+
+**Findings**: The page audit found 2 untested pages: `GPIO.jsx` and `MapPage.jsx`.
+
+**Files:**
+- Create: `webui/frontend/src/pages/__tests__/GPIO.test.jsx`
+- Create: `webui/frontend/src/pages/__tests__/MapPage.test.jsx`
+
+These are basic render/smoke tests — verify the page renders without crashing, key elements are present, and loading/error states work. Follow the pattern from `Dashboard.test.jsx`.
+
+**Important**: Both pages likely use hooks that fetch data. Mock the API modules (`utils/api.js`, `utils/schedulerApi.js`) and wrap with `QueryClientProvider`. For map-specific components, mock `react-leaflet` since it requires a DOM environment that happy-dom doesn't fully support.
+
+**Step 1: Write basic render tests for both pages**
+
+The implementer should:
+1. Read `GPIO.jsx` and `MapPage.jsx` to understand their structure
+2. Read `Dashboard.test.jsx` for the test pattern
+3. Write smoke tests: renders without crash, shows expected headings/elements, handles loading state
+4. Mock any API calls and heavy dependencies (leaflet/map components)
+
+**Step 2: Run tests**
+
+Run: `cd /home/zane/projects/Mothbox/Firmware/webui/frontend && npx vitest run src/pages/__tests__/GPIO.test.jsx src/pages/__tests__/MapPage.test.jsx`
+Expected: All tests PASS
+
+**Step 3: Commit**
+
+```bash
+git add webui/frontend/src/pages/__tests__/GPIO.test.jsx \
+        webui/frontend/src/pages/__tests__/MapPage.test.jsx
+git commit -m "test(frontend): add smoke tests for GPIO and MapPage (#406)"
+```
+
+---
+
+## Task 6: SavePresetModal Tests (#68)
+
+**Files:**
+- Create: `webui/frontend/src/components/__tests__/SavePresetModal.test.jsx`
+
+`SavePresetModal` (287 lines) is a form modal with:
+- Name input with validation (alphanumeric + underscores, 3-50 chars)
+- Description textarea (optional, 200 char display)
+- Workflow radio buttons (photo/liveview/both)
+- Save button (disabled when name invalid or empty)
+- Cancel button (resets form)
+- Enter key submits
+- Settings validation via `validatePresetSettings()` (only for non-photo workflows)
+- Validation error display (role="alert")
+
+**Dependencies to mock**: `validatePresetSettings` from `../../utils/presetValidation`
+
+```jsx
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import SavePresetModal from '../SavePresetModal'
+
+vi.mock('../../utils/presetValidation', () => ({
+  validatePresetSettings: vi.fn(() => []),
+}))
+
+import { validatePresetSettings } from '../../utils/presetValidation'
+
+describe('SavePresetModal', () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    onSave: vi.fn().mockResolvedValue(undefined),
+    isSaving: false,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    validatePresetSettings.mockReturnValue([])
+  })
+
+  it('returns null when not open', () => {
+    const { container } = render(<SavePresetModal {...defaultProps} isOpen={false} />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders modal when open', () => {
+    render(<SavePresetModal {...defaultProps} />)
+    expect(screen.getByText('Save Current Settings as Preset')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('e.g., my_field_setup')).toBeInTheDocument()
+    expect(screen.getByText('Cancel')).toBeInTheDocument()
+    expect(screen.getByText('Save Preset')).toBeInTheDocument()
+  })
+
+  it('shows validation error for short name', async () => {
+    render(<SavePresetModal {...defaultProps} />)
+    const input = screen.getByPlaceholderText('e.g., my_field_setup')
+    await userEvent.type(input, 'ab')
+    expect(screen.getByText('Name must be at least 3 characters')).toBeInTheDocument()
+  })
+
+  it('shows validation error for invalid characters', async () => {
+    render(<SavePresetModal {...defaultProps} />)
+    const input = screen.getByPlaceholderText('e.g., my_field_setup')
+    await userEvent.type(input, 'my preset!')
+    expect(screen.getByText('Name can only contain letters, numbers, and underscores')).toBeInTheDocument()
+  })
+
+  it('accepts valid name', async () => {
+    render(<SavePresetModal {...defaultProps} />)
+    const input = screen.getByPlaceholderText('e.g., my_field_setup')
+    await userEvent.type(input, 'valid_preset_123')
+    expect(screen.queryByText(/Name must/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Name can only/)).not.toBeInTheDocument()
+  })
+
+  it('save button disabled when name is empty', () => {
+    render(<SavePresetModal {...defaultProps} />)
+    expect(screen.getByText('Save Preset')).toBeDisabled()
+  })
+
+  it('save button enabled with valid name', async () => {
+    render(<SavePresetModal {...defaultProps} />)
+    await userEvent.type(screen.getByPlaceholderText('e.g., my_field_setup'), 'valid_name')
+    expect(screen.getByText('Save Preset')).not.toBeDisabled()
+  })
+
+  it('calls onSave with correct data', async () => {
+    render(<SavePresetModal {...defaultProps} />)
+    await userEvent.type(screen.getByPlaceholderText('e.g., my_field_setup'), 'test_preset')
+    await userEvent.type(screen.getByPlaceholderText('Describe when to use this preset...'), 'A test description')
+    await userEvent.click(screen.getByText('Save Preset'))
+
+    expect(defaultProps.onSave).toHaveBeenCalledWith({
+      name: 'test_preset',
+      description: 'A test description',
+      workflow: 'both',
+      from_current: true,
+    })
+  })
+
+  it('selects photo workflow', async () => {
+    render(<SavePresetModal {...defaultProps} />)
+    await userEvent.type(screen.getByPlaceholderText('e.g., my_field_setup'), 'test_preset')
+    await userEvent.click(screen.getByLabelText(/Photo/))
+    await userEvent.click(screen.getByText('Save Preset'))
+
+    expect(defaultProps.onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ workflow: 'photo' })
+    )
+  })
+
+  it('skips settings validation for photo-only workflow', async () => {
+    render(<SavePresetModal {...defaultProps} />)
+    await userEvent.type(screen.getByPlaceholderText('e.g., my_field_setup'), 'test_preset')
+    await userEvent.click(screen.getByLabelText(/Photo/))
+    await userEvent.click(screen.getByText('Save Preset'))
+
+    expect(validatePresetSettings).not.toHaveBeenCalled()
+  })
+
+  it('validates settings for non-photo workflow', async () => {
+    render(<SavePresetModal {...defaultProps} />)
+    await userEvent.type(screen.getByPlaceholderText('e.g., my_field_setup'), 'test_preset')
+    // Default workflow is 'both', which triggers validation
+    await userEvent.click(screen.getByText('Save Preset'))
+
+    expect(validatePresetSettings).toHaveBeenCalled()
+  })
+
+  it('displays validation errors', async () => {
+    validatePresetSettings.mockReturnValue([
+      { key: 'Brightness', value: '999', message: 'Must be between -1.0 and 1.0' },
+    ])
+
+    render(<SavePresetModal {...defaultProps} />)
+    await userEvent.type(screen.getByPlaceholderText('e.g., my_field_setup'), 'test_preset')
+    await userEvent.click(screen.getByText('Save Preset'))
+
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.getByText('Brightness')).toBeInTheDocument()
+    expect(defaultProps.onSave).not.toHaveBeenCalled()
+  })
+
+  it('calls onClose and resets form on cancel', async () => {
+    render(<SavePresetModal {...defaultProps} />)
+    await userEvent.type(screen.getByPlaceholderText('e.g., my_field_setup'), 'test_preset')
+    await userEvent.click(screen.getByText('Cancel'))
+
+    expect(defaultProps.onClose).toHaveBeenCalled()
+  })
+
+  it('shows saving state', () => {
+    render(<SavePresetModal {...defaultProps} isSaving={true} />)
+    expect(screen.getByText('Saving...')).toBeInTheDocument()
+  })
+
+  it('disables inputs while saving', () => {
+    render(<SavePresetModal {...defaultProps} isSaving={true} />)
+    expect(screen.getByPlaceholderText('e.g., my_field_setup')).toBeDisabled()
+    expect(screen.getByText('Cancel')).toBeDisabled()
+  })
+})
+```
+
+**Step 1: Create test file**
+
+Write the file above.
+
+**Step 2: Run tests**
+
+Run: `cd /home/zane/projects/Mothbox/Firmware/webui/frontend && npx vitest run src/components/__tests__/SavePresetModal.test.jsx`
+Expected: All tests PASS
+
+**Step 3: Commit**
+
+```bash
+git add webui/frontend/src/components/__tests__/SavePresetModal.test.jsx
+git commit -m "test(frontend): add tests for SavePresetModal (#68)"
+```
+
+---
+
+## Task 7: Final Verification
+
+**Step 1: Run all frontend tests**
+
+Run: `cd /home/zane/projects/Mothbox/Firmware/webui/frontend && npx vitest run --reporter=verbose 2>&1 | tail -10`
+Expected: All tests PASS, no regressions
+
+**Step 2: Lint backend**
+
+Run: `ruff check webui/backend/app.py`
+Expected: Clean
+
+**Step 3: Verify git log**
+
+Run: `git log --oneline -6`
+Expected:
+```
+abc123 test(frontend): add tests for SavePresetModal (#68)
+def456 test(frontend): add smoke tests for GPIO and MapPage (#406)
+ghi789 test(frontend): add tests for useSelection and useValidateDraft hooks (#406)
+jkl012 test(frontend): add coverage threshold to vitest config (#406)
+mno345 ci(frontend): add GitHub Actions workflow with 4-shard parallelization (#406)
+pqr678 fix(backend): wire up orphaned lock cleanup at startup (#408)
+```

--- a/Firmware/webui/backend/app.py
+++ b/Firmware/webui/backend/app.py
@@ -307,6 +307,26 @@ except Exception as e:
     logger.warning(f"Failed to initialize deployment service: {e}")
     app.config["DEPLOYMENT_SERVICE"] = None
 
+# Clean up orphaned lock files from previous sessions (#408)
+# These functions already exist and are tested — we just need to invoke them at startup.
+try:
+    from webui.backend.lib.schedule_storage import cleanup_temp_files as cleanup_schedule_locks
+
+    removed = cleanup_schedule_locks()
+    if removed > 0:
+        logger.info(f"Cleaned up {removed} orphaned schedule lock file(s)")
+except Exception as e:
+    logger.warning(f"Schedule lock cleanup failed (non-fatal): {e}")
+
+try:
+    from webui.backend.lib.deployment_sidecar import cleanup_temp_files as cleanup_deployment_locks
+
+    removed = cleanup_deployment_locks(PHOTOS_DIR)
+    if removed > 0:
+        logger.info(f"Cleaned up {removed} orphaned deployment lock file(s)")
+except Exception as e:
+    logger.warning(f"Deployment lock cleanup failed (non-fatal): {e}")
+
 # Initialize export preset manager
 from mothbox_paths import EXPORT_BUILTIN_PRESET_DIR, EXPORT_USER_PRESET_DIR
 from webui.backend.export_preset_manager import ExportPresetManager

--- a/Firmware/webui/frontend/src/components/__tests__/SavePresetModal.test.jsx
+++ b/Firmware/webui/frontend/src/components/__tests__/SavePresetModal.test.jsx
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import SavePresetModal from '../SavePresetModal'
+import { validatePresetSettings } from '../../utils/presetValidation'
+
+// Mock the preset validation module
+vi.mock('../../utils/presetValidation', () => ({
+  validatePresetSettings: vi.fn(() => []),
+}))
+
+describe('SavePresetModal', () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    onSave: vi.fn().mockResolvedValue(undefined),
+    isSaving: false,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    validatePresetSettings.mockReturnValue([])
+  })
+
+  const renderModal = (props = {}) => {
+    return render(<SavePresetModal {...defaultProps} {...props} />)
+  }
+
+  it('returns null when isOpen is false', () => {
+    const { container } = renderModal({ isOpen: false })
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders modal when open with title, inputs, and buttons', () => {
+    renderModal()
+
+    expect(screen.getByText(/Save Current Settings as Preset/i)).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('e.g., my_field_setup')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Describe when to use this preset...')).toBeInTheDocument()
+    expect(screen.getByText('Cancel')).toBeInTheDocument()
+    expect(screen.getByText('Save Preset')).toBeInTheDocument()
+  })
+
+  it('shows validation error for short name (< 3 chars)', async () => {
+    const user = userEvent.setup()
+    renderModal()
+
+    const nameInput = screen.getByPlaceholderText('e.g., my_field_setup')
+    await user.type(nameInput, 'ab')
+
+    expect(screen.getByText('Name must be at least 3 characters')).toBeInTheDocument()
+  })
+
+  it('shows validation error for invalid characters', async () => {
+    const user = userEvent.setup()
+    renderModal()
+
+    const nameInput = screen.getByPlaceholderText('e.g., my_field_setup')
+    await user.type(nameInput, 'my preset!')
+
+    expect(screen.getByText('Name can only contain letters, numbers, and underscores')).toBeInTheDocument()
+  })
+
+  it('accepts valid name without showing validation errors', async () => {
+    const user = userEvent.setup()
+    renderModal()
+
+    const nameInput = screen.getByPlaceholderText('e.g., my_field_setup')
+    await user.type(nameInput, 'my_valid_preset')
+
+    expect(screen.queryByText('Name must be at least 3 characters')).not.toBeInTheDocument()
+    expect(screen.queryByText('Name can only contain letters, numbers, and underscores')).not.toBeInTheDocument()
+    expect(screen.queryByText('Preset name is required')).not.toBeInTheDocument()
+  })
+
+  it('disables save button when name is empty', () => {
+    renderModal()
+
+    const saveButton = screen.getByText('Save Preset')
+    expect(saveButton).toBeDisabled()
+  })
+
+  it('enables save button with valid name', async () => {
+    const user = userEvent.setup()
+    renderModal()
+
+    const nameInput = screen.getByPlaceholderText('e.g., my_field_setup')
+    await user.type(nameInput, 'valid_name')
+
+    const saveButton = screen.getByText('Save Preset')
+    expect(saveButton).not.toBeDisabled()
+  })
+
+  it('calls onSave with correct data (name, description, workflow, from_current)', async () => {
+    const user = userEvent.setup()
+    renderModal()
+
+    const nameInput = screen.getByPlaceholderText('e.g., my_field_setup')
+    await user.type(nameInput, 'test_preset')
+
+    const descInput = screen.getByPlaceholderText('Describe when to use this preset...')
+    await user.type(descInput, 'A test description')
+
+    const saveButton = screen.getByText('Save Preset')
+    await user.click(saveButton)
+
+    expect(defaultProps.onSave).toHaveBeenCalledWith({
+      name: 'test_preset',
+      description: 'A test description',
+      workflow: 'both',
+      from_current: true,
+    })
+  })
+
+  it('selects photo workflow correctly', async () => {
+    const user = userEvent.setup()
+    renderModal()
+
+    // Select photo workflow — use exact label text to avoid matching "Both (Photo & Live View)"
+    const photoRadio = screen.getByRole('radio', { name: /Photo.*Capture only/i })
+    await user.click(photoRadio)
+    expect(photoRadio).toBeChecked()
+
+    // Fill in name and save
+    const nameInput = screen.getByPlaceholderText('e.g., my_field_setup')
+    await user.type(nameInput, 'photo_preset')
+
+    const saveButton = screen.getByText('Save Preset')
+    await user.click(saveButton)
+
+    expect(defaultProps.onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ workflow: 'photo' })
+    )
+  })
+
+  it('skips settings validation for photo-only workflow', async () => {
+    const user = userEvent.setup()
+    renderModal({ currentSettings: { sharpness: 99 } })
+
+    // Select photo workflow — use exact label text to avoid matching "Both (Photo & Live View)"
+    const photoRadio = screen.getByRole('radio', { name: /Photo.*Capture only/i })
+    await user.click(photoRadio)
+
+    // Fill in name and save
+    const nameInput = screen.getByPlaceholderText('e.g., my_field_setup')
+    await user.type(nameInput, 'photo_only')
+
+    const saveButton = screen.getByText('Save Preset')
+    await user.click(saveButton)
+
+    expect(validatePresetSettings).not.toHaveBeenCalled()
+    expect(defaultProps.onSave).toHaveBeenCalled()
+  })
+
+  it('validates settings for non-photo workflow', async () => {
+    const user = userEvent.setup()
+    const settings = { sharpness: 2.0 }
+    renderModal({ currentSettings: settings })
+
+    // Default workflow is 'both' (non-photo), fill name and save
+    const nameInput = screen.getByPlaceholderText('e.g., my_field_setup')
+    await user.type(nameInput, 'both_preset')
+
+    const saveButton = screen.getByText('Save Preset')
+    await user.click(saveButton)
+
+    expect(validatePresetSettings).toHaveBeenCalledWith(settings)
+  })
+
+  it('displays validation errors from validatePresetSettings with role="alert"', async () => {
+    const user = userEvent.setup()
+    validatePresetSettings.mockReturnValue([
+      { key: 'sharpness', value: 99, message: 'Sharpness must be between 0.0 and 4.0' },
+    ])
+
+    renderModal({ currentSettings: { sharpness: 99 } })
+
+    const nameInput = screen.getByPlaceholderText('e.g., my_field_setup')
+    await user.type(nameInput, 'bad_settings')
+
+    const saveButton = screen.getByText('Save Preset')
+    await user.click(saveButton)
+
+    // Should NOT call onSave
+    expect(defaultProps.onSave).not.toHaveBeenCalled()
+
+    // Should display validation errors in an alert role
+    const alert = screen.getByRole('alert')
+    expect(alert).toBeInTheDocument()
+    expect(screen.getByText('sharpness')).toBeInTheDocument()
+    expect(screen.getByText('99')).toBeInTheDocument()
+    expect(screen.getByText('Sharpness must be between 0.0 and 4.0')).toBeInTheDocument()
+  })
+
+  it('calls onClose when cancel button is clicked', async () => {
+    const user = userEvent.setup()
+    renderModal()
+
+    const cancelButton = screen.getByText('Cancel')
+    await user.click(cancelButton)
+
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows saving state with "Saving..." text and disabled inputs', () => {
+    renderModal({ isSaving: true })
+
+    expect(screen.getByText('Saving...')).toBeInTheDocument()
+
+    const nameInput = screen.getByPlaceholderText('e.g., my_field_setup')
+    expect(nameInput).toBeDisabled()
+
+    const descInput = screen.getByPlaceholderText('Describe when to use this preset...')
+    expect(descInput).toBeDisabled()
+
+    const cancelButton = screen.getByText('Cancel')
+    expect(cancelButton).toBeDisabled()
+  })
+})

--- a/Firmware/webui/frontend/src/hooks/__tests__/useSelection.test.jsx
+++ b/Firmware/webui/frontend/src/hooks/__tests__/useSelection.test.jsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import React from 'react'
+import useSelection from '../useSelection'
+import { SelectionProvider } from '../../contexts/SelectionContext'
+
+const wrapper = ({ children }) => (
+  <SelectionProvider>{children}</SelectionProvider>
+)
+
+describe('useSelection', () => {
+  it('throws when used outside SelectionProvider', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    expect(() => renderHook(() => useSelection())).toThrow(
+      'useSelection must be used within SelectionProvider'
+    )
+    spy.mockRestore()
+  })
+
+  it('returns context value when inside SelectionProvider', () => {
+    const { result } = renderHook(() => useSelection(), { wrapper })
+    expect(result.current).toBeDefined()
+    expect(result.current.isSelectMode).toBe(false)
+    expect(result.current.selectedCount).toBe(0)
+    expect(typeof result.current.toggleSelectMode).toBe('function')
+    expect(typeof result.current.selectPhoto).toBe('function')
+    expect(typeof result.current.deselectPhoto).toBe('function')
+    expect(typeof result.current.isSelected).toBe('function')
+  })
+
+  it('provides all expected context properties', () => {
+    const { result } = renderHook(() => useSelection(), { wrapper })
+    const expectedKeys = [
+      'isSelectMode', 'selectedPhotos', 'lastClickedIndex',
+      'selectedCount', 'selectedArray',
+      'toggleSelectMode', 'selectPhoto', 'deselectPhoto',
+      'togglePhoto', 'selectRange', 'selectAll', 'deselectAll', 'isSelected',
+    ]
+    expectedKeys.forEach(key => {
+      expect(result.current).toHaveProperty(key)
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/hooks/__tests__/useValidateDraft.test.jsx
+++ b/Firmware/webui/frontend/src/hooks/__tests__/useValidateDraft.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { renderHook, act, waitFor } from '@testing-library/react'
+import { renderHook, act } from '@testing-library/react'
 import React from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useValidateDraft } from '../useValidateDraft'

--- a/Firmware/webui/frontend/src/hooks/__tests__/useValidateDraft.test.jsx
+++ b/Firmware/webui/frontend/src/hooks/__tests__/useValidateDraft.test.jsx
@@ -1,0 +1,253 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import React from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useValidateDraft } from '../useValidateDraft'
+import * as schedulerApi from '../../utils/schedulerApi'
+
+vi.mock('../../utils/schedulerApi')
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+  return ({ children }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+const validRoutine = {
+  trigger: { trigger_type: 'interval' },
+  actions: [{ type: 'takephoto' }],
+}
+
+/**
+ * Helper: advance fake timers past the debounce delay and flush all pending
+ * promises so React Query can resolve its queryFn.
+ */
+async function flushDebounceAndQuery() {
+  // Advance past the 400ms debounce
+  act(() => {
+    vi.advanceTimersByTime(500)
+  })
+  // Flush pending microtasks / promises (React Query queryFn resolution)
+  await act(async () => {
+    await vi.runAllTimersAsync()
+  })
+}
+
+describe('useValidateDraft', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('returns initial state', () => {
+    const { result } = renderHook(() => useValidateDraft(), {
+      wrapper: createWrapper(),
+    })
+    // React Query data is undefined when query is disabled (no routines yet)
+    expect(result.current.conflictReport).toBeUndefined()
+    expect(result.current.isValidating).toBe(false)
+    expect(result.current.isError).toBe(false)
+    expect(result.current.error).toBeNull()
+    expect(typeof result.current.validateDraft).toBe('function')
+    expect(typeof result.current.reset).toBe('function')
+  })
+
+  it('debounces validation calls', () => {
+    const { result } = renderHook(() => useValidateDraft(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.validateDraft([validRoutine])
+    })
+
+    expect(schedulerApi.validateDraftRoutines).not.toHaveBeenCalled()
+  })
+
+  it('triggers validation after debounce delay', async () => {
+    const mockResponse = { data: { conflicts: [], total_conflicts: 0 } }
+    schedulerApi.validateDraftRoutines.mockResolvedValue(mockResponse)
+
+    const { result } = renderHook(() => useValidateDraft(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.validateDraft([validRoutine])
+    })
+
+    await flushDebounceAndQuery()
+
+    expect(schedulerApi.validateDraftRoutines).toHaveBeenCalledTimes(1)
+  })
+
+  it('filters routines without trigger_type or actions', async () => {
+    const mockResponse = { data: { conflicts: [], total_conflicts: 0 } }
+    schedulerApi.validateDraftRoutines.mockResolvedValue(mockResponse)
+
+    const { result } = renderHook(() => useValidateDraft(), {
+      wrapper: createWrapper(),
+    })
+
+    const routines = [
+      validRoutine,
+      { trigger: {}, actions: [{ type: 'takephoto' }] },
+      { trigger: { trigger_type: 'interval' }, actions: [] },
+      null,
+    ]
+
+    act(() => {
+      result.current.validateDraft(routines)
+    })
+
+    await flushDebounceAndQuery()
+
+    expect(schedulerApi.validateDraftRoutines).toHaveBeenCalledTimes(1)
+    const callArgs = schedulerApi.validateDraftRoutines.mock.calls[0][0]
+    expect(callArgs.routines).toHaveLength(1)
+  })
+
+  it('does not call API when all routines are invalid', async () => {
+    const { result } = renderHook(() => useValidateDraft(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.validateDraft([{ trigger: {}, actions: [] }])
+    })
+
+    await flushDebounceAndQuery()
+
+    expect(schedulerApi.validateDraftRoutines).not.toHaveBeenCalled()
+  })
+
+  it('passes options to API call', async () => {
+    const mockResponse = { data: { conflicts: [], total_conflicts: 0 } }
+    schedulerApi.validateDraftRoutines.mockResolvedValue(mockResponse)
+
+    const { result } = renderHook(
+      () => useValidateDraft({ days: 3, latitude: 9.0, longitude: -79.5, timezone: 'America/Panama' }),
+      { wrapper: createWrapper() }
+    )
+
+    act(() => {
+      result.current.validateDraft([validRoutine])
+    })
+
+    await flushDebounceAndQuery()
+
+    const callArgs = schedulerApi.validateDraftRoutines.mock.calls[0][0]
+    expect(callArgs.days).toBe(3)
+    expect(callArgs.latitude).toBe(9.0)
+    expect(callArgs.longitude).toBe(-79.5)
+    expect(callArgs.timezone).toBe('America/Panama')
+  })
+
+  it('returns conflict report after validation', async () => {
+    const mockReport = {
+      conflicts: [{ type: 'time_overlap', severity: 'warning' }],
+      total_conflicts: 1,
+    }
+    schedulerApi.validateDraftRoutines.mockResolvedValue({ data: mockReport })
+
+    const { result } = renderHook(() => useValidateDraft(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.validateDraft([validRoutine])
+    })
+
+    await flushDebounceAndQuery()
+
+    expect(result.current.conflictReport).toEqual(mockReport)
+  })
+
+  it('handles API errors', async () => {
+    schedulerApi.validateDraftRoutines.mockRejectedValue(new Error('Network error'))
+
+    const { result } = renderHook(() => useValidateDraft(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.validateDraft([validRoutine])
+    })
+
+    await flushDebounceAndQuery()
+
+    expect(result.current.isError).toBe(true)
+    expect(result.current.error).toBeTruthy()
+  })
+
+  it('resets state when reset is called', async () => {
+    const mockResponse = { data: { conflicts: [], total_conflicts: 0 } }
+    schedulerApi.validateDraftRoutines.mockResolvedValue(mockResponse)
+
+    const { result } = renderHook(() => useValidateDraft(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.validateDraft([validRoutine])
+    })
+
+    await flushDebounceAndQuery()
+
+    expect(result.current.conflictReport).toBeDefined()
+
+    act(() => {
+      result.current.reset()
+    })
+
+    // After reset, debouncedRoutines is null, query is disabled, data reverts to undefined
+    await act(async () => {
+      await vi.runAllTimersAsync()
+    })
+
+    expect(result.current.conflictReport).toBeUndefined()
+  })
+
+  it('cancels pending debounce on reset', async () => {
+    const { result } = renderHook(() => useValidateDraft(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.validateDraft([validRoutine])
+    })
+
+    act(() => {
+      result.current.reset()
+    })
+
+    await flushDebounceAndQuery()
+
+    expect(schedulerApi.validateDraftRoutines).not.toHaveBeenCalled()
+  })
+
+  it('handles null/undefined routines array', async () => {
+    const { result } = renderHook(() => useValidateDraft(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.validateDraft(null)
+    })
+
+    await flushDebounceAndQuery()
+
+    expect(schedulerApi.validateDraftRoutines).not.toHaveBeenCalled()
+  })
+})

--- a/Firmware/webui/frontend/src/pages/__tests__/GPIO.test.jsx
+++ b/Firmware/webui/frontend/src/pages/__tests__/GPIO.test.jsx
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import GPIO from '../GPIO'
+import * as api from '../../utils/api'
+
+// Mock the API module
+vi.mock('../../utils/api', () => ({
+  getGpioStatus: vi.fn(),
+  controlGpio: vi.fn(),
+  triggerFlash: vi.fn(),
+}))
+
+describe('GPIO', () => {
+  let queryClient
+
+  const mockGpioStatus = {
+    Relay_Ch1: false,
+    Relay_Ch2: true,
+    Relay_Ch3: false,
+  }
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    })
+
+    vi.clearAllMocks()
+
+    // Set default mock response
+    api.getGpioStatus.mockResolvedValue({ data: mockGpioStatus })
+  })
+
+  const renderComponent = () => {
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <GPIO />
+      </QueryClientProvider>
+    )
+  }
+
+  it('renders loading state initially', () => {
+    // Use a never-resolving promise to keep loading state
+    api.getGpioStatus.mockImplementation(() => new Promise(() => {}))
+    renderComponent()
+    expect(screen.getByText(/Loading GPIO status.../i)).toBeInTheDocument()
+  })
+
+  it('renders page heading after loading', async () => {
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByText('GPIO Controls')).toBeInTheDocument()
+    })
+  })
+
+  it('renders all three relay control cards', async () => {
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByText('Attract Lights')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Photo Flash')).toBeInTheDocument()
+    expect(screen.getByText('UV Light')).toBeInTheDocument()
+  })
+
+  it('displays relay channel labels', async () => {
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByText('Relay Ch1')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Relay Ch2')).toBeInTheDocument()
+    expect(screen.getByText('Relay Ch3')).toBeInTheDocument()
+  })
+
+  it('displays correct ON/OFF states from API data', async () => {
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByText('GPIO Controls')).toBeInTheDocument()
+    })
+
+    // Relay_Ch1 is false -> OFF, Relay_Ch2 is true -> ON, Relay_Ch3 is false -> OFF
+    const offButtons = screen.getAllByText('OFF')
+    const onButtons = screen.getAllByText('ON')
+    expect(offButtons).toHaveLength(2)
+    expect(onButtons).toHaveLength(1)
+  })
+
+  it('renders the flash trigger button', async () => {
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByText(/Trigger Flash/i)).toBeInTheDocument()
+    })
+  })
+
+  it('displays the hardware note', async () => {
+    renderComponent()
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/GPIO controls interact directly with the Mothbox hardware/i)
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('displays error state when GPIO returns an error', async () => {
+    api.getGpioStatus.mockResolvedValue({
+      data: { error: 'GPIO not available on this platform' },
+    })
+
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByText('GPIO not available on this platform')).toBeInTheDocument()
+    })
+
+    expect(
+      screen.getByText(/GPIO may not be available in this environment/i)
+    ).toBeInTheDocument()
+  })
+
+  it('calls controlGpio when a relay toggle is clicked', async () => {
+    const user = userEvent.setup()
+    api.controlGpio.mockResolvedValue({ data: { success: true } })
+
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByText('Attract Lights')).toBeInTheDocument()
+    })
+
+    // Click the Relay_Ch1 OFF button (first OFF button in the grid)
+    const offButtons = screen.getAllByText('OFF')
+    await user.click(offButtons[0])
+
+    expect(api.controlGpio).toHaveBeenCalledWith('Relay_Ch1', true)
+  })
+
+  it('calls triggerFlash when flash button is clicked', async () => {
+    const user = userEvent.setup()
+    api.triggerFlash.mockResolvedValue({ data: { success: true } })
+
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByText(/Trigger Flash/i)).toBeInTheDocument()
+    })
+
+    const flashButton = screen.getByText(/Trigger Flash/i)
+    await user.click(flashButton)
+
+    expect(api.triggerFlash).toHaveBeenCalled()
+  })
+
+  it('does not show loading text after data has loaded', async () => {
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByText('GPIO Controls')).toBeInTheDocument()
+    })
+
+    expect(screen.queryByText(/Loading GPIO status.../i)).not.toBeInTheDocument()
+  })
+})

--- a/Firmware/webui/frontend/src/pages/__tests__/MapPage.test.jsx
+++ b/Firmware/webui/frontend/src/pages/__tests__/MapPage.test.jsx
@@ -1,0 +1,340 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import MapPage from '../MapPage'
+import * as api from '../../utils/api'
+
+// Mock the API module
+vi.mock('../../utils/api', () => ({
+  getPhotosPaginated: vi.fn(),
+  getClusteredLocations: vi.fn(),
+}))
+
+// Mock react-leaflet (Leaflet has issues in happy-dom/jsdom)
+vi.mock('react-leaflet', () => ({
+  MapContainer: ({ children, ...props }) => (
+    <div data-testid="map-container" {...props}>
+      {children}
+    </div>
+  ),
+  TileLayer: (props) => <div data-testid="tile-layer" {...props} />,
+  Marker: ({ children, ...props }) => (
+    <div data-testid="marker" {...props}>
+      {children}
+    </div>
+  ),
+  Popup: ({ children, ...props }) => (
+    <div data-testid="popup" {...props}>
+      {children}
+    </div>
+  ),
+  useMap: () => ({
+    fitBounds: vi.fn(),
+    getBounds: vi.fn(),
+    setView: vi.fn(),
+    getZoom: vi.fn(() => 13),
+    flyTo: vi.fn(),
+  }),
+}))
+
+// Mock react-leaflet-cluster
+vi.mock('react-leaflet-cluster', () => ({
+  default: ({ children, ...props }) => (
+    <div data-testid="marker-cluster-group" {...props}>
+      {children}
+    </div>
+  ),
+}))
+
+// Mock leaflet
+vi.mock('leaflet', () => ({
+  default: {
+    Icon: class MockIcon {
+      constructor(options) {
+        this.options = options
+      }
+    },
+    divIcon: vi.fn((options) => ({
+      options,
+      _type: 'divIcon',
+      _getIconUrl: vi.fn(),
+    })),
+  },
+}))
+
+// Mock MapView component (already tested separately)
+// vi.mock factories are hoisted and cannot reference top-level imports.
+// Use a plain function component; the ref prop is simply ignored for smoke tests.
+vi.mock('../../components/MapView', () => ({
+  default: ({ isLoading, locations, clusters, className }) => (
+    <div data-testid="map-view" className={className}>
+      {isLoading ? (
+        <div data-testid="map-loading">Loading map...</div>
+      ) : (
+        <div data-testid="map-content">
+          Map with {(locations || []).length} locations and{' '}
+          {(clusters || []).length} clusters
+        </div>
+      )}
+    </div>
+  ),
+}))
+
+// Mock PhotoLightbox component
+vi.mock('../../components/PhotoLightbox', () => ({
+  default: ({ photo, onClose }) =>
+    photo ? (
+      <div data-testid="photo-lightbox">
+        <span>{photo.filename}</span>
+        <button onClick={onClose}>Close</button>
+      </div>
+    ) : null,
+}))
+
+// Mock ErrorBoundary component
+vi.mock('../../components/ErrorBoundary', () => ({
+  default: ({ children }) => <div data-testid="error-boundary">{children}</div>,
+}))
+
+// Mock LightboxErrorFallback component
+vi.mock('../../components/LightboxErrorFallback', () => ({
+  default: ({ error, onClose }) => (
+    <div data-testid="lightbox-error-fallback">Error: {error?.message}</div>
+  ),
+}))
+
+// Mock useClusteredLocations hook
+vi.mock('../../hooks/useClusteredLocations', () => ({
+  useClusteredLocations: vi.fn(),
+  default: vi.fn(),
+}))
+
+// Mock useMapLightboxSync hook
+vi.mock('../../hooks/useMapLightboxSync', () => ({
+  default: vi.fn(),
+}))
+
+// Mock heroicons
+vi.mock('@heroicons/react/24/outline', () => ({
+  ArrowLeftIcon: (props) => <svg data-testid="arrow-left-icon" {...props} />,
+  ExclamationTriangleIcon: (props) => (
+    <svg data-testid="exclamation-icon" {...props} />
+  ),
+  ArrowPathIcon: (props) => <svg data-testid="arrow-path-icon" {...props} />,
+}))
+
+// Now import the mocked modules so we can control them
+import { useClusteredLocations } from '../../hooks/useClusteredLocations'
+import useMapLightboxSync from '../../hooks/useMapLightboxSync'
+
+describe('MapPage', () => {
+  let queryClient
+
+  const defaultClusteredLocations = {
+    clusters: [],
+    unclustered: [],
+    metadata: { total_without_gps: 0 },
+    isLoading: false,
+    isPartialResult: false,
+    partialWarning: null,
+    settings: { enabled: true, radius: 100 },
+    setEnabled: vi.fn(),
+    setRadius: vi.fn(),
+    refetch: vi.fn(),
+  }
+
+  const defaultMapLightboxSync = {
+    currentPhoto: null,
+    highlightedPhotoPath: null,
+    openLightbox: vi.fn(),
+    closeLightbox: vi.fn(),
+    onMarkerClick: vi.fn(),
+    onClusterClick: vi.fn(),
+  }
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    })
+
+    vi.clearAllMocks()
+
+    // Set default mock responses
+    api.getPhotosPaginated.mockResolvedValue({
+      data: {
+        photos: [],
+        pagination: { has_next: false, offset: 0, limit: 200 },
+      },
+    })
+
+    useClusteredLocations.mockReturnValue(defaultClusteredLocations)
+    useMapLightboxSync.mockReturnValue(defaultMapLightboxSync)
+  })
+
+  const renderComponent = () => {
+    return render(
+      <MemoryRouter>
+        <QueryClientProvider client={queryClient}>
+          <MapPage />
+        </QueryClientProvider>
+      </MemoryRouter>
+    )
+  }
+
+  it('renders without crashing', () => {
+    renderComponent()
+    expect(screen.getByText('Photo Locations')).toBeInTheDocument()
+  })
+
+  it('renders the page heading', () => {
+    renderComponent()
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      'Photo Locations'
+    )
+  })
+
+  it('renders the back to gallery link', () => {
+    renderComponent()
+    const backLink = screen.getByLabelText('Back to gallery')
+    expect(backLink).toBeInTheDocument()
+    expect(backLink).toHaveAttribute('href', '/gallery')
+  })
+
+  it('renders MapView component', () => {
+    renderComponent()
+    expect(screen.getByTestId('map-view')).toBeInTheDocument()
+  })
+
+  it('renders ErrorBoundary wrapper for lightbox', () => {
+    renderComponent()
+    expect(screen.getByTestId('error-boundary')).toBeInTheDocument()
+  })
+
+  it('displays photo count when locations are loaded', () => {
+    useClusteredLocations.mockReturnValue({
+      ...defaultClusteredLocations,
+      unclustered: [
+        {
+          path: 'photo1.jpg',
+          filename: 'photo1.jpg',
+          latitude: 37.7749,
+          longitude: -122.4194,
+          lat: 37.7749,
+          lon: -122.4194,
+        },
+      ],
+    })
+
+    renderComponent()
+
+    expect(screen.getByText(/1 photo with GPS coordinates/)).toBeInTheDocument()
+  })
+
+  it('displays plural photo count for multiple locations', () => {
+    useClusteredLocations.mockReturnValue({
+      ...defaultClusteredLocations,
+      unclustered: [
+        {
+          path: 'photo1.jpg',
+          filename: 'photo1.jpg',
+          latitude: 37.7749,
+          longitude: -122.4194,
+          lat: 37.7749,
+          lon: -122.4194,
+        },
+        {
+          path: 'photo2.jpg',
+          filename: 'photo2.jpg',
+          latitude: 34.0522,
+          longitude: -118.2437,
+          lat: 34.0522,
+          lon: -118.2437,
+        },
+      ],
+    })
+
+    renderComponent()
+
+    expect(screen.getByText(/2 photos with GPS coordinates/)).toBeInTheDocument()
+  })
+
+  it('shows count of photos without GPS when present', () => {
+    useClusteredLocations.mockReturnValue({
+      ...defaultClusteredLocations,
+      unclustered: [
+        {
+          path: 'photo1.jpg',
+          filename: 'photo1.jpg',
+          latitude: 37.7749,
+          longitude: -122.4194,
+          lat: 37.7749,
+          lon: -122.4194,
+        },
+      ],
+      metadata: { total_without_gps: 5 },
+    })
+
+    renderComponent()
+
+    expect(screen.getByText(/5 photos without GPS/)).toBeInTheDocument()
+  })
+
+  it('does not show photo count while loading', () => {
+    useClusteredLocations.mockReturnValue({
+      ...defaultClusteredLocations,
+      isLoading: true,
+    })
+
+    renderComponent()
+
+    expect(
+      screen.queryByText(/photo.*with GPS coordinates/)
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows partial results warning when applicable', () => {
+    useClusteredLocations.mockReturnValue({
+      ...defaultClusteredLocations,
+      isPartialResult: true,
+      partialWarning: 'Clustering timed out, showing partial results',
+    })
+
+    renderComponent()
+
+    expect(
+      screen.getByText('Clustering timed out, showing partial results')
+    ).toBeInTheDocument()
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+  })
+
+  it('shows retry button when partial results are shown', () => {
+    useClusteredLocations.mockReturnValue({
+      ...defaultClusteredLocations,
+      isPartialResult: true,
+      partialWarning: 'Timeout',
+    })
+
+    renderComponent()
+
+    expect(
+      screen.getByLabelText('Retry loading all locations')
+    ).toBeInTheDocument()
+  })
+
+  it('does not show partial warning when results are complete', () => {
+    renderComponent()
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('does not render lightbox when no photo is selected', () => {
+    renderComponent()
+
+    expect(screen.queryByTestId('photo-lightbox')).not.toBeInTheDocument()
+  })
+})

--- a/Firmware/webui/frontend/src/pages/__tests__/MapPage.test.jsx
+++ b/Firmware/webui/frontend/src/pages/__tests__/MapPage.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter } from 'react-router-dom'
 import MapPage from '../MapPage'
@@ -99,7 +99,7 @@ vi.mock('../../components/ErrorBoundary', () => ({
 
 // Mock LightboxErrorFallback component
 vi.mock('../../components/LightboxErrorFallback', () => ({
-  default: ({ error, onClose }) => (
+  default: ({ error }) => (
     <div data-testid="lightbox-error-fallback">Error: {error?.message}</div>
   ),
 }))

--- a/Firmware/webui/frontend/vitest.config.js
+++ b/Firmware/webui/frontend/vitest.config.js
@@ -44,7 +44,13 @@ export default defineConfig({
       exclude: [
         'node_modules/',
         'src/setupTests.js',
-      ]
+      ],
+      thresholds: {
+        statements: 70,
+        branches: 60,
+        functions: 70,
+        lines: 70,
+      },
     }
   },
 })


### PR DESCRIPTION
## Summary

- **#408**: Wire up orphaned lock file cleanup at Flask startup (schedule + deployment locks, non-fatal)
- **#406**: Add GitHub Actions CI workflow with 4-shard test parallelization, vitest coverage thresholds (70/60/70/70), hook tests (useSelection, useValidateDraft), and page smoke tests (GPIO, MapPage)
- **#68**: Add 14 tests for SavePresetModal covering render states, name validation, workflow selection, settings validation, and save/cancel behavior

## Test plan

- [x] All 5,774 frontend tests pass (221 files, 0 regressions)
- [x] Backend lint clean (`ruff check webui/backend/app.py`)
- [x] 52 new tests across 6 files: useSelection (3), useValidateDraft (11), GPIO (11), MapPage (13), SavePresetModal (14)
- [ ] Verify CI workflow triggers on push to dev
- [ ] Verify coverage thresholds don't block existing coverage levels

Closes #408, closes #406, closes #68