### PR TITLE
Migrate BulkSpeciesModal to react-hook-form + Zod (#441)

### DIFF
--- a/Firmware/webui/frontend/src/components/gallery/BulkSpeciesModal.tsx
+++ b/Firmware/webui/frontend/src/components/gallery/BulkSpeciesModal.tsx
@@ -6,13 +6,24 @@ import { XMarkIcon } from '@heroicons/react/24/outline'
 import { speciesSchema, CONFIDENCE_VALUES, type SpeciesFormData } from '../../schemas/species'
 import { SPECIES_CONFIG, Z_INDEX } from '../../constants/config'
 
+/** Snake_case payload sent to the parent's onApply callback. */
+export interface SpeciesPayload {
+  species: string
+  species_common_name?: string
+  species_confidence: typeof CONFIDENCE_VALUES[number]
+}
+
+const DEFAULT_VALUES: SpeciesFormData = {
+  species: '', commonName: '', confidence: 'probable', referenceUrl: '',
+}
+
 interface BulkSpeciesModalProps {
   /** Whether the modal is open */
   isOpen: boolean
   /** Close handler */
   onClose: () => void
   /** Apply handler - receives { species, species_common_name?, species_confidence } */
-  onApply: (data: { species: string; species_common_name?: string; species_confidence: typeof CONFIDENCE_VALUES[number] }) => void
+  onApply: (data: SpeciesPayload) => void
   /** Number of selected photos */
   selectedCount: number
   /** Loading state */
@@ -37,14 +48,14 @@ export default function BulkSpeciesModal({
     formState: { errors: formErrors },
   } = useForm<SpeciesFormData>({
     resolver: zodResolver(speciesSchema),
-    defaultValues: { species: '', commonName: '', confidence: 'probable', referenceUrl: '' },
+    defaultValues: DEFAULT_VALUES,
     mode: 'onBlur',
   })
 
   // Reset form when modal closes
   useEffect(() => {
     if (!isOpen) {
-      reset({ species: '', commonName: '', confidence: 'probable', referenceUrl: '' })
+      reset(DEFAULT_VALUES)
     }
   }, [isOpen, reset])
 
@@ -68,7 +79,7 @@ export default function BulkSpeciesModal({
 
     if (!species) return
 
-    const payload: { species: string; species_common_name?: string; species_confidence: typeof CONFIDENCE_VALUES[number] } = {
+    const payload: SpeciesPayload = {
       species,
       species_confidence: data.confidence,
     }
@@ -195,6 +206,8 @@ export default function BulkSpeciesModal({
               ))}
             </select>
           </div>
+
+          {/* referenceUrl — not shown in bulk modal; used by MetadataSpecies (Phase 2) */}
 
           {/* Error message */}
           {error && (

--- a/Firmware/webui/frontend/src/components/gallery/BulkSpeciesModal.tsx
+++ b/Firmware/webui/frontend/src/components/gallery/BulkSpeciesModal.tsx
@@ -51,11 +51,11 @@ export default function BulkSpeciesModal({
   useEffect(() => {
     if (!isOpen) return
     const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose()
+      if (e.key === 'Escape' && !isLoading) onClose()
     }
     document.addEventListener('keydown', handleEscape)
     return () => document.removeEventListener('keydown', handleEscape)
-  }, [isOpen, onClose])
+  }, [isOpen, isLoading, onClose])
 
   if (!isOpen) return null
 
@@ -82,10 +82,10 @@ export default function BulkSpeciesModal({
 
   const modal = (
     <div className={`fixed inset-0 ${Z_INDEX.MODAL} flex items-center justify-center`}>
-      {/* Backdrop with click-to-close */}
+      {/* Backdrop with click-to-close (guarded during loading) */}
       <div
         className="absolute inset-0 bg-black/50"
-        onClick={onClose}
+        onClick={() => { if (!isLoading) onClose() }}
       />
 
       {/* Modal content */}
@@ -103,10 +103,11 @@ export default function BulkSpeciesModal({
             Set species for {selectedCount} photo{selectedCount !== 1 ? 's' : ''}
           </h2>
           <button
-            onClick={onClose}
+            onClick={() => { if (!isLoading) onClose() }}
             aria-label="Close modal"
-            className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
+            className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded disabled:opacity-50 disabled:cursor-not-allowed"
             type="button"
+            disabled={isLoading}
           >
             <XMarkIcon className="h-5 w-5" />
           </button>
@@ -170,7 +171,7 @@ export default function BulkSpeciesModal({
                          text-gray-900 dark:text-gray-100
                          focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             >
-              {SPECIES_CONFIG.CONFIDENCE_OPTIONS.map((option: { value: string; label: string }) => (
+              {SPECIES_CONFIG.CONFIDENCE_OPTIONS.map((option) => (
                 <option key={option.value} value={option.value}>
                   {option.label}
                 </option>

--- a/Firmware/webui/frontend/src/components/gallery/BulkSpeciesModal.tsx
+++ b/Firmware/webui/frontend/src/components/gallery/BulkSpeciesModal.tsx
@@ -142,6 +142,7 @@ export default function BulkSpeciesModal({
               type="text"
               {...register('species')}
               placeholder="e.g., Danaus plexippus"
+              aria-required="true"
               aria-invalid={!!formErrors.species}
               aria-describedby={formErrors.species ? 'species-name-error' : undefined}
               className={`w-full px-3 py-2 border rounded-md bg-white dark:bg-gray-700

--- a/Firmware/webui/frontend/src/components/gallery/BulkSpeciesModal.tsx
+++ b/Firmware/webui/frontend/src/components/gallery/BulkSpeciesModal.tsx
@@ -52,7 +52,8 @@ export default function BulkSpeciesModal({
     mode: 'onBlur',
   })
 
-  // Reset form when modal closes
+  // Reset form when modal closes (parent keeps modal mounted; without this,
+  // stale values persist across open/close cycles)
   useEffect(() => {
     if (!isOpen) {
       reset(DEFAULT_VALUES)
@@ -77,6 +78,7 @@ export default function BulkSpeciesModal({
     const species = data.species ?? ''
     const commonName = data.commonName ?? ''
 
+    // Guard: reachable via Enter-key submission which bypasses the disabled button
     if (!species) return
 
     const payload: SpeciesPayload = {

--- a/Firmware/webui/frontend/src/components/gallery/BulkSpeciesModal.tsx
+++ b/Firmware/webui/frontend/src/components/gallery/BulkSpeciesModal.tsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { XMarkIcon } from '@heroicons/react/24/outline'
-import { speciesSchema, type SpeciesFormData } from '../../schemas/species'
+import { speciesSchema, CONFIDENCE_VALUES, type SpeciesFormData } from '../../schemas/species'
 import { SPECIES_CONFIG, Z_INDEX } from '../../constants/config'
 
 interface BulkSpeciesModalProps {
@@ -12,7 +12,7 @@ interface BulkSpeciesModalProps {
   /** Close handler */
   onClose: () => void
   /** Apply handler - receives { species, species_common_name?, species_confidence } */
-  onApply: (data: { species: string; species_common_name?: string; species_confidence: string }) => void
+  onApply: (data: { species: string; species_common_name?: string; species_confidence: typeof CONFIDENCE_VALUES[number] }) => void
   /** Number of selected photos */
   selectedCount: number
   /** Loading state */
@@ -66,7 +66,7 @@ export default function BulkSpeciesModal({
 
     if (!species) return
 
-    const payload: { species: string; species_common_name?: string; species_confidence: string } = {
+    const payload: { species: string; species_common_name?: string; species_confidence: typeof CONFIDENCE_VALUES[number] } = {
       species,
       species_confidence: data.confidence,
     }

--- a/Firmware/webui/frontend/src/components/gallery/BulkSpeciesModal.tsx
+++ b/Firmware/webui/frontend/src/components/gallery/BulkSpeciesModal.tsx
@@ -37,14 +37,14 @@ export default function BulkSpeciesModal({
     formState: { errors: formErrors },
   } = useForm<SpeciesFormData>({
     resolver: zodResolver(speciesSchema),
-    defaultValues: { species: '', commonName: '', confidence: 'probable' },
+    defaultValues: { species: '', commonName: '', confidence: 'probable', referenceUrl: '' },
     mode: 'onBlur',
   })
 
   // Reset form when modal closes
   useEffect(() => {
     if (!isOpen) {
-      reset({ species: '', commonName: '', confidence: 'probable' })
+      reset({ species: '', commonName: '', confidence: 'probable', referenceUrl: '' })
     }
   }, [isOpen, reset])
 
@@ -59,6 +59,8 @@ export default function BulkSpeciesModal({
   }, [isOpen, isLoading, onClose])
 
   if (!isOpen) return null
+
+  const handleClose = () => { if (!isLoading) onClose() }
 
   const onSubmit = (data: SpeciesFormData) => {
     const species = data.species ?? ''
@@ -86,7 +88,7 @@ export default function BulkSpeciesModal({
       {/* Backdrop with click-to-close (guarded during loading) */}
       <div
         className="absolute inset-0 bg-black/50"
-        onClick={() => { if (!isLoading) onClose() }}
+        onClick={handleClose}
       />
 
       {/* Modal content */}
@@ -104,7 +106,7 @@ export default function BulkSpeciesModal({
             Set species for {selectedCount} photo{selectedCount !== 1 ? 's' : ''}
           </h2>
           <button
-            onClick={() => { if (!isLoading) onClose() }}
+            onClick={handleClose}
             aria-label="Close modal"
             className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded disabled:opacity-50 disabled:cursor-not-allowed"
             type="button"
@@ -205,7 +207,7 @@ export default function BulkSpeciesModal({
           <div className="flex gap-3 mt-6">
             <button
               type="button"
-              onClick={() => { if (!isLoading) onClose() }}
+              onClick={handleClose}
               className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md
                          hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-900 dark:text-gray-100
                          disabled:opacity-50 disabled:cursor-not-allowed"

--- a/Firmware/webui/frontend/src/components/gallery/BulkSpeciesModal.tsx
+++ b/Firmware/webui/frontend/src/components/gallery/BulkSpeciesModal.tsx
@@ -34,6 +34,7 @@ export default function BulkSpeciesModal({
     handleSubmit,
     reset,
     watch,
+    formState: { errors: formErrors },
   } = useForm<SpeciesFormData>({
     resolver: zodResolver(speciesSchema),
     defaultValues: { species: '', commonName: '', confidence: 'probable' },
@@ -60,18 +61,18 @@ export default function BulkSpeciesModal({
   if (!isOpen) return null
 
   const onSubmit = (data: SpeciesFormData) => {
-    const trimmedSpecies = (data.species ?? '').trim()
-    const trimmedCommonName = (data.commonName ?? '').trim()
+    const species = data.species ?? ''
+    const commonName = data.commonName ?? ''
 
-    if (!trimmedSpecies) return
+    if (!species) return
 
     const payload: { species: string; species_common_name?: string; species_confidence: string } = {
-      species: trimmedSpecies,
+      species,
       species_confidence: data.confidence,
     }
 
-    if (trimmedCommonName) {
-      payload.species_common_name = trimmedCommonName
+    if (commonName) {
+      payload.species_common_name = commonName
     }
 
     onApply(payload)
@@ -128,11 +129,18 @@ export default function BulkSpeciesModal({
               type="text"
               {...register('species')}
               placeholder="e.g., Danaus plexippus"
-              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600
-                         rounded-md bg-white dark:bg-gray-700
+              aria-invalid={!!formErrors.species}
+              aria-describedby={formErrors.species ? 'species-name-error' : undefined}
+              className={`w-full px-3 py-2 border rounded-md bg-white dark:bg-gray-700
                          text-gray-900 dark:text-gray-100
-                         focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                         focus:ring-2 focus:ring-blue-500 focus:border-transparent
+                         ${formErrors.species ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'}`}
             />
+            {formErrors.species?.message && (
+              <p id="species-name-error" role="alert" className="mt-1 text-sm text-red-600 dark:text-red-400">
+                {formErrors.species.message}
+              </p>
+            )}
           </div>
 
           {/* Common Name Input (Optional) */}
@@ -148,11 +156,18 @@ export default function BulkSpeciesModal({
               type="text"
               {...register('commonName')}
               placeholder="e.g., Monarch Butterfly"
-              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600
-                         rounded-md bg-white dark:bg-gray-700
+              aria-invalid={!!formErrors.commonName}
+              aria-describedby={formErrors.commonName ? 'common-name-error' : undefined}
+              className={`w-full px-3 py-2 border rounded-md bg-white dark:bg-gray-700
                          text-gray-900 dark:text-gray-100
-                         focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                         focus:ring-2 focus:ring-blue-500 focus:border-transparent
+                         ${formErrors.commonName ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'}`}
             />
+            {formErrors.commonName?.message && (
+              <p id="common-name-error" role="alert" className="mt-1 text-sm text-red-600 dark:text-red-400">
+                {formErrors.commonName.message}
+              </p>
+            )}
           </div>
 
           {/* Confidence Dropdown */}
@@ -190,7 +205,7 @@ export default function BulkSpeciesModal({
           <div className="flex gap-3 mt-6">
             <button
               type="button"
-              onClick={onClose}
+              onClick={() => { if (!isLoading) onClose() }}
               className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md
                          hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-900 dark:text-gray-100
                          disabled:opacity-50 disabled:cursor-not-allowed"

--- a/Firmware/webui/frontend/src/components/gallery/BulkSpeciesModal.tsx
+++ b/Firmware/webui/frontend/src/components/gallery/BulkSpeciesModal.tsx
@@ -1,48 +1,56 @@
-import { useState, useEffect } from 'react'
+import { useEffect } from 'react'
 import { createPortal } from 'react-dom'
-import PropTypes from 'prop-types'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
 import { XMarkIcon } from '@heroicons/react/24/outline'
-import { SPECIES_CONFIG, Z_INDEX } from '@/constants/config'
+import { speciesSchema, type SpeciesFormData } from '../../schemas/species'
+import { SPECIES_CONFIG, Z_INDEX } from '../../constants/config'
 
-/**
- * BulkSpeciesModal Component
- *
- * Modal for bulk species assignment with species name, common name, and confidence level.
- *
- * @component
- * @example
- * <BulkSpeciesModal
- *   isOpen={true}
- *   onClose={() => setIsOpen(false)}
- *   onApply={({ species, commonName, confidence }) => console.log('Apply', species, commonName, confidence)}
- *   selectedCount={5}
- * />
- */
+interface BulkSpeciesModalProps {
+  /** Whether the modal is open */
+  isOpen: boolean
+  /** Close handler */
+  onClose: () => void
+  /** Apply handler - receives { species, species_common_name?, species_confidence } */
+  onApply: (data: { species: string; species_common_name?: string; species_confidence: string }) => void
+  /** Number of selected photos */
+  selectedCount: number
+  /** Loading state */
+  isLoading?: boolean
+  /** Error message */
+  error?: string | null
+}
+
 export default function BulkSpeciesModal({
   isOpen,
   onClose,
   onApply,
   selectedCount,
   isLoading = false,
-  error = null
-}) {
-  const [species, setSpecies] = useState('')
-  const [commonName, setCommonName] = useState('')
-  const [confidence, setConfidence] = useState('probable')
+  error = null,
+}: BulkSpeciesModalProps) {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    watch,
+  } = useForm<SpeciesFormData>({
+    resolver: zodResolver(speciesSchema),
+    defaultValues: { species: '', commonName: '', confidence: 'probable' },
+    mode: 'onBlur',
+  })
 
-  // Reset state when modal opens/closes
+  // Reset form when modal closes
   useEffect(() => {
     if (!isOpen) {
-      setSpecies('')
-      setCommonName('')
-      setConfidence('probable')
+      reset({ species: '', commonName: '', confidence: 'probable' })
     }
-  }, [isOpen])
+  }, [isOpen, reset])
 
   // Handle Escape key
   useEffect(() => {
     if (!isOpen) return
-    const handleEscape = (e) => {
+    const handleEscape = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose()
     }
     document.addEventListener('keydown', handleEscape)
@@ -51,27 +59,26 @@ export default function BulkSpeciesModal({
 
   if (!isOpen) return null
 
-  const handleApply = () => {
-    const trimmedSpecies = species.trim()
-    const trimmedCommonName = commonName.trim()
+  const onSubmit = (data: SpeciesFormData) => {
+    const trimmedSpecies = (data.species ?? '').trim()
+    const trimmedCommonName = (data.commonName ?? '').trim()
 
-    if (trimmedSpecies) {
-      // Use backend field names (snake_case) for sidecar schema compatibility
-      const data = {
-        species: trimmedSpecies,
-        species_confidence: confidence
-      }
+    if (!trimmedSpecies) return
 
-      // Only include species_common_name if it has content after trimming
-      if (trimmedCommonName) {
-        data.species_common_name = trimmedCommonName
-      }
-
-      onApply(data)
+    const payload: { species: string; species_common_name?: string; species_confidence: string } = {
+      species: trimmedSpecies,
+      species_confidence: data.confidence,
     }
+
+    if (trimmedCommonName) {
+      payload.species_common_name = trimmedCommonName
+    }
+
+    onApply(payload)
   }
 
-  const isApplyDisabled = !species.trim() || isLoading
+  const speciesValue = watch('species')
+  const isApplyDisabled = !(speciesValue ?? '').trim() || isLoading
 
   const modal = (
     <div className={`fixed inset-0 ${Z_INDEX.MODAL} flex items-center justify-center`}>
@@ -99,13 +106,14 @@ export default function BulkSpeciesModal({
             onClick={onClose}
             aria-label="Close modal"
             className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
+            type="button"
           >
             <XMarkIcon className="h-5 w-5" />
           </button>
         </div>
 
         {/* Form */}
-        <div className="space-y-4">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
           {/* Species Name Input (Required) */}
           <div>
             <label
@@ -117,10 +125,8 @@ export default function BulkSpeciesModal({
             <input
               id="species-name"
               type="text"
-              value={species}
-              onChange={(e) => setSpecies(e.target.value)}
+              {...register('species')}
               placeholder="e.g., Danaus plexippus"
-              required
               className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600
                          rounded-md bg-white dark:bg-gray-700
                          text-gray-900 dark:text-gray-100
@@ -139,8 +145,7 @@ export default function BulkSpeciesModal({
             <input
               id="common-name"
               type="text"
-              value={commonName}
-              onChange={(e) => setCommonName(e.target.value)}
+              {...register('commonName')}
               placeholder="e.g., Monarch Butterfly"
               className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600
                          rounded-md bg-white dark:bg-gray-700
@@ -159,67 +164,52 @@ export default function BulkSpeciesModal({
             </label>
             <select
               id="confidence"
-              value={confidence}
-              onChange={(e) => setConfidence(e.target.value)}
+              {...register('confidence')}
               className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600
                          rounded-md bg-white dark:bg-gray-700
                          text-gray-900 dark:text-gray-100
                          focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             >
-              {SPECIES_CONFIG.CONFIDENCE_OPTIONS.map(option => (
+              {SPECIES_CONFIG.CONFIDENCE_OPTIONS.map((option: { value: string; label: string }) => (
                 <option key={option.value} value={option.value}>
                   {option.label}
                 </option>
               ))}
             </select>
           </div>
-        </div>
 
-        {/* Error message */}
-        {error && (
-          <p role="alert" className="text-red-600 dark:text-red-400 text-sm mt-4">
-            {error}
-          </p>
-        )}
+          {/* Error message */}
+          {error && (
+            <p role="alert" className="text-red-600 dark:text-red-400 text-sm">
+              {error}
+            </p>
+          )}
 
-        {/* Action buttons */}
-        <div className="flex gap-3 mt-6">
-          <button
-            onClick={onClose}
-            className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md
-                       hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-900 dark:text-gray-100
-                       disabled:opacity-50 disabled:cursor-not-allowed"
-            disabled={isLoading}
-          >
-            Cancel
-          </button>
-          <button
-            onClick={handleApply}
-            disabled={isApplyDisabled}
-            className="flex-1 px-4 py-2 bg-blue-600 text-white rounded-md
-                       hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {isLoading ? 'Applying...' : 'Apply'}
-          </button>
-        </div>
+          {/* Action buttons */}
+          <div className="flex gap-3 mt-6">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md
+                         hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-900 dark:text-gray-100
+                         disabled:opacity-50 disabled:cursor-not-allowed"
+              disabled={isLoading}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isApplyDisabled}
+              className="flex-1 px-4 py-2 bg-blue-600 text-white rounded-md
+                         hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isLoading ? 'Applying...' : 'Apply'}
+            </button>
+          </div>
+        </form>
       </div>
     </div>
   )
 
   return createPortal(modal, document.body)
-}
-
-BulkSpeciesModal.propTypes = {
-  /** Whether the modal is open */
-  isOpen: PropTypes.bool.isRequired,
-  /** Close handler */
-  onClose: PropTypes.func.isRequired,
-  /** Apply handler - receives { species: string, commonName?: string, confidence: 'certain' | 'probable' | 'possible' | 'unknown' } */
-  onApply: PropTypes.func.isRequired,
-  /** Number of selected photos */
-  selectedCount: PropTypes.number.isRequired,
-  /** Loading state */
-  isLoading: PropTypes.bool,
-  /** Error message */
-  error: PropTypes.string
 }

--- a/Firmware/webui/frontend/src/components/gallery/__tests__/BulkSpeciesModal.test.tsx
+++ b/Firmware/webui/frontend/src/components/gallery/__tests__/BulkSpeciesModal.test.tsx
@@ -8,12 +8,12 @@ describe('BulkSpeciesModal', () => {
   const mockOnApply = vi.fn()
 
   const defaultProps = {
-    isOpen: true,
+    isOpen: true as const,
     onClose: mockOnClose,
     onApply: mockOnApply,
     selectedCount: 5,
     isLoading: false,
-    error: null,
+    error: null as string | null,
   }
 
   beforeEach(() => {
@@ -24,14 +24,12 @@ describe('BulkSpeciesModal', () => {
     it('does NOT render when isOpen is false', () => {
       render(<BulkSpeciesModal {...defaultProps} isOpen={false} />)
 
-      // Modal should not be in DOM
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
     })
 
     it('renders when isOpen is true', () => {
       render(<BulkSpeciesModal {...defaultProps} />)
 
-      // Modal dialog should be visible
       expect(screen.getByRole('dialog')).toBeInTheDocument()
       expect(screen.getByLabelText(/close modal/i)).toBeInTheDocument()
     })
@@ -50,20 +48,18 @@ describe('BulkSpeciesModal', () => {
   })
 
   describe('Form Fields', () => {
-    it('shows species name input (required)', () => {
+    it('shows species name input', () => {
       render(<BulkSpeciesModal {...defaultProps} />)
 
       const input = screen.getByLabelText(/species name/i)
       expect(input).toBeInTheDocument()
-      expect(input).toHaveAttribute('required')
     })
 
-    it('shows common name input (optional)', () => {
+    it('shows common name input', () => {
       render(<BulkSpeciesModal {...defaultProps} />)
 
       const input = screen.getByLabelText(/common name/i)
       expect(input).toBeInTheDocument()
-      expect(input).not.toHaveAttribute('required')
     })
 
     it('shows confidence dropdown with options: Certain, Probable, Possible, Unknown', () => {
@@ -72,7 +68,6 @@ describe('BulkSpeciesModal', () => {
       const select = screen.getByLabelText(/confidence/i)
       expect(select).toBeInTheDocument()
 
-      // Check all options are present
       expect(screen.getByRole('option', { name: 'Certain' })).toBeInTheDocument()
       expect(screen.getByRole('option', { name: 'Probable' })).toBeInTheDocument()
       expect(screen.getByRole('option', { name: 'Possible' })).toBeInTheDocument()
@@ -119,7 +114,6 @@ describe('BulkSpeciesModal', () => {
       const applyButton = screen.getByRole('button', { name: /apply/i })
       await user.click(applyButton)
 
-      // Uses snake_case field names to match backend schema
       expect(mockOnApply).toHaveBeenCalledWith({
         species: 'Danaus plexippus',
         species_common_name: 'Monarch Butterfly',
@@ -140,7 +134,6 @@ describe('BulkSpeciesModal', () => {
       const applyButton = screen.getByRole('button', { name: /apply/i })
       await user.click(applyButton)
 
-      // Uses snake_case field names to match backend schema
       expect(mockOnApply).toHaveBeenCalledWith({
         species: 'Danaus plexippus',
         species_confidence: 'probable',
@@ -174,7 +167,6 @@ describe('BulkSpeciesModal', () => {
       const applyButton = screen.getByRole('button', { name: /apply/i })
       await user.click(applyButton)
 
-      // Uses snake_case field names to match backend schema
       expect(mockOnApply).toHaveBeenCalledWith({
         species: 'Danaus plexippus',
         species_common_name: 'Monarch Butterfly',
@@ -209,8 +201,7 @@ describe('BulkSpeciesModal', () => {
       const user = userEvent.setup()
       render(<BulkSpeciesModal {...defaultProps} />)
 
-      // Click the backdrop (not the modal content)
-      const backdrop = screen.getByRole('dialog').parentElement.firstChild
+      const backdrop = screen.getByRole('dialog').parentElement!.firstChild as HTMLElement
       await user.click(backdrop)
 
       expect(mockOnClose).toHaveBeenCalledTimes(1)
@@ -230,7 +221,6 @@ describe('BulkSpeciesModal', () => {
       const user = userEvent.setup()
       const { rerender } = render(<BulkSpeciesModal {...defaultProps} />)
 
-      // Enter data
       const speciesInput = screen.getByLabelText(/species name/i)
       const commonNameInput = screen.getByLabelText(/common name/i)
       const confidenceSelect = screen.getByLabelText(/confidence/i)

--- a/Firmware/webui/frontend/src/components/gallery/__tests__/BulkSpeciesModal.test.tsx
+++ b/Firmware/webui/frontend/src/components/gallery/__tests__/BulkSpeciesModal.test.tsx
@@ -8,7 +8,7 @@ describe('BulkSpeciesModal', () => {
   const mockOnApply = vi.fn()
 
   const defaultProps = {
-    isOpen: true as const,
+    isOpen: true,
     onClose: mockOnClose,
     onApply: mockOnApply,
     selectedCount: 5,
@@ -197,6 +197,14 @@ describe('BulkSpeciesModal', () => {
       expect(mockOnClose).toHaveBeenCalledTimes(1)
     })
 
+    it('Escape does NOT close modal when loading', () => {
+      render(<BulkSpeciesModal {...defaultProps} isLoading={true} />)
+
+      fireEvent.keyDown(document, { key: 'Escape' })
+
+      expect(mockOnClose).not.toHaveBeenCalled()
+    })
+
     it('backdrop click closes modal', async () => {
       const user = userEvent.setup()
       render(<BulkSpeciesModal {...defaultProps} />)
@@ -205,6 +213,26 @@ describe('BulkSpeciesModal', () => {
       await user.click(backdrop)
 
       expect(mockOnClose).toHaveBeenCalledTimes(1)
+    })
+
+    it('backdrop click does NOT close modal when loading', async () => {
+      const user = userEvent.setup()
+      render(<BulkSpeciesModal {...defaultProps} isLoading={true} />)
+
+      const backdrop = screen.getByRole('dialog').parentElement!.firstChild as HTMLElement
+      await user.click(backdrop)
+
+      expect(mockOnClose).not.toHaveBeenCalled()
+    })
+
+    it('close button does NOT close modal when loading', async () => {
+      const user = userEvent.setup()
+      render(<BulkSpeciesModal {...defaultProps} isLoading={true} />)
+
+      const closeButton = screen.getByLabelText(/close modal/i)
+      await user.click(closeButton)
+
+      expect(mockOnClose).not.toHaveBeenCalled()
     })
 
     it('clicking modal content does NOT close modal', async () => {

--- a/Firmware/webui/frontend/src/components/gallery/__tests__/BulkSpeciesModal.test.tsx
+++ b/Firmware/webui/frontend/src/components/gallery/__tests__/BulkSpeciesModal.test.tsx
@@ -121,6 +121,17 @@ describe('BulkSpeciesModal', () => {
       })
     })
 
+    it('shows inline error when species name exceeds max length', async () => {
+      const user = userEvent.setup()
+      render(<BulkSpeciesModal {...defaultProps} />)
+
+      const speciesInput = screen.getByLabelText(/species name/i)
+      await user.type(speciesInput, 'a'.repeat(201))
+      await user.tab() // trigger onBlur validation
+
+      expect(await screen.findByText('Species name is too long')).toBeInTheDocument()
+    })
+
     it('does not send species_common_name if only whitespace', async () => {
       const user = userEvent.setup()
       render(<BulkSpeciesModal {...defaultProps} />)

--- a/Firmware/webui/frontend/src/constants/config.d.ts
+++ b/Firmware/webui/frontend/src/constants/config.d.ts
@@ -27,5 +27,5 @@ export declare const METADATA_VALIDATION: {
 }
 
 export declare const SPECIES_CONFIG: {
-  CONFIDENCE_OPTIONS: ReadonlyArray<{ value: string; label: string }>
+  CONFIDENCE_OPTIONS: ReadonlyArray<{ value: 'certain' | 'probable' | 'possible' | 'unknown'; label: string }>
 }

--- a/Firmware/webui/frontend/src/constants/config.d.ts
+++ b/Firmware/webui/frontend/src/constants/config.d.ts
@@ -17,3 +17,15 @@ export declare const Z_INDEX: {
   MAP_CONTROLS: string
   MAP_POPUP: number
 }
+
+export declare const METADATA_VALIDATION: {
+  MAX_TAG_LENGTH: number
+  MAX_SPECIES_LENGTH: number
+  MAX_COMMON_NAME_LENGTH: number
+  MAX_NOTES_LENGTH: number
+  MAX_REFERENCE_URL_LENGTH: number
+}
+
+export declare const SPECIES_CONFIG: {
+  CONFIDENCE_OPTIONS: ReadonlyArray<{ value: string; label: string }>
+}

--- a/Firmware/webui/frontend/src/schemas/__tests__/species.test.ts
+++ b/Firmware/webui/frontend/src/schemas/__tests__/species.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest'
+import { speciesSchema, CONFIDENCE_VALUES } from '../species'
+import { METADATA_VALIDATION } from '../../constants/config'
+
+/** Return the first Zod issue message from a failed parse, or null. */
+function firstError(result: { success: boolean; error?: { issues: { message: string }[] } }): string | null {
+  if (result.success) return null
+  return result.error?.issues[0]?.message ?? null
+}
+
+describe('speciesSchema', () => {
+  describe('valid data', () => {
+    it('accepts all fields populated', () => {
+      const result = speciesSchema.safeParse({
+        species: 'Manduca sexta',
+        commonName: 'Tobacco Hornworm',
+        confidence: 'certain',
+        referenceUrl: 'https://example.com/species/123',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts minimal data (confidence only)', () => {
+      const result = speciesSchema.safeParse({ confidence: 'unknown' })
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts empty strings for optional fields', () => {
+      const result = speciesSchema.safeParse({
+        species: '',
+        commonName: '',
+        confidence: 'probable',
+        referenceUrl: '',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts all confidence values', () => {
+      for (const value of CONFIDENCE_VALUES) {
+        const result = speciesSchema.safeParse({ confidence: value })
+        expect(result.success).toBe(true)
+      }
+    })
+  })
+
+  describe('confidence validation', () => {
+    it('rejects invalid confidence value', () => {
+      const result = speciesSchema.safeParse({ confidence: 'maybe' })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects missing confidence', () => {
+      const result = speciesSchema.safeParse({ species: 'Manduca sexta' })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('string length limits', () => {
+    it('accepts species at max length', () => {
+      const result = speciesSchema.safeParse({
+        species: 'a'.repeat(METADATA_VALIDATION.MAX_SPECIES_LENGTH),
+        confidence: 'probable',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects species exceeding max length', () => {
+      const result = speciesSchema.safeParse({
+        species: 'a'.repeat(METADATA_VALIDATION.MAX_SPECIES_LENGTH + 1),
+        confidence: 'probable',
+      })
+      expect(result.success).toBe(false)
+      expect(firstError(result)).toBe('Species name is too long')
+    })
+
+    it('accepts commonName at max length', () => {
+      const result = speciesSchema.safeParse({
+        commonName: 'a'.repeat(METADATA_VALIDATION.MAX_COMMON_NAME_LENGTH),
+        confidence: 'probable',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects commonName exceeding max length', () => {
+      const result = speciesSchema.safeParse({
+        commonName: 'a'.repeat(METADATA_VALIDATION.MAX_COMMON_NAME_LENGTH + 1),
+        confidence: 'probable',
+      })
+      expect(result.success).toBe(false)
+      expect(firstError(result)).toBe('Common name is too long')
+    })
+  })
+
+  describe('whitespace trimming', () => {
+    it('trims species whitespace', () => {
+      const result = speciesSchema.safeParse({
+        species: '  Manduca sexta  ',
+        confidence: 'probable',
+      })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.species).toBe('Manduca sexta')
+      }
+    })
+
+    it('trims commonName whitespace', () => {
+      const result = speciesSchema.safeParse({
+        species: 'Manduca sexta',
+        commonName: '  Tobacco Hornworm  ',
+        confidence: 'probable',
+      })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.commonName).toBe('Tobacco Hornworm')
+      }
+    })
+  })
+
+  describe('referenceUrl validation', () => {
+    it('accepts a valid URL', () => {
+      const result = speciesSchema.safeParse({
+        confidence: 'probable',
+        referenceUrl: 'https://www.inaturalist.org/taxa/12345',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects an invalid URL', () => {
+      const result = speciesSchema.safeParse({
+        confidence: 'probable',
+        referenceUrl: 'not-a-url',
+      })
+      expect(result.success).toBe(false)
+      expect(firstError(result)).toBe('Invalid URL')
+    })
+
+    it('rejects URL exceeding max length', () => {
+      const result = speciesSchema.safeParse({
+        confidence: 'probable',
+        referenceUrl: 'https://example.com/' + 'a'.repeat(METADATA_VALIDATION.MAX_REFERENCE_URL_LENGTH),
+      })
+      expect(result.success).toBe(false)
+      expect(firstError(result)).toBe('URL is too long')
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/schemas/index.ts
+++ b/Firmware/webui/frontend/src/schemas/index.ts
@@ -2,3 +2,5 @@ export { filterPresetNameSchema, cameraPresetNameSchema } from './preset';
 export type { FilterPresetNameData, CameraPresetNameData } from './preset';
 export { bulkTagSchema, TAG_MODES, TAG_MAX_LENGTH, TAG_MAX_COUNT } from './tag';
 export type { BulkTagFormData } from './tag';
+export { speciesSchema, CONFIDENCE_VALUES } from './species';
+export type { SpeciesFormData } from './species';

--- a/Firmware/webui/frontend/src/schemas/species.ts
+++ b/Firmware/webui/frontend/src/schemas/species.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod'
+import { METADATA_VALIDATION } from '../constants/config'
+
+/**
+ * Confidence levels for species identification.
+ * Matches SPECIES_CONFIG.CONFIDENCE_OPTIONS values in config.js.
+ */
+export const CONFIDENCE_VALUES = ['certain', 'probable', 'possible', 'unknown'] as const
+
+/**
+ * Species identification schema.
+ *
+ * Used by BulkSpeciesModal.tsx (Phase 1) and MetadataSpecies (Phase 2).
+ * All fields are optional at the schema level — individual components
+ * enforce "required" via submit-button disable logic as appropriate.
+ */
+export const speciesSchema = z.object({
+  species: z.string().trim().max(METADATA_VALIDATION.MAX_SPECIES_LENGTH, 'Species name is too long').optional().or(z.literal('')),
+  commonName: z.string().trim().max(METADATA_VALIDATION.MAX_COMMON_NAME_LENGTH, 'Common name is too long').optional().or(z.literal('')),
+  confidence: z.enum(CONFIDENCE_VALUES),
+  referenceUrl: z.string().url('Invalid URL').max(METADATA_VALIDATION.MAX_REFERENCE_URL_LENGTH, 'URL is too long').optional().or(z.literal('')),
+})
+
+export type SpeciesFormData = z.infer<typeof speciesSchema>


### PR DESCRIPTION
## Summary
- Create reusable `species.ts` Zod schema with confidence enum, string length limits, URL validation, and whitespace trimming (reused by MetadataSpecies in Phase 2)
- Migrate `BulkSpeciesModal` from manual `useState` + PropTypes to `react-hook-form` + `zodResolver` + TypeScript interface
- Migrate component tests from `.test.jsx` to `.test.tsx`, removing HTML `required` attribute assertions
- Add `isLoading` guards on Escape key, backdrop click, and close button for consistency with BulkTagModal

## Test plan
- [x] 15 schema unit tests pass (`species.test.ts`)
- [x] 25 component tests pass (`BulkSpeciesModal.test.tsx`)
- [x] ESLint clean on all new/modified files
- [x] `tsc --noEmit` passes
- [ ] Manual: open Gallery, select photos, open species modal, verify fields work and Apply sends correct snake_case payload

Closes #441