### PR TITLE
feat(#453): migrate GPSSettings to TypeScript with RHF + Zod

### DIFF
--- a/Firmware/webui/frontend/src/components/GPSSettings.tsx
+++ b/Firmware/webui/frontend/src/components/GPSSettings.tsx
@@ -68,9 +68,14 @@ export default function GPSSettings() {
 
   const { data: gpsConfig, isLoading: configLoading } = useQuery({
     queryKey: QUERY_KEYS.GPS_CONFIG,
-    queryFn: () => getGpsConfig().then((res: { data: unknown }) =>
-      gpsSettingsSchema.parse(res.data)
-    ),
+    queryFn: () => getGpsConfig().then((res: { data: unknown }) => {
+      const result = gpsSettingsSchema.safeParse(res.data)
+      if (!result.success) {
+        console.warn('GPS config from server failed validation:', result.error)
+        return res.data as GpsSettingsFormData
+      }
+      return result.data
+    }),
   })
 
   // Sync form with query data. While the user is editing (isDirty), incoming
@@ -294,7 +299,8 @@ export default function GPSSettings() {
     pendingValues.current = null
   }
 
-  const { enabled, device, timeout_hot, timeout_warm, timeout_cold, timeout_almanac } = watch()
+  const [enabled, device, timeout_hot, timeout_warm, timeout_cold, timeout_almanac] =
+    watch(['enabled', 'device', 'timeout_hot', 'timeout_warm', 'timeout_cold', 'timeout_almanac'])
 
   if (configLoading) {
     return <div className="text-gray-500">Loading GPS configuration...</div>

--- a/Firmware/webui/frontend/src/components/GPSSettings.tsx
+++ b/Firmware/webui/frontend/src/components/GPSSettings.tsx
@@ -7,8 +7,8 @@ import { formatCoordinateDisplay } from '../utils/gpsCoordinates'
 import { GPS_PRECISION_OPTIONS, getGpsPrecision, setGpsPrecision } from '../utils/gpsPrecision'
 // @ts-expect-error — queryKeys.js has no type declarations (pre-migration)
 import { QUERY_KEYS } from '../utils/queryKeys'
-import { useEffect, useMemo, useState } from 'react'
-import { useForm, type Resolver } from 'react-hook-form'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Controller, useForm, type Resolver } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import {
   gpsSettingsSchema,
@@ -30,11 +30,13 @@ export default function GPSSettings() {
   // Zod 4's public ZodType uses `unknown` for its input parameter (z.coerce).
   // The cast through `unknown` is safe because the schema validates the same
   // shape at runtime. TODO: Remove when @hookform/resolvers aligns with Zod 4.
-  const { register, reset, handleSubmit, watch, getValues, setValue, formState: { errors, isDirty } } = useForm<GpsSettingsFormData>({
+  const { register, reset, handleSubmit, watch, getValues, setValue, control, formState: { errors, isDirty } } = useForm<GpsSettingsFormData>({
     resolver: zodResolver(gpsSettingsSchema as unknown as Parameters<typeof zodResolver>[0]) as unknown as Resolver<GpsSettingsFormData>,
     defaultValues: GPS_SETTINGS_DEFAULTS,
     mode: 'onBlur',
   })
+
+  const pendingValues = useRef<GpsSettingsFormData | null>(null)
 
   const [isCollapsed, setIsCollapsed] = useState(false)
   const [timeoutsCollapsed, setTimeoutsCollapsed] = useState(true)
@@ -66,10 +68,14 @@ export default function GPSSettings() {
 
   const { data: gpsConfig, isLoading: configLoading } = useQuery({
     queryKey: QUERY_KEYS.GPS_CONFIG,
-    queryFn: () => getGpsConfig().then((res: { data: GpsSettingsFormData }) => res.data),
+    queryFn: () => getGpsConfig().then((res: { data: unknown }) =>
+      gpsSettingsSchema.parse(res.data)
+    ),
   })
 
-  // Sync form with query data (isDirty guard fixes polling overwrite bug)
+  // Sync form with query data. While the user is editing (isDirty), incoming
+  // polling updates are ignored to prevent overwriting keystrokes. Config changes
+  // made elsewhere will only take effect after the user saves or discards.
   useEffect(() => {
     if (gpsConfig && !isDirty) {
       reset(gpsConfig)
@@ -253,21 +259,7 @@ export default function GPSSettings() {
     }
   }
 
-  const handleSaveConfig = (values: GpsSettingsFormData) => {
-    const deviceChanged = values.device !== gpsConfig?.device
-    const baudrateChanged = values.baudrate !== gpsConfig?.baudrate
-
-    if (deviceChanged || baudrateChanged) {
-      setShowRestartConfirm(true)
-      return
-    }
-
-    doSaveConfig()
-  }
-
-  const doSaveConfig = () => {
-    const values = getValues()
-    setShowRestartConfirm(false)
+  const submitConfig = (values: GpsSettingsFormData) => {
     updateConfigMutation.mutate({
       gps_enabled: values.enabled,
       gps_device: values.device,
@@ -278,6 +270,26 @@ export default function GPSSettings() {
       gps_timeout_cold: values.timeout_cold,
       gps_timeout_almanac: values.timeout_almanac,
     })
+  }
+
+  const handleSaveConfig = (values: GpsSettingsFormData) => {
+    const deviceChanged = values.device !== gpsConfig?.device
+    const baudrateChanged = values.baudrate !== gpsConfig?.baudrate
+
+    if (deviceChanged || baudrateChanged) {
+      pendingValues.current = values
+      setShowRestartConfirm(true)
+      return
+    }
+
+    submitConfig(values)
+  }
+
+  const doSaveConfig = () => {
+    setShowRestartConfirm(false)
+    const values = pendingValues.current ?? getValues()
+    pendingValues.current = null
+    submitConfig(values)
   }
 
   if (configLoading) {
@@ -445,25 +457,30 @@ export default function GPSSettings() {
                     <span className="ml-2 text-green-600 text-xs">✓</span>
                   )}
                 </label>
-                <select
-                  value={String(watch('baudrate'))}
-                  onChange={(e) => setValue('baudrate', Number(e.target.value), { shouldDirty: true, shouldValidate: true })}
-                  onBlur={register('baudrate').onBlur}
+                <Controller
                   name="baudrate"
-                  aria-label="Baud Rate"
-                  className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 ${
-                    errors.baudrate
-                      ? 'border-red-300 focus:ring-red-500 bg-red-50'
-                      : 'border-green-300 focus:ring-green-500 bg-green-50'
-                  }`}
-                >
-                  <option value="4800">4800</option>
-                  <option value="9600">9600 (Default)</option>
-                  <option value="19200">19200</option>
-                  <option value="38400">38400</option>
-                  <option value="57600">57600</option>
-                  <option value="115200">115200</option>
-                </select>
+                  control={control}
+                  render={({ field }) => (
+                    <select
+                      {...field}
+                      value={String(field.value)}
+                      onChange={(e) => field.onChange(Number(e.target.value))}
+                      aria-label="Baud Rate"
+                      className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 ${
+                        errors.baudrate
+                          ? 'border-red-300 focus:ring-red-500 bg-red-50'
+                          : 'border-green-300 focus:ring-green-500 bg-green-50'
+                      }`}
+                    >
+                      <option value="4800">4800</option>
+                      <option value="9600">9600 (Default)</option>
+                      <option value="19200">19200</option>
+                      <option value="38400">38400</option>
+                      <option value="57600">57600</option>
+                      <option value="115200">115200</option>
+                    </select>
+                  )}
+                />
                 {errors.baudrate ? (
                   <p className="text-xs text-red-600 mt-1">
                     ⚠️ {errors.baudrate.message}

--- a/Firmware/webui/frontend/src/components/GPSSettings.tsx
+++ b/Firmware/webui/frontend/src/components/GPSSettings.tsx
@@ -273,8 +273,10 @@ export default function GPSSettings() {
   }
 
   const handleSaveConfig = (values: GpsSettingsFormData) => {
-    const deviceChanged = values.device !== gpsConfig?.device
-    const baudrateChanged = values.baudrate !== gpsConfig?.baudrate
+    if (!gpsConfig) { submitConfig(values); return }
+
+    const deviceChanged = values.device !== gpsConfig.device
+    const baudrateChanged = values.baudrate !== gpsConfig.baudrate
 
     if (deviceChanged || baudrateChanged) {
       pendingValues.current = values
@@ -287,10 +289,12 @@ export default function GPSSettings() {
 
   const doSaveConfig = () => {
     setShowRestartConfirm(false)
-    // pendingValues is always set by handleSaveConfig before the dialog opens
-    submitConfig(pendingValues.current!)
+    if (!pendingValues.current) return
+    submitConfig(pendingValues.current)
     pendingValues.current = null
   }
+
+  const { enabled, device, timeout_hot, timeout_warm, timeout_cold, timeout_almanac } = watch()
 
   if (configLoading) {
     return <div className="text-gray-500">Loading GPS configuration...</div>
@@ -321,7 +325,7 @@ export default function GPSSettings() {
           </label>
         </div>
 
-        {watch('enabled') && (
+        {enabled && (
           <>
             {/* Current GPS Status */}
             {gpsStatus && (
@@ -421,7 +425,7 @@ export default function GPSSettings() {
                   {errors.device && (
                     <span className="ml-2 text-red-600 text-xs">✗</span>
                   )}
-                  {!errors.device && watch('device') && (
+                  {!errors.device && device && (
                     <span className="ml-2 text-green-600 text-xs">✓</span>
                   )}
                 </label>
@@ -433,7 +437,7 @@ export default function GPSSettings() {
                   className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 ${
                     errors.device
                       ? 'border-red-300 focus:ring-red-500 bg-red-50'
-                      : watch('device')
+                      : device
                       ? 'border-green-300 focus:ring-green-500 bg-green-50'
                       : 'border-gray-300 focus:ring-blue-500'
                   }`}
@@ -605,7 +609,7 @@ export default function GPSSettings() {
                     {/* Hot Start Timeout */}
                     <div>
                       <label className="block text-xs font-medium text-gray-700 mb-1">
-                        🟢 Hot Start (&lt;4 hours): {watch('timeout_hot')}s
+                        🟢 Hot Start (&lt;4 hours): {timeout_hot}s
                       </label>
                       <input
                         type="range"
@@ -625,7 +629,7 @@ export default function GPSSettings() {
                     {/* Warm Start Timeout */}
                     <div>
                       <label className="block text-xs font-medium text-gray-700 mb-1">
-                        🟡 Warm Start (4h-6d): {watch('timeout_warm')}s
+                        🟡 Warm Start (4h-6d): {timeout_warm}s
                       </label>
                       <input
                         type="range"
@@ -645,7 +649,7 @@ export default function GPSSettings() {
                     {/* Cold Start Timeout */}
                     <div>
                       <label className="block text-xs font-medium text-gray-700 mb-1">
-                        🟠 Cold Start (6-28d): {watch('timeout_cold')}s
+                        🟠 Cold Start (6-28d): {timeout_cold}s
                       </label>
                       <input
                         type="range"
@@ -665,7 +669,7 @@ export default function GPSSettings() {
                     {/* Almanac Expired Timeout */}
                     <div>
                       <label className="block text-xs font-medium text-gray-700 mb-1">
-                        🔴 Almanac Expired (&gt;28d): {Math.floor(watch('timeout_almanac') / 60)}m
+                        🔴 Almanac Expired (&gt;28d): {Math.floor(timeout_almanac / 60)}m
                       </label>
                       <input
                         type="range"

--- a/Firmware/webui/frontend/src/components/GPSSettings.tsx
+++ b/Firmware/webui/frontend/src/components/GPSSettings.tsx
@@ -30,7 +30,7 @@ export default function GPSSettings() {
   // Zod 4's public ZodType uses `unknown` for its input parameter (z.coerce).
   // The cast through `unknown` is safe because the schema validates the same
   // shape at runtime. TODO: Remove when @hookform/resolvers aligns with Zod 4.
-  const { register, reset, watch, getValues, setValue, formState: { errors, isDirty } } = useForm<GpsSettingsFormData>({
+  const { register, reset, handleSubmit, watch, getValues, setValue, formState: { errors, isDirty } } = useForm<GpsSettingsFormData>({
     resolver: zodResolver(gpsSettingsSchema as unknown as Parameters<typeof zodResolver>[0]) as unknown as Resolver<GpsSettingsFormData>,
     defaultValues: GPS_SETTINGS_DEFAULTS,
     mode: 'onBlur',
@@ -253,9 +253,7 @@ export default function GPSSettings() {
     }
   }
 
-  const handleSaveConfig = () => {
-    const values = getValues()
-
+  const handleSaveConfig = (values: GpsSettingsFormData) => {
     const deviceChanged = values.device !== gpsConfig?.device
     const baudrateChanged = values.baudrate !== gpsConfig?.baudrate
 
@@ -667,14 +665,10 @@ export default function GPSSettings() {
                     {/* Reset to Defaults Button */}
                     <button
                       onClick={() => {
-                        const current = getValues()
-                        reset({
-                          ...current,
-                          timeout_hot: GPS_SETTINGS_DEFAULTS.timeout_hot,
-                          timeout_warm: GPS_SETTINGS_DEFAULTS.timeout_warm,
-                          timeout_cold: GPS_SETTINGS_DEFAULTS.timeout_cold,
-                          timeout_almanac: GPS_SETTINGS_DEFAULTS.timeout_almanac,
-                        })
+                        setValue('timeout_hot', GPS_SETTINGS_DEFAULTS.timeout_hot, { shouldDirty: true })
+                        setValue('timeout_warm', GPS_SETTINGS_DEFAULTS.timeout_warm, { shouldDirty: true })
+                        setValue('timeout_cold', GPS_SETTINGS_DEFAULTS.timeout_cold, { shouldDirty: true })
+                        setValue('timeout_almanac', GPS_SETTINGS_DEFAULTS.timeout_almanac, { shouldDirty: true })
                       }}
                       className="w-full px-3 py-1 text-xs bg-gray-100 text-gray-700 rounded hover:bg-gray-200"
                     >
@@ -695,7 +689,7 @@ export default function GPSSettings() {
                 {syncing ? 'Syncing...' : '🛰️ Sync GPS Now'}
               </button>
               <button
-                onClick={handleSaveConfig}
+                onClick={handleSubmit(handleSaveConfig)}
                 disabled={updateConfigMutation.isPending || Object.keys(errors).length > 0}
                 className="flex-1 bg-green-600 text-white px-4 py-2 rounded-md hover:bg-green-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
                 title={Object.keys(errors).length > 0 ? 'Please fix validation errors' : ''}

--- a/Firmware/webui/frontend/src/components/GPSSettings.tsx
+++ b/Firmware/webui/frontend/src/components/GPSSettings.tsx
@@ -287,9 +287,9 @@ export default function GPSSettings() {
 
   const doSaveConfig = () => {
     setShowRestartConfirm(false)
-    const values = pendingValues.current ?? getValues()
+    // pendingValues is always set by handleSaveConfig before the dialog opens
+    submitConfig(pendingValues.current!)
     pendingValues.current = null
-    submitConfig(values)
   }
 
   if (configLoading) {
@@ -457,6 +457,9 @@ export default function GPSSettings() {
                     <span className="ml-2 text-green-600 text-xs">✓</span>
                   )}
                 </label>
+                {/* Controller keeps RHF's ref attached to the DOM element.
+                    Manual Number() cast is needed because <select> produces
+                    strings; z.coerce.number() only runs at validation time. */}
                 <Controller
                   name="baudrate"
                   control={control}
@@ -681,6 +684,7 @@ export default function GPSSettings() {
 
                     {/* Reset to Defaults Button */}
                     <button
+                      type="button"
                       onClick={() => {
                         setValue('timeout_hot', GPS_SETTINGS_DEFAULTS.timeout_hot, { shouldDirty: true })
                         setValue('timeout_warm', GPS_SETTINGS_DEFAULTS.timeout_warm, { shouldDirty: true })

--- a/Firmware/webui/frontend/src/components/GPSSettings.tsx
+++ b/Firmware/webui/frontend/src/components/GPSSettings.tsx
@@ -29,7 +29,7 @@ export default function GPSSettings() {
   // zodResolver's Zod 4 overload expects $ZodType<Output, FieldValues> but
   // Zod 4's public ZodType uses `unknown` for its input parameter (z.coerce).
   // The cast through `unknown` is safe because the schema validates the same
-  // shape at runtime. TODO: Remove when @hookform/resolvers aligns with Zod 4.
+  // shape at runtime. TODO(#485): Remove when @hookform/resolvers aligns with Zod 4.
   const { register, reset, handleSubmit, watch, getValues, setValue, control, formState: { errors, isDirty } } = useForm<GpsSettingsFormData>({
     resolver: zodResolver(gpsSettingsSchema as unknown as Parameters<typeof zodResolver>[0]) as unknown as Resolver<GpsSettingsFormData>,
     defaultValues: GPS_SETTINGS_DEFAULTS,
@@ -72,7 +72,7 @@ export default function GPSSettings() {
       const result = gpsSettingsSchema.safeParse(res.data)
       if (!result.success) {
         console.warn('GPS config from server failed validation:', result.error)
-        return res.data as GpsSettingsFormData
+        return { ...GPS_SETTINGS_DEFAULTS, ...(res.data as Partial<GpsSettingsFormData>) }
       }
       return result.data
     }),
@@ -117,6 +117,7 @@ export default function GPSSettings() {
     return !Number.isNaN(val) ? formatCoordinateDisplay(val, false, 'dms', gpsPrecision) : null
   }, [gpsStatus?.last_known_lon, gpsPrecision])
 
+  // TODO(#197): Type mutation generics once api.js is migrated to TypeScript
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const updateConfigMutation = useMutation<any, any, Record<string, unknown>>({
     mutationFn: updateGpsConfig,
@@ -760,7 +761,7 @@ export default function GPSSettings() {
       {/* GPS Service Restart Confirmation */}
       <ConfirmDialog
         isOpen={showRestartConfirm}
-        onClose={() => setShowRestartConfirm(false)}
+        onClose={() => { setShowRestartConfirm(false); pendingValues.current = null }}
         onConfirm={doSaveConfig}
         title="Restart GPS Service?"
         message="Changing device or baud rate will restart the GPS service. Any GPS sync in progress will be interrupted."

--- a/Firmware/webui/frontend/src/components/GPSSettings.tsx
+++ b/Firmware/webui/frontend/src/components/GPSSettings.tsx
@@ -8,6 +8,7 @@ import { GPS_PRECISION_OPTIONS, getGpsPrecision, setGpsPrecision } from '../util
 // @ts-expect-error — queryKeys.js has no type declarations (pre-migration)
 import { QUERY_KEYS } from '../utils/queryKeys'
 import { useEffect, useMemo, useRef, useState } from 'react'
+// Resolver type import is only needed for the zodResolver cast workaround — remove with TODO(#485)
 import { Controller, useForm, type Resolver } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import {
@@ -33,7 +34,7 @@ export default function GPSSettings() {
   const { register, reset, handleSubmit, watch, getValues, setValue, control, formState: { errors, isDirty } } = useForm<GpsSettingsFormData>({
     resolver: zodResolver(gpsSettingsSchema as unknown as Parameters<typeof zodResolver>[0]) as unknown as Resolver<GpsSettingsFormData>,
     defaultValues: GPS_SETTINGS_DEFAULTS,
-    mode: 'onBlur',
+    mode: 'onTouched',
   })
 
   const pendingValues = useRef<GpsSettingsFormData | null>(null)
@@ -240,7 +241,7 @@ export default function GPSSettings() {
       const isTimeout = message.includes('timeout') || error.response?.status === 408
 
       if (isTimeout) {
-        const timeoutValue = values.timeout || 60
+        const timeoutValue = gpsConfig?.timeout ?? 60
         toast.error(
           `⏱️ GPS sync timeout (${timeoutValue}s)\n\n` +
           `Troubleshooting:\n` +

--- a/Firmware/webui/frontend/src/components/GPSSettings.tsx
+++ b/Firmware/webui/frontend/src/components/GPSSettings.tsx
@@ -1,23 +1,44 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+// @ts-expect-error — api.js has no type declarations (pre-migration)
 import { getGpsConfig, updateGpsConfig, getGpsStatus, syncGps } from '../utils/api'
+// @ts-expect-error — helpers.js has no type declarations (pre-migration)
 import { formatTimestamp } from '../utils/helpers'
-import { validateDevicePath, validateBaudrate } from '../utils/gpsValidation'
 import { formatCoordinateDisplay } from '../utils/gpsCoordinates'
 import { GPS_PRECISION_OPTIONS, getGpsPrecision, setGpsPrecision } from '../utils/gpsPrecision'
+// @ts-expect-error — queryKeys.js has no type declarations (pre-migration)
 import { QUERY_KEYS } from '../utils/queryKeys'
-import { useState, useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { useForm, type Resolver } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import {
+  gpsSettingsSchema,
+  GPS_SETTINGS_DEFAULTS,
+  type GpsSettingsFormData,
+} from '../schemas/gps-settings'
 import toast from 'react-hot-toast'
+// @ts-expect-error — CollapsibleCard.jsx has no type declarations (pre-migration)
 import CollapsibleCard from './CollapsibleCard'
+// @ts-expect-error — ConfirmDialog.jsx has no type declarations (pre-migration)
 import ConfirmDialog from './common/ConfirmDialog'
+// @ts-expect-error — useGpsExif.js has no type declarations (pre-migration)
 import { useGpsExifStatus, useGpsExifConfig, useUpdateGpsExifConfig } from '../hooks/useGpsExif'
 
 export default function GPSSettings() {
   const queryClient = useQueryClient()
+
+  // zodResolver's Zod 4 overload expects $ZodType<Output, FieldValues> but
+  // Zod 4's public ZodType uses `unknown` for its input parameter (z.coerce).
+  // The cast through `unknown` is safe because the schema validates the same
+  // shape at runtime. TODO: Remove when @hookform/resolvers aligns with Zod 4.
+  const { register, reset, watch, getValues, setValue, formState: { errors, isDirty } } = useForm<GpsSettingsFormData>({
+    resolver: zodResolver(gpsSettingsSchema as unknown as Parameters<typeof zodResolver>[0]) as unknown as Resolver<GpsSettingsFormData>,
+    defaultValues: GPS_SETTINGS_DEFAULTS,
+    mode: 'onBlur',
+  })
+
   const [isCollapsed, setIsCollapsed] = useState(false)
   const [timeoutsCollapsed, setTimeoutsCollapsed] = useState(true)
   const [syncing, setSyncing] = useState(false)
-  const [localConfig, setLocalConfig] = useState(null)
-  const [validationErrors, setValidationErrors] = useState({})
   const [showRestartConfirm, setShowRestartConfirm] = useState(false)
   const [gpsPrecision, setGpsPrecisionState] = useState(() => getGpsPrecision())
   const [exifSectionOpen, setExifSectionOpen] = useState(false)
@@ -35,7 +56,7 @@ export default function GPSSettings() {
   }, [exifConfig])
 
   // Handle precision change
-  const handlePrecisionChange = (newPrecision) => {
+  const handlePrecisionChange = (newPrecision: string) => {
     const precision = parseInt(newPrecision, 10)
     setGpsPrecisionState(precision)
     if (!setGpsPrecision(precision)) {
@@ -45,19 +66,20 @@ export default function GPSSettings() {
 
   const { data: gpsConfig, isLoading: configLoading } = useQuery({
     queryKey: QUERY_KEYS.GPS_CONFIG,
-    queryFn: () => getGpsConfig().then(res => res.data),
+    queryFn: () => getGpsConfig().then((res: { data: GpsSettingsFormData }) => res.data),
   })
 
-  // Sync local config with query data (replaces deprecated onSuccess)
+  // Sync form with query data (isDirty guard fixes polling overwrite bug)
   useEffect(() => {
-    if (gpsConfig) {
-      setLocalConfig(gpsConfig)
+    if (gpsConfig && !isDirty) {
+      reset(gpsConfig)
     }
-  }, [gpsConfig])
+  }, [gpsConfig, isDirty, reset])
 
   const { data: gpsStatus } = useQuery({
     queryKey: QUERY_KEYS.GPS_STATUS,
-    queryFn: () => getGpsStatus().then(res => res.data),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    queryFn: () => getGpsStatus().then((res: { data: any }) => res.data),
     // Pause polling during sync to avoid spam, otherwise poll every 15s
     refetchInterval: () => syncing ? false : 15000,
   })
@@ -84,9 +106,11 @@ export default function GPSSettings() {
     return !Number.isNaN(val) ? formatCoordinateDisplay(val, false, 'dms', gpsPrecision) : null
   }, [gpsStatus?.last_known_lon, gpsPrecision])
 
-  const updateConfigMutation = useMutation({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const updateConfigMutation = useMutation<any, any, Record<string, unknown>>({
     mutationFn: updateGpsConfig,
-    onSuccess: (response) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onSuccess: (response: any) => {
       queryClient.invalidateQueries(QUERY_KEYS.GPS_CONFIG)
       queryClient.invalidateQueries(QUERY_KEYS.GPS_STATUS)
 
@@ -96,14 +120,15 @@ export default function GPSSettings() {
         toast.success('GPS configuration updated successfully!')
       }
     },
-    onError: (error) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onError: (error: any) => {
       const message = error.response?.data?.message || error.response?.data?.error || 'Failed to update GPS config'
       toast.error(`Error: ${message}`, { duration: 6000 })
     },
   })
 
   // Helper to format GPS state description
-  const formatGpsStateInfo = (gpstime) => {
+  const formatGpsStateInfo = (gpstime: number) => {
     if (gpstime === 0) {
       return { state: 'almanac_expired', time: '5-20 min', description: 'First sync (almanac download)' }
     }
@@ -120,7 +145,8 @@ export default function GPSSettings() {
   }
 
   const handleSyncGPS = async () => {
-    if (!gpsConfig?.enabled) {
+    const values = getValues()
+    if (!values.enabled) {
       toast.error('GPS is disabled. Enable it first.')
       return
     }
@@ -131,11 +157,11 @@ export default function GPSSettings() {
     const stateInfo = formatGpsStateInfo(gpsStatus?.gpstime || 0)
 
     // Use actual configured timeout values based on GPS state
-    const timeoutMap = {
-      'hot_start': localConfig?.timeout_hot || 15,
-      'warm_start': localConfig?.timeout_warm || 60,
-      'cold_start': localConfig?.timeout_cold || 90,
-      'almanac_expired': localConfig?.timeout_almanac || 1200
+    const timeoutMap: Record<string, number> = {
+      'hot_start': values.timeout_hot || 15,
+      'warm_start': values.timeout_warm || 60,
+      'cold_start': values.timeout_cold || 90,
+      'almanac_expired': values.timeout_almanac || 1200
     }
     const expectedSeconds = timeoutMap[stateInfo.state] || 60
 
@@ -193,14 +219,15 @@ export default function GPSSettings() {
       }
       queryClient.invalidateQueries(QUERY_KEYS.GPS_STATUS)
       queryClient.invalidateQueries(QUERY_KEYS.SYSTEM_STATUS)
-    } catch (error) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (error: any) {
       clearInterval(progressInterval)
       toast.dismiss(toastId)
       const message = error.response?.data?.message || error.message
       const isTimeout = message.includes('timeout') || error.response?.status === 408
 
       if (isTimeout) {
-        const timeoutValue = localConfig?.timeout || 60
+        const timeoutValue = values.timeout || 60
         toast.error(
           `⏱️ GPS sync timeout (${timeoutValue}s)\n\n` +
           `Troubleshooting:\n` +
@@ -226,45 +253,13 @@ export default function GPSSettings() {
     }
   }
 
-  // Validate config changes in real-time
-  const handleDeviceChange = (newDevice) => {
-    setLocalConfig({...localConfig, device: newDevice})
-    const validation = validateDevicePath(newDevice)
-    setValidationErrors(prev => ({
-      ...prev,
-      device: validation.valid ? null : validation.error
-    }))
-  }
-
-  const handleBaudrateChange = (newBaudrate) => {
-    setLocalConfig({...localConfig, baudrate: newBaudrate})
-    const validation = validateBaudrate(newBaudrate)
-    setValidationErrors(prev => ({
-      ...prev,
-      baudrate: validation.valid ? null : validation.error
-    }))
-  }
-
-  // Removed - timeout field no longer used (replaced by adaptive timeouts)
-
-  // Check if form is valid
-  const isFormValid = () => {
-    if (!localConfig) return false
-    return !validationErrors.device && !validationErrors.baudrate && !validationErrors.timeout
-  }
-
   const handleSaveConfig = () => {
-    if (!isFormValid()) {
-      toast.error('Please fix validation errors before saving')
-      return
-    }
+    const values = getValues()
 
-    // Check if device or baudrate changed (requires gpsd restart)
-    const deviceChanged = localConfig.device !== gpsConfig.device
-    const baudrateChanged = localConfig.baudrate !== gpsConfig.baudrate
+    const deviceChanged = values.device !== gpsConfig?.device
+    const baudrateChanged = values.baudrate !== gpsConfig?.baudrate
 
     if (deviceChanged || baudrateChanged) {
-      // Show warning that gpsd will restart
       setShowRestartConfirm(true)
       return
     }
@@ -273,16 +268,17 @@ export default function GPSSettings() {
   }
 
   const doSaveConfig = () => {
+    const values = getValues()
     setShowRestartConfirm(false)
     updateConfigMutation.mutate({
-      gps_enabled: localConfig.enabled,
-      gps_device: localConfig.device,
-      gps_baudrate: localConfig.baudrate,
-      gps_timeout: localConfig.timeout,
-      gps_timeout_hot: localConfig.timeout_hot,
-      gps_timeout_warm: localConfig.timeout_warm,
-      gps_timeout_cold: localConfig.timeout_cold,
-      gps_timeout_almanac: localConfig.timeout_almanac
+      gps_enabled: values.enabled,
+      gps_device: values.device,
+      gps_baudrate: values.baudrate,
+      gps_timeout: values.timeout,
+      gps_timeout_hot: values.timeout_hot,
+      gps_timeout_warm: values.timeout_warm,
+      gps_timeout_cold: values.timeout_cold,
+      gps_timeout_almanac: values.timeout_almanac,
     })
   }
 
@@ -308,15 +304,14 @@ export default function GPSSettings() {
           <label className="relative inline-flex items-center cursor-pointer">
             <input
               type="checkbox"
-              checked={localConfig?.enabled || false}
-              onChange={(e) => setLocalConfig({...localConfig, enabled: e.target.checked})}
+              {...register('enabled')}
               className="sr-only peer"
             />
             <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
           </label>
         </div>
 
-        {localConfig?.enabled && (
+        {watch('enabled') && (
           <>
             {/* Current GPS Status */}
             {gpsStatus && (
@@ -413,30 +408,29 @@ export default function GPSSettings() {
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
                   GPS Device Path
-                  {validationErrors.device && (
+                  {errors.device && (
                     <span className="ml-2 text-red-600 text-xs">✗</span>
                   )}
-                  {!validationErrors.device && localConfig?.device && (
+                  {!errors.device && watch('device') && (
                     <span className="ml-2 text-green-600 text-xs">✓</span>
                   )}
                 </label>
                 <input
                   type="text"
-                  value={localConfig?.device || ''}
-                  onChange={(e) => handleDeviceChange(e.target.value)}
+                  {...register('device')}
                   placeholder="/dev/ttyAMA0"
                   aria-label="GPS Device Path"
                   className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 ${
-                    validationErrors.device
+                    errors.device
                       ? 'border-red-300 focus:ring-red-500 bg-red-50'
-                      : localConfig?.device
+                      : watch('device')
                       ? 'border-green-300 focus:ring-green-500 bg-green-50'
                       : 'border-gray-300 focus:ring-blue-500'
                   }`}
                 />
-                {validationErrors.device ? (
+                {errors.device ? (
                   <p className="text-xs text-red-600 mt-1">
-                    ⚠️ {validationErrors.device}
+                    ⚠️ {errors.device.message}
                   </p>
                 ) : (
                   <p className="text-xs text-gray-500 mt-1">
@@ -449,16 +443,18 @@ export default function GPSSettings() {
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
                   Baud Rate
-                  {!validationErrors.baudrate && (
+                  {!errors.baudrate && (
                     <span className="ml-2 text-green-600 text-xs">✓</span>
                   )}
                 </label>
                 <select
-                  value={localConfig?.baudrate || 9600}
-                  onChange={(e) => handleBaudrateChange(parseInt(e.target.value))}
+                  value={String(watch('baudrate'))}
+                  onChange={(e) => setValue('baudrate', Number(e.target.value), { shouldDirty: true, shouldValidate: true })}
+                  onBlur={register('baudrate').onBlur}
+                  name="baudrate"
                   aria-label="Baud Rate"
                   className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 ${
-                    validationErrors.baudrate
+                    errors.baudrate
                       ? 'border-red-300 focus:ring-red-500 bg-red-50'
                       : 'border-green-300 focus:ring-green-500 bg-green-50'
                   }`}
@@ -470,9 +466,9 @@ export default function GPSSettings() {
                   <option value="57600">57600</option>
                   <option value="115200">115200</option>
                 </select>
-                {validationErrors.baudrate ? (
+                {errors.baudrate ? (
                   <p className="text-xs text-red-600 mt-1">
-                    ⚠️ {validationErrors.baudrate}
+                    ⚠️ {errors.baudrate.message}
                   </p>
                 ) : (
                   <p className="text-xs text-gray-500 mt-1">
@@ -591,15 +587,14 @@ export default function GPSSettings() {
                     {/* Hot Start Timeout */}
                     <div>
                       <label className="block text-xs font-medium text-gray-700 mb-1">
-                        🟢 Hot Start (&lt;4 hours): {localConfig?.timeout_hot || 15}s
+                        🟢 Hot Start (&lt;4 hours): {watch('timeout_hot')}s
                       </label>
                       <input
                         type="range"
                         min="5"
                         max="60"
                         step="5"
-                        value={localConfig?.timeout_hot || 15}
-                        onChange={(e) => setLocalConfig({...localConfig, timeout_hot: parseInt(e.target.value)})}
+                        {...register('timeout_hot', { valueAsNumber: true })}
                         className="w-full"
                       />
                       <div className="flex justify-between text-xs text-gray-500">
@@ -612,15 +607,14 @@ export default function GPSSettings() {
                     {/* Warm Start Timeout */}
                     <div>
                       <label className="block text-xs font-medium text-gray-700 mb-1">
-                        🟡 Warm Start (4h-6d): {localConfig?.timeout_warm || 60}s
+                        🟡 Warm Start (4h-6d): {watch('timeout_warm')}s
                       </label>
                       <input
                         type="range"
                         min="30"
                         max="180"
                         step="10"
-                        value={localConfig?.timeout_warm || 60}
-                        onChange={(e) => setLocalConfig({...localConfig, timeout_warm: parseInt(e.target.value)})}
+                        {...register('timeout_warm', { valueAsNumber: true })}
                         className="w-full"
                       />
                       <div className="flex justify-between text-xs text-gray-500">
@@ -633,15 +627,14 @@ export default function GPSSettings() {
                     {/* Cold Start Timeout */}
                     <div>
                       <label className="block text-xs font-medium text-gray-700 mb-1">
-                        🟠 Cold Start (6-28d): {localConfig?.timeout_cold || 90}s
+                        🟠 Cold Start (6-28d): {watch('timeout_cold')}s
                       </label>
                       <input
                         type="range"
                         min="60"
                         max="300"
                         step="10"
-                        value={localConfig?.timeout_cold || 90}
-                        onChange={(e) => setLocalConfig({...localConfig, timeout_cold: parseInt(e.target.value)})}
+                        {...register('timeout_cold', { valueAsNumber: true })}
                         className="w-full"
                       />
                       <div className="flex justify-between text-xs text-gray-500">
@@ -654,15 +647,14 @@ export default function GPSSettings() {
                     {/* Almanac Expired Timeout */}
                     <div>
                       <label className="block text-xs font-medium text-gray-700 mb-1">
-                        🔴 Almanac Expired (&gt;28d): {Math.floor((localConfig?.timeout_almanac || 1200) / 60)}m
+                        🔴 Almanac Expired (&gt;28d): {Math.floor(watch('timeout_almanac') / 60)}m
                       </label>
                       <input
                         type="range"
                         min="300"
                         max="1800"
                         step="60"
-                        value={localConfig?.timeout_almanac || 1200}
-                        onChange={(e) => setLocalConfig({...localConfig, timeout_almanac: parseInt(e.target.value)})}
+                        {...register('timeout_almanac', { valueAsNumber: true })}
                         className="w-full"
                       />
                       <div className="flex justify-between text-xs text-gray-500">
@@ -674,13 +666,16 @@ export default function GPSSettings() {
 
                     {/* Reset to Defaults Button */}
                     <button
-                      onClick={() => setLocalConfig({
-                        ...localConfig,
-                        timeout_hot: 15,
-                        timeout_warm: 60,
-                        timeout_cold: 90,
-                        timeout_almanac: 1200
-                      })}
+                      onClick={() => {
+                        const current = getValues()
+                        reset({
+                          ...current,
+                          timeout_hot: GPS_SETTINGS_DEFAULTS.timeout_hot,
+                          timeout_warm: GPS_SETTINGS_DEFAULTS.timeout_warm,
+                          timeout_cold: GPS_SETTINGS_DEFAULTS.timeout_cold,
+                          timeout_almanac: GPS_SETTINGS_DEFAULTS.timeout_almanac,
+                        })
+                      }}
                       className="w-full px-3 py-1 text-xs bg-gray-100 text-gray-700 rounded hover:bg-gray-200"
                     >
                       Reset to Defaults
@@ -701,11 +696,11 @@ export default function GPSSettings() {
               </button>
               <button
                 onClick={handleSaveConfig}
-                disabled={updateConfigMutation.isLoading || !isFormValid()}
+                disabled={updateConfigMutation.isPending || Object.keys(errors).length > 0}
                 className="flex-1 bg-green-600 text-white px-4 py-2 rounded-md hover:bg-green-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
-                title={!isFormValid() ? 'Please fix validation errors' : ''}
+                title={Object.keys(errors).length > 0 ? 'Please fix validation errors' : ''}
               >
-                {updateConfigMutation.isLoading ? 'Saving...' : '💾 Save Configuration'}
+                {updateConfigMutation.isPending ? 'Saving...' : '💾 Save Configuration'}
               </button>
             </div>
 

--- a/Firmware/webui/frontend/src/components/GPSSettings.tsx
+++ b/Firmware/webui/frontend/src/components/GPSSettings.tsx
@@ -157,11 +157,12 @@ export default function GPSSettings() {
   }
 
   const handleSyncGPS = async () => {
-    const values = getValues()
-    if (!values.enabled) {
+    // Check server state, not form state — user may have toggled enabled without saving
+    if (!gpsConfig?.enabled) {
       toast.error('GPS is disabled. Enable it first.')
       return
     }
+    const values = getValues()
 
     setSyncing(true)
 
@@ -295,7 +296,10 @@ export default function GPSSettings() {
 
   const doSaveConfig = () => {
     setShowRestartConfirm(false)
-    if (!pendingValues.current) return
+    if (!pendingValues.current) {
+      console.error('doSaveConfig called without pending values')
+      return
+    }
     submitConfig(pendingValues.current)
     pendingValues.current = null
   }

--- a/Firmware/webui/frontend/src/components/GPSSettings.tsx
+++ b/Firmware/webui/frontend/src/components/GPSSettings.tsx
@@ -170,12 +170,15 @@ export default function GPSSettings() {
     // Get expected GPS state based on last sync
     const stateInfo = formatGpsStateInfo(gpsStatus?.gpstime || 0)
 
-    // Use actual configured timeout values based on GPS state
+    // Read timeout values from the form (not server state) so the progress
+    // timer reflects whatever the user currently sees in the UI sliders, even
+    // if those values haven't been saved yet. This keeps the displayed estimate
+    // consistent with the user's intent.
     const timeoutMap: Record<string, number> = {
-      'hot_start': values.timeout_hot || 15,
-      'warm_start': values.timeout_warm || 60,
-      'cold_start': values.timeout_cold || 90,
-      'almanac_expired': values.timeout_almanac || 1200
+      'hot_start': values.timeout_hot,
+      'warm_start': values.timeout_warm,
+      'cold_start': values.timeout_cold,
+      'almanac_expired': values.timeout_almanac,
     }
     const expectedSeconds = timeoutMap[stateInfo.state] || 60
 

--- a/Firmware/webui/frontend/src/components/GPSSettings.tsx
+++ b/Firmware/webui/frontend/src/components/GPSSettings.tsx
@@ -31,7 +31,7 @@ export default function GPSSettings() {
   // Zod 4's public ZodType uses `unknown` for its input parameter (z.coerce).
   // The cast through `unknown` is safe because the schema validates the same
   // shape at runtime. TODO(#485): Remove when @hookform/resolvers aligns with Zod 4.
-  const { register, reset, handleSubmit, watch, getValues, setValue, control, formState: { errors, isDirty } } = useForm<GpsSettingsFormData>({
+  const { register, reset, handleSubmit, watch, getValues, setValue, control, formState: { errors, isDirty, isValid } } = useForm<GpsSettingsFormData>({
     resolver: zodResolver(gpsSettingsSchema as unknown as Parameters<typeof zodResolver>[0]) as unknown as Resolver<GpsSettingsFormData>,
     defaultValues: GPS_SETTINGS_DEFAULTS,
     mode: 'onTouched',
@@ -731,9 +731,9 @@ export default function GPSSettings() {
               </button>
               <button
                 onClick={handleSubmit(handleSaveConfig)}
-                disabled={updateConfigMutation.isPending || Object.keys(errors).length > 0}
+                disabled={updateConfigMutation.isPending || !isValid}
                 className="flex-1 bg-green-600 text-white px-4 py-2 rounded-md hover:bg-green-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
-                title={Object.keys(errors).length > 0 ? 'Please fix validation errors' : ''}
+                title={!isValid ? 'Please fix validation errors' : ''}
               >
                 {updateConfigMutation.isPending ? 'Saving...' : '💾 Save Configuration'}
               </button>

--- a/Firmware/webui/frontend/src/components/GPSSettings.tsx
+++ b/Firmware/webui/frontend/src/components/GPSSettings.tsx
@@ -31,7 +31,7 @@ export default function GPSSettings() {
   // Zod 4's public ZodType uses `unknown` for its input parameter (z.coerce).
   // The cast through `unknown` is safe because the schema validates the same
   // shape at runtime. TODO(#485): Remove when @hookform/resolvers aligns with Zod 4.
-  const { register, reset, handleSubmit, watch, getValues, setValue, control, formState: { errors, isDirty, isValid } } = useForm<GpsSettingsFormData>({
+  const { register, reset, handleSubmit, watch, getValues, setValue, control, formState: { errors, isDirty } } = useForm<GpsSettingsFormData>({
     resolver: zodResolver(gpsSettingsSchema as unknown as Parameters<typeof zodResolver>[0]) as unknown as Resolver<GpsSettingsFormData>,
     defaultValues: GPS_SETTINGS_DEFAULTS,
     mode: 'onTouched',
@@ -726,14 +726,14 @@ export default function GPSSettings() {
                 onClick={handleSyncGPS}
                 disabled={syncing}
                 className="flex-1 bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
+                title="Progress estimate uses current slider values (even if unsaved)"
               >
                 {syncing ? 'Syncing...' : '🛰️ Sync GPS Now'}
               </button>
               <button
                 onClick={handleSubmit(handleSaveConfig)}
-                disabled={updateConfigMutation.isPending || !isValid}
+                disabled={updateConfigMutation.isPending}
                 className="flex-1 bg-green-600 text-white px-4 py-2 rounded-md hover:bg-green-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
-                title={!isValid ? 'Please fix validation errors' : ''}
               >
                 {updateConfigMutation.isPending ? 'Saving...' : '💾 Save Configuration'}
               </button>

--- a/Firmware/webui/frontend/src/components/GPSSettings.tsx
+++ b/Firmware/webui/frontend/src/components/GPSSettings.tsx
@@ -299,6 +299,7 @@ export default function GPSSettings() {
     setShowRestartConfirm(false)
     if (!pendingValues.current) {
       console.error('doSaveConfig called without pending values')
+      toast.error('Unable to save — please try again.')
       return
     }
     submitConfig(pendingValues.current)

--- a/Firmware/webui/frontend/src/components/__tests__/GPSSettings.test.tsx
+++ b/Firmware/webui/frontend/src/components/__tests__/GPSSettings.test.tsx
@@ -3,14 +3,21 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import GPSSettings from '../GPSSettings'
-import * as api from '../../utils/api'
+
+// Create typed mock functions (hoisted so vi.mock can reference them)
+const { mockGetGpsConfig, mockGetGpsStatus, mockUpdateGpsConfig, mockSyncGps } = vi.hoisted(() => ({
+  mockGetGpsConfig: vi.fn(),
+  mockGetGpsStatus: vi.fn(),
+  mockUpdateGpsConfig: vi.fn(),
+  mockSyncGps: vi.fn(),
+}))
 
 // Mock the API module
 vi.mock('../../utils/api', () => ({
-  getGpsConfig: vi.fn(),
-  updateGpsConfig: vi.fn(),
-  getGpsStatus: vi.fn(),
-  syncGps: vi.fn(),
+  getGpsConfig: mockGetGpsConfig,
+  updateGpsConfig: mockUpdateGpsConfig,
+  getGpsStatus: mockGetGpsStatus,
+  syncGps: mockSyncGps,
 }))
 
 // Mock toast
@@ -24,7 +31,7 @@ vi.mock('react-hot-toast', () => ({
 }))
 
 describe('GPSSettings', () => {
-  let queryClient
+  let queryClient: QueryClient
 
   const mockGPSConfig = {
     enabled: true,
@@ -59,8 +66,8 @@ describe('GPSSettings', () => {
     vi.clearAllMocks()
 
     // Set default mock responses
-    api.getGpsConfig.mockResolvedValue({ data: mockGPSConfig })
-    api.getGpsStatus.mockResolvedValue({ data: mockGPSStatus })
+    mockGetGpsConfig.mockResolvedValue({ data: mockGPSConfig })
+    mockGetGpsStatus.mockResolvedValue({ data: mockGPSStatus })
   })
 
   const renderComponent = () => {
@@ -101,7 +108,7 @@ describe('GPSSettings', () => {
   })
 
   it('displays "No GPS Fix" when GPS has no fix', async () => {
-    api.getGpsStatus.mockResolvedValue({
+    mockGetGpsStatus.mockResolvedValue({
       data: { ...mockGPSStatus, has_fix: false },
     })
 
@@ -124,7 +131,7 @@ describe('GPSSettings', () => {
   })
 
   it('hides configuration fields when GPS is disabled', async () => {
-    api.getGpsConfig.mockResolvedValue({
+    mockGetGpsConfig.mockResolvedValue({
       data: { ...mockGPSConfig, enabled: false },
     })
 
@@ -186,7 +193,7 @@ describe('GPSSettings', () => {
 
   it('saves configuration when save button clicked', async () => {
     const user = userEvent.setup()
-    api.updateGpsConfig.mockResolvedValue({ data: { success: true } })
+    mockUpdateGpsConfig.mockResolvedValue({ data: { success: true } })
 
     renderComponent()
 
@@ -198,8 +205,8 @@ describe('GPSSettings', () => {
     await user.click(saveButton)
 
     await waitFor(() => {
-      expect(api.updateGpsConfig).toHaveBeenCalled()
-      const callArgs = api.updateGpsConfig.mock.calls[0][0]
+      expect(mockUpdateGpsConfig).toHaveBeenCalled()
+      const callArgs = mockUpdateGpsConfig.mock.calls[0][0]
       expect(callArgs).toEqual({
         gps_enabled: true,
         gps_device: '/dev/ttyAMA0',
@@ -217,8 +224,8 @@ describe('GPSSettings', () => {
     const user = userEvent.setup()
 
     // Create a promise that won't resolve immediately to allow us to see the "Syncing..." state
-    let resolveSyncGps
-    api.syncGps.mockImplementation(() => new Promise((resolve) => {
+    let resolveSyncGps: (() => void) | undefined
+    mockSyncGps.mockImplementation(() => new Promise((resolve) => {
       resolveSyncGps = () => resolve({
         data: {
           success: true,
@@ -242,10 +249,10 @@ describe('GPSSettings', () => {
       expect(screen.getByText(/Syncing.../i)).toBeInTheDocument()
     })
 
-    expect(api.syncGps).toHaveBeenCalled()
+    expect(mockSyncGps).toHaveBeenCalled()
 
     // Resolve the promise to complete the sync
-    resolveSyncGps()
+    resolveSyncGps!()
 
     // Wait for sync to complete and button to return to normal state
     await waitFor(() => {

--- a/Firmware/webui/frontend/src/components/__tests__/GPSSettings.test.tsx
+++ b/Firmware/webui/frontend/src/components/__tests__/GPSSettings.test.tsx
@@ -220,6 +220,39 @@ describe('GPSSettings', () => {
     })
   })
 
+  it('shows restart dialog when device path changes, then submits on confirm', async () => {
+    const user = userEvent.setup()
+    mockUpdateGpsConfig.mockResolvedValue({ data: { success: true } })
+
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: /GPS Device Path/i })).toBeInTheDocument()
+    })
+
+    // Change the device path to trigger restart confirmation
+    const input = screen.getByRole('textbox', { name: /GPS Device Path/i })
+    await user.clear(input)
+    await user.type(input, '/dev/ttyUSB0')
+
+    // Click save — should show restart confirmation dialog
+    const saveButton = screen.getByText(/💾 Save Configuration/i)
+    await user.click(saveButton)
+
+    await waitFor(() => {
+      expect(screen.getByText(/Restart GPS Service/i)).toBeInTheDocument()
+    })
+
+    // Confirm the dialog
+    const confirmButton = screen.getByText(/Continue/i)
+    await user.click(confirmButton)
+
+    await waitFor(() => {
+      expect(mockUpdateGpsConfig).toHaveBeenCalled()
+      expect(mockUpdateGpsConfig.mock.calls[0][0].gps_device).toBe('/dev/ttyUSB0')
+    })
+  })
+
   it('syncs GPS when sync button clicked', async () => {
     const user = userEvent.setup()
 

--- a/Firmware/webui/frontend/src/components/__tests__/GPSSettings.test.tsx
+++ b/Firmware/webui/frontend/src/components/__tests__/GPSSettings.test.tsx
@@ -83,6 +83,27 @@ describe('GPSSettings', () => {
     expect(screen.getByText(/Loading GPS configuration/i)).toBeInTheDocument()
   })
 
+  it('falls back to defaults when server returns malformed config', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    // Return config missing the required 'device' field
+    mockGetGpsConfig.mockResolvedValue({
+      data: { enabled: true, baudrate: 9600, timeout: 10, timeout_hot: 15, timeout_warm: 60, timeout_cold: 90, timeout_almanac: 1200 },
+    })
+
+    renderComponent()
+
+    // Should still render (fallback fills in defaults for missing fields)
+    await waitFor(() => {
+      expect(screen.getByText(/GPS Module Configuration/i)).toBeInTheDocument()
+    })
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'GPS config from server failed validation:',
+      expect.anything(),
+    )
+    warnSpy.mockRestore()
+  })
+
   it('renders GPS configuration when loaded', async () => {
     renderComponent()
 

--- a/Firmware/webui/frontend/src/components/__tests__/GPSSettings.test.tsx
+++ b/Firmware/webui/frontend/src/components/__tests__/GPSSettings.test.tsx
@@ -195,7 +195,9 @@ describe('GPSSettings', () => {
       data: { ...mockGPSConfig, device: '/dev/ttyS0' },
     })
 
-    // Trigger a re-render by invalidating (simulate TanStack Query refetch)
+    // Actually trigger the refetch via TanStack Query invalidation
+    await queryClient.invalidateQueries({ queryKey: ['gps-config'] })
+
     // The form should keep the user's typed value, not reset to /dev/ttyS0
     await waitFor(() => {
       expect(input).toHaveValue('/dev/ttyUSB1')

--- a/Firmware/webui/frontend/src/components/__tests__/GPSSettings.test.tsx
+++ b/Firmware/webui/frontend/src/components/__tests__/GPSSettings.test.tsx
@@ -176,6 +176,32 @@ describe('GPSSettings', () => {
     expect(input).toHaveValue('/dev/ttyUSB0')
   })
 
+  it('does not reset form with polling data while user is editing', async () => {
+    const user = userEvent.setup()
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: /GPS Device Path/i })).toBeInTheDocument()
+    })
+
+    // Type into the device field (makes the form dirty)
+    const input = screen.getByRole('textbox', { name: /GPS Device Path/i })
+    await user.clear(input)
+    await user.type(input, '/dev/ttyUSB1')
+    expect(input).toHaveValue('/dev/ttyUSB1')
+
+    // Simulate a polling re-fetch returning different data
+    mockGetGpsConfig.mockResolvedValue({
+      data: { ...mockGPSConfig, device: '/dev/ttyS0' },
+    })
+
+    // Trigger a re-render by invalidating (simulate TanStack Query refetch)
+    // The form should keep the user's typed value, not reset to /dev/ttyS0
+    await waitFor(() => {
+      expect(input).toHaveValue('/dev/ttyUSB1')
+    })
+  })
+
   it('updates baudrate selection', async () => {
     const user = userEvent.setup()
     renderComponent()

--- a/Firmware/webui/frontend/src/schemas/__tests__/gps-settings.test.ts
+++ b/Firmware/webui/frontend/src/schemas/__tests__/gps-settings.test.ts
@@ -220,9 +220,14 @@ describe('gpsSettingsSchema', () => {
   })
 
   describe('timeout (base, legacy pass-through)', () => {
-    it('accepts any numeric value (no UI constraints — backend-only field)', () => {
+    it('accepts positive values (no upper bound — backend-only field)', () => {
       expect(gpsSettingsSchema.safeParse(validConfig({ timeout: 1 })).success).toBe(true)
       expect(gpsSettingsSchema.safeParse(validConfig({ timeout: 300 })).success).toBe(true)
+    })
+
+    it('rejects zero and negative values', () => {
+      expect(gpsSettingsSchema.safeParse(validConfig({ timeout: 0 })).success).toBe(false)
+      expect(gpsSettingsSchema.safeParse(validConfig({ timeout: -1 })).success).toBe(false)
     })
 
     it('coerces string to number', () => {

--- a/Firmware/webui/frontend/src/schemas/__tests__/gps-settings.test.ts
+++ b/Firmware/webui/frontend/src/schemas/__tests__/gps-settings.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect } from 'vitest'
+import {
+  gpsSettingsSchema,
+  GPS_SETTINGS_DEFAULTS,
+  BAUDRATE_VALUES,
+} from '../gps-settings'
+
+/** Build a valid config, optionally overriding specific fields. */
+function validConfig(overrides: Record<string, unknown> = {}) {
+  return { ...GPS_SETTINGS_DEFAULTS, ...overrides }
+}
+
+describe('gpsSettingsSchema', () => {
+  describe('BAUDRATE_VALUES', () => {
+    it('contains the expected baud rates', () => {
+      expect([...BAUDRATE_VALUES]).toEqual([4800, 9600, 19200, 38400, 57600, 115200])
+    })
+  })
+
+  describe('GPS_SETTINGS_DEFAULTS', () => {
+    it('passes schema validation', () => {
+      const result = gpsSettingsSchema.safeParse(GPS_SETTINGS_DEFAULTS)
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('valid config', () => {
+    it('accepts a complete valid config', () => {
+      const result = gpsSettingsSchema.safeParse(validConfig())
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts config with all fields overridden', () => {
+      const result = gpsSettingsSchema.safeParse({
+        enabled: true,
+        device: '/dev/ttyUSB0',
+        baudrate: 115200,
+        timeout: 30,
+        timeout_hot: 10,
+        timeout_warm: 90,
+        timeout_cold: 120,
+        timeout_almanac: 600,
+      })
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('device path validation', () => {
+    it.each([
+      '/dev/ttyAMA0',
+      '/dev/ttyS0',
+      '/dev/ttyUSB0',
+      '/dev/serial0',
+      '/dev/ttyAMA1',
+      '/dev/ttyUSB2',
+    ])('accepts valid device path: %s', (device) => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ device }))
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects empty device path', () => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ device: '' }))
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects path not starting with /dev/', () => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ device: '/tmp/ttyAMA0' }))
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects invalid device format like /dev/sda1', () => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ device: '/dev/sda1' }))
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects bare device name without /dev/ prefix', () => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ device: 'ttyAMA0' }))
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('baudrate validation', () => {
+    it.each(BAUDRATE_VALUES)('accepts valid baudrate: %d', (baudrate) => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ baudrate }))
+      expect(result.success).toBe(true)
+    })
+
+    it('coerces string "9600" to number 9600', () => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ baudrate: '9600' }))
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.baudrate).toBe(9600)
+      }
+    })
+
+    it('rejects invalid baudrate 12345', () => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ baudrate: 12345 }))
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('timeout_hot validation', () => {
+    it('accepts value at minimum (5)', () => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ timeout_hot: 5 }))
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts value at maximum (60)', () => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ timeout_hot: 60 }))
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects value below minimum', () => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ timeout_hot: 4 }))
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects value above maximum', () => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ timeout_hot: 61 }))
+      expect(result.success).toBe(false)
+    })
+
+    it('coerces string to number', () => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ timeout_hot: '15' }))
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.timeout_hot).toBe(15)
+      }
+    })
+  })
+
+  describe('timeout_warm validation', () => {
+    it('accepts value at minimum (30)', () => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ timeout_warm: 30 }))
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts value at maximum (180)', () => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ timeout_warm: 180 }))
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects value below minimum', () => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ timeout_warm: 29 }))
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects value above maximum', () => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ timeout_warm: 181 }))
+      expect(result.success).toBe(false)
+    })
+
+    it('coerces string to number', () => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ timeout_warm: '60' }))
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.timeout_warm).toBe(60)
+      }
+    })
+  })
+
+  describe('timeout_cold validation', () => {
+    it('accepts value at minimum (60)', () => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ timeout_cold: 60 }))
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts value at maximum (300)', () => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ timeout_cold: 300 }))
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects value below minimum', () => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ timeout_cold: 59 }))
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects value above maximum', () => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ timeout_cold: 301 }))
+      expect(result.success).toBe(false)
+    })
+
+    it('coerces string to number', () => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ timeout_cold: '90' }))
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.timeout_cold).toBe(90)
+      }
+    })
+  })
+
+  describe('timeout_almanac validation', () => {
+    it('accepts value at minimum (300)', () => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ timeout_almanac: 300 }))
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts value at maximum (1800)', () => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ timeout_almanac: 1800 }))
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects value below minimum', () => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ timeout_almanac: 299 }))
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects value above maximum', () => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ timeout_almanac: 1801 }))
+      expect(result.success).toBe(false)
+    })
+
+    it('coerces string to number', () => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ timeout_almanac: '1200' }))
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.timeout_almanac).toBe(1200)
+      }
+    })
+  })
+
+  describe('timeout (base) validation', () => {
+    it('accepts value at minimum (5)', () => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ timeout: 5 }))
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts value at maximum (60)', () => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ timeout: 60 }))
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects value below minimum', () => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ timeout: 4 }))
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects value above maximum', () => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ timeout: 61 }))
+      expect(result.success).toBe(false)
+    })
+
+    it('coerces string to number', () => {
+      const result = gpsSettingsSchema.safeParse(validConfig({ timeout: '10' }))
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.timeout).toBe(10)
+      }
+    })
+  })
+
+  describe('missing required fields', () => {
+    it('rejects missing enabled', () => {
+      const { enabled: _enabled, ...rest } = validConfig()
+      const result = gpsSettingsSchema.safeParse(rest)
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects missing device', () => {
+      const { device: _device, ...rest } = validConfig()
+      const result = gpsSettingsSchema.safeParse(rest)
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects missing baudrate', () => {
+      const { baudrate: _baudrate, ...rest } = validConfig()
+      const result = gpsSettingsSchema.safeParse(rest)
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects empty object', () => {
+      const result = gpsSettingsSchema.safeParse({})
+      expect(result.success).toBe(false)
+    })
+  })
+})

--- a/Firmware/webui/frontend/src/schemas/__tests__/gps-settings.test.ts
+++ b/Firmware/webui/frontend/src/schemas/__tests__/gps-settings.test.ts
@@ -48,8 +48,10 @@ describe('gpsSettingsSchema', () => {
   describe('device path validation', () => {
     it.each([
       '/dev/ttyAMA0',
+      '/dev/ttyACM0',
       '/dev/ttyS0',
       '/dev/ttyUSB0',
+      '/dev/ttyO0',
       '/dev/serial0',
       '/dev/ttyAMA1',
       '/dev/ttyUSB2',

--- a/Firmware/webui/frontend/src/schemas/__tests__/gps-settings.test.ts
+++ b/Firmware/webui/frontend/src/schemas/__tests__/gps-settings.test.ts
@@ -219,25 +219,10 @@ describe('gpsSettingsSchema', () => {
     })
   })
 
-  describe('timeout (base) validation', () => {
-    it('accepts value at minimum (5)', () => {
-      const result = gpsSettingsSchema.safeParse(validConfig({ timeout: 5 }))
-      expect(result.success).toBe(true)
-    })
-
-    it('accepts value at maximum (60)', () => {
-      const result = gpsSettingsSchema.safeParse(validConfig({ timeout: 60 }))
-      expect(result.success).toBe(true)
-    })
-
-    it('rejects value below minimum', () => {
-      const result = gpsSettingsSchema.safeParse(validConfig({ timeout: 4 }))
-      expect(result.success).toBe(false)
-    })
-
-    it('rejects value above maximum', () => {
-      const result = gpsSettingsSchema.safeParse(validConfig({ timeout: 61 }))
-      expect(result.success).toBe(false)
+  describe('timeout (base, legacy pass-through)', () => {
+    it('accepts any numeric value (no UI constraints — backend-only field)', () => {
+      expect(gpsSettingsSchema.safeParse(validConfig({ timeout: 1 })).success).toBe(true)
+      expect(gpsSettingsSchema.safeParse(validConfig({ timeout: 300 })).success).toBe(true)
     })
 
     it('coerces string to number', () => {

--- a/Firmware/webui/frontend/src/schemas/gps-settings.ts
+++ b/Firmware/webui/frontend/src/schemas/gps-settings.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod'
+
+export const BAUDRATE_VALUES = [4800, 9600, 19200, 38400, 57600, 115200] as const
+
+const DEVICE_PATH_PATTERN = /^\/dev\/(ttyAMA\d+|ttyS\d+|ttyUSB\d+|serial\d+)$/
+
+export const gpsSettingsSchema = z.object({
+  enabled: z.boolean(),
+  device: z.string()
+    .min(1, 'Device path is required')
+    .regex(DEVICE_PATH_PATTERN, 'Invalid device path format. Expected /dev/ttyAMA0, /dev/ttyUSB0, etc.'),
+  baudrate: z.coerce.number().refine(
+    (v) => (BAUDRATE_VALUES as readonly number[]).includes(v),
+    'Invalid baudrate',
+  ),
+  timeout: z.coerce.number().min(5, 'Must be at least 5s').max(60, 'Cannot exceed 60s'),
+  timeout_hot: z.coerce.number().min(5, 'Must be at least 5s').max(60, 'Cannot exceed 60s'),
+  timeout_warm: z.coerce.number().min(30, 'Must be at least 30s').max(180, 'Cannot exceed 180s'),
+  timeout_cold: z.coerce.number().min(60, 'Must be at least 60s').max(300, 'Cannot exceed 300s'),
+  timeout_almanac: z.coerce.number().min(300, 'Must be at least 300s').max(1800, 'Cannot exceed 1800s'),
+})
+
+export type GpsSettingsFormData = z.infer<typeof gpsSettingsSchema>
+
+export const GPS_SETTINGS_DEFAULTS: GpsSettingsFormData = {
+  enabled: false,
+  device: '/dev/ttyAMA0',
+  baudrate: 9600,
+  timeout: 10,
+  timeout_hot: 15,
+  timeout_warm: 60,
+  timeout_cold: 90,
+  timeout_almanac: 1200,
+}

--- a/Firmware/webui/frontend/src/schemas/gps-settings.ts
+++ b/Firmware/webui/frontend/src/schemas/gps-settings.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 export const BAUDRATE_VALUES = [4800, 9600, 19200, 38400, 57600, 115200] as const
 
-const DEVICE_PATH_PATTERN = /^\/dev\/(ttyAMA\d+|ttyS\d+|ttyUSB\d+|serial\d+)$/
+const DEVICE_PATH_PATTERN = /^\/dev\/(ttyAMA\d+|ttyACM\d+|ttyS\d+|ttyUSB\d+|ttyO\d+|serial\d+)$/
 
 export const gpsSettingsSchema = z.object({
   enabled: z.boolean(),

--- a/Firmware/webui/frontend/src/schemas/gps-settings.ts
+++ b/Firmware/webui/frontend/src/schemas/gps-settings.ts
@@ -13,8 +13,9 @@ export const gpsSettingsSchema = z.object({
     (v) => (BAUDRATE_VALUES as readonly number[]).includes(v),
     'Invalid baudrate',
   ),
-  // Legacy field: no UI control, replaced by adaptive timeouts. Kept because
-  // the backend still expects gps_timeout in the mutation payload.
+  /** @deprecated Legacy field with no UI control — replaced by adaptive timeouts
+   *  (timeout_hot/warm/cold/almanac). Kept only because the backend still
+   *  expects gps_timeout in the mutation payload. Remove once backend drops it. */
   timeout: z.coerce.number().min(1),
   timeout_hot: z.coerce.number().min(5, 'Must be at least 5s').max(60, 'Cannot exceed 60s'),
   timeout_warm: z.coerce.number().min(30, 'Must be at least 30s').max(180, 'Cannot exceed 180s'),

--- a/Firmware/webui/frontend/src/schemas/gps-settings.ts
+++ b/Firmware/webui/frontend/src/schemas/gps-settings.ts
@@ -15,7 +15,7 @@ export const gpsSettingsSchema = z.object({
   ),
   // Legacy field: no UI control, replaced by adaptive timeouts. Kept because
   // the backend still expects gps_timeout in the mutation payload.
-  timeout: z.coerce.number(),
+  timeout: z.coerce.number().min(1),
   timeout_hot: z.coerce.number().min(5, 'Must be at least 5s').max(60, 'Cannot exceed 60s'),
   timeout_warm: z.coerce.number().min(30, 'Must be at least 30s').max(180, 'Cannot exceed 180s'),
   timeout_cold: z.coerce.number().min(60, 'Must be at least 60s').max(300, 'Cannot exceed 300s'),

--- a/Firmware/webui/frontend/src/schemas/gps-settings.ts
+++ b/Firmware/webui/frontend/src/schemas/gps-settings.ts
@@ -13,7 +13,9 @@ export const gpsSettingsSchema = z.object({
     (v) => (BAUDRATE_VALUES as readonly number[]).includes(v),
     'Invalid baudrate',
   ),
-  timeout: z.coerce.number().min(5, 'Must be at least 5s').max(60, 'Cannot exceed 60s'),
+  // Legacy field: no UI control, replaced by adaptive timeouts. Kept because
+  // the backend still expects gps_timeout in the mutation payload.
+  timeout: z.coerce.number(),
   timeout_hot: z.coerce.number().min(5, 'Must be at least 5s').max(60, 'Cannot exceed 60s'),
   timeout_warm: z.coerce.number().min(30, 'Must be at least 30s').max(180, 'Cannot exceed 180s'),
   timeout_cold: z.coerce.number().min(60, 'Must be at least 60s').max(300, 'Cannot exceed 300s'),

--- a/Firmware/webui/frontend/src/schemas/index.ts
+++ b/Firmware/webui/frontend/src/schemas/index.ts
@@ -28,3 +28,5 @@ export {
   BOOLEAN_OPERATORS,
 } from './search';
 export type { AdvancedSearchFormData, SearchCondition } from './search';
+export { gpsSettingsSchema, BAUDRATE_VALUES, GPS_SETTINGS_DEFAULTS } from './gps-settings';
+export type { GpsSettingsFormData } from './gps-settings';


### PR DESCRIPTION
## Summary
- Migrate GPSSettings from manual `useState` + `gpsValidation.js` + `.jsx` to `react-hook-form` + Zod + TypeScript (`.tsx`)
- Fix polling overwrite bug: `isDirty` guard prevents 15s GPS status polling from overwriting mid-edit keystrokes
- Add `handleSubmit` validation gate so Save always runs full Zod validation

## Changes
- **New**: `src/schemas/gps-settings.ts` — Zod schema with `z.coerce.number()` for HTML range/select inputs, replaces `gpsValidation.js`
- **New**: `src/schemas/__tests__/gps-settings.test.ts` — 51 schema tests (boundaries, coercion, invalid inputs)
- **Modified**: `src/schemas/index.ts` — barrel exports
- **Migrated**: `GPSSettings.jsx` → `GPSSettings.tsx` — `useForm` + `zodResolver` replaces `useState` + manual validation
- **Migrated**: `GPSSettings.test.jsx` → `GPSSettings.test.tsx` — typed mocks via `vi.hoisted()`

## Test plan
- [x] 51 schema tests pass
- [x] 13 component tests pass (unchanged behavior)
- [x] Full suite: 6,247 tests pass, 0 failures
- [x] `tsc --noEmit` clean
- [x] ESLint clean (1 pre-existing deprecation warning)

Closes #453